### PR TITLE
[codex] Fix thesis CI Hspec summary parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Changed
+- Fixed the thesis-conformance CI gate so colored Hspec summaries from GitHub
+  Actions are parsed before enforcing matcher coverage. Validation:
+  `cabal build all && cabal test` (`1609 examples, 0 failures, 7 pending`) and
+  `./scripts/thesis-conformance-gate.sh`.
 - Added `.mlfp` first-class-polymorphism parity at
   `test/programs/unified/first-class-polymorphism.mlfp`. `.mlfp` application
   elaboration now preserves a top-level polymorphic argument when the callee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 ### Changed
-- Fixed the thesis-conformance CI gate so colored Hspec summaries from GitHub
-  Actions are parsed before enforcing matcher coverage. Validation:
+- Fixed the thesis-conformance CI gate so colored Hspec summaries and Ruby
+  3.2 YAML dates from GitHub Actions are parsed before enforcing matcher
+  coverage. Validation:
   `cabal build all && cabal test` (`1609 examples, 0 failures, 7 pending`) and
   `./scripts/thesis-conformance-gate.sh`.
 - Added `.mlfp` first-class-polymorphism parity at

--- a/scripts/check-thesis-claims.sh
+++ b/scripts/check-thesis-claims.sh
@@ -22,6 +22,7 @@ fi
 
 echo "[thesis-claims] Validating claims, deviations, and cross-links"
 ruby - "${CLAIMS}" "${DEVIATIONS}" "${OBLIGATIONS}" "${ROOT}" <<'RUBY'
+require 'date'
 require 'yaml'
 require 'set'
 
@@ -30,9 +31,18 @@ deviations_path = ARGV.fetch(1)
 obligations_path = ARGV.fetch(2)
 root = ARGV.fetch(3)
 
-claims_doc = YAML.load_file(claims_path)
-deviations_doc = YAML.load_file(deviations_path)
-obligations_doc = YAML.load_file(obligations_path)
+def load_yaml_file(path)
+  YAML.safe_load(
+    File.read(path),
+    permitted_classes: [Date],
+    aliases: true,
+    filename: path
+  )
+end
+
+claims_doc = load_yaml_file(claims_path)
+deviations_doc = load_yaml_file(deviations_path)
+obligations_doc = load_yaml_file(obligations_path)
 
 errors = Hash.new { |h, k| h[k] = [] }
 

--- a/scripts/check-thesis-obligations-ledger.sh
+++ b/scripts/check-thesis-obligations-ledger.sh
@@ -24,10 +24,16 @@ trap 'rm -f "${tmp_rows}"' EXIT
 
 echo "[thesis-obligations] Validating ledger schema, ID set, and anchors"
 ruby - "${LEDGER}" "${ROOT}" >"${tmp_rows}" <<'RUBY'
+require 'date'
 require 'yaml'
 
 ledger_path = ARGV.fetch(0)
-doc = YAML.load_file(ledger_path)
+doc = YAML.safe_load(
+  File.read(ledger_path),
+  permitted_classes: [Date],
+  aliases: true,
+  filename: ledger_path
+)
 root = ARGV.fetch(1)
 
 expected_ids = []

--- a/scripts/check-thesis-obligations-ledger.sh
+++ b/scripts/check-thesis-obligations-ledger.sh
@@ -170,6 +170,12 @@ parse_failures=()
 zero_examples=()
 test_failures=()
 
+hspec_summary_line() {
+  ruby -pe '$_.gsub!(/\e\[[0-9;?]*[ -\/]*[@-~]/, "")' "$1" |
+    grep -E '^[0-9]+ examples?, [0-9]+ failures$' |
+    tail -n 1 || true
+}
+
 while IFS=$'\t' read -r id matcher _file; do
   [[ -n "${id}" ]] || continue
   log_file="$(mktemp)"
@@ -186,7 +192,7 @@ while IFS=$'\t' read -r id matcher _file; do
 
   cat "${log_file}"
 
-  summary_line="$(grep -E '^[0-9]+ examples?, [0-9]+ failures$' "${log_file}" | tail -n 1 || true)"
+  summary_line="$(hspec_summary_line "${log_file}")"
   if [[ -z "${summary_line}" ]]; then
     parse_failures+=("${id}")
     rm -f "${log_file}"

--- a/scripts/render-thesis-obligations-ledger.rb
+++ b/scripts/render-thesis-obligations-ledger.rb
@@ -3,6 +3,7 @@
 
 require 'optparse'
 require 'pathname'
+require 'date'
 require 'yaml'
 
 ROOT = File.expand_path('..', __dir__)
@@ -62,6 +63,15 @@ def validate_schema!(doc)
       fail_validation("obligation #{o['id']} test_anchor missing `#{field}`") unless ta[field].is_a?(String) && !ta[field].strip.empty?
     end
   end
+end
+
+def load_yaml_file(path)
+  YAML.safe_load(
+    File.read(path),
+    permitted_classes: [Date],
+    aliases: true,
+    filename: path
+  )
 end
 
 def render_markdown(obligations)
@@ -124,7 +134,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-doc = YAML.load_file(LEDGER_PATH)
+doc = load_yaml_file(LEDGER_PATH)
 validate_schema!(doc)
 obligations = doc['obligations']
 

--- a/scripts/thesis-conformance-gate.sh
+++ b/scripts/thesis-conformance-gate.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+hspec_summary_line() {
+  ruby -pe '$_.gsub!(/\e\[[0-9;?]*[ -\/]*[@-~]/, "")' "$1" |
+    grep -E '^[0-9]+ examples?, [0-9]+ failures$' |
+    tail -n 1 || true
+}
+
 run_anchor() {
   local label="$1"
   local matcher="$2"
@@ -24,7 +30,7 @@ run_anchor() {
 
   cat "${tmp_log}"
 
-  summary_line="$(grep -E '^[0-9]+ examples?, [0-9]+ failures$' "${tmp_log}" | tail -n 1 || true)"
+  summary_line="$(hspec_summary_line "${tmp_log}")"
   if [[ -z "${summary_line}" ]]; then
     echo "[thesis-gate] FAILED: could not parse Hspec summary for '${label}'"
     exit 1


### PR DESCRIPTION
## Summary

- Strip ANSI escape sequences from Hspec output before parsing summary lines in the thesis obligation and conformance gate scripts.
- Keep matcher coverage enforcement unchanged after sanitizing colored CI output.
- Record the CI gate fix and validation in the changelog.

## Root Cause

GitHub Actions can emit colored Hspec summaries such as `1 example, 0 failures` with ANSI escape sequences. The CI gate scripts matched only plain summary lines, so passing matcher runs were reported as unparseable and the thesis conformance job failed.

## Validation

- `cabal build all && cabal test` (`1609 examples, 0 failures, 7 pending`)
- `./scripts/thesis-conformance-gate.sh`
- `git diff --check`

Fixes #2