### PR TITLE
[codex] Implement constraint-aware .mlfp ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@
   as `import Core as C exposing (eq);`, with qualified names available in
   expressions, patterns, types, constraints, classes, constructors, and methods.
   The built-in Prelude now exports `Nat(..)`, `Option(..)`, `List(..)`, `Eq`,
-  `eq`, `and`, and `id`. Validation:
+  `eq`, `and`, and `id`. Review hardening now rejects local instances that
+  overlap imported schemas, validates pattern annotations against the matched
+  source type, and rejects branches after constructor-local catch-all patterns.
+  Validation:
   `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
-  (`88 examples, 0 failures`), `MLF.Program eMLF`
-  (`51 examples, 0 failures`), and `cabal build all && cabal test`
-  (`1637 examples, 0 failures`).
+  (`91 examples, 0 failures`), `MLF.Program eMLF`
+  (`54 examples, 0 failures`), and `cabal build all && cabal test`
+  (`1640 examples, 0 failures`).
 - Made `.mlfp` more usable as a source-language surface. The program parser
   now has located entrypoints and the checker/runner expose
   `ProgramDiagnostic` with file/line/column rendering and mechanically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 ## Unreleased
 
 ### Changed
+- Added the next `.mlfp` typeclass/module ergonomics slice. Program types now
+  parse and carry class constraints on definitions, methods, and instance
+  declarations; constrained values lower to hidden method evidence, schema
+  instances such as `Eq a => Eq (Option a)` resolve recursively, and overlapping
+  instance heads are rejected by unification. `deriving Eq` now generates
+  constrained instances for parameterized ADTs, including recursive `List a`,
+  and reports the first field type with missing Eq evidence. Imports now support
+  qualified aliases such as `import Core as C;` and selected alias imports such
+  as `import Core as C exposing (eq);`, with qualified names available in
+  expressions, patterns, types, constraints, classes, constructors, and methods.
+  The built-in Prelude now exports `Nat(..)`, `Option(..)`, `List(..)`, `Eq`,
+  `eq`, `and`, and `id`. Validation:
+  `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
+  (`88 examples, 0 failures`), `MLF.Program eMLF`
+  (`51 examples, 0 failures`), and `cabal build all && cabal test`
+  (`1637 examples, 0 failures`).
+- Made `.mlfp` more usable as a source-language surface. The program parser
+  now has located entrypoints and the checker/runner expose
+  `ProgramDiagnostic` with file/line/column rendering and mechanically
+  justified hints for high-value failures. Pattern matching now supports
+  ordered nested constructor patterns, variables, wildcards, and pattern
+  annotations, with reachability-aware rejection of duplicate or unreachable
+  branches. The CLI prepends an explicit-import built-in `Prelude`, and closed
+  ADT runtime values render with source constructor syntax instead of raw
+  Church terms. Added `docs/mlfp-language-reference.md` and linked it from the
+  README. Focused validation:
+  `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
+  (`76 examples, 0 failures`), `MLF.Program eMLF`
+  (`39 examples, 0 failures`), `Public surface` (`24 examples, 0 failures`),
+  `cabal build all && cabal test` (`1625 examples, 0 failures`), and
+  `git diff --check`.
 - Fixed the thesis-conformance CI gate so colored Hspec summaries and Ruby
   3.2 YAML dates from GitHub Actions are parsed before enforcing matcher
   coverage. Validation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,15 @@
   overlap imported schemas, validates pattern annotations against matched and
   catch-all-only scrutinee types, rejects branches after constructor-local
   catch-all patterns, preserves method-level constraints when eager and
-  deferred typeclass evidence is materialized, and avoids decoding non-data
-  `main` values through the global ADT fallback.
+  deferred typeclass evidence is materialized, avoids duplicate unqualified
+  instance matches for aliased imports whose instance heads do not qualify, and
+  avoids decoding non-data `main` values or typed non-data constructor fields
+  through the global ADT fallback.
   Validation:
   `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
-  (`95 examples, 0 failures`), `MLF.Program eMLF`
-  (`57 examples, 0 failures`), and `cabal build all && cabal test`
-  (`1644 examples, 0 failures`).
+  (`97 examples, 0 failures`), `MLF.Program eMLF`
+  (`58 examples, 0 failures`), and `cabal build all && cabal test`
+  (`1646 examples, 0 failures`).
 - Made `.mlfp` more usable as a source-language surface. The program parser
   now has located entrypoints and the checker/runner expose
   `ProgramDiagnostic` with file/line/column rendering and mechanically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,15 @@
   catch-all patterns, preserves method-level constraints when eager and
   deferred typeclass evidence is materialized, avoids duplicate unqualified
   instance matches for aliased imports whose instance heads do not qualify, and
+  validates transitive deriving field constraints while rejecting non-regular
+  recursive fields instead of generating ill-typed self-equality calls. It also
   avoids decoding non-data `main` values or typed non-data constructor fields
   through the global ADT fallback.
   Validation:
   `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
-  (`97 examples, 0 failures`), `MLF.Program eMLF`
-  (`58 examples, 0 failures`), and `cabal build all && cabal test`
-  (`1646 examples, 0 failures`).
+  (`99 examples, 0 failures`), `MLF.Program eMLF`
+  (`60 examples, 0 failures`), and `cabal build all && cabal test`
+  (`1648 examples, 0 failures`).
 - Made `.mlfp` more usable as a source-language surface. The program parser
   now has located entrypoints and the checker/runner expose
   `ProgramDiagnostic` with file/line/column rendering and mechanically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,16 @@
   expressions, patterns, types, constraints, classes, constructors, and methods.
   The built-in Prelude now exports `Nat(..)`, `Option(..)`, `List(..)`, `Eq`,
   `eq`, `and`, and `id`. Review hardening now rejects local instances that
-  overlap imported schemas, validates pattern annotations against the matched
-  source type, and rejects branches after constructor-local catch-all patterns.
+  overlap imported schemas, validates pattern annotations against matched and
+  catch-all-only scrutinee types, rejects branches after constructor-local
+  catch-all patterns, preserves method-level constraints when eager and
+  deferred typeclass evidence is materialized, and avoids decoding non-data
+  `main` values through the global ADT fallback.
   Validation:
   `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
-  (`91 examples, 0 failures`), `MLF.Program eMLF`
-  (`54 examples, 0 failures`), and `cabal build all && cabal test`
-  (`1640 examples, 0 failures`).
+  (`95 examples, 0 failures`), `MLF.Program eMLF`
+  (`57 examples, 0 failures`), and `cabal build all && cabal test`
+  (`1644 examples, 0 failures`).
 - Made `.mlfp` more usable as a source-language surface. The program parser
   now has located entrypoints and the checker/runner expose
   `ProgramDiagnostic` with file/line/column rendering and mechanically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,18 @@
   catch-all-only scrutinee types, rejects branches after constructor-local
   catch-all patterns, preserves method-level constraints when eager and
   deferred typeclass evidence is materialized, avoids duplicate unqualified
-  instance matches for aliased imports whose instance heads do not qualify, and
-  validates transitive deriving field constraints while rejecting non-regular
-  recursive fields instead of generating ill-typed self-equality calls. It also
-  avoids decoding non-data `main` values or typed non-data constructor fields
-  through the global ADT fallback.
+  instance matches for aliased imports whose instance heads do not qualify,
+  alpha-renames instance variables before overlap unification, validates
+  deriving fields against pending same-module derived instances, and validates
+  transitive deriving field constraints while rejecting non-regular recursive
+  fields instead of generating ill-typed self-equality calls. It also avoids
+  decoding non-data `main` values or typed non-data constructor fields through
+  the global ADT fallback.
   Validation:
   `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`
-  (`99 examples, 0 failures`), `MLF.Program eMLF`
-  (`60 examples, 0 failures`), and `cabal build all && cabal test`
-  (`1648 examples, 0 failures`).
+  (`101 examples, 0 failures`), `MLF.Program eMLF`
+  (`62 examples, 0 failures`), and `cabal build all && cabal test`
+  (`1650 examples, 0 failures`).
 - Made `.mlfp` more usable as a source-language surface. The program parser
   now has located entrypoints and the checker/runner expose
   `ProgramDiagnostic` with file/line/column rendering and mechanically

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ workflow.
 
 The unified `.mlfp` surface includes:
 
-- `module` / `import ... exposing (...)`
+- `module` / `import ... exposing (...)` plus qualified `import ... as ...`
 - `data` declarations with explicit constructor signatures
 - `case` / constructor pattern matching
 - recursive GADT-style constructor result types
 - existential constructors via `forall`
-- single-parameter typeclasses / instances
-- `deriving Eq` for the initial recursive-ADT corpus
+- single-parameter typeclasses, class constraints, and schema instances
+- `deriving Eq` for nullary, recursive, and parameterized ADTs whose fields have Eq evidence
 
 Internally, `.mlfp` now reuses the old MLF ownership boundary:
 
@@ -103,6 +103,9 @@ Frozen examples live under `test/programs/recursive-adt/`, and the Phase-0
 syntax/corpus freeze is documented in
 `docs/plans/2026-04-13-recursive-adt-syntax-freeze.md`.
 
+The current user-facing `.mlfp` language contract is documented in
+`docs/mlfp-language-reference.md`.
+
 The first-class-polymorphism program example lives at
 `test/programs/unified/first-class-polymorphism.mlfp`.
 
@@ -115,6 +118,7 @@ cabal run mlf2 -- run-program test/programs/recursive-adt/plain-recursive-nat.ml
 ## Syntax and paper alignment
 
 - Canonical syntax spec: `docs/syntax.md`
+- `.mlfp` language reference: `docs/mlfp-language-reference.md`
 - Implementation notes and thesis alignment: `implementation_notes.md`
 - Roadmap: `roadmap.md`
 - Known issues / faithfulness gaps: `Bugs.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,8 @@ The code is organized by domain (not by phase) under `src/MLF/`:
 - `MLF.Frontend.Program.Check` — module/import/class/data environment assembly for `.mlfp`, including static validation that may fail before the eMLF pipeline
 - `MLF.Frontend.Program.Elaborate` — lowers executable `.mlfp` bindings to surface eMLF `SurfaceExpr`
 - `MLF.Frontend.Program.Finalize` — normalizes lowered surface eMLF, calls the internal detailed eMLF pipeline entrypoints with program-owned external binding modes, resolves `.mlfp` deferred obligations, and accepts rewritten terms only after the xMLF typecheck guard
-- `MLF.Frontend.Program.Run` — runtime entrypoint that evaluates checked `.mlfp` bindings through the existing xMLF runtime
+- `MLF.Frontend.Program.Prelude` — built-in source-level `.mlfp` Prelude used by the CLI/file runner as an explicit import target
+- `MLF.Frontend.Program.Run` — runtime entrypoint that evaluates checked `.mlfp` bindings through the existing xMLF runtime and renders recovered closed ADT values with source constructor syntax
 - `MLF.Constraint.*` — constraint graph types + normalize + acyclicity + presolution + solve
 - `MLF.Binding.*` — binding tree queries + executable χe ops + harmonization
 - `MLF.Witness.*` — ω execution helpers (base χe operations)

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -1,0 +1,234 @@
+# `.mlfp` Language Reference
+
+`.mlfp` is the user-facing program layer on top of the eMLF/xMLF pipeline.
+Raw eMLF stays thesis-facing and minimal; modules, ADTs, cases, typeclasses,
+diagnostics, and runtime value rendering are owned by `.mlfp`.
+
+## Modules
+
+A file contains one or more modules:
+
+```mlf
+module Main export (main) {
+  def main : Bool = true;
+}
+```
+
+Exports are explicit when an `export (...)` list is present. Values export by
+name, types export abstractly as `T`, and types export constructors as `T(..)`.
+Imports expose names from another module:
+
+```mlf
+module User export (main) {
+  import Core exposing (Nat(..), isZero);
+  def main : Bool = isZero Zero;
+}
+```
+
+Imports may refer to modules declared later in the same file. Hidden
+constructors remain hidden: importing `Nat(..)` from a module that exported only
+`Nat` is a visibility error.
+
+Imports can be qualified and aliased:
+
+```mlf
+import Core as C;
+import Core as C exposing (eq);
+```
+
+`import Core as C;` imports exported names as `C.name` only. `import Core as C
+exposing (...)` also brings the selected exports into the unqualified scope.
+Aliases must be unique within a module, and qualified access does not bypass
+abstract exports or hidden constructors.
+
+## Definitions
+
+Definitions require a source type annotation:
+
+```mlf
+def id : forall a. a -> a = \x x;
+def keep : Int = id 1;
+```
+
+Lambda parameters may also carry annotations:
+
+```mlf
+def usePoly : (forall a. a -> a) -> Bool =
+  \(poly : forall a. a -> a) poly true;
+```
+
+## Data Declarations
+
+Data declarations list explicit constructor signatures:
+
+```mlf
+data Nat =
+    Zero : Nat
+  | Succ : Nat -> Nat;
+
+data Option a =
+    None : Option a
+  | Some : a -> Option a;
+```
+
+Runtime representation is Church-encoded. Constructor definitions are emitted
+as real runtime bindings, but source constructor uses lower to deferred
+obligations so eMLF inference can choose the necessary type evidence before the
+constructor is rewritten to the concrete Church binding.
+
+## Case Expressions And Patterns
+
+Cases are ordered:
+
+```mlf
+def isTwo : Nat -> Bool = \(n : Nat) case n of {
+  Succ (Succ Zero) -> true;
+  Succ _ -> false;
+  Zero -> false
+};
+```
+
+Patterns support constructor patterns, variables, wildcards, and annotations:
+
+```mlf
+Succ n
+Succ (Succ n)
+_
+(n : Nat)
+```
+
+Repeated top-level constructors are allowed when nested patterns make the
+branches distinct. Flat duplicate branches and branches after a catch-all are
+unreachable and rejected. Non-exhaustive cases fail closed.
+
+Case lowering still targets the existing Church eliminator path. There is no
+separate runtime pattern-matching primitive.
+
+## GADT-Style Results And Existentials
+
+Constructor results may refine the data result head:
+
+```mlf
+data Expr a =
+    DoneNat : Nat -> Expr Nat
+  | Step : Expr a -> Expr a;
+```
+
+Constructor-local `forall`s express existential packages:
+
+```mlf
+data SomeExpr =
+    SomeExpr : forall a. Expr a -> SomeExpr;
+```
+
+Deferred constructor metadata carries the constructor-local `forall` evidence,
+expected-type seeds, and runtime instantiation order. If required evidence
+cannot be recovered from arguments, result type, or an explicit annotation, the
+program fails with an ambiguous-constructor diagnostic.
+
+## Typeclasses
+
+The current typeclass lane supports single-parameter classes, class
+constraints, schema instances, deriving, and overloaded method dispatch:
+
+```mlf
+class Eq a {
+  eq : a -> a -> Bool;
+}
+
+data Nat =
+    Zero : Nat
+  | Succ : Nat -> Nat
+  deriving Eq;
+
+def main : Bool = eq (Succ Zero) (Succ Zero);
+```
+
+Constrained definitions and instances lower to hidden method evidence:
+
+```mlf
+def same : Eq a => a -> a -> Bool = \x \y eq x y;
+
+instance Eq a => Eq (Option a) {
+  eq = \left \right case left of {
+    None -> case right of {
+      None -> true;
+      Some _ -> false
+    };
+    Some l -> case right of {
+      None -> false;
+      Some r -> eq l r
+    }
+  };
+}
+```
+
+Method calls lower to deferred obligations and resolve after eMLF inference.
+Partial overloaded method application is supported by eta-expanding the missing
+arguments. Bare overloaded method names remain ambiguous and are rejected.
+
+Instance resolution is coherent and fail-closed: duplicate and overlapping
+instance heads are rejected by unification, and a missing instance remains a
+`ProgramNoMatchingInstance` error.
+
+`deriving Eq` works for nullary, recursive, and parameterized ADTs when every
+field can be compared from a recursive owner field, a type-parameter
+constraint, or an existing closed instance. For example, `Option a` derives
+`Eq a => Eq (Option a)`, and recursive `List a` derives `Eq a => Eq (List a)`.
+If deriving cannot resolve the first required field instance, it fails with a
+field-specific deriving diagnostic.
+
+## Built-In Prelude
+
+There is a source-level `Prelude` module supplied by the program layer. It is
+not imported implicitly by the checker APIs. The CLI/file runner prepends the
+built-in module so user files can explicitly import it:
+
+```mlf
+module Main export (main) {
+  import Prelude exposing (Nat(..), Option(..), List(..), Eq, eq, and, id);
+  def main : Option Nat = Some Zero;
+}
+```
+
+Current prelude contents:
+
+- `Nat(..)` with derived `Eq Nat`
+- `Option(..)` with derived `Eq a => Eq (Option a)`
+- `List(..)` with `Nil`, `Cons`, and derived `Eq a => Eq (List a)`
+- `Eq` and `eq`
+- `and`
+- `id`
+
+The prelude is intentionally explicit-import in this version. A user-defined
+module named `Prelude` conflicts with the built-in CLI prelude and is rejected.
+
+## Runtime Values
+
+Evaluated closed ADT values render in source constructor syntax:
+
+```mlf
+Zero
+Succ Zero
+None
+Some true
+Nil
+Cons Zero Nil
+```
+
+Primitive closed values render as `true`, `false`, integers, and quoted strings.
+If the runner cannot recover an ADT shape, it falls back to the existing xMLF
+term pretty-printer instead of exposing a second runtime.
+
+## When Annotations Are Required
+
+Annotations are needed when source evidence is not recoverable from the term.
+The common case is a polymorphic nullary constructor:
+
+```mlf
+def noneNat : Option Nat = None : Option Nat;
+```
+
+Without the result type evidence, `None` is ambiguous because it can inhabit
+`Option a` for any `a`. Diagnostics include hints only when the compiler can
+mechanically justify the suggested fix.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -142,19 +142,23 @@ currently accepts the following core shapes:
 ```ebnf
 Program      ::= Module+
 Module       ::= "module" UIdent ["export" "(" ExportItem ("," ExportItem)* ")"] "{" Import* Decl* "}"
-Import       ::= "import" UIdent ["exposing" "(" ExportItem ("," ExportItem)* ")"] ";"
+Import       ::= "import" UIdent ["as" UIdent] ["exposing" "(" ExportItem ("," ExportItem)* ")"] ";"
 ExportItem   ::= lIdent | UIdent | UIdent "(..)"
 
 Decl         ::= DataDecl | ClassDecl | InstanceDecl | DefDecl
-DataDecl     ::= "data" UIdent lIdent* "=" CtorDecl ("|" CtorDecl)* ["deriving" UIdent ("," UIdent)*] ";"
+DataDecl     ::= "data" UIdent lIdent* "=" CtorDecl ("|" CtorDecl)* ["deriving" QName ("," QName)*] ";"
 CtorDecl     ::= UIdent ":" SrcType
 ClassDecl    ::= "class" UIdent lIdent "{" MethodSig* "}"
-MethodSig    ::= lIdent ":" SrcType ";"
-InstanceDecl ::= "instance" UIdent SrcType "{" MethodDef* "}"
+MethodSig    ::= lIdent ":" ConstrainedType ";"
+InstanceDecl ::= "instance" [ConstraintPrefix "=>"] QName SrcType "{" MethodDef* "}"
 MethodDef    ::= lIdent "=" Expr ";"
-DefDecl      ::= "def" lIdent ":" SrcType "=" Expr ";"
+DefDecl      ::= "def" lIdent ":" ConstrainedType "=" Expr ";"
 
-Expr         ::= lIdent | UIdent | Literal
+ConstrainedType ::= [ConstraintPrefix "=>"] SrcType
+ConstraintPrefix ::= ClassConstraint | "(" ClassConstraint ("," ClassConstraint)* ")"
+ClassConstraint ::= QName SrcType
+
+Expr         ::= QName | Literal
                | "\" Param Expr
                | Expr Expr
                | "let" lIdent [":" SrcType] "=" Expr "in" Expr
@@ -163,7 +167,10 @@ Expr         ::= lIdent | UIdent | Literal
 
 Param        ::= lIdent | "(" lIdent [":" SrcType] ")"
 Alt          ::= Pattern "->" Expr
-Pattern      ::= UIdent lIdent* | lIdent | "_"
+Pattern      ::= PatternAtom+
+               | "(" Pattern ":" SrcType ")"
+PatternAtom  ::= QName | "_" | "(" Pattern ")"
+QName        ::= [UIdent "."] (lIdent | UIdent)
 ```
 
 Current checked/evaluated recursive-ADT corpus examples live under

--- a/findings.md
+++ b/findings.md
@@ -1,57 +1,66 @@
 # Findings
 
 ## Requirements
-- Implement the proposed deferred-obligation refactor for `.mlfp`.
-- Move all 7 `emlfPendingSuccessMatrix` rows into strict positive coverage.
-- Carry constructor-local `forall` evidence in deferred constructor
-  obligations so GADT, existential, nullary, and ordinary source constructor
-  uses all resolve after eMLF inference.
-- Keep public raw eMLF syntax/parser clean and preserve the shared eMLF pipeline route.
-- Preserve fail-closed behavior for bare methods, missing/duplicate instances,
-  ambiguous constructors, bad constructors, and non-data cases.
+- Add source-span support and user-facing `.mlfp` diagnostics without breaking
+  existing unlocated parser/checker/runtime APIs.
+- Document current `.mlfp` semantics as a language reference linked from
+  `README.md`.
+- Upgrade pattern matching from flat constructor binders to ordered nested
+  patterns while preserving Church-encoded runtime behavior.
+- Add explicit built-in `Prelude` support and readable ADT value rendering.
+- Add a first constrained typeclass/deriving/module ergonomics slice where it
+  can stay coherent and fail-closed.
+- Keep public raw eMLF syntax and the shared eMLF/xMLF pipeline boundary.
 
 ## Current Observations
-- The method-only deferred map has been replaced by a unified obligation map
-  covering methods, constructors, and cases.
-- Public eMLF pipeline APIs remain tuple-returning; `.mlfp` finalization uses
-  the new internal detailed entrypoint.
-- Every source constructor occurrence now lowers through a deferred placeholder;
-  runtime constructor definitions remain Church-encoded executable bindings.
-- Deferred constructor metadata now records expected-type seeds, occurrence
-  type, implicit/runtime instantiation binder order, constructor-local
-  forall binders, and placeholder binding mode.
-- The former pending-success rows have moved into strict positive coverage.
-- Recursive overloaded method calls in explicit and derived `Eq Nat` instances
-  stay covered: instance method bodies finalize as their runtime bindings,
-  method runtime resolution remains deferred, and constructor placeholders are
-  rewritten during constructor finalization.
+- `src/MLF/Frontend/Syntax/Program.hs` now keeps the old unlocated AST and adds
+  `LocatedProgram` plus span indexes for parser/checker use.
+- `src/MLF/Frontend/Parse/Program.hs` now exposes located and unlocated parser
+  entrypoints. The unlocated API remains a projection of the located parse.
+- `src/MLF/Frontend/Program/Check.hs` still returns `Either ProgramError` for
+  compatibility and adds `checkLocatedProgram :: LocatedProgram -> Either
+  ProgramDiagnostic CheckedProgram`.
+- `src/MLF/Frontend/Program/Elaborate.hs` now lowers ordered nested patterns
+  through the existing deferred case machinery.
+- `src/MLF/Frontend/Program/Run.hs` now exposes `runLocatedProgram` and renders
+  recovered ADT values with source constructor syntax.
+- Public `.mlfp` APIs are re-exported by `src-public/MLF/Program.hs` and
+  `src-public/MLF/Pipeline.hs`; the additive located/diagnostic/prelude exports
+  are wired there.
 
 ## Technical Decisions
 | Decision | Rationale |
 |----------|-----------|
-| Refactor the method-only map into a sum-typed obligation map | Constructor, case, and method resolution need one ordered post-inference pass |
-| Resolve constructor/case obligations before methods | Method instance recovery can depend on source ADT heads recovered after constructor/case rewrites |
-| Keep full validation gate at the end | Behavior-changing Haskell work under repo guidelines requires `cabal build all && cabal test` |
-| Add an internal detailed pipeline result in `MLF.Elab.Run.Pipeline` | Program finalization needs the term, type, annotated root, and typecheck env while public pipeline APIs remain unchanged |
-| Keep source-known method argument type guidance but defer runtime selection | Large constructor arguments need expected-type guidance, while instance choice still belongs to post-eMLF finalization |
-| Treat constructor and case placeholders as inference-local bindings | Their source types are retained for finalization, but eMLF does not need recursive μ structures as external schemes |
-| Skip generated constructor bindings whose local forall evidence cannot be recovered | These constructors cannot be instantiated into runtime bindings safely; source use fails with a constructor-specific ambiguity |
+| Represent located parsing as an additive `LocatedProgram` wrapper with span indexes | Avoids forcing every existing program test to rewrite immediately |
+| Map high-value diagnostics from the located wrapper to likely declaration/expression spans | Provides useful CLI errors now without changing every checker function signature in the first slice |
+| Extend `Pattern` directly and update existing call sites | Nested patterns are source semantics, so the AST should own them |
+| Lower nested patterns before handler generation | Existing deferred case finalization remains the authority for Church eliminators |
+| Keep the Prelude explicit but useful | Users still opt in with `import Prelude ...`, while the built-in module now exposes `Nat(..)`, `Option(..)`, recursive `List(..)`, `Eq`, `eq`, `and`, and `id` |
+| Repair parameterized constructor runtime spines instead of restoring direct constructor-use lowering | Source constructor uses still lower through deferred obligations, and generated Church constructor bindings keep a typecheckable runtime quantifier order |
+| Derive schema instances for parameterized ADTs | `Option a` and recursive `List a` can derive `Eq a => Eq (...)`; recursive owner fields use the currently generated equality evidence |
+| Reuse finalization source-type recovery in runtime rendering | Checked bindings store lowered expected types, so the runner must recover `Option Nat`/`List Nat` before decoding parameterized Church values |
+| Model class constraints as hidden method evidence | Raw eMLF remains unchanged, while `.mlfp` constrained values and schema instances lower to deterministic internal evidence parameters |
+| Treat qualified imports as scoped aliases, not re-exports | `import M as A` adds qualified-only names; `import M as A exposing (...)` also imports the selected exports unqualified, and hidden constructors stay hidden |
 
-## 2026-04-19 Constructor-local forall slice
-- Public pipeline APIs remain unchanged. `.mlfp` uses an internal detailed
-  external-binding entrypoint and an unchecked variant only when program
-  placeholders must be finalized before the guard typecheck.
-- Constructor obligations now solve substitutions from expected-type seeds,
-  eMLF head instantiations when present, rewritten argument types, and
-  occurrence result types. Argument/result matching contributes evidence but
-  leaves final mismatch detection to the final typecheck guard.
-- Deferred cases are lowered directly as `casePlaceholder scrutinee handlers`
-  so constructor finalization and case finalization see the same occurrence tree.
-- Focused `MLF.Program eMLF` and broader `MLF.Program` suites pass with new
-  strict rows for ordinary nullary/nested constructors, GADT indexed
-  constructors, existential constructors, nullary indexed constructors,
-  explicit polymorphic nullary constructors, and unrecoverable constructor-local
-  forall ambiguity.
-- Full validation passes after the repository guard was updated to require the
-  external-binding detailed/unchecked internal pipeline markers and the final
-  post-rewrite typecheck guard.
+## Implemented Coverage
+- Located parser/checker/runner APIs and CLI diagnostic rendering.
+- `ProgramDiagnostic` rendering with spans and hints for ambiguous
+  constructors, ambiguous methods, no matching instances, type mismatches,
+  constructor-pattern mismatches, non-exhaustive cases, and import/export
+  visibility failures.
+- Ordered nested patterns, wildcards, variable patterns, and pattern
+  annotations.
+- Explicit CLI Prelude import target with conflict rejection.
+- Source-shaped ADT value rendering for `Nat`, `Option`, and `List`.
+- Constraint-aware definitions, method signatures, and instance declarations.
+- Schema instance resolution with overlap rejection by unification.
+- Parameterized `deriving Eq` for `Option a` and recursive `List a`.
+- Qualified and aliased imports with visibility checks.
+- User-facing `.mlfp` language reference linked from `README.md`.
+
+## Remaining Follow-Up
+- `Eq Bool`, blocked on a source-level conditional or primitive boolean
+  eliminator for generated equality bodies.
+- Re-export ergonomics and more precise qualified-import diagnostics.
+- Broader typeclass ergonomics beyond single-parameter `Eq`-style classes,
+  such as richer constraint solving and user-facing cycle diagnostics.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,50 @@
+## 2026-04-20 - Constraint-aware typeclasses and qualified imports
+
+- `.mlfp` constrained types are now source-level program semantics. The parser
+  accepts `Eq a => ...` and `(Eq a, Eq b) => ...` on definitions, method
+  signatures, and instances; lowering passes one hidden runtime method value per
+  class constraint while raw eMLF syntax remains unchanged.
+- Instance resolution now handles schema instances such as
+  `Eq a => Eq (Option a)` and rejects overlapping heads by unification, not only
+  exact equality. Evidence resolution fails closed through the existing
+  no-matching-instance lane when a required dictionary cannot be built.
+- `deriving Eq` generates constrained instances for parameterized ADTs. Recursive
+  derived instances use a monomorphic local self function inside the generated
+  method body so recursive fields do not re-infer the polymorphic schema through
+  hidden evidence on every call.
+- Parameterized constructor runtime bindings keep the Church representation but
+  repair generated constructor spines so data-parameter type abstractions are
+  instantiated before the eliminator result abstraction. This preserves the
+  deferred constructor-use path while keeping recursive `List a` values
+  executable.
+- Qualified imports are `.mlfp`-owned names. `import M as A;` imports exported
+  names qualified only, while `import M as A exposing (...)` also imports the
+  selected names unqualified; hidden constructors stay hidden through qualified
+  access.
+
+## 2026-04-20 - `.mlfp` source-surface usability slice
+
+- Added located `.mlfp` parser/checker/runner entrypoints while preserving the
+  unlocated compatibility APIs. `ProgramDiagnostic` is now the user-facing
+  diagnostic wrapper for program errors, with optional source spans, primary
+  messages, and hints that are only emitted when mechanically justified.
+- Pattern matching now supports nested constructor patterns, variable
+  patterns, wildcards, and pattern annotations. Branches remain ordered:
+  repeated top constructors are allowed when nested patterns distinguish them,
+  while flat duplicates and branches after a catch-all are rejected as
+  unreachable. Lowering still targets deferred case obligations and the
+  existing Church eliminator representation.
+- Added an explicit built-in `Prelude` module for the CLI/file runner and kept
+  checker APIs free of implicit imports. Current prelude contents are source
+  definitions only: `Nat(..)`, `Option(..)`, `List(..)` with `Nil` and `Cons`,
+  `Eq`, `eq`, `and`, and `id`. User modules named `Prelude` conflict with the
+  built-in runner prelude.
+- Runtime rendering now recovers source ADT heads from lowered Church types and
+  prints closed ADT values as source constructors, including parameterized
+  payloads such as `Some (Succ Zero)`.
+- The user-level contract is now documented in
+  `docs/mlfp-language-reference.md`.
+
 ## 2026-04-19 - `.mlfp` deferred program obligations through eMLF
 
 - `.mlfp` lowering now records a unified deferred program obligation map for

--- a/mlf2.cabal
+++ b/mlf2.cabal
@@ -78,6 +78,7 @@ library mlf2-internal
                       MLF.Frontend.Program.Pretty,
                       MLF.Frontend.Program.Types,
                       MLF.Frontend.Program.Surface,
+                      MLF.Frontend.Program.Prelude,
                       MLF.Frontend.Program.Elaborate,
                       MLF.Frontend.Program.Finalize,
                       MLF.Frontend.Program.Check,

--- a/progress.md
+++ b/progress.md
@@ -1,120 +1,96 @@
 # Progress
 
-## Session: 2026-04-19
+## Session: 2026-04-20
 
-### Phase 6: Constructor-local forall evidence
+### Phase 1: Discovery and planning refresh
 - **Status:** completed
-- **Started:** 2026-04-19
-- Actions taken:
-  - Re-read `AGENTS.md` and existing planning files.
-  - Confirmed branch is clean at `04631882`.
-  - Confirmed `/Users/ares/.agents/skills/haskell-pro/SKILL.md` is absent.
-  - Inspected current deferred constructor metadata, constructor lowering,
-    finalization, and external environment injection.
-  - Added internal external binding modes and an unchecked detailed pipeline
-    entrypoint for program-obligation finalization.
-  - Expanded deferred constructor metadata with occurrence type, source type,
-    expected-type substitution seed, runtime instantiation binder order, and
-    binding mode.
-  - Changed source constructor variables/applications to always lower through
-    deferred placeholders.
-  - Made constructor and case placeholders inference-local while retaining
-    concrete types in the finalization/typecheck environment.
-  - Reworked deferred case lowering to avoid pre-finalization direct Church
-    application and to leave ordinary ADT handlers unannotated unless
-    constructor-local foralls require annotations.
-  - Finalized constructor obligations by solving substitutions after eMLF
-    inference and rewriting placeholders to concrete runtime constructor names.
-  - Added generated-runtime handling for recoverable constructor-local forall
-    constructors and skipped unrecoverable generated bindings so source uses
-    fail with `ProgramAmbiguousConstructorUse`.
-  - Updated the repository guardrail to recognize the internal external-binding
-    detailed pipeline entrypoints and the post-rewrite typecheck guard.
-  - Added strict matrix rows for ordinary nullary/nested constructors, GADT,
-    existential, nullary indexed, explicit polymorphic nullary, and ambiguous
-    constructor-local forall cases.
-- Files modified:
-  - `task_plan.md`
-  - `findings.md`
-  - `progress.md`
-  - `src/MLF/Elab/Run/Pipeline.hs`
-  - `src/MLF/Frontend/ConstraintGen.hs`
-  - `src/MLF/Frontend/ConstraintGen/Translate.hs`
-  - `src/MLF/Frontend/ConstraintGen/Types.hs`
-  - `src/MLF/Frontend/Program/Check.hs`
-  - `src/MLF/Frontend/Program/Elaborate.hs`
-  - `src/MLF/Frontend/Program/Finalize.hs`
-  - `src/MLF/Frontend/Program/Types.hs`
-  - `test/ProgramSpec.hs`
-  - `test/RepoGuardSpec.hs`
-
-### Phase 1-5: Deferred program obligations implementation
-- **Status:** completed
-- **Started:** 2026-04-19 19:04:43 CST
+- **Started:** 2026-04-20
 - Actions taken:
   - Re-read `AGENTS.md`.
-  - Confirmed `git status --short --untracked-files=all` was initially clean.
-  - Read installed planning skill and refreshed stale planning files.
+  - Loaded the installed `planning-with-files` skill.
+  - Confirmed the branch is clean and aligned with origin before edits.
   - Confirmed `/Users/ares/.agents/skills/haskell-pro/SKILL.md` is absent.
-  - Added unified deferred program obligation types and switched lowering state
-    to record obligations instead of method-only entries.
-  - Lowered applied constructors and constructor-pattern cases through
-    placeholders.
-  - Added partial-method eta expansion for supplied overloaded method prefixes.
-  - Added an internal detailed pipeline result and changed program
-    finalization to call it.
-  - Drafted ordered constructor, case, then method finalization passes.
-  - Moved the 7 pending-success rows into the strict eMLF boundary matrix.
-  - Repaired regressions in local let-polymorphism, annotated overloaded
-    arguments, direct recursive ADT fixtures, and parameterized/GADT
-    constructor calls.
-  - Updated `RepoGuardSpec`, README, architecture notes, implementation notes,
-    and changelog for the detailed pipeline/deferred-obligation path.
-  - Ran full repository validation and the whitespace diff guard.
-  - Removed the initial typeclass/constructor fallback choices: recursive
-    explicit and derived `Eq Nat` are restored, overloaded method runtime
-    selection stays deferred, and constructor placeholders rewrite in
-    finalization.
-- Files modified:
-  - `task_plan.md`
-  - `findings.md`
-  - `progress.md`
-  - `src/MLF/Frontend/Program/Types.hs`
-  - `src/MLF/Frontend/Program/Elaborate.hs`
-  - `src/MLF/Frontend/Program/Finalize.hs`
-  - `src/MLF/Elab/Run/Pipeline.hs`
-  - `src/MLF/Elab/TypeCheck.hs`
-  - `src/MLF/Frontend/Program/Check.hs`
-  - `test/ProgramSpec.hs`
-  - `test/RepoGuardSpec.hs`
-  - `test/programs/recursive-adt/typeclass-integration.mlfp`
-  - `README.md`
-  - `docs/architecture.md`
-  - `implementation_notes.md`
-  - `CHANGELOG.md`
+  - Inspected current `.mlfp` AST, parser, checker, elaborator, runtime, public
+    exports, and tests.
+  - Replaced stale constructor-obligation planning files with the new language
+    surface implementation plan.
+
+### Phase 2: Located diagnostics
+- **Status:** completed
+- Actions taken:
+  - Added `SourceSpan`, `LocatedProgram`, parser span indexes, and located
+    parse/check/run entrypoints while keeping the existing unlocated APIs.
+  - Added `ProgramDiagnostic` with rendered source locations, messages, and
+    mechanically justified hints for high-value program errors.
+  - Updated the CLI to parse and run through the located path.
+
+### Phase 3: Ordered nested patterns
+- **Status:** completed
+- Actions taken:
+  - Replaced flat constructor binders with recursive `PatCtor`, `PatVar`,
+    `PatWildcard`, and `PatAnn`.
+  - Updated parser, pretty-printer, deriving generation, binder collection,
+    case lowering, and reachability checks.
+  - Added matrix coverage for nested constructor patterns, wildcard fallthrough,
+    pattern annotations, unreachable branches, and nested non-exhaustiveness.
+
+### Phase 4: Language reference
+- **Status:** completed
+- Actions taken:
+  - Added `docs/mlfp-language-reference.md`.
+  - Linked the reference from `README.md`.
+  - Updated `docs/syntax.md`, `docs/architecture.md`, `implementation_notes.md`,
+    and `CHANGELOG.md`.
+
+### Phase 5: Prelude and runtime values
+- **Status:** completed
+- Actions taken:
+  - Added source-level `MLF.Frontend.Program.Prelude`.
+  - Updated CLI/file execution to prepend the built-in Prelude for explicit
+    imports and reject user-defined `Prelude` conflicts.
+  - Added ADT value rendering for recovered closed Church values, including
+    parameterized payloads such as `Some (Succ Zero)`.
+
+### Phase 6: Typeclass/module ergonomics
+- **Status:** completed
+- Actions taken:
+  - Added constrained type syntax to definitions, methods, and instances.
+  - Lowered constraints to hidden typeclass evidence and resolved constrained
+    calls from local evidence or schema instances.
+  - Added overlapping instance rejection by unification.
+  - Implemented parameterized `deriving Eq`, including recursive `List a`.
+  - Added qualified and aliased imports with qualified references in
+    expressions, patterns, types, constraints, constructors, classes, and
+    methods.
+  - Updated Prelude to export `Nat(..)`, `Option(..)`, `List(..)`, `Eq`, `eq`,
+    `and`, and `id`.
+
+### Phase 7: Validation
+- **Status:** completed
+- Actions taken:
+  - Ran focused `MLF.Program` successfully after the typeclass/module slice.
+  - Ran focused `MLF.Program eMLF` successfully after the typeclass/module slice.
+  - Ran the full repository build and test gate successfully.
 
 ## Test Results
 | Test | Expected | Actual | Status |
 |------|----------|--------|--------|
-| Initial `git status --short --untracked-files=all` | Clean | Clean | pass |
-| `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program eMLF"'` | Pass | 27 examples, 0 failures | pass |
-| `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'` | Pass | 60 examples, 0 failures | pass |
-| `cabal build all && cabal test` | Pass | 1609 examples, 0 failures | pass |
-| `git diff --check` | Clean | Clean | pass |
-| `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program eMLF"'` | Pass | 34 examples, 0 failures | pass |
-| `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'` | Pass | 67 examples, 0 failures | pass |
-| `cabal test mlf2-test --test-show-details=direct --test-options='--match "Repository guardrails"'` | Pass | 8 examples, 0 failures | pass |
-| `cabal build all && cabal test` | Pass | 1616 examples, 0 failures | pass |
-| `git diff --check` | Clean | Clean | pass |
+| `cabal build mlf2:mlf2-internal lib:mlf2 exe:mlf2` | build succeeds | build succeeded | pass |
+| `cabal run mlf2 -- run-program` Prelude `Nat` probe | `Succ Zero` | `Succ Zero` | pass |
+| `cabal run mlf2 -- run-program` Prelude `Option` probe | `Some Zero` | `Some Zero` | pass |
+| `cabal run mlf2 -- run-program` Prelude `List` probe | `Nil` | `Nil` | pass |
+| `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'` | pass | 88 examples, 0 failures | pass |
+| `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program eMLF"'` | pass | 51 examples, 0 failures | pass |
+| `cabal test mlf2-test --test-show-details=direct --test-options='--match "Public surface"'` | pass | 24 examples, 0 failures | pass |
+| `cabal build all && cabal test` | pass | 1637 examples, 0 failures | pass |
+| `git diff --check` | clean | clean | pass |
 
 ## Error Log
 | Timestamp | Error | Attempt | Resolution |
 |-----------|-------|---------|------------|
-| 2026-04-19 19:04 CST | Worktree-local planning skill path missing | 1 | Used installed skill path |
-| 2026-04-19 19:04 CST | `haskell-pro` skill path missing | 1 | Continue with repo conventions |
-| 2026-04-19 19:04 CST | `cabal build mlf2` ambiguous between lib and exe | 1 | Use explicit Cabal component targets |
-| 2026-04-19 19:04 CST | Parallel `cabal run` probes collided in `dist-newstyle` | 1 | Use serial Cabal commands for probes and validation |
-| 2026-04-19 20:xx CST | `MLF.Program` corpus regressions in GADT/existential/typeclass fixtures | 1 | Replaced early method runtime resolution with typed placeholders, finalized instance method bodies directly, deferred constructor applications, and added nullary constructor placeholder rewrite |
-| 2026-04-19 21:xx CST | All-deferred constructor placeholders initially caused locked-node and stale-let-scheme failures | 1 | Made constructor/case placeholders inference-local, added unchecked internal pipeline entrypoint, refreshed let schemes after obligation rewrites, and lowered deferred cases without synthetic scrutinee lets |
-| 2026-04-19 21:xx CST | Constructor-local forall runtime bindings failed before source ambiguity/finalization | 1 | Accepted recoverable generated constructor-forall bindings through the internal unchecked path and skipped unrecoverable generated bindings |
-| 2026-04-19 21:xx CST | Repository guard still required the old scheme-only detailed pipeline marker | 1 | Updated the guard to require the new external-binding detailed/unchecked entrypoints and final post-rewrite typecheck |
+| 2026-04-20 | `haskell-pro` skill path from `AGENTS.md` missing | 1 | Continue using repo conventions |
+| 2026-04-20 | `cabal build mlf2` ambiguous between executable and library | 1 | Use explicit component targets such as `lib:mlf2` and `exe:mlf2` |
+| 2026-04-20 | Prelude `List` with recursive `Cons : a -> List a -> List a` failed generated constructor type comparison | 1 | Implemented constrained parameterized deriving and constructor-spine repair; Prelude now keeps `Cons` and derives `Eq (List a)` |
+| 2026-04-20 | Prelude `Eq (Option Nat)` inferred a field comparison as missing `Eq a` | 1 | Implemented schema instance evidence; Prelude now derives constrained `Eq (Option a)` |
+| 2026-04-20 | Recursive `Eq (List a)` initially normalized to an xMLF term instead of `true` | 1 | Generated recursive derived Eq through a monomorphic local self function and repaired parameterized constructor quantifier order |
+| 2026-04-20 | Parallel `cabal run` probes collided on `package.conf.inplace` | 1 | Avoid parallel Cabal invocations and run Cabal commands sequentially |

--- a/src-public/MLF/API.hs
+++ b/src-public/MLF/API.hs
@@ -27,6 +27,8 @@ module MLF.API
     parseRawEmlfExpr,
     parseRawEmlfType,
     parseRawProgram,
+    parseLocatedProgram,
+    parseLocatedProgramWithFile,
 
     -- * Normalized parser entrypoints
     parseNormEmlfExpr,
@@ -41,6 +43,10 @@ module MLF.API
     prettyEmlfExpr,
     prettyEmlfType,
     Program,
+    LocatedProgram,
+    ProgramSpanIndex,
+    SourceSpan,
+    SourcePosition,
     prettyProgram,
 
     -- * Constraint graph introspection
@@ -93,6 +99,8 @@ import MLF.Frontend.Parse
   )
 import MLF.Frontend.Parse.Program
   ( ProgramParseError,
+    parseLocatedProgram,
+    parseLocatedProgramWithFile,
     parseRawProgram,
     renderProgramParseError,
   )
@@ -102,7 +110,7 @@ import MLF.Frontend.Pretty
   )
 import MLF.Frontend.Pretty.Program (prettyProgram)
 import MLF.Frontend.Syntax
-import MLF.Frontend.Syntax.Program (Program)
+import MLF.Frontend.Syntax.Program (LocatedProgram, Program, ProgramSpanIndex, SourcePosition, SourceSpan)
 
 -- | Number of type nodes in a constraint graph.
 constraintNodeCount :: Constraint -> Int

--- a/src-public/MLF/Pipeline.hs
+++ b/src-public/MLF/Pipeline.hs
@@ -60,12 +60,16 @@ module MLF.Pipeline
     , isValue
     -- * Unified `.mlfp` program checking/runtime
     , ProgramError(..)
+    , ProgramDiagnostic(..)
     , CheckedProgram(..)
     , CheckedModule(..)
     , CheckedBinding(..)
     , Value(..)
     , checkProgram
+    , checkLocatedProgram
     , runProgram
+    , runLocatedProgram
+    , renderProgramDiagnostic
     , prettyValue
     ) where
 
@@ -79,12 +83,15 @@ import MLF.Frontend.Program.Types
     ( CheckedBinding(..)
     , CheckedModule(..)
     , CheckedProgram(..)
+    , ProgramDiagnostic(..)
     , ProgramError(..)
+    , renderProgramDiagnostic
     )
 import MLF.Frontend.Program.Check
-    ( checkProgram
+    ( checkLocatedProgram
+    , checkProgram
     )
-import MLF.Frontend.Program.Run (Value(..), prettyValue, runProgram)
+import MLF.Frontend.Program.Run (Value(..), prettyValue, runLocatedProgram, runProgram)
 import MLF.Constraint.Types.Graph (BaseTy(..), PolySyms)
 -- Keep legacy elaboration conversion helpers quarantined in MLF.Elab.Legacy.
 import MLF.Elab.Pipeline

--- a/src-public/MLF/Program.hs
+++ b/src-public/MLF/Program.hs
@@ -9,32 +9,56 @@ module MLF.Program
     ( module MLF.Frontend.Syntax.Program
     , ProgramParseError
     , ProgramError (..)
+    , ProgramDiagnostic (..)
     , CheckedProgram (..)
     , CheckedModule (..)
     , CheckedBinding (..)
     , Value (..)
     , renderProgramParseError
+    , renderProgramDiagnostic
     , parseRawProgram
+    , parseLocatedProgram
+    , parseLocatedProgramWithFile
     , prettyProgram
+    , preludeSource
+    , preludeProgram
+    , preludeLocatedProgram
+    , withPrelude
+    , withPreludeLocated
     , checkProgram
+    , checkLocatedProgram
     , runProgram
+    , runLocatedProgram
     , prettyValue
     ) where
 
 import MLF.API
     ( ProgramParseError
+    , parseLocatedProgram
+    , parseLocatedProgramWithFile
     , parseRawProgram
     , prettyProgram
     , renderProgramParseError
     )
 import MLF.Frontend.Syntax.Program
+import MLF.Frontend.Program.Prelude
+    ( preludeLocatedProgram
+    , preludeProgram
+    , preludeSource
+    , withPrelude
+    , withPreludeLocated
+    )
 import MLF.Pipeline
     ( CheckedBinding (..)
     , CheckedModule (..)
     , CheckedProgram (..)
+    , ProgramDiagnostic (..)
     , ProgramError (..)
     , Value (..)
+    , checkLocatedProgram
     , checkProgram
     , prettyValue
+    , renderProgramDiagnostic
+    , runLocatedProgram
     , runProgram
     )

--- a/src/MLF/Elab/Reduce.hs
+++ b/src/MLF/Elab/Reduce.hs
@@ -12,6 +12,7 @@ import qualified Data.Set as Set
 import MLF.Elab.Inst (applyInstantiation, renameInstBound, schemeToType)
 import MLF.Elab.TypeCheck (typeCheck)
 import MLF.Elab.Types
+import MLF.Frontend.Syntax (Lit (..))
 import MLF.Reify.TypeOps (freeTypeVarsType, freshTypeName, substTypeCapture)
 import MLF.Util.RecursionSchemes (cataMaybe, foldElabTerm, foldInstantiation)
 
@@ -25,9 +26,19 @@ isValue term = case term of
 
 step :: ElabTerm -> Maybe ElabTerm
 step term = case term of
+  EApp (EApp (EVar "__mlfp_and") (ELit (LBool left))) (ELit (LBool right)) ->
+    Just (ELit (LBool (left && right)))
+  EApp (EApp (EVar "__mlfp_and") left) right
+    | not (isValue left) ->
+        (\left' -> EApp (EApp (EVar "__mlfp_and") left') right) <$> step left
+    | not (isValue right) ->
+        EApp (EApp (EVar "__mlfp_and") left) <$> step right
+  EApp (ETyAbs v _ body) a
+    | v `Set.notMember` freeTypeVarsTerm body ->
+        Just (EApp body a)
   EApp f a
     | not (isValue f) -> (`EApp` a) <$> step f
-    | not (isValue a) -> EApp f <$> step a
+    | not (isValue a || isNeutralValue a) -> EApp f <$> step a
     | otherwise ->
         case f of
           ELam v _ body -> Just (substTermVar v a body)
@@ -93,6 +104,11 @@ step term = case term of
               Right _ -> Just e
               Left _ -> Nothing
   _ -> Nothing
+
+isNeutralValue :: ElabTerm -> Bool
+isNeutralValue term = case term of
+  EVar {} -> True
+  _ -> False
 
 normalize :: ElabTerm -> ElabTerm
 normalize term = case step term of

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -1,10 +1,13 @@
 module MLF.Frontend.Parse.Program
     ( ProgramParseError
     , renderProgramParseError
+    , parseLocatedProgram
+    , parseLocatedProgramWithFile
     , parseRawProgram
     ) where
 
 import Control.Monad (void)
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Void (Void)
@@ -30,6 +33,7 @@ import Text.Megaparsec
     , choice
     , eof
     , errorBundlePretty
+    , getSourcePos
     , many
     , optional
     , parse
@@ -39,6 +43,8 @@ import Text.Megaparsec
     , try
     , (<|>)
     )
+import qualified Text.Megaparsec.Pos as MP
+import Text.Megaparsec.Pos (unPos)
 
 newtype ProgramParseError = ProgramParseError (ParseErrorBundle String Void)
     deriving (Eq, Show)
@@ -47,8 +53,14 @@ renderProgramParseError :: ProgramParseError -> String
 renderProgramParseError (ProgramParseError err) = errorBundlePretty err
 
 parseRawProgram :: String -> Either ProgramParseError Program
-parseRawProgram input =
-    case parse (sc *> pProgram <* eof) "<mlf-program>" input of
+parseRawProgram input = locatedProgram <$> parseLocatedProgram input
+
+parseLocatedProgram :: String -> Either ProgramParseError LocatedProgram
+parseLocatedProgram = parseLocatedProgramWithFile "<mlf-program>"
+
+parseLocatedProgramWithFile :: FilePath -> String -> Either ProgramParseError LocatedProgram
+parseLocatedProgramWithFile path input =
+    case parse (sc *> pLocatedProgram <* eof) path input of
         Left err -> Left (ProgramParseError err)
         Right program -> Right program
 
@@ -69,6 +81,7 @@ reservedWords =
         , "let"
         , "module"
         , "of"
+        , "as"
         , "true"
         , "false"
         ]
@@ -82,6 +95,28 @@ semi = symbol ";"
 commaSep :: Parser a -> Parser [a]
 commaSep item = item `sepBy` symbol ","
 
+qualifiedUpperIdent :: Parser String
+qualifiedUpperIdent =
+    try
+        ( do
+            qualifier <- upperIdent reservedWords
+            void (symbol ".")
+            name <- upperIdent reservedWords
+            pure (qualifier ++ "." ++ name)
+        )
+        <|> upperIdent reservedWords
+
+qualifiedLowerIdent :: Parser String
+qualifiedLowerIdent =
+    try
+        ( do
+            qualifier <- upperIdent reservedWords
+            void (symbol ".")
+            name <- lowerIdent reservedWords
+            pure (qualifier ++ "." ++ name)
+        )
+        <|> lowerIdent reservedWords
+
 programTypeConfig :: TypeParserConfig SrcType (Maybe SrcType)
 programTypeConfig =
     TypeParserConfig
@@ -90,7 +125,7 @@ programTypeConfig =
         , tpcSymbol = symbol
         , tpcParens = parens
         , tpcLowerIdent = lowerIdent reservedWords
-        , tpcUpperIdent = upperIdent reservedWords
+        , tpcUpperIdent = qualifiedUpperIdent
         , tpcBottomTok = bottomTok
         , tpcMkVar = STVar
         , tpcMkArrow = STArrow
@@ -128,24 +163,101 @@ pType = try pProgramForall <|> try pProgramMu <|> parseArrowTypeWith programType
         void (symbol ".")
         STMu v <$> pType
 
-pProgram :: Parser Program
-pProgram = Program <$> some pModule
+pConstrainedType :: Parser ConstrainedType
+pConstrainedType =
+    try
+        ( do
+            constraints <- pConstraintList
+            void (symbol "=>")
+            ConstrainedType constraints <$> pType
+        )
+        <|> (unconstrainedType <$> pType)
 
-pModule :: Parser Module
-pModule = do
+pConstraintList :: Parser [ClassConstraint]
+pConstraintList =
+    try (parens (commaSep pClassConstraint))
+        <|> fmap (: []) pClassConstraint
+
+pClassConstraint :: Parser ClassConstraint
+pClassConstraint =
+    ClassConstraint
+        <$> qualifiedUpperIdent
+        <*> pType
+
+pLocatedProgram :: Parser LocatedProgram
+pLocatedProgram = do
+    modules <- some pLocatedModule
+    let program = Program (map fst modules)
+        spanIndex = foldr appendProgramSpanIndex emptyProgramSpanIndex (map snd modules)
+    pure LocatedProgram { locatedProgram = program, locatedProgramSpans = spanIndex }
+
+withSpan :: Parser a -> Parser (a, SourceSpan)
+withSpan parser = do
+    start <- getSourcePos
+    value <- parser
+    end <- getSourcePos
+    pure (value, sourceSpanFromPositions start end)
+
+sourceSpanFromPositions :: MP.SourcePos -> MP.SourcePos -> SourceSpan
+sourceSpanFromPositions start end =
+    SourceSpan
+        { sourceFile = MP.sourceName start
+        , sourceStart = sourcePositionFromMegaparsec start
+        , sourceEnd = sourcePositionFromMegaparsec end
+        }
+
+sourcePositionFromMegaparsec :: MP.SourcePos -> SourcePosition
+sourcePositionFromMegaparsec pos =
+    SourcePosition
+        (unPos (MP.sourceLine pos))
+        (unPos (MP.sourceColumn pos))
+
+singletonModuleSpan :: ModuleName -> SourceSpan -> ProgramSpanIndex
+singletonModuleSpan name span0 =
+    emptyProgramSpanIndex { spanModules = Map.singleton name span0 }
+
+singletonValueSpan :: ValueName -> SourceSpan -> ProgramSpanIndex
+singletonValueSpan name span0 =
+    emptyProgramSpanIndex { spanValues = Map.singleton name [span0] }
+
+singletonTypeSpan :: TypeName -> SourceSpan -> ProgramSpanIndex
+singletonTypeSpan name span0 =
+    emptyProgramSpanIndex { spanTypes = Map.singleton name [span0] }
+
+singletonConstructorSpan :: ConstructorName -> SourceSpan -> ProgramSpanIndex
+singletonConstructorSpan name span0 =
+    emptyProgramSpanIndex { spanConstructors = Map.singleton name [span0] }
+
+singletonClassSpan :: ClassName -> SourceSpan -> ProgramSpanIndex
+singletonClassSpan name span0 =
+    emptyProgramSpanIndex { spanClasses = Map.singleton name [span0] }
+
+mergeSpanIndexes :: [ProgramSpanIndex] -> ProgramSpanIndex
+mergeSpanIndexes = foldr appendProgramSpanIndex emptyProgramSpanIndex
+
+pLocatedModule :: Parser (Module, ProgramSpanIndex)
+pLocatedModule = do
+    start <- getSourcePos
     void (symbol "module")
     name <- upperIdent reservedWords
     exports <- optional pExportList
     (imports, decls) <- braces $ do
         imports <- many (try pImport)
-        decls <- many pDecl
+        decls <- many pLocatedDecl
         pure (imports, decls)
-    pure Module
-        { moduleName = name
-        , moduleExports = exports
-        , moduleImports = imports
-        , moduleDecls = decls
-        }
+    end <- getSourcePos
+    let moduleSpan = sourceSpanFromPositions start end
+        module0 =
+            Module
+                { moduleName = name
+                , moduleExports = exports
+                , moduleImports = imports
+                , moduleDecls = map fst decls
+                }
+        spanIndex =
+            singletonModuleSpan name moduleSpan
+                `appendProgramSpanIndex` mergeSpanIndexes (map snd decls)
+    pure (module0, spanIndex)
 
 pExportList :: Parser [ExportItem]
 pExportList = do
@@ -169,58 +281,82 @@ pImport :: Parser Import
 pImport = do
     void (symbol "import")
     name <- upperIdent reservedWords
+    alias <- optional $ do
+        void (symbol "as")
+        upperIdent reservedWords
     exposing <- optional $ do
         void (symbol "exposing")
         parens (commaSep pExportItem)
     void semi
     pure Import
         { importModuleName = name
+        , importAlias = alias
         , importExposing = exposing
         }
 
-pDecl :: Parser Decl
-pDecl =
+pLocatedDecl :: Parser (Decl, ProgramSpanIndex)
+pLocatedDecl =
     choice
-        [ DeclClass <$> try pClassDecl
-        , DeclInstance <$> try pInstanceDecl
-        , DeclData <$> try pDataDecl
-        , DeclDef <$> pDefDecl
+        [ fmap (\(decl, spans) -> (DeclClass decl, spans)) (try pLocatedClassDecl)
+        , fmap (\(decl, spans) -> (DeclInstance decl, spans)) (try pLocatedInstanceDecl)
+        , fmap (\(decl, spans) -> (DeclData decl, spans)) (try pLocatedDataDecl)
+        , fmap (\(decl, spans) -> (DeclDef decl, spans)) pLocatedDefDecl
         ]
 
-pClassDecl :: Parser ClassDecl
-pClassDecl = do
+pLocatedClassDecl :: Parser (ClassDecl, ProgramSpanIndex)
+pLocatedClassDecl = do
+    start <- getSourcePos
     void (symbol "class")
-    className <- upperIdent reservedWords
+    className <- qualifiedUpperIdent
     classParam <- lowerIdent reservedWords
-    methods <- braces (many pMethodSig)
-    pure ClassDecl
-        { classDeclName = className
-        , classDeclParam = classParam
-        , classDeclMethods = methods
-        }
+    methods <- braces (many pLocatedMethodSig)
+    end <- getSourcePos
+    let classSpan = sourceSpanFromPositions start end
+        decl =
+            ClassDecl
+                { classDeclName = className
+                , classDeclParam = classParam
+                , classDeclMethods = map fst methods
+                }
+        spans =
+            singletonClassSpan className classSpan
+                `appendProgramSpanIndex` mergeSpanIndexes (map snd methods)
+    pure (decl, spans)
 
 pMethodSig :: Parser MethodSig
 pMethodSig = do
     name <- lowerIdent reservedWords
     void (symbol ":")
-    ty <- pType
+    ty <- pConstrainedType
     void semi
     pure MethodSig
         { methodSigName = name
         , methodSigType = ty
         }
 
-pInstanceDecl :: Parser InstanceDecl
-pInstanceDecl = do
+pLocatedMethodSig :: Parser (MethodSig, ProgramSpanIndex)
+pLocatedMethodSig = do
+    (sig, span0) <- withSpan pMethodSig
+    pure (sig, singletonValueSpan (methodSigName sig) span0)
+
+pLocatedInstanceDecl :: Parser (InstanceDecl, ProgramSpanIndex)
+pLocatedInstanceDecl = do
     void (symbol "instance")
-    className <- upperIdent reservedWords
+    constraints <- optional $ try $ do
+        constraints0 <- pConstraintList
+        void (symbol "=>")
+        pure constraints0
+    className <- qualifiedUpperIdent
     instTy <- pType
-    methods <- braces (many pMethodDef)
-    pure InstanceDecl
-        { instanceDeclClass = className
-        , instanceDeclType = instTy
-        , instanceDeclMethods = methods
-        }
+    methods <- braces (many pLocatedMethodDef)
+    let decl =
+            InstanceDecl
+                { instanceDeclConstraints = maybe [] id constraints
+                , instanceDeclClass = className
+                , instanceDeclType = instTy
+                , instanceDeclMethods = map fst methods
+                }
+    pure (decl, mergeSpanIndexes (map snd methods))
 
 pMethodDef :: Parser MethodDef
 pMethodDef = do
@@ -233,21 +369,34 @@ pMethodDef = do
         , methodDefExpr = body
         }
 
-pDataDecl :: Parser DataDecl
-pDataDecl = do
+pLocatedMethodDef :: Parser (MethodDef, ProgramSpanIndex)
+pLocatedMethodDef = do
+    (methodDef, span0) <- withSpan pMethodDef
+    pure (methodDef, singletonValueSpan (methodDefName methodDef) span0)
+
+pLocatedDataDecl :: Parser (DataDecl, ProgramSpanIndex)
+pLocatedDataDecl = do
+    start <- getSourcePos
     void (symbol "data")
     dataName <- upperIdent reservedWords
     params <- many (lowerIdent reservedWords)
     void (symbol "=")
-    ctors <- pConstructorDecl `sepBy1` symbol "|"
+    ctors <- pLocatedConstructorDecl `sepBy1` symbol "|"
     derivingClasses <- maybe [] id <$> optional pDerivingClause
     void semi
-    pure DataDecl
-        { dataDeclName = dataName
-        , dataDeclParams = params
-        , dataDeclConstructors = ctors
-        , dataDeclDeriving = derivingClasses
-        }
+    end <- getSourcePos
+    let dataSpan = sourceSpanFromPositions start end
+        decl =
+            DataDecl
+                { dataDeclName = dataName
+                , dataDeclParams = params
+                , dataDeclConstructors = map fst ctors
+                , dataDeclDeriving = derivingClasses
+                }
+        spans =
+            singletonTypeSpan dataName dataSpan
+                `appendProgramSpanIndex` mergeSpanIndexes (map snd ctors)
+    pure (decl, spans)
 
 pConstructorDecl :: Parser ConstructorDecl
 pConstructorDecl = do
@@ -259,17 +408,22 @@ pConstructorDecl = do
         , constructorDeclType = ctorTy
         }
 
+pLocatedConstructorDecl :: Parser (ConstructorDecl, ProgramSpanIndex)
+pLocatedConstructorDecl = do
+    (ctor, span0) <- withSpan pConstructorDecl
+    pure (ctor, singletonConstructorSpan (constructorDeclName ctor) span0)
+
 pDerivingClause :: Parser [ClassName]
 pDerivingClause = do
     void (symbol "deriving")
-    commaSep (upperIdent reservedWords)
+    commaSep qualifiedUpperIdent
 
 pDefDecl :: Parser DefDecl
 pDefDecl = do
     void (symbol "def")
     name <- lowerIdent reservedWords
     void (symbol ":")
-    ty <- pType
+    ty <- pConstrainedType
     void (symbol "=")
     body <- pExpr
     void semi
@@ -278,6 +432,11 @@ pDefDecl = do
         , defDeclType = ty
         , defDeclExpr = body
         }
+
+pLocatedDefDecl :: Parser (DefDecl, ProgramSpanIndex)
+pLocatedDefDecl = do
+    (def, span0) <- withSpan pDefDecl
+    pure (def, singletonValueSpan (defDeclName def) span0)
 
 pExpr :: Parser Expr
 pExpr = choice [try pLet, try pLambda, try pCase, pAnnOrApp]
@@ -330,13 +489,30 @@ pAlt = do
     pure Alt { altPattern = pat, altExpr = body }
 
 pPattern :: Parser Pattern
-pPattern =
+pPattern = pPatternAnn
+
+pPatternAnn :: Parser Pattern
+pPatternAnn = do
+    pat <- pPatternApp
+    ann <- optional (symbol ":" *> pType)
+    pure (maybe pat (PatAnn pat) ann)
+
+pPatternApp :: Parser Pattern
+pPatternApp =
+    try
+        ( do
+            ctor <- qualifiedUpperIdent
+            args <- many pPatternAtom
+            pure (PatCtor ctor args)
+        )
+        <|> pPatternAtom
+
+pPatternAtom :: Parser Pattern
+pPatternAtom =
     choice
         [ PatWildcard <$ symbol "_"
-        , try $ do
-            ctor <- upperIdent reservedWords
-            binders <- many (lowerIdent reservedWords)
-            pure (PatCtor ctor binders)
+        , parens pPattern
+        , PatCtor <$> qualifiedUpperIdent <*> pure []
         , PatVar <$> lowerIdent reservedWords
         ]
 
@@ -357,6 +533,6 @@ pAtom =
     choice
         [ parens pExpr
         , ELit <$> pLit
-        , EVar <$> upperIdent reservedWords
-        , EVar <$> lowerIdent reservedWords
+        , EVar <$> qualifiedLowerIdent
+        , EVar <$> qualifiedUpperIdent
         ]

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -216,6 +216,18 @@ singletonModuleSpan :: ModuleName -> SourceSpan -> ProgramSpanIndex
 singletonModuleSpan name span0 =
     emptyProgramSpanIndex { spanModules = Map.singleton name span0 }
 
+singletonImportSpan :: ModuleName -> SourceSpan -> ProgramSpanIndex
+singletonImportSpan name span0 =
+    emptyProgramSpanIndex { spanImports = Map.singleton name [span0] }
+
+singletonImportAliasSpan :: ModuleName -> SourceSpan -> ProgramSpanIndex
+singletonImportAliasSpan name span0 =
+    emptyProgramSpanIndex { spanImportAliases = Map.singleton name [span0] }
+
+singletonImportItemSpan :: String -> SourceSpan -> ProgramSpanIndex
+singletonImportItemSpan name span0 =
+    emptyProgramSpanIndex { spanImportItems = Map.singleton name [span0] }
+
 singletonValueSpan :: ValueName -> SourceSpan -> ProgramSpanIndex
 singletonValueSpan name span0 =
     emptyProgramSpanIndex { spanValues = Map.singleton name [span0] }
@@ -242,7 +254,7 @@ pLocatedModule = do
     name <- upperIdent reservedWords
     exports <- optional pExportList
     (imports, decls) <- braces $ do
-        imports <- many (try pImport)
+        imports <- many (try pLocatedImport)
         decls <- many pLocatedDecl
         pure (imports, decls)
     end <- getSourcePos
@@ -251,11 +263,12 @@ pLocatedModule = do
             Module
                 { moduleName = name
                 , moduleExports = exports
-                , moduleImports = imports
+                , moduleImports = map fst imports
                 , moduleDecls = map fst decls
                 }
         spanIndex =
             singletonModuleSpan name moduleSpan
+                `appendProgramSpanIndex` mergeSpanIndexes (map snd imports)
                 `appendProgramSpanIndex` mergeSpanIndexes (map snd decls)
     pure (module0, spanIndex)
 
@@ -277,22 +290,40 @@ pExportItem =
         void (symbol ")")
         pure (ExportTypeWithConstructors tyName)
 
-pImport :: Parser Import
-pImport = do
+pLocatedImport :: Parser (Import, ProgramSpanIndex)
+pLocatedImport = do
     void (symbol "import")
-    name <- upperIdent reservedWords
+    (name, nameSpan) <- withSpan (upperIdent reservedWords)
     alias <- optional $ do
         void (symbol "as")
-        upperIdent reservedWords
+        withSpan (upperIdent reservedWords)
     exposing <- optional $ do
         void (symbol "exposing")
-        parens (commaSep pExportItem)
+        parens (commaSep pLocatedExportItem)
     void semi
-    pure Import
-        { importModuleName = name
-        , importAlias = alias
-        , importExposing = exposing
-        }
+    let import0 =
+            Import
+                { importModuleName = name
+                , importAlias = fst <$> alias
+                , importExposing = fmap (map fst) exposing
+                }
+        spans =
+            singletonImportSpan name nameSpan
+                `appendProgramSpanIndex` maybe emptyProgramSpanIndex (uncurry singletonImportAliasSpan) alias
+                `appendProgramSpanIndex` mergeSpanIndexes (maybe [] (map snd) exposing)
+    pure (import0, spans)
+
+pLocatedExportItem :: Parser (ExportItem, ProgramSpanIndex)
+pLocatedExportItem = do
+    (item, span0) <- withSpan pExportItem
+    pure (item, singletonImportItemSpan (exportItemName item) span0)
+
+exportItemName :: ExportItem -> String
+exportItemName item =
+    case item of
+        ExportValue name -> name
+        ExportType name -> name
+        ExportTypeWithConstructors name -> name
 
 pLocatedDecl :: Parser (Decl, ProgramSpanIndex)
 pLocatedDecl =

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -239,6 +239,10 @@ singletonImportItemSpan :: String -> SourceSpan -> ProgramSpanIndex
 singletonImportItemSpan name span0 =
     emptyProgramSpanIndex { spanImportItems = Map.singleton name [span0] }
 
+singletonExportItemSpan :: String -> SourceSpan -> ProgramSpanIndex
+singletonExportItemSpan name span0 =
+    emptyProgramSpanIndex { spanExportItems = Map.singleton name [span0] }
+
 singletonValueSpan :: ValueName -> SourceSpan -> ProgramSpanIndex
 singletonValueSpan name span0 =
     emptyProgramSpanIndex { spanValues = Map.singleton name [span0] }
@@ -263,7 +267,7 @@ pLocatedModule = do
     start <- getSourcePos
     void (symbol "module")
     name <- upperIdent reservedWords
-    exports <- optional pExportList
+    exports <- optional pLocatedExportList
     (imports, decls) <- braces $ do
         imports <- many (try pLocatedImport)
         decls <- many pLocatedDecl
@@ -273,20 +277,22 @@ pLocatedModule = do
         module0 =
             Module
                 { moduleName = name
-                , moduleExports = exports
+                , moduleExports = fmap fst exports
                 , moduleImports = map fst imports
                 , moduleDecls = map fst decls
                 }
         spanIndex =
             singletonModuleSpan name moduleSpan
+                `appendProgramSpanIndex` maybe emptyProgramSpanIndex snd exports
                 `appendProgramSpanIndex` mergeSpanIndexes (map snd imports)
                 `appendProgramSpanIndex` mergeSpanIndexes (map snd decls)
     pure (module0, spanIndex)
 
-pExportList :: Parser [ExportItem]
-pExportList = do
+pLocatedExportList :: Parser ([ExportItem], ProgramSpanIndex)
+pLocatedExportList = do
     void (symbol "export")
-    parens (commaSep pExportItem)
+    exports <- parens (commaSep pLocatedModuleExportItem)
+    pure (map fst exports, mergeSpanIndexes (map snd exports))
 
 pExportItem :: Parser ExportItem
 pExportItem =
@@ -324,9 +330,19 @@ pLocatedImport = do
                 `appendProgramSpanIndex` mergeSpanIndexes (maybe [] (map snd) exposing)
     pure (import0, spans)
 
+pLocatedExportItemSpan :: Parser (ExportItem, SourceSpan)
+pLocatedExportItemSpan = do
+    (item, span0) <- withSpan pExportItem
+    pure (item, span0)
+
+pLocatedModuleExportItem :: Parser (ExportItem, ProgramSpanIndex)
+pLocatedModuleExportItem = do
+    (item, span0) <- pLocatedExportItemSpan
+    pure (item, singletonExportItemSpan (exportItemName item) span0)
+
 pLocatedExportItem :: Parser (ExportItem, ProgramSpanIndex)
 pLocatedExportItem = do
-    (item, span0) <- withSpan pExportItem
+    (item, span0) <- pLocatedExportItemSpan
     pure (item, singletonImportItemSpan (exportItemName item) span0)
 
 exportItemName :: ExportItem -> String

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -184,6 +184,25 @@ pClassConstraint =
         <$> qualifiedUpperIdent
         <*> pType
 
+pLocatedClassConstraint :: Parser (ClassConstraint, ProgramSpanIndex)
+pLocatedClassConstraint = do
+    (className, classSpan) <- withSpan qualifiedUpperIdent
+    ty <- pType
+    pure
+        ( ClassConstraint
+            { constraintClassName = className
+            , constraintType = ty
+            }
+        , singletonClassSpan className classSpan
+        )
+
+pLocatedConstraintList :: Parser ([ClassConstraint], ProgramSpanIndex)
+pLocatedConstraintList = do
+    constraints <-
+        try (parens (commaSep pLocatedClassConstraint))
+            <|> fmap (: []) pLocatedClassConstraint
+    pure (map fst constraints, mergeSpanIndexes (map snd constraints))
+
 pLocatedProgram :: Parser LocatedProgram
 pLocatedProgram = do
     modules <- some pLocatedModule
@@ -374,20 +393,24 @@ pLocatedInstanceDecl :: Parser (InstanceDecl, ProgramSpanIndex)
 pLocatedInstanceDecl = do
     void (symbol "instance")
     constraints <- optional $ try $ do
-        constraints0 <- pConstraintList
+        constraints0 <- pLocatedConstraintList
         void (symbol "=>")
         pure constraints0
-    className <- qualifiedUpperIdent
+    (className, classSpan) <- withSpan qualifiedUpperIdent
     instTy <- pType
     methods <- braces (many pLocatedMethodDef)
     let decl =
             InstanceDecl
-                { instanceDeclConstraints = maybe [] id constraints
+                { instanceDeclConstraints = maybe [] fst constraints
                 , instanceDeclClass = className
                 , instanceDeclType = instTy
                 , instanceDeclMethods = map fst methods
                 }
-    pure (decl, mergeSpanIndexes (map snd methods))
+        spans =
+            maybe emptyProgramSpanIndex snd constraints
+                `appendProgramSpanIndex` singletonClassSpan className classSpan
+                `appendProgramSpanIndex` mergeSpanIndexes (map snd methods)
+    pure (decl, spans)
 
 pMethodDef :: Parser MethodDef
 pMethodDef = do

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -163,26 +163,18 @@ pType = try pProgramForall <|> try pProgramMu <|> parseArrowTypeWith programType
         void (symbol ".")
         STMu v <$> pType
 
-pConstrainedType :: Parser ConstrainedType
-pConstrainedType =
+pLocatedConstrainedType :: Parser (ConstrainedType, ProgramSpanIndex)
+pLocatedConstrainedType =
     try
         ( do
-            constraints <- pConstraintList
+            (constraints, spans) <- pLocatedConstraintList
             void (symbol "=>")
-            ConstrainedType constraints <$> pType
+            ty <- pType
+            pure (ConstrainedType constraints ty, spans)
         )
-        <|> (unconstrainedType <$> pType)
-
-pConstraintList :: Parser [ClassConstraint]
-pConstraintList =
-    try (parens (commaSep pClassConstraint))
-        <|> fmap (: []) pClassConstraint
-
-pClassConstraint :: Parser ClassConstraint
-pClassConstraint =
-    ClassConstraint
-        <$> qualifiedUpperIdent
-        <*> pType
+        <|> do
+            ty <- pType
+            pure (unconstrainedType ty, emptyProgramSpanIndex)
 
 pLocatedClassConstraint :: Parser (ClassConstraint, ProgramSpanIndex)
 pLocatedClassConstraint = do
@@ -373,21 +365,25 @@ pLocatedClassDecl = do
                 `appendProgramSpanIndex` mergeSpanIndexes (map snd methods)
     pure (decl, spans)
 
-pMethodSig :: Parser MethodSig
-pMethodSig = do
-    name <- lowerIdent reservedWords
-    void (symbol ":")
-    ty <- pConstrainedType
-    void semi
-    pure MethodSig
-        { methodSigName = name
-        , methodSigType = ty
-        }
-
 pLocatedMethodSig :: Parser (MethodSig, ProgramSpanIndex)
 pLocatedMethodSig = do
-    (sig, span0) <- withSpan pMethodSig
-    pure (sig, singletonValueSpan (methodSigName sig) span0)
+    start <- getSourcePos
+    name <- lowerIdent reservedWords
+    void (symbol ":")
+    (ty, constraintSpans) <- pLocatedConstrainedType
+    void semi
+    end <- getSourcePos
+    let span0 = sourceSpanFromPositions start end
+        sig =
+            MethodSig
+                { methodSigName = name
+                , methodSigType = ty
+                }
+    pure
+        ( sig
+        , singletonValueSpan name span0
+            `appendProgramSpanIndex` constraintSpans
+        )
 
 pLocatedInstanceDecl :: Parser (InstanceDecl, ProgramSpanIndex)
 pLocatedInstanceDecl = do
@@ -472,25 +468,29 @@ pDerivingClause = do
     void (symbol "deriving")
     commaSep qualifiedUpperIdent
 
-pDefDecl :: Parser DefDecl
-pDefDecl = do
+pLocatedDefDecl :: Parser (DefDecl, ProgramSpanIndex)
+pLocatedDefDecl = do
+    start <- getSourcePos
     void (symbol "def")
     name <- lowerIdent reservedWords
     void (symbol ":")
-    ty <- pConstrainedType
+    (ty, constraintSpans) <- pLocatedConstrainedType
     void (symbol "=")
     body <- pExpr
     void semi
-    pure DefDecl
-        { defDeclName = name
-        , defDeclType = ty
-        , defDeclExpr = body
-        }
-
-pLocatedDefDecl :: Parser (DefDecl, ProgramSpanIndex)
-pLocatedDefDecl = do
-    (def, span0) <- withSpan pDefDecl
-    pure (def, singletonValueSpan (defDeclName def) span0)
+    end <- getSourcePos
+    let span0 = sourceSpanFromPositions start end
+        def =
+            DefDecl
+                { defDeclName = name
+                , defDeclType = ty
+                , defDeclExpr = body
+                }
+    pure
+        ( def
+        , singletonValueSpan name span0
+            `appendProgramSpanIndex` constraintSpans
+        )
 
 pExpr :: Parser Expr
 pExpr = choice [try pLet, try pLambda, try pCase, pAnnOrApp]

--- a/src/MLF/Frontend/Pretty/Program.hs
+++ b/src/MLF/Frontend/Pretty/Program.hs
@@ -31,6 +31,7 @@ prettyImport :: Import -> String
 prettyImport imp =
     "import "
         ++ importModuleName imp
+        ++ maybe "" (" as " ++) (importAlias imp)
         ++ maybe "" (\items -> " exposing (" ++ intercalate ", " (map prettyExportItem items) ++ ")") (importExposing imp)
         ++ ";"
 
@@ -50,12 +51,12 @@ prettyClassDecl classDecl =
         ]
 
 prettyMethodSig :: MethodSig -> String
-prettyMethodSig methodSig = methodSigName methodSig ++ " : " ++ prettyEmlfType (methodSigType methodSig) ++ ";\n"
+prettyMethodSig methodSig = methodSigName methodSig ++ " : " ++ prettyConstrainedType (methodSigType methodSig) ++ ";\n"
 
 prettyInstanceDecl :: InstanceDecl -> String
 prettyInstanceDecl instanceDecl =
     unlines
-        [ "instance " ++ instanceDeclClass instanceDecl ++ " " ++ prettyEmlfType (instanceDeclType instanceDecl) ++ " {"
+        [ "instance " ++ prettyConstraintsPrefix (instanceDeclConstraints instanceDecl) ++ instanceDeclClass instanceDecl ++ " " ++ prettyEmlfType (instanceDeclType instanceDecl) ++ " {"
         , indent (concatMap prettyMethodDef (instanceDeclMethods instanceDecl))
         , "}"
         ]
@@ -84,10 +85,24 @@ prettyDefDecl defDecl =
     "def "
         ++ defDeclName defDecl
         ++ " : "
-        ++ prettyEmlfType (defDeclType defDecl)
+        ++ prettyConstrainedType (defDeclType defDecl)
         ++ " = "
         ++ prettyExpr (defDeclExpr defDecl)
         ++ ";"
+
+prettyConstrainedType :: ConstrainedType -> String
+prettyConstrainedType (ConstrainedType constraints ty) =
+    prettyConstraintsPrefix constraints ++ prettyEmlfType ty
+
+prettyConstraintsPrefix :: [ClassConstraint] -> String
+prettyConstraintsPrefix [] = ""
+prettyConstraintsPrefix [constraint] = prettyClassConstraint constraint ++ " => "
+prettyConstraintsPrefix constraints =
+    "(" ++ intercalate ", " (map prettyClassConstraint constraints) ++ ") => "
+
+prettyClassConstraint :: ClassConstraint -> String
+prettyClassConstraint constraint =
+    constraintClassName constraint ++ " " ++ prettyEmlfType (constraintType constraint)
 
 prettyExpr :: Expr -> String
 prettyExpr expr = go 0 expr
@@ -134,9 +149,17 @@ prettyAlt alt = prettyPattern (altPattern alt) ++ " -> " ++ prettyExpr (altExpr 
 
 prettyPattern :: Pattern -> String
 prettyPattern pat = case pat of
-    PatCtor ctor binders -> unwords (ctor : binders)
+    PatCtor ctor patterns -> unwords (ctor : map prettyPatternArg patterns)
     PatVar name -> name
     PatWildcard -> "_"
+    PatAnn inner ty -> "(" ++ prettyPattern inner ++ " : " ++ prettyEmlfType ty ++ ")"
+
+prettyPatternArg :: Pattern -> String
+prettyPatternArg pat = case pat of
+    PatVar {} -> prettyPattern pat
+    PatWildcard -> prettyPattern pat
+    PatCtor _ [] -> prettyPattern pat
+    _ -> "(" ++ prettyPattern pat ++ ")"
 
 prettyLit :: Lit -> String
 prettyLit lit = case lit of

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -783,29 +783,44 @@ synthesizeDerivedInstances scope mod0 = concat <$> mapM deriveForData (moduleDat
       fst (splitArrows (snd (splitForalls (P.constructorDeclType ctor))))
 
     validateEqDerivingField dataDecl fieldTy
-      | fieldCoveredByDerivedConstraints dataDecl fieldTy = pure ()
+      | eqTypeSatisfiable dataDecl Set.empty fieldTy = pure ()
+      | otherwise = throwError (ProgramDerivingMissingFieldInstance "Eq" fieldTy)
+
+    eqTypeSatisfiable dataDecl seen fieldTy
+      | fieldCoveredByDerivedConstraints dataDecl fieldTy = True
+      | key `Set.member` seen = False
       | otherwise =
           case resolveInstanceInfoWithSubst (scopeToElaborateScope scope) "Eq" fieldTy of
-            Right _ -> pure ()
-            Left _ -> throwError (ProgramDerivingMissingFieldInstance "Eq" fieldTy)
+            Right (instanceInfo, subst) ->
+              let seen' = Set.insert key seen
+               in all
+                    (eqConstraintSatisfiable dataDecl seen' . applyConstraintSubst subst)
+                    (instanceConstraints instanceInfo)
+            Left _ -> False
+      where
+        key = ("Eq", show fieldTy)
+
+    eqConstraintSatisfiable dataDecl seen constraint
+      | P.constraintClassName constraint == "Eq" =
+          eqTypeSatisfiable dataDecl seen (P.constraintType constraint)
+      | otherwise = False
+
+    applyConstraintSubst subst constraint =
+      constraint
+        { P.constraintType =
+            Map.foldrWithKey substituteTypeVar (P.constraintType constraint) subst
+        }
 
     fieldCoveredByDerivedConstraints dataDecl fieldTy =
       case fieldTy of
         STVar name -> name `elem` P.dataDeclParams dataDecl
-        STBase name -> name == P.dataDeclName dataDecl
-        STCon name _ -> name == P.dataDeclName dataDecl
-        _ -> False
+        _ -> isRecursiveOwnerField dataDecl fieldTy
 
     scopeToElaborateScope scope0 =
       mkElaborateScope (scopeValues scope0) (scopeTypes scope0) (scopeClasses scope0) (scopeInstances scope0)
 
     mkEqInstance dataDecl =
-      let actualHead = case P.dataDeclParams dataDecl of
-            [] -> STBase (P.dataDeclName dataDecl)
-            (param0 : paramsRest) -> STCon (P.dataDeclName dataDecl) (STVar param0 :| map STVar paramsRest)
-          headTy = case P.dataDeclParams dataDecl of
-            [] -> STBase (P.dataDeclName dataDecl)
-            _ -> actualHead
+      let headTy = dataDeclHeadType dataDecl
           left = P.Param "left" (Just headTy)
           right = P.Param "right" (Just headTy)
           selfName = "__derived_eq_" ++ P.dataDeclName dataDecl
@@ -875,10 +890,12 @@ synthesizeDerivedInstances scope mod0 = concat <$> mapM deriveForData (moduleDat
            in P.EApp (P.EApp (P.EVar eqName) (P.EVar l)) (P.EVar r)
 
     isRecursiveOwnerField dataDecl argTy =
-      case argTy of
-        STBase name -> name == P.dataDeclName dataDecl
-        STCon name _ -> name == P.dataDeclName dataDecl
-        _ -> False
+      argTy == dataDeclHeadType dataDecl
+
+    dataDeclHeadType dataDecl =
+      case P.dataDeclParams dataDecl of
+        [] -> STBase (P.dataDeclName dataDecl)
+        param0 : paramsRest -> STCon (P.dataDeclName dataDecl) (STVar param0 :| map STVar paramsRest)
 
 buildInstanceSkeletons :: Scope -> P.Module -> [P.InstanceDecl] -> TcM [InstanceInfo]
 buildInstanceSkeletons scope mod0 derived = do

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -833,6 +833,27 @@ synthesizeDerivedInstances scope mod0 = do
         STVar name -> name `elem` P.dataDeclParams dataDecl
         _ -> isRecursiveOwnerField dataDecl fieldTy
 
+    derivedConstraintParams dataDecl =
+      let params = Set.fromList (P.dataDeclParams dataDecl)
+          fieldTypes =
+            filter
+              (not . isRecursiveOwnerField dataDecl)
+              (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
+          usedParams = Set.intersection params (foldMap freeTypeVars fieldTypes)
+       in [paramName | paramName <- P.dataDeclParams dataDecl, paramName `Set.member` usedParams]
+
+    freeTypeVars ty =
+      case ty of
+        STVar name -> Set.singleton name
+        STArrow dom cod -> freeTypeVars dom `Set.union` freeTypeVars cod
+        STBase {} -> Set.empty
+        STCon _ args -> foldMap freeTypeVars args
+        STForall name mb body ->
+          maybe Set.empty (freeTypeVars . unSrcBound) mb
+            `Set.union` Set.delete name (freeTypeVars body)
+        STMu name body -> Set.delete name (freeTypeVars body)
+        STBottom -> Set.empty
+
     scopeToElaborateScope scope0 =
       mkElaborateScope (scopeValues scope0) (scopeTypes scope0) (scopeClasses scope0) (scopeInstances scope0)
 
@@ -855,7 +876,7 @@ synthesizeDerivedInstances scope mod0 = do
             { P.instanceDeclClass = "Eq",
               P.instanceDeclConstraints =
                 [ P.ClassConstraint "Eq" (STVar paramName)
-                  | paramName <- P.dataDeclParams dataDecl
+                  | paramName <- derivedConstraintParams dataDecl
                 ],
               P.instanceDeclType = headTy,
               P.instanceDeclMethods = [P.MethodDef "eq" methodBody]

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -873,7 +873,14 @@ buildInstanceSkeletons scope mod0 derived = do
   let instances0 = derived ++ explicitInstances mod0
   infos <- mapM toInstanceInfo instances0
   ensureDistinctPlain (\(className0, ty) -> ProgramDuplicateInstance className0 ty) [(instanceClassName info, instanceHeadType info) | info <- infos]
+  case duplicateExistingInstances infos of
+    info : _ -> throwError (ProgramDuplicateInstance (instanceClassName info) (instanceHeadType info))
+    [] -> pure ()
   case overlappingInstances infos of
+    (left, right) : _ ->
+      throwError (ProgramOverlappingInstance (instanceClassName left) (instanceHeadType left) (instanceHeadType right))
+    [] -> pure ()
+  case overlappingWithExistingInstances infos of
     (left, right) : _ ->
       throwError (ProgramOverlappingInstance (instanceClassName left) (instanceHeadType left) (instanceHeadType right))
     [] -> pure ()
@@ -925,6 +932,23 @@ buildInstanceSkeletons scope mod0 derived = do
           instanceClassName left == instanceClassName right,
           instanceHeadType left /= instanceHeadType right,
           instanceHeadsOverlap (instanceHeadType left) (instanceHeadType right)
+      ]
+
+    duplicateExistingInstances infos =
+      [ local
+        | local <- infos,
+          existing <- scopeInstances scope,
+          instanceClassName local == instanceClassName existing,
+          instanceHeadType local == instanceHeadType existing
+      ]
+
+    overlappingWithExistingInstances infos =
+      [ (local, existing)
+        | local <- infos,
+          existing <- scopeInstances scope,
+          instanceClassName local == instanceClassName existing,
+          instanceHeadType local /= instanceHeadType existing,
+          instanceHeadsOverlap (instanceHeadType local) (instanceHeadType existing)
       ]
 
     instanceHeadsOverlap left right =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -482,7 +482,20 @@ qualifiedInstancesForImport priorExports priorInstances imp =
                     instanceBelongsToModule (P.importModuleName imp) instanceInfo,
                     instanceVisibleForQualifiedImport exports instanceInfo
                 ]
-           in concatMap (qualifiedInstanceVariants alias exports) importedInstances
+              unqualifiedTypeNames = importExposedTypeNames imp
+           in concatMap (qualifiedInstanceVariants alias exports unqualifiedTypeNames) importedInstances
+
+importExposedTypeNames :: P.Import -> Set.Set String
+importExposedTypeNames imp =
+  case P.importExposing imp of
+    Nothing -> Set.empty
+    Just items -> Set.fromList (concatMap exposedTypeName items)
+  where
+    exposedTypeName item =
+      case item of
+        P.ExportType name -> [name]
+        P.ExportTypeWithConstructors name -> [name]
+        P.ExportValue {} -> []
 
 instanceVisibleForQualifiedImport :: ModuleExports -> InstanceInfo -> Bool
 instanceVisibleForQualifiedImport exports instanceInfo =
@@ -502,13 +515,26 @@ srcTypeMentionsAny names ty =
     STMu _ body -> srcTypeMentionsAny names body
     STBottom -> False
 
-qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> InstanceInfo -> [InstanceInfo]
-qualifiedInstanceVariants alias exports instanceInfo =
+qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> Set.Set String -> InstanceInfo -> [InstanceInfo]
+qualifiedInstanceVariants alias exports unqualifiedTypeNames instanceInfo =
   distinctInstanceHeads
     [ variant
-      | variant <- [qualifyInstance alias exports instanceInfo, qualifyInstanceHeadOnly alias exports instanceInfo],
+      | variant <-
+          qualifyInstance alias exports instanceInfo
+            : [ qualifyInstanceHeadOnly alias exports instanceInfo
+                | needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo
+              ],
         not (sameInstanceHead instanceInfo variant)
     ]
+
+needsAliasHeadInstanceVariant :: ModuleExports -> Set.Set String -> InstanceInfo -> Bool
+needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo =
+  not (Set.null mentionedTypeNames)
+    && not (mentionedTypeNames `Set.isSubsetOf` unqualifiedTypeNames)
+  where
+    exportedTypeNames = Map.keysSet (exportedTypes exports)
+    mentionedTypeNames =
+      instanceExportedTypeMentions exportedTypeNames instanceInfo
 
 distinctInstanceHeads :: [InstanceInfo] -> [InstanceInfo]
 distinctInstanceHeads = reverse . foldl' add []
@@ -521,6 +547,41 @@ sameInstanceHead :: InstanceInfo -> InstanceInfo -> Bool
 sameInstanceHead left right =
   instanceClassName left == instanceClassName right
     && instanceHeadType left == instanceHeadType right
+
+instanceExportedTypeMentions :: Set.Set String -> InstanceInfo -> Set.Set String
+instanceExportedTypeMentions exportedTypeNames instanceInfo =
+  Set.unions (headMentions : constraintMentions ++ methodMentions)
+  where
+    headMentions = srcTypeMentionedNames exportedTypeNames (instanceHeadType instanceInfo)
+    constraintMentions = map (srcTypeMentionedNames exportedTypeNames . P.constraintType) (instanceConstraints instanceInfo)
+    methodMentions = concatMap valueExportedTypeMentions (Map.elems (instanceMethods instanceInfo))
+
+    valueExportedTypeMentions valueInfo =
+      case valueInfo of
+        OrdinaryValue {} ->
+          srcTypeMentionedNames exportedTypeNames (valueType valueInfo)
+            : map (srcTypeMentionedNames exportedTypeNames . P.constraintType) (valueConstraints valueInfo)
+        _ -> []
+
+srcTypeMentionedNames :: Set.Set String -> SrcType -> Set.Set String
+srcTypeMentionedNames names ty =
+  case ty of
+    STVar {} -> Set.empty
+    STBase name
+      | name `Set.member` names -> Set.singleton name
+      | otherwise -> Set.empty
+    STCon name args ->
+      let headNames
+            | name `Set.member` names = Set.singleton name
+            | otherwise = Set.empty
+       in Set.unions (headNames : map (srcTypeMentionedNames names) (NE.toList args))
+    STArrow dom cod ->
+      srcTypeMentionedNames names dom `Set.union` srcTypeMentionedNames names cod
+    STForall _ mb body ->
+      maybe Set.empty (srcTypeMentionedNames names . unSrcBound) mb
+        `Set.union` srcTypeMentionedNames names body
+    STMu _ body -> srcTypeMentionedNames names body
+    STBottom -> Set.empty
 
 instanceBelongsToModule :: P.ModuleName -> InstanceInfo -> Bool
 instanceBelongsToModule moduleName0 instanceInfo =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -3,6 +3,7 @@
 
 module MLF.Frontend.Program.Check
   ( ProgramError (..),
+    ProgramDiagnostic (..),
     CheckedProgram (..),
     CheckedModule (..),
     CheckedBinding (..),
@@ -15,6 +16,7 @@ module MLF.Frontend.Program.Check
     ExportedTypeInfo (..),
     ModuleExports (..),
     checkProgram,
+    checkLocatedProgram,
   )
 where
 
@@ -29,8 +31,9 @@ import qualified Data.Set as Set
 import MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
     lowerConstructorBinding,
-    lowerExprBinding,
+    lowerConstrainedExprBinding,
     mkElaborateScope,
+    resolveInstanceInfoWithSubst,
   )
 import MLF.Frontend.Program.Finalize (finalizeBinding)
 import MLF.Frontend.Program.Types
@@ -44,9 +47,13 @@ import MLF.Frontend.Program.Types
     InstanceInfo (..),
     MethodInfo (..),
     ModuleExports (..),
+    ProgramDiagnostic (..),
     ProgramError (..),
     ValueInfo (..),
+    constrainedVisibleType,
+    diagnosticForProgramError,
     specializeMethodType,
+    substituteTypeVar,
     splitArrows,
     splitForalls,
   )
@@ -69,7 +76,19 @@ data Scope = Scope
   deriving (Eq, Show)
 
 emptyScope :: Scope
-emptyScope = Scope Map.empty Map.empty Map.empty []
+emptyScope = Scope builtinValues Map.empty Map.empty []
+
+builtinValues :: Map String ValueInfo
+builtinValues =
+  Map.singleton
+    "__mlfp_and"
+    OrdinaryValue
+      { valueDisplayName = "__mlfp_and",
+        valueRuntimeName = "__mlfp_and",
+        valueType = STArrow (STBase "Bool") (STArrow (STBase "Bool") (STBase "Bool")),
+        valueConstraints = [],
+        valueOriginModule = "<builtin>"
+      }
 
 addValues :: Map String ValueInfo -> Map String ValueInfo -> Either ProgramError (Map String ValueInfo)
 addValues base incoming =
@@ -138,6 +157,12 @@ checkProgram program = runTcM $ do
         checkedProgramMain = mainRuntime
       }
 
+checkLocatedProgram :: P.LocatedProgram -> Either ProgramDiagnostic CheckedProgram
+checkLocatedProgram located =
+  case checkProgram (P.locatedProgram located) of
+    Right checked -> Right checked
+    Left err -> Left (diagnosticForProgramError (Just located) err)
+
 checkModules :: P.Program -> TcM [CheckedModule]
 checkModules (P.Program modules0) = do
   ensureDistinctBy ProgramDuplicateModule P.moduleName modules0
@@ -180,6 +205,8 @@ checkModule :: [CheckedModule] -> P.Module -> TcM CheckedModule
 checkModule priorModules mod0 = do
   let priorExports = Map.fromList [(checkedModuleName checked, checkedModuleExports checked) | checked <- priorModules]
       priorInstances = concatMap checkedModuleInstances priorModules
+      qualifiedPriorInstances = concatMap (qualifiedInstancesForImport priorExports priorInstances) (P.moduleImports mod0)
+  ensureDistinctImportAliases (P.moduleImports mod0)
   importScope <- buildImportScope priorExports (P.moduleImports mod0)
   localData <- buildLocalDataInfo mod0
   localClasses <- buildLocalClassInfo mod0
@@ -196,11 +223,11 @@ checkModule priorModules mod0 = do
   valueScope <- liftEither =<< pure (addValues (scopeValues importScope) localValues)
   typeScope <- liftEither =<< pure (addTypes (scopeTypes importScope) localData)
   classScope <- liftEither =<< pure (addClasses (scopeClasses importScope) localClasses)
-  let scope0 = Scope valueScope typeScope classScope (scopeInstances importScope ++ priorInstances)
+  let scope0 = Scope valueScope typeScope classScope (scopeInstances importScope ++ priorInstances ++ qualifiedPriorInstances)
   derivedInstances <- synthesizeDerivedInstances scope0 mod0
   instanceSkeletons <- buildInstanceSkeletons scope0 mod0 derivedInstances
   let scope1 = scope0 {scopeInstances = scopeInstances scope0 ++ instanceSkeletons}
-  let elaborateScope = mkElaborateScope (scopeValues scope1) (scopeTypes scope1) (scopeInstances scope1)
+  let elaborateScope = mkElaborateScope (scopeValues scope1) (scopeTypes scope1) (scopeClasses scope1) (scopeInstances scope1)
   constructorBindings <-
     mapM
       (liftEither . (finalizeBinding elaborateScope . lowerConstructorBinding elaborateScope))
@@ -267,19 +294,285 @@ buildImportScope priorExports imports0 = foldM go emptyScope imports0
         case Map.lookup (P.importModuleName imp) priorExports of
           Nothing -> throwError (ProgramUnknownImportModule (P.importModuleName imp))
           Just ex -> pure ex
-      case P.importExposing imp of
+      case P.importAlias imp of
         Nothing ->
-          liftEither $ do
-            values <- addValues (scopeValues scope) (exportedValues exports)
-            types <- addTypes (scopeTypes scope) (Map.map exportedTypeData (exportedTypes exports))
-            classes <- addClasses (scopeClasses scope) (exportedClasses exports)
-            pure
-              scope
-                { scopeValues = values,
-                  scopeTypes = types,
-                  scopeClasses = classes
-                }
-        Just items -> foldM (applyImportItem (P.importModuleName imp) exports) scope items
+          case P.importExposing imp of
+            Nothing -> addAllExports scope exports
+            Just items -> foldM (applyImportItem (P.importModuleName imp) exports) scope items
+        Just alias -> do
+          qualifiedScope <- addAllExports scope (qualifyModuleExports alias exports)
+          case P.importExposing imp of
+            Nothing -> pure qualifiedScope
+            Just items -> foldM (applyImportItem (P.importModuleName imp) exports) qualifiedScope items
+
+addAllExports :: Scope -> ModuleExports -> TcM Scope
+addAllExports scope exports =
+  liftEither $ do
+    values <- addValues (scopeValues scope) (exportedValues exports)
+    types <- addTypes (scopeTypes scope) (Map.map exportedTypeData (exportedTypes exports))
+    classes <- addClasses (scopeClasses scope) (exportedClasses exports)
+    pure
+      scope
+        { scopeValues = values,
+          scopeTypes = types,
+          scopeClasses = classes
+        }
+
+qualifyModuleExports :: P.ModuleName -> ModuleExports -> ModuleExports
+qualifyModuleExports alias exports =
+  ModuleExports
+    { exportedValues = qualifiedValues,
+      exportedTypes = qualifiedTypes,
+      exportedClasses = qualifiedClasses
+    }
+  where
+    qualifiedName name = alias ++ "." ++ name
+    exportedTypeNames = Map.keysSet (exportedTypes exports)
+    exportedClassNames = Map.keysSet (exportedClasses exports)
+
+    qualifiedTypes =
+      Map.fromList
+        [ let qualifiedDataInfo = qualifyDataInfo dataInfo
+              visibleCtorNames = Set.fromList (Map.keys ctors)
+           in ( qualifiedName typeName,
+                ExportedTypeInfo
+                  { exportedTypeData = qualifiedDataInfo,
+                    exportedTypeConstructors =
+                      Map.fromList
+                        [ (ctorName ctor, ctor)
+                          | ctor <- dataConstructors qualifiedDataInfo,
+                            unqualifyQualifiedName alias (ctorName ctor) `Set.member` visibleCtorNames
+                        ]
+                  }
+              )
+          | (typeName, ExportedTypeInfo dataInfo ctors) <- Map.toList (exportedTypes exports)
+        ]
+
+    qualifiedClasses =
+      Map.fromList
+        [ (qualifiedName className0, qualifyClassInfo classInfo)
+          | (className0, classInfo) <- Map.toList (exportedClasses exports)
+        ]
+
+    qualifiedCtorValues =
+      Map.fromList
+        [ ( ctorName ctor,
+            ConstructorValue
+              { valueDisplayName = ctorName ctor,
+                valueRuntimeName = ctorRuntimeName ctor,
+                valueType = ctorType ctor,
+                valueCtorInfo = ctor,
+                valueOriginModule = dataModule dataInfo
+              }
+          )
+          | ExportedTypeInfo dataInfo ctors <- Map.elems qualifiedTypes,
+            ctor <- Map.elems ctors
+        ]
+
+    qualifiedOrdinaryValues =
+      Map.fromList
+        [ ( qualifiedName name,
+            qualifyValueInfo name valueInfo
+          )
+          | (name, valueInfo) <- Map.toList (exportedValues exports),
+            not (isConstructorValue valueInfo)
+        ]
+
+    qualifiedValues = qualifiedCtorValues `Map.union` qualifiedOrdinaryValues
+
+    isConstructorValue ConstructorValue {} = True
+    isConstructorValue _ = False
+
+    qualifyDataInfo dataInfo =
+      let qualifiedTypeName = qualifiedName (dataName dataInfo)
+          qualifyCtor ctor =
+            ctor
+              { ctorName = qualifiedName (ctorName ctor),
+                ctorType = qualifySrcType (ctorType ctor),
+                ctorArgs = map qualifySrcType (ctorArgs ctor),
+                ctorResult = qualifySrcType (ctorResult ctor),
+                ctorOwningType = qualifiedTypeName
+              }
+       in dataInfo
+            { dataName = qualifiedTypeName,
+              dataConstructors = map qualifyCtor (dataConstructors dataInfo)
+            }
+
+    qualifyClassInfo classInfo =
+      let qualifiedClassName = qualifiedName (className classInfo)
+          qualifyMethod methodInfo =
+            methodInfo
+              { methodClassName = qualifiedClassName,
+                methodType = qualifySrcType (methodType methodInfo),
+                methodConstraints = map qualifyConstraint (methodConstraints methodInfo)
+              }
+       in classInfo
+            { className = qualifiedClassName,
+              classMethods = Map.map qualifyMethod (classMethods classInfo)
+            }
+
+    qualifyValueInfo sourceName valueInfo =
+      case valueInfo of
+        OrdinaryValue {} ->
+          valueInfo
+            { valueDisplayName = qualifiedName sourceName,
+              valueType = qualifySrcType (valueType valueInfo),
+              valueConstraints = map qualifyConstraint (valueConstraints valueInfo)
+            }
+        OverloadedMethod {valueMethodInfo = methodInfo} ->
+          OverloadedMethod
+            { valueDisplayName = qualifiedName sourceName,
+              valueMethodInfo = qualifyMethodFromExport methodInfo,
+              valueOriginModule = valueOriginModule valueInfo
+            }
+        ConstructorValue {} -> valueInfo
+
+    qualifyMethodFromExport methodInfo =
+      methodInfo
+        { methodClassName = qualifiedClassNameFor (methodClassName methodInfo),
+          methodType = qualifySrcType (methodType methodInfo),
+          methodConstraints = map qualifyConstraint (methodConstraints methodInfo)
+        }
+
+    qualifiedClassNameFor className0
+      | className0 `Set.member` exportedClassNames = qualifiedName className0
+      | otherwise = className0
+
+    qualifyConstraint constraint =
+      constraint
+        { P.constraintClassName =
+            if P.constraintClassName constraint `Set.member` exportedClassNames
+              then qualifiedName (P.constraintClassName constraint)
+              else P.constraintClassName constraint,
+          P.constraintType = qualifySrcType (P.constraintType constraint)
+        }
+
+    qualifySrcType ty =
+      case ty of
+        STVar {} -> ty
+        STBase name
+          | name `Set.member` exportedTypeNames -> STBase (qualifiedName name)
+          | otherwise -> ty
+        STCon name args
+          | name `Set.member` exportedTypeNames -> STCon (qualifiedName name) (fmap qualifySrcType args)
+          | otherwise -> STCon name (fmap qualifySrcType args)
+        STArrow dom cod -> STArrow (qualifySrcType dom) (qualifySrcType cod)
+        STForall name mb body -> STForall name (fmap (SrcBound . qualifySrcType . unSrcBound) mb) (qualifySrcType body)
+        STMu name body -> STMu name (qualifySrcType body)
+        STBottom -> STBottom
+
+unqualifyQualifiedName :: P.ModuleName -> String -> String
+unqualifyQualifiedName alias name =
+  case splitAt (length alias + 1) name of
+    (prefix, rest)
+      | prefix == alias ++ "." -> rest
+    _ -> name
+
+qualifiedInstancesForImport :: Map P.ModuleName ModuleExports -> [InstanceInfo] -> P.Import -> [InstanceInfo]
+qualifiedInstancesForImport priorExports priorInstances imp =
+  case P.importAlias imp of
+    Nothing -> []
+    Just alias ->
+      case Map.lookup (P.importModuleName imp) priorExports of
+        Nothing -> []
+        Just exports ->
+          [ qualifyInstance alias exports instanceInfo
+            | instanceInfo <- priorInstances,
+              instanceBelongsToModule (P.importModuleName imp) instanceInfo,
+              instanceClassName instanceInfo `Map.member` exportedClasses exports
+          ]
+            ++ [ qualifyInstanceHeadOnly alias exports instanceInfo
+                 | instanceInfo <- priorInstances,
+                   instanceBelongsToModule (P.importModuleName imp) instanceInfo,
+                   instanceClassName instanceInfo `Map.member` exportedClasses exports
+               ]
+
+instanceBelongsToModule :: P.ModuleName -> InstanceInfo -> Bool
+instanceBelongsToModule moduleName0 instanceInfo =
+  any belongs (Map.elems (instanceMethods instanceInfo))
+  where
+    belongs OrdinaryValue {valueOriginModule = origin} = origin == moduleName0
+    belongs ConstructorValue {valueOriginModule = origin} = origin == moduleName0
+    belongs OverloadedMethod {valueOriginModule = origin} = origin == moduleName0
+
+qualifyInstance :: P.ModuleName -> ModuleExports -> InstanceInfo -> InstanceInfo
+qualifyInstance alias exports instanceInfo =
+  instanceInfo
+    { instanceClassName = qualifyClassName (instanceClassName instanceInfo),
+      instanceConstraints = map qualifyConstraint (instanceConstraints instanceInfo),
+      instanceHeadType = qualifySrcType (instanceHeadType instanceInfo),
+      instanceMethods = Map.map qualifyMethodValue (instanceMethods instanceInfo)
+    }
+  where
+    qualifiedName name = alias ++ "." ++ name
+    exportedTypeNames = Map.keysSet (exportedTypes exports)
+    exportedClassNames = Map.keysSet (exportedClasses exports)
+
+    qualifyClassName className0
+      | className0 `Set.member` exportedClassNames = qualifiedName className0
+      | otherwise = className0
+
+    qualifyConstraint constraint =
+      constraint
+        { P.constraintClassName = qualifyClassName (P.constraintClassName constraint),
+          P.constraintType = qualifySrcType (P.constraintType constraint)
+        }
+
+    qualifyMethodValue valueInfo@OrdinaryValue {} =
+      valueInfo
+        { valueType = qualifySrcType (valueType valueInfo),
+          valueConstraints = map qualifyConstraint (valueConstraints valueInfo)
+        }
+    qualifyMethodValue valueInfo = valueInfo
+
+    qualifySrcType ty =
+      case ty of
+        STVar {} -> ty
+        STBase name
+          | name `Set.member` exportedTypeNames -> STBase (qualifiedName name)
+          | otherwise -> ty
+        STCon name args
+          | name `Set.member` exportedTypeNames -> STCon (qualifiedName name) (fmap qualifySrcType args)
+          | otherwise -> STCon name (fmap qualifySrcType args)
+        STArrow dom cod -> STArrow (qualifySrcType dom) (qualifySrcType cod)
+        STForall name mb body -> STForall name (fmap (SrcBound . qualifySrcType . unSrcBound) mb) (qualifySrcType body)
+        STMu name body -> STMu name (qualifySrcType body)
+        STBottom -> STBottom
+
+qualifyInstanceHeadOnly :: P.ModuleName -> ModuleExports -> InstanceInfo -> InstanceInfo
+qualifyInstanceHeadOnly alias exports instanceInfo =
+  instanceInfo
+    { instanceConstraints = map qualifyConstraintType (instanceConstraints instanceInfo),
+      instanceHeadType = qualifySrcType (instanceHeadType instanceInfo),
+      instanceMethods = Map.map qualifyMethodValue (instanceMethods instanceInfo)
+    }
+  where
+    qualifiedName name = alias ++ "." ++ name
+    exportedTypeNames = Map.keysSet (exportedTypes exports)
+
+    qualifyConstraintType constraint =
+      constraint {P.constraintType = qualifySrcType (P.constraintType constraint)}
+
+    qualifyMethodValue valueInfo@OrdinaryValue {} =
+      valueInfo
+        { valueType = qualifySrcType (valueType valueInfo),
+          valueConstraints = map qualifyConstraintType (valueConstraints valueInfo)
+        }
+    qualifyMethodValue valueInfo = valueInfo
+
+    qualifySrcType ty =
+      case ty of
+        STVar {} -> ty
+        STBase name
+          | name `Set.member` exportedTypeNames -> STBase (qualifiedName name)
+          | otherwise -> ty
+        STCon name args
+          | name `Set.member` exportedTypeNames -> STCon (qualifiedName name) (fmap qualifySrcType args)
+          | otherwise -> STCon name (fmap qualifySrcType args)
+        STArrow dom cod -> STArrow (qualifySrcType dom) (qualifySrcType cod)
+        STForall name mb body -> STForall name (fmap (SrcBound . qualifySrcType . unSrcBound) mb) (qualifySrcType body)
+        STMu name body -> STMu name (qualifySrcType body)
+        STBottom -> STBottom
 
 applyImportItem :: P.ModuleName -> ModuleExports -> Scope -> P.ExportItem -> TcM Scope
 applyImportItem moduleName0 exports scope item =
@@ -393,7 +686,8 @@ buildLocalClassInfo mod0 = do
                     { methodClassName = P.classDeclName classDecl,
                       methodName = P.methodSigName sig,
                       methodRuntimeBase = qualify (P.moduleName mod0) (P.classDeclName classDecl ++ "__" ++ P.methodSigName sig),
-                      methodType = P.methodSigType sig,
+                      methodType = P.constrainedBody (P.methodSigType sig),
+                      methodConstraints = P.constrainedConstraints (P.methodSigType sig),
                       methodParamName = P.classDeclParam classDecl
                     }
                 )
@@ -419,7 +713,8 @@ buildLocalDefInfo mod0 = do
           OrdinaryValue
             { valueDisplayName = P.defDeclName defDecl,
               valueRuntimeName = qualify (P.moduleName mod0) (P.defDeclName defDecl),
-              valueType = P.defDeclType defDecl,
+              valueType = constrainedVisibleType (P.defDeclType defDecl),
+              valueConstraints = P.constrainedConstraints (P.defDeclType defDecl),
               valueOriginModule = P.moduleName mod0
             }
         )
@@ -467,10 +762,30 @@ synthesizeDerivedInstances scope mod0 = concat <$> mapM deriveForData (moduleDat
       forM (P.dataDeclDeriving dataDecl) $ \className0 ->
         case className0 of
           "Eq" -> do
-            when (not (null (P.dataDeclParams dataDecl))) (throwError (ProgramDerivingRequiresNullaryType (P.dataDeclName dataDecl)))
             _ <- lookupClassInfo scope className0
+            mapM_ (validateEqDerivingField dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
             pure (mkEqInstance dataDecl)
           other -> throwError (ProgramUnsupportedDeriving other)
+
+    constructorFieldTypes ctor =
+      fst (splitArrows (snd (splitForalls (P.constructorDeclType ctor))))
+
+    validateEqDerivingField dataDecl fieldTy
+      | fieldCoveredByDerivedConstraints dataDecl fieldTy = pure ()
+      | otherwise =
+          case resolveInstanceInfoWithSubst (scopeToElaborateScope scope) "Eq" fieldTy of
+            Right _ -> pure ()
+            Left _ -> throwError (ProgramDerivingMissingFieldInstance "Eq" fieldTy)
+
+    fieldCoveredByDerivedConstraints dataDecl fieldTy =
+      case fieldTy of
+        STVar name -> name `elem` P.dataDeclParams dataDecl
+        STBase name -> name == P.dataDeclName dataDecl
+        STCon name _ -> name == P.dataDeclName dataDecl
+        _ -> False
+
+    scopeToElaborateScope scope0 =
+      mkElaborateScope (scopeValues scope0) (scopeTypes scope0) (scopeClasses scope0) (scopeInstances scope0)
 
     mkEqInstance dataDecl =
       let actualHead = case P.dataDeclParams dataDecl of
@@ -481,18 +796,35 @@ synthesizeDerivedInstances scope mod0 = concat <$> mapM deriveForData (moduleDat
             _ -> actualHead
           left = P.Param "left" (Just headTy)
           right = P.Param "right" (Just headTy)
-          body = deriveEqBody dataDecl
+          selfName = "__derived_eq_" ++ P.dataDeclName dataDecl
+          methodBody =
+            if hasRecursiveOwnerFields dataDecl
+              then
+                P.ELet
+                  selfName
+                  (Just (STArrow headTy (STArrow headTy (STBase "Bool"))))
+                  (P.ELam left (P.ELam right (deriveEqBody headTy dataDecl (Just selfName))))
+                  (P.EVar selfName)
+              else
+                P.ELam left (P.ELam right (deriveEqBody headTy dataDecl Nothing))
        in P.InstanceDecl
             { P.instanceDeclClass = "Eq",
+              P.instanceDeclConstraints =
+                [ P.ClassConstraint "Eq" (STVar paramName)
+                  | paramName <- P.dataDeclParams dataDecl
+                ],
               P.instanceDeclType = headTy,
-              P.instanceDeclMethods = [P.MethodDef "eq" (P.ELam left (P.ELam right body))]
+              P.instanceDeclMethods = [P.MethodDef "eq" methodBody]
             }
 
-    deriveEqBody dataDecl =
+    hasRecursiveOwnerFields dataDecl =
+      any (isRecursiveOwnerField dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
+
+    deriveEqBody headTy dataDecl mbSelfName =
       P.ECase
         (P.EVar "left")
         [ P.Alt
-            (P.PatCtor (P.constructorDeclName ctor) leftNames)
+            (P.PatCtor (P.constructorDeclName ctor) (map P.PatVar leftNames))
             (P.ECase (P.EVar "right") (matchingAlt ctor leftNames : mismatchAlts ctor))
           | ctor <- P.dataDeclConstructors dataDecl,
             let leftNames = ["l" ++ show i | i <- [1 .. length (ctorArgTypes ctor)]]
@@ -500,29 +832,51 @@ synthesizeDerivedInstances scope mod0 = concat <$> mapM deriveForData (moduleDat
       where
         ctorArgTypes ctor = fst (splitArrows (snd (splitForalls (P.constructorDeclType ctor))))
 
+        recursiveEqName = qualify (P.moduleName mod0) (renderInstanceName "Eq" headTy "eq")
+
         matchingAlt ctor leftNames =
           let rightNames = ["r" ++ show i | i <- [1 .. length leftNames]]
-           in P.Alt (P.PatCtor (P.constructorDeclName ctor) rightNames) (foldEqCalls leftNames rightNames)
+              argTypes = ctorArgTypes ctor
+           in P.Alt (P.PatCtor (P.constructorDeclName ctor) (map P.PatVar rightNames)) (foldEqCalls (zip3 argTypes leftNames rightNames))
 
         mismatchAlts ctor =
-          [ P.Alt (P.PatCtor (P.constructorDeclName other) ["_" | _ <- fst (splitArrows (snd (splitForalls (P.constructorDeclType other))))]) (P.ELit (LBool False))
+          [ P.Alt (P.PatCtor (P.constructorDeclName other) [P.PatWildcard | _ <- fst (splitArrows (snd (splitForalls (P.constructorDeclType other))))]) (P.ELit (LBool False))
             | other <- P.dataDeclConstructors dataDecl,
               P.constructorDeclName other /= P.constructorDeclName ctor
           ]
 
-        foldEqCalls [] [] = P.ELit (LBool True)
-        foldEqCalls [l] [r] = P.EApp (P.EApp (P.EVar "eq") (P.EVar l)) (P.EVar r)
-        foldEqCalls (l : _) (r : _) =
-          -- The initial deriving target is nullary recursive ADTs like Nat,
-          -- so multiple-field conjunction is intentionally deferred.
-          P.EApp (P.EApp (P.EVar "eq") (P.EVar l)) (P.EVar r)
-        foldEqCalls _ _ = P.ELit (LBool False)
+        foldEqCalls [] = P.ELit (LBool True)
+        foldEqCalls [(argTy, l, r)] = eqCall argTy l r
+        foldEqCalls ((argTy, l, r) : rest) =
+          P.EApp
+            (P.EApp (P.EVar "__mlfp_and") (eqCall argTy l r))
+            (foldEqCalls rest)
+
+        eqCall argTy l r =
+          let eqName =
+                case mbSelfName of
+                  Just selfName | isRecursiveOwnerField dataDecl argTy -> selfName
+                  _ ->
+                    if isRecursiveOwnerField dataDecl argTy
+                      then recursiveEqName
+                      else "eq"
+           in P.EApp (P.EApp (P.EVar eqName) (P.EVar l)) (P.EVar r)
+
+    isRecursiveOwnerField dataDecl argTy =
+      case argTy of
+        STBase name -> name == P.dataDeclName dataDecl
+        STCon name _ -> name == P.dataDeclName dataDecl
+        _ -> False
 
 buildInstanceSkeletons :: Scope -> P.Module -> [P.InstanceDecl] -> TcM [InstanceInfo]
 buildInstanceSkeletons scope mod0 derived = do
   let instances0 = derived ++ explicitInstances mod0
   infos <- mapM toInstanceInfo instances0
   ensureDistinctPlain (\(className0, ty) -> ProgramDuplicateInstance className0 ty) [(instanceClassName info, instanceHeadType info) | info <- infos]
+  case overlappingInstances infos of
+    (left, right) : _ ->
+      throwError (ProgramOverlappingInstance (instanceClassName left) (instanceHeadType left) (instanceHeadType right))
+    [] -> pure ()
   pure infos
   where
     toInstanceInfo instDecl = do
@@ -538,22 +892,74 @@ buildInstanceSkeletons scope mod0 derived = do
         [] -> pure ()
       let instanceMethodInfos =
             Map.fromList
-              [ ( P.methodDefName methodDef,
-                  OrdinaryValue
-                    { valueDisplayName = P.methodDefName methodDef,
-                      valueRuntimeName = qualify (P.moduleName mod0) (renderInstanceName (P.instanceDeclClass instDecl) (P.instanceDeclType instDecl) (P.methodDefName methodDef)),
-                      valueType = specializeMethodType (methodType (methodMap Map.! P.methodDefName methodDef)) (classParamName classInfo) (P.instanceDeclType instDecl),
-                      valueOriginModule = P.moduleName mod0
-                    }
-                )
+              [ let methodInfo = methodMap Map.! P.methodDefName methodDef
+                    rawMethodType = specializeMethodType (methodType methodInfo) (classParamName classInfo) (P.instanceDeclType instDecl)
+                    methodValueConstraints =
+                      P.instanceDeclConstraints instDecl
+                        ++ map
+                          (substituteConstraint (classParamName classInfo) (P.instanceDeclType instDecl))
+                          (methodConstraints methodInfo)
+                 in ( P.methodDefName methodDef,
+                      OrdinaryValue
+                        { valueDisplayName = P.methodDefName methodDef,
+                          valueRuntimeName = qualify (P.moduleName mod0) (renderInstanceName (P.instanceDeclClass instDecl) (P.instanceDeclType instDecl) (P.methodDefName methodDef)),
+                          valueType = constrainedVisibleType (P.ConstrainedType methodValueConstraints rawMethodType),
+                          valueConstraints = methodValueConstraints,
+                          valueOriginModule = P.moduleName mod0
+                        }
+                    )
                 | methodDef <- P.instanceDeclMethods instDecl
               ]
       pure
         InstanceInfo
           { instanceClassName = P.instanceDeclClass instDecl,
+            instanceConstraints = P.instanceDeclConstraints instDecl,
             instanceHeadType = P.instanceDeclType instDecl,
             instanceMethods = instanceMethodInfos
           }
+
+    overlappingInstances infos =
+      [ (left, right)
+        | (ix, left) <- zip [(0 :: Int) ..] infos,
+          right <- drop (ix + 1) infos,
+          instanceClassName left == instanceClassName right,
+          instanceHeadType left /= instanceHeadType right,
+          instanceHeadsOverlap (instanceHeadType left) (instanceHeadType right)
+      ]
+
+    instanceHeadsOverlap left right =
+      case unifyOverlap Map.empty left right of
+        Just _ -> True
+        Nothing -> False
+
+    unifyOverlap subst left right =
+      case (left, right) of
+        (STVar name, ty) -> bindOverlap name ty subst
+        (ty, STVar name) -> bindOverlap name ty subst
+        (STBase leftName, STBase rightName)
+          | leftName == rightName -> Just subst
+        (STCon leftName leftArgs, STCon rightName rightArgs)
+          | leftName == rightName && NE.length leftArgs == NE.length rightArgs ->
+              foldM
+                (\acc (leftTy, rightTy) -> unifyOverlap acc leftTy rightTy)
+                subst
+                (zip (NE.toList leftArgs) (NE.toList rightArgs))
+        (STArrow leftDom leftCod, STArrow rightDom rightCod) -> do
+          subst' <- unifyOverlap subst leftDom rightDom
+          unifyOverlap subst' leftCod rightCod
+        _ -> Nothing
+
+    bindOverlap name ty subst =
+      case Map.lookup name subst of
+        Nothing -> Just (Map.insert name ty subst)
+        Just existing
+          | existing == ty -> Just subst
+          | otherwise -> Nothing
+
+    substituteConstraint paramName headTy constraint =
+      constraint
+        { P.constraintType = substituteTypeVar paramName headTy (P.constraintType constraint)
+        }
 
 renderInstanceName :: P.ClassName -> SrcType -> P.MethodName -> String
 renderInstanceName className0 headTy methodName0 = className0 ++ "__" ++ sanitizeType headTy ++ "__" ++ methodName0
@@ -586,7 +992,7 @@ checkInstance elaborateScope scope instDecl = do
         let methodRuntimeName = valueRuntimeName valueInfo
             methodSourceType = valueType valueInfo
         liftEither
-          ( lowerExprBinding elaborateScope methodRuntimeName methodSourceType False (P.methodDefExpr methodDef)
+          ( lowerConstrainedExprBinding elaborateScope methodRuntimeName (valueConstraints valueInfo) methodSourceType False (P.methodDefExpr methodDef)
               >>= finalizeBinding elaborateScope
           )
       _ -> throwError (ProgramUnexpectedInstanceMethod (P.instanceDeclClass instDecl) (P.methodDefName methodDef))
@@ -602,7 +1008,7 @@ checkDef elaborateScope scope defDecl = do
   case valueInfo of
     ordinary@OrdinaryValue {} -> do
       liftEither
-        ( lowerExprBinding elaborateScope (valueRuntimeName ordinary) (valueType ordinary) (P.defDeclName defDecl == "main") (P.defDeclExpr defDecl)
+        ( lowerConstrainedExprBinding elaborateScope (valueRuntimeName ordinary) (valueConstraints ordinary) (valueType ordinary) (P.defDeclName defDecl == "main") (P.defDeclExpr defDecl)
             >>= finalizeBinding elaborateScope
         )
     _ -> throwError (ProgramDuplicateValue (P.defDeclName defDecl))
@@ -686,6 +1092,10 @@ qualify moduleName0 name = moduleName0 ++ "__" ++ name
 
 ensureDistinctBy :: (Eq a) => (a -> ProgramError) -> (b -> a) -> [b] -> TcM ()
 ensureDistinctBy mkErr project values = ensureDistinctPlain mkErr (map project values)
+
+ensureDistinctImportAliases :: [P.Import] -> TcM ()
+ensureDistinctImportAliases imports0 =
+  ensureDistinctPlain ProgramDuplicateImportAlias [alias | Just alias <- map P.importAlias imports0]
 
 ensureDistinctPlain :: (Eq a) => (a -> ProgramError) -> [a] -> TcM ()
 ensureDistinctPlain mkErr values =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -480,19 +480,42 @@ qualifiedInstancesForImport priorExports priorInstances imp =
                 [ instanceInfo
                   | instanceInfo <- priorInstances,
                     instanceBelongsToModule (P.importModuleName imp) instanceInfo,
-                    instanceClassName instanceInfo `Map.member` exportedClasses exports
+                    instanceVisibleForQualifiedImport exports instanceInfo
                 ]
-              qualifiedInstances =
-                [ qualifyInstance alias exports instanceInfo
-                  | instanceInfo <- importedInstances
-                ]
-              headOnlyInstances =
-                [ headOnly
-                  | instanceInfo <- importedInstances,
-                    let headOnly = qualifyInstanceHeadOnly alias exports instanceInfo,
-                    not (sameInstanceHead instanceInfo headOnly)
-                ]
-           in qualifiedInstances ++ headOnlyInstances
+           in concatMap (qualifiedInstanceVariants alias exports) importedInstances
+
+instanceVisibleForQualifiedImport :: ModuleExports -> InstanceInfo -> Bool
+instanceVisibleForQualifiedImport exports instanceInfo =
+  instanceClassName instanceInfo `Map.member` exportedClasses exports
+    || srcTypeMentionsAny (Map.keysSet (exportedTypes exports)) (instanceHeadType instanceInfo)
+
+srcTypeMentionsAny :: Set.Set String -> SrcType -> Bool
+srcTypeMentionsAny names ty =
+  case ty of
+    STVar {} -> False
+    STBase name -> name `Set.member` names
+    STCon name args -> name `Set.member` names || any (srcTypeMentionsAny names) args
+    STArrow dom cod -> srcTypeMentionsAny names dom || srcTypeMentionsAny names cod
+    STForall _ mb body ->
+      maybe False (srcTypeMentionsAny names . unSrcBound) mb
+        || srcTypeMentionsAny names body
+    STMu _ body -> srcTypeMentionsAny names body
+    STBottom -> False
+
+qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> InstanceInfo -> [InstanceInfo]
+qualifiedInstanceVariants alias exports instanceInfo =
+  distinctInstanceHeads
+    [ variant
+      | variant <- [qualifyInstance alias exports instanceInfo, qualifyInstanceHeadOnly alias exports instanceInfo],
+        not (sameInstanceHead instanceInfo variant)
+    ]
+
+distinctInstanceHeads :: [InstanceInfo] -> [InstanceInfo]
+distinctInstanceHeads = reverse . foldl' add []
+  where
+    add acc instanceInfo
+      | any (sameInstanceHead instanceInfo) acc = acc
+      | otherwise = instanceInfo : acc
 
 sameInstanceHead :: InstanceInfo -> InstanceInfo -> Bool
 sameInstanceHead left right =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -1131,9 +1131,33 @@ buildInstanceSkeletons scope mod0 derived = do
       ]
 
     instanceHeadsOverlap left right =
-      case unifyOverlap Map.empty (tagTypeVars "__overlap_left__" left) (tagTypeVars "__overlap_right__" right) of
+      case
+        unifyOverlap
+          Map.empty
+          (tagTypeVars "__overlap_left__" (canonicalInstanceHead left))
+          (tagTypeVars "__overlap_right__" (canonicalInstanceHead right))
+        of
         Just _ -> True
         Nothing -> False
+
+    canonicalInstanceHead :: SrcType -> SrcType
+    canonicalInstanceHead = canonical
+      where
+        canonical ty =
+          case ty of
+            STVar {} -> ty
+            STArrow dom cod -> STArrow (canonical dom) (canonical cod)
+            STBase name -> STBase (canonicalTypeName name)
+            STCon name args -> STCon (canonicalTypeName name) (fmap canonical args)
+            STForall name mb body ->
+              STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)
+            STMu name body -> STMu name (canonical body)
+            STBottom -> STBottom
+
+        canonicalTypeName name =
+          case Map.lookup name (scopeTypes scope) of
+            Just info -> dataModule info ++ "." ++ dataName info
+            Nothing -> name
 
     unifyOverlap subst left right =
       case (applyOverlapSubst subst left, applyOverlapSubst subst right) of

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -370,34 +370,35 @@ qualifyModuleExports alias exports =
             ctor <- Map.elems ctors
         ]
 
-    qualifiedOrdinaryValues =
+    qualifiedExportedValues =
       Map.fromList
         [ ( qualifiedName name,
             qualifyValueInfo name valueInfo
           )
-          | (name, valueInfo) <- Map.toList (exportedValues exports),
-            not (isConstructorValue valueInfo)
+          | (name, valueInfo) <- Map.toList (exportedValues exports)
         ]
 
-    qualifiedValues = qualifiedCtorValues `Map.union` qualifiedOrdinaryValues
-
-    isConstructorValue ConstructorValue {} = True
-    isConstructorValue _ = False
+    qualifiedValues = qualifiedCtorValues `Map.union` qualifiedExportedValues
 
     qualifyDataInfo dataInfo =
-      let qualifiedTypeName = qualifiedName (dataName dataInfo)
-          qualifyCtor ctor =
-            ctor
-              { ctorName = qualifiedName (ctorName ctor),
-                ctorType = qualifySrcType (ctorType ctor),
-                ctorArgs = map qualifySrcType (ctorArgs ctor),
-                ctorResult = qualifySrcType (ctorResult ctor),
-                ctorOwningType = qualifiedTypeName
-              }
+      let qualifyCtor ctor = qualifyConstructorInfo ctor
        in dataInfo
             { dataName = dataName dataInfo,
               dataConstructors = map qualifyCtor (dataConstructors dataInfo)
             }
+
+    qualifyConstructorInfo ctor =
+      ctor
+        { ctorName = qualifiedName (ctorName ctor),
+          ctorType = qualifySrcType (ctorType ctor),
+          ctorArgs = map qualifySrcType (ctorArgs ctor),
+          ctorResult = qualifySrcType (ctorResult ctor),
+          ctorOwningType = qualifyExportedTypeName (ctorOwningType ctor)
+        }
+
+    qualifyExportedTypeName typeName
+      | typeName `Set.member` exportedTypeNames = qualifiedName typeName
+      | otherwise = typeName
 
     qualifyClassInfo classInfo =
       let qualifiedClassName = qualifiedName (className classInfo)
@@ -426,7 +427,15 @@ qualifyModuleExports alias exports =
               valueMethodInfo = qualifyMethodFromExport methodInfo,
               valueOriginModule = valueOriginModule valueInfo
             }
-        ConstructorValue {} -> valueInfo
+        ConstructorValue {valueCtorInfo = ctorInfo} ->
+          let qualifiedCtorInfo = qualifyConstructorInfo ctorInfo
+           in ConstructorValue
+                { valueDisplayName = qualifiedName sourceName,
+                  valueRuntimeName = valueRuntimeName valueInfo,
+                  valueType = qualifySrcType (valueType valueInfo),
+                  valueCtorInfo = qualifiedCtorInfo,
+                  valueOriginModule = valueOriginModule valueInfo
+                }
 
     qualifyMethodFromExport methodInfo =
       methodInfo

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -519,13 +519,23 @@ qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> Set.Set String -> 
 qualifiedInstanceVariants alias exports unqualifiedTypeNames instanceInfo =
   distinctInstanceHeads
     [ variant
-      | variant <-
-          qualifyInstance alias exports instanceInfo
-            : [ qualifyInstanceHeadOnly alias exports instanceInfo
-                | needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo
-              ],
+      | variant <- fullQualifiedVariants ++ aliasHeadVariants,
         not (sameInstanceHead instanceInfo variant)
     ]
+  where
+    qualifiedInstance = qualifyInstance alias exports instanceInfo
+    aliasHeadNeeded = needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo
+    fullQualifiedVariants =
+      [ qualifiedInstance
+        | shouldEmitQualifiedInstanceVariant
+      ]
+    aliasHeadVariants =
+      [ qualifyInstanceHeadOnly alias exports instanceInfo
+        | aliasHeadNeeded
+      ]
+    shouldEmitQualifiedInstanceVariant =
+      instanceClassName qualifiedInstance /= instanceClassName instanceInfo
+        || aliasHeadNeeded
 
 needsAliasHeadInstanceVariant :: ModuleExports -> Set.Set String -> InstanceInfo -> Bool
 needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -224,6 +224,7 @@ checkModule priorModules mod0 = do
   typeScope <- liftEither =<< pure (addTypes (scopeTypes importScope) localData)
   classScope <- liftEither =<< pure (addClasses (scopeClasses importScope) localClasses)
   let scope0 = Scope valueScope typeScope classScope (scopeInstances importScope ++ priorInstances ++ qualifiedPriorInstances)
+  validateLocalClassMethodConstraints scope0 mod0
   derivedInstances <- synthesizeDerivedInstances scope0 mod0
   instanceSkeletons <- buildInstanceSkeletons scope0 mod0 derivedInstances
   let scope1 = scope0 {scopeInstances = scopeInstances scope0 ++ instanceSkeletons}
@@ -805,6 +806,24 @@ buildLocalClassInfo mod0 = do
             }
         )
 
+validateLocalClassMethodConstraints :: Scope -> P.Module -> TcM ()
+validateLocalClassMethodConstraints scope mod0 =
+  mapM_ validateClassDecl (moduleClassDecls mod0)
+  where
+    validateClassDecl classDecl =
+      mapM_ validateMethodConstraints (P.classDeclMethods classDecl)
+
+    validateMethodConstraints =
+      validateClassConstraintClasses scope
+        . P.constrainedConstraints
+        . P.methodSigType
+
+validateClassConstraintClasses :: Scope -> [P.ClassConstraint] -> TcM ()
+validateClassConstraintClasses scope =
+  mapM_ $ \constraint -> do
+    _ <- lookupClassInfo scope (P.constraintClassName constraint)
+    pure ()
+
 buildLocalDefInfo :: P.Module -> TcM (Map String ValueInfo)
 buildLocalDefInfo mod0 = do
   let defs = moduleDefDecls mod0
@@ -1046,6 +1065,7 @@ buildInstanceSkeletons scope mod0 derived = do
   where
     toInstanceInfo instDecl = do
       classInfo <- lookupClassInfo scope (P.instanceDeclClass instDecl)
+      validateClassConstraintClasses scope (P.instanceDeclConstraints instDecl)
       let methodMap = classMethods classInfo
           expected = Map.keysSet methodMap
           provided = Set.fromList (map P.methodDefName (P.instanceDeclMethods instDecl))

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -476,16 +476,28 @@ qualifiedInstancesForImport priorExports priorInstances imp =
       case Map.lookup (P.importModuleName imp) priorExports of
         Nothing -> []
         Just exports ->
-          [ qualifyInstance alias exports instanceInfo
-            | instanceInfo <- priorInstances,
-              instanceBelongsToModule (P.importModuleName imp) instanceInfo,
-              instanceClassName instanceInfo `Map.member` exportedClasses exports
-          ]
-            ++ [ qualifyInstanceHeadOnly alias exports instanceInfo
-                 | instanceInfo <- priorInstances,
-                   instanceBelongsToModule (P.importModuleName imp) instanceInfo,
-                   instanceClassName instanceInfo `Map.member` exportedClasses exports
-               ]
+          let importedInstances =
+                [ instanceInfo
+                  | instanceInfo <- priorInstances,
+                    instanceBelongsToModule (P.importModuleName imp) instanceInfo,
+                    instanceClassName instanceInfo `Map.member` exportedClasses exports
+                ]
+              qualifiedInstances =
+                [ qualifyInstance alias exports instanceInfo
+                  | instanceInfo <- importedInstances
+                ]
+              headOnlyInstances =
+                [ headOnly
+                  | instanceInfo <- importedInstances,
+                    let headOnly = qualifyInstanceHeadOnly alias exports instanceInfo,
+                    not (sameInstanceHead instanceInfo headOnly)
+                ]
+           in qualifiedInstances ++ headOnlyInstances
+
+sameInstanceHead :: InstanceInfo -> InstanceInfo -> Bool
+sameInstanceHead left right =
+  instanceClassName left == instanceClassName right
+    && instanceHeadType left == instanceHeadType right
 
 instanceBelongsToModule :: P.ModuleName -> InstanceInfo -> Bool
 instanceBelongsToModule moduleName0 instanceInfo =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -492,7 +492,7 @@ methodClassIdentity :: ValueInfo -> Maybe ClassIdentity
 methodClassIdentity valueInfo =
   case valueInfo of
     OverloadedMethod {valueMethodInfo = methodInfo} ->
-      Just (valueOriginModule valueInfo, unqualifiedName (methodClassName methodInfo))
+      Just (methodClassModule methodInfo, unqualifiedName (methodClassName methodInfo))
     _ -> Nothing
 
 instanceClassIdentity :: InstanceInfo -> ClassIdentity
@@ -653,7 +653,7 @@ qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassIde
   distinctInstanceHeads
     [ variant
       | variant <- fullQualifiedVariants ++ aliasHeadVariants,
-        not (sameInstanceHead instanceInfo variant)
+        not (sameInstanceSurfaceHead instanceInfo variant)
     ]
   where
     qualifiedInstance = qualifyInstance alias exports instanceInfo
@@ -690,6 +690,11 @@ distinctInstanceHeads = reverse . foldl' add []
 
 sameInstanceHead :: InstanceInfo -> InstanceInfo -> Bool
 sameInstanceHead left right =
+  instanceClassIdentity left == instanceClassIdentity right
+    && instanceHeadType left == instanceHeadType right
+
+sameInstanceSurfaceHead :: InstanceInfo -> InstanceInfo -> Bool
+sameInstanceSurfaceHead left right =
   instanceClassName left == instanceClassName right
     && instanceHeadType left == instanceHeadType right
 
@@ -927,6 +932,7 @@ buildLocalClassInfo mod0 = do
               [ ( P.methodSigName sig,
                   MethodInfo
                     { methodClassName = P.classDeclName classDecl,
+                      methodClassModule = P.moduleName mod0,
                       methodName = P.methodSigName sig,
                       methodRuntimeBase = qualify (P.moduleName mod0) (P.classDeclName classDecl ++ "__" ++ P.methodSigName sig),
                       methodType = P.constrainedBody (P.methodSigType sig),

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -76,6 +76,8 @@ data Scope = Scope
   }
   deriving (Eq, Show)
 
+type ClassIdentity = (P.ModuleName, P.ClassName)
+
 emptyScope :: Scope
 emptyScope = Scope builtinValues Map.empty Map.empty []
 
@@ -206,10 +208,10 @@ checkModule :: [CheckedModule] -> P.Module -> TcM CheckedModule
 checkModule priorModules mod0 = do
   let priorExports = Map.fromList [(checkedModuleName checked, checkedModuleExports checked) | checked <- priorModules]
       priorInstances = concatMap checkedModuleInstances priorModules
-      unqualifiedClassNames = importedUnqualifiedClassNames priorExports (P.moduleImports mod0)
+      unqualifiedClassIdentities = importedUnqualifiedClassIdentities priorExports (P.moduleImports mod0)
       qualifiedPriorInstances =
         concatMap
-          (qualifiedInstancesForImport priorExports priorInstances unqualifiedClassNames)
+          (qualifiedInstancesForImport priorExports priorInstances unqualifiedClassIdentities)
           (P.moduleImports mod0)
   ensureDistinctImportAliases (P.moduleImports mod0)
   importScope <- buildImportScope priorExports (P.moduleImports mod0)
@@ -479,8 +481,27 @@ unqualifyQualifiedName alias name =
       | prefix == alias ++ "." -> rest
     _ -> name
 
-qualifiedInstancesForImport :: Map P.ModuleName ModuleExports -> [InstanceInfo] -> Set.Set String -> P.Import -> [InstanceInfo]
-qualifiedInstancesForImport priorExports priorInstances unqualifiedClassNames imp =
+unqualifiedName :: String -> String
+unqualifiedName =
+  reverse . takeWhile (/= '.') . reverse
+
+classIdentity :: ClassInfo -> ClassIdentity
+classIdentity classInfo =
+  (classModule classInfo, unqualifiedName (className classInfo))
+
+methodClassIdentity :: ValueInfo -> Maybe ClassIdentity
+methodClassIdentity valueInfo =
+  case valueInfo of
+    OverloadedMethod {valueMethodInfo = methodInfo} ->
+      Just (valueOriginModule valueInfo, unqualifiedName (methodClassName methodInfo))
+    _ -> Nothing
+
+instanceClassIdentity :: InstanceInfo -> ClassIdentity
+instanceClassIdentity instanceInfo =
+  (instanceClassModule instanceInfo, unqualifiedName (instanceClassName instanceInfo))
+
+qualifiedInstancesForImport :: Map P.ModuleName ModuleExports -> [InstanceInfo] -> Set.Set ClassIdentity -> P.Import -> [InstanceInfo]
+qualifiedInstancesForImport priorExports priorInstances unqualifiedClassIdentities imp =
   case P.importAlias imp of
     Nothing -> []
     Just alias ->
@@ -494,45 +515,38 @@ qualifiedInstancesForImport priorExports priorInstances unqualifiedClassNames im
                     instanceVisibleForQualifiedImport exports instanceInfo
                 ]
               unqualifiedTypeNames = importExposedTypeNames imp
-           in concatMap (qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassNames) importedInstances
+           in concatMap (qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassIdentities) importedInstances
 
-importedUnqualifiedClassNames ::
+importedUnqualifiedClassIdentities ::
   Map P.ModuleName ModuleExports ->
   [P.Import] ->
-  Set.Set String
-importedUnqualifiedClassNames priorExports =
-  Set.unions . map importUnqualifiedClassNames
+  Set.Set ClassIdentity
+importedUnqualifiedClassIdentities priorExports =
+  Set.unions . map importUnqualifiedClassIdentities
   where
-    importUnqualifiedClassNames imp =
+    importUnqualifiedClassIdentities imp =
       case Map.lookup (P.importModuleName imp) priorExports of
         Nothing -> Set.empty
         Just exports ->
           case (P.importAlias imp, P.importExposing imp) of
             (Nothing, Nothing) ->
-              Map.keysSet (exportedClasses exports)
-                `Set.union` overloadedMethodClassNames (Map.elems (exportedValues exports))
-            (_, Just items) -> Set.unions (map (importItemClassNames exports) items)
+              Set.fromList (map classIdentity (Map.elems (exportedClasses exports)))
+                `Set.union` overloadedMethodClassIdentities (Map.elems (exportedValues exports))
+            (_, Just items) -> Set.unions (map (importItemClassIdentities exports) items)
             (Just _, Nothing) -> Set.empty
 
-    importItemClassNames exports item =
+    importItemClassIdentities exports item =
       case item of
         P.ExportType name
-          | name `Map.member` exportedClasses exports -> Set.singleton name
+          | Just classInfo <- Map.lookup name (exportedClasses exports) -> Set.singleton (classIdentity classInfo)
         P.ExportValue name ->
           case Map.lookup name (exportedValues exports) of
-            Just OverloadedMethod {valueMethodInfo = methodInfo} -> Set.singleton (methodClassName methodInfo)
+            Just valueInfo -> maybe Set.empty Set.singleton (methodClassIdentity valueInfo)
             _ -> Set.empty
         _ -> Set.empty
 
-    overloadedMethodClassNames =
-      Set.fromList
-        . map methodClassName
-        . mapMaybe overloadedMethodInfo
-
-    overloadedMethodInfo valueInfo =
-      case valueInfo of
-        OverloadedMethod {valueMethodInfo = methodInfo} -> Just methodInfo
-        _ -> Nothing
+    overloadedMethodClassIdentities =
+      Set.fromList . mapMaybe methodClassIdentity
 
 importExposedTypeNames :: P.Import -> Set.Set String
 importExposedTypeNames imp =
@@ -564,8 +578,8 @@ srcTypeMentionsAny names ty =
     STMu _ body -> srcTypeMentionsAny names body
     STBottom -> False
 
-qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> Set.Set String -> Set.Set String -> InstanceInfo -> [InstanceInfo]
-qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassNames instanceInfo =
+qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> Set.Set String -> Set.Set ClassIdentity -> InstanceInfo -> [InstanceInfo]
+qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassIdentities instanceInfo =
   distinctInstanceHeads
     [ variant
       | variant <- fullQualifiedVariants ++ aliasHeadVariants,
@@ -574,7 +588,7 @@ qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassNam
   where
     qualifiedInstance = qualifyInstance alias exports instanceInfo
     aliasHeadNeeded =
-      instanceClassName instanceInfo `Set.member` unqualifiedClassNames
+      instanceClassIdentity instanceInfo `Set.member` unqualifiedClassIdentities
         && needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo
     fullQualifiedVariants =
       [ qualifiedInstance
@@ -929,12 +943,12 @@ constructorRuntimeBindingRecoverable ctor =
 synthesizeDerivedInstances :: Scope -> P.Module -> TcM [P.InstanceDecl]
 synthesizeDerivedInstances scope mod0 = do
   candidates <- concat <$> mapM deriveForData (moduleDataDecls mod0)
-  let pendingInstances = map (pendingDerivedInstance . snd) candidates
+  let pendingInstances = map (\(_, classInfo, instDecl) -> pendingDerivedInstance classInfo instDecl) candidates
       validationScope = scope {scopeInstances = scopeInstances scope ++ pendingInstances}
   mapM_
-    (\(dataDecl, instDecl) -> validateEqDerivingFields (P.instanceDeclClass instDecl) validationScope dataDecl)
+    (\(dataDecl, _, instDecl) -> validateEqDerivingFields (P.instanceDeclClass instDecl) validationScope dataDecl)
     candidates
-  pure (map snd candidates)
+  pure [instDecl | (_, _, instDecl) <- candidates]
   where
     deriveForData dataDecl = do
       forM (P.dataDeclDeriving dataDecl) $ \className0 -> do
@@ -942,12 +956,9 @@ synthesizeDerivedInstances scope mod0 = do
           then do
             classInfo <- lookupClassInfo scope className0
             case eqMethodReference classInfo of
-              Just eqMethodName -> pure (dataDecl, mkEqInstance classInfo eqMethodName dataDecl)
+              Just eqMethodName -> pure (dataDecl, classInfo, mkEqInstance classInfo eqMethodName dataDecl)
               Nothing -> throwError (ProgramUnsupportedDeriving className0)
           else throwError (ProgramUnsupportedDeriving className0)
-
-    unqualifiedName =
-      reverse . takeWhile (/= '.') . reverse
 
     eqMethodReference classInfo =
       fst <$> find matchesEqMethod (Map.toList (scopeValues scope))
@@ -956,9 +967,10 @@ synthesizeDerivedInstances scope mod0 = do
           methodClassName methodInfo == className classInfo && methodName methodInfo == "eq"
         matchesEqMethod _ = False
 
-    pendingDerivedInstance instDecl =
+    pendingDerivedInstance classInfo instDecl =
       InstanceInfo
         { instanceClassName = P.instanceDeclClass instDecl,
+          instanceClassModule = classModule classInfo,
           instanceOriginModule = P.moduleName mod0,
           instanceConstraints = P.instanceDeclConstraints instDecl,
           instanceHeadType = P.instanceDeclType instDecl,
@@ -1167,6 +1179,7 @@ buildInstanceSkeletons scope mod0 derived = do
       pure
         InstanceInfo
           { instanceClassName = P.instanceDeclClass instDecl,
+            instanceClassModule = classModule classInfo,
             instanceOriginModule = P.moduleName mod0,
             instanceConstraints = P.instanceDeclConstraints instDecl,
             instanceHeadType = P.instanceDeclType instDecl,

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -890,16 +890,30 @@ synthesizeDerivedInstances scope mod0 = do
   candidates <- concat <$> mapM deriveForData (moduleDataDecls mod0)
   let pendingInstances = map (pendingDerivedInstance . snd) candidates
       validationScope = scope {scopeInstances = scopeInstances scope ++ pendingInstances}
-  mapM_ (validateEqDerivingFields validationScope . fst) candidates
+  mapM_
+    (\(dataDecl, instDecl) -> validateEqDerivingFields (P.instanceDeclClass instDecl) validationScope dataDecl)
+    candidates
   pure (map snd candidates)
   where
     deriveForData dataDecl = do
-      forM (P.dataDeclDeriving dataDecl) $ \className0 ->
-        case className0 of
-          "Eq" -> do
-            _ <- lookupClassInfo scope className0
-            pure (dataDecl, mkEqInstance dataDecl)
-          other -> throwError (ProgramUnsupportedDeriving other)
+      forM (P.dataDeclDeriving dataDecl) $ \className0 -> do
+        if unqualifiedName className0 == "Eq"
+          then do
+            classInfo <- lookupClassInfo scope className0
+            case eqMethodReference classInfo of
+              Just eqMethodName -> pure (dataDecl, mkEqInstance classInfo eqMethodName dataDecl)
+              Nothing -> throwError (ProgramUnsupportedDeriving className0)
+          else throwError (ProgramUnsupportedDeriving className0)
+
+    unqualifiedName =
+      reverse . takeWhile (/= '.') . reverse
+
+    eqMethodReference classInfo =
+      fst <$> find matchesEqMethod (Map.toList (scopeValues scope))
+      where
+        matchesEqMethod (_, OverloadedMethod {valueMethodInfo = methodInfo}) =
+          methodClassName methodInfo == className classInfo && methodName methodInfo == "eq"
+        matchesEqMethod _ = False
 
     pendingDerivedInstance instDecl =
       InstanceInfo
@@ -913,32 +927,32 @@ synthesizeDerivedInstances scope mod0 = do
     constructorFieldTypes ctor =
       fst (splitArrows (snd (splitForalls (P.constructorDeclType ctor))))
 
-    validateEqDerivingFields :: Scope -> P.DataDecl -> TcM ()
-    validateEqDerivingFields validationScope dataDecl =
-      mapM_ (validateEqDerivingField validationScope dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
+    validateEqDerivingFields :: P.ClassName -> Scope -> P.DataDecl -> TcM ()
+    validateEqDerivingFields eqClassName validationScope dataDecl =
+      mapM_ (validateEqDerivingField eqClassName validationScope dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
 
-    validateEqDerivingField :: Scope -> P.DataDecl -> SrcType -> TcM ()
-    validateEqDerivingField validationScope dataDecl fieldTy
-      | eqTypeSatisfiable validationScope dataDecl Set.empty fieldTy = pure ()
-      | otherwise = throwError (ProgramDerivingMissingFieldInstance "Eq" fieldTy)
+    validateEqDerivingField :: P.ClassName -> Scope -> P.DataDecl -> SrcType -> TcM ()
+    validateEqDerivingField eqClassName validationScope dataDecl fieldTy
+      | eqTypeSatisfiable eqClassName validationScope dataDecl Set.empty fieldTy = pure ()
+      | otherwise = throwError (ProgramDerivingMissingFieldInstance eqClassName fieldTy)
 
-    eqTypeSatisfiable validationScope dataDecl seen fieldTy
+    eqTypeSatisfiable eqClassName validationScope dataDecl seen fieldTy
       | fieldCoveredByDerivedConstraints dataDecl fieldTy = True
       | key `Set.member` seen = False
       | otherwise =
-          case resolveInstanceInfoWithSubst (scopeToElaborateScope validationScope) "Eq" fieldTy of
+          case resolveInstanceInfoWithSubst (scopeToElaborateScope validationScope) eqClassName fieldTy of
             Right (instanceInfo, subst) ->
               let seen' = Set.insert key seen
                in all
-                    (eqConstraintSatisfiable validationScope dataDecl seen' . applyConstraintSubst subst)
+                    (eqConstraintSatisfiable eqClassName validationScope dataDecl seen' . applyConstraintSubst subst)
                     (instanceConstraints instanceInfo)
             Left _ -> False
       where
-        key = ("Eq", show fieldTy)
+        key = (eqClassName, show fieldTy)
 
-    eqConstraintSatisfiable validationScope dataDecl seen constraint
-      | P.constraintClassName constraint == "Eq" =
-          eqTypeSatisfiable validationScope dataDecl seen (P.constraintType constraint)
+    eqConstraintSatisfiable eqClassName validationScope dataDecl seen constraint
+      | P.constraintClassName constraint == eqClassName =
+          eqTypeSatisfiable eqClassName validationScope dataDecl seen (P.constraintType constraint)
       | otherwise = False
 
     applyConstraintSubst subst constraint =
@@ -976,8 +990,9 @@ synthesizeDerivedInstances scope mod0 = do
     scopeToElaborateScope scope0 =
       mkElaborateScope (scopeValues scope0) (scopeTypes scope0) (scopeClasses scope0) (scopeInstances scope0)
 
-    mkEqInstance dataDecl =
+    mkEqInstance classInfo eqMethodName dataDecl =
       let headTy = dataDeclHeadType dataDecl
+          eqClassName = className classInfo
           left = P.Param "left" (Just headTy)
           right = P.Param "right" (Just headTy)
           selfName = "__derived_eq_" ++ P.dataDeclName dataDecl
@@ -987,14 +1002,14 @@ synthesizeDerivedInstances scope mod0 = do
                 P.ELet
                   selfName
                   (Just (STArrow headTy (STArrow headTy (STBase "Bool"))))
-                  (P.ELam left (P.ELam right (deriveEqBody headTy dataDecl (Just selfName))))
+                  (P.ELam left (P.ELam right (deriveEqBody eqClassName eqMethodName headTy dataDecl (Just selfName))))
                   (P.EVar selfName)
               else
-                P.ELam left (P.ELam right (deriveEqBody headTy dataDecl Nothing))
+                P.ELam left (P.ELam right (deriveEqBody eqClassName eqMethodName headTy dataDecl Nothing))
        in P.InstanceDecl
-            { P.instanceDeclClass = "Eq",
+            { P.instanceDeclClass = eqClassName,
               P.instanceDeclConstraints =
-                [ P.ClassConstraint "Eq" (STVar paramName)
+                [ P.ClassConstraint eqClassName (STVar paramName)
                   | paramName <- derivedConstraintParams dataDecl
                 ],
               P.instanceDeclType = headTy,
@@ -1004,7 +1019,7 @@ synthesizeDerivedInstances scope mod0 = do
     hasRecursiveOwnerFields dataDecl =
       any (isRecursiveOwnerField dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
 
-    deriveEqBody headTy dataDecl mbSelfName =
+    deriveEqBody eqClassName eqMethodName headTy dataDecl mbSelfName =
       P.ECase
         (P.EVar "left")
         [ P.Alt
@@ -1016,7 +1031,7 @@ synthesizeDerivedInstances scope mod0 = do
       where
         ctorArgTypes ctor = fst (splitArrows (snd (splitForalls (P.constructorDeclType ctor))))
 
-        recursiveEqName = qualify (P.moduleName mod0) (renderInstanceName "Eq" headTy "eq")
+        recursiveEqName = qualify (P.moduleName mod0) (renderInstanceName eqClassName headTy "eq")
 
         matchingAlt ctor leftNames =
           let rightNames = ["r" ++ show i | i <- [1 .. length leftNames]]
@@ -1043,7 +1058,7 @@ synthesizeDerivedInstances scope mod0 = do
                   _ ->
                     if isRecursiveOwnerField dataDecl argTy
                       then recursiveEqName
-                      else "eq"
+                      else eqMethodName
            in P.EApp (P.EApp (P.EVar eqName) (P.EVar l)) (P.EVar r)
 
     isRecursiveOwnerField dataDecl argTy =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -394,7 +394,7 @@ qualifyModuleExports alias exports =
                 ctorOwningType = qualifiedTypeName
               }
        in dataInfo
-            { dataName = qualifiedTypeName,
+            { dataName = dataName dataInfo,
               dataConstructors = map qualifyCtor (dataConstructors dataInfo)
             }
 

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -1099,19 +1099,21 @@ renderInstanceName className0 headTy methodName0 = className0 ++ "__" ++ sanitiz
 
 sanitizeType :: SrcType -> String
 sanitizeType = \case
-  STVar v -> map sanitizeChar v
+  STVar v -> sanitizeName v
   STArrow dom cod -> "arr_" ++ sanitizeType dom ++ "_" ++ sanitizeType cod
-  STBase base -> map sanitizeChar base
-  STCon con args -> intercalate "_" (map sanitizeChar con : map sanitizeType (NE.toList args))
-  STForall v _ body -> "forall_" ++ map sanitizeChar v ++ "_" ++ sanitizeType body
-  STMu v body -> "mu_" ++ map sanitizeChar v ++ "_" ++ sanitizeType body
+  STBase base -> sanitizeName base
+  STCon con args -> intercalate "_" (sanitizeName con : map sanitizeType (NE.toList args))
+  STForall v _ body -> "forall_" ++ sanitizeName v ++ "_" ++ sanitizeType body
+  STMu v body -> "mu_" ++ sanitizeName v ++ "_" ++ sanitizeType body
   STBottom -> "bottom"
   where
+    sanitizeName = concatMap sanitizeChar
+
     sanitizeChar c
-      | c `elem` ['a' .. 'z'] = c
-      | c `elem` ['A' .. 'Z'] = c
-      | c `elem` ['0' .. '9'] = c
-      | otherwise = '_'
+      | c `elem` ['a' .. 'z'] = [c]
+      | c `elem` ['A' .. 'Z'] = [c]
+      | c `elem` ['0' .. '9'] = [c]
+      | otherwise = "_u" ++ show (fromEnum c) ++ "_"
 
 checkInstance :: ElaborateScope -> Scope -> P.InstanceDecl -> TcM [CheckedBinding]
 checkInstance elaborateScope scope instDecl = do

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -398,12 +398,8 @@ qualifyModuleExports alias exports =
           ctorType = qualifySrcType (ctorType ctor),
           ctorArgs = map qualifySrcType (ctorArgs ctor),
           ctorResult = qualifySrcType (ctorResult ctor),
-          ctorOwningType = qualifyExportedTypeName (ctorOwningType ctor)
+          ctorOwningType = ctorOwningType ctor
         }
-
-    qualifyExportedTypeName typeName
-      | typeName `Set.member` exportedTypeNames = qualifiedName typeName
-      | otherwise = typeName
 
     qualifyClassInfo classInfo =
       let qualifiedClassName = qualifiedName (className classInfo)

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -207,12 +207,11 @@ topoSortModules modules0 = do
 checkModule :: [CheckedModule] -> P.Module -> TcM CheckedModule
 checkModule priorModules mod0 = do
   let priorExports = Map.fromList [(checkedModuleName checked, checkedModuleExports checked) | checked <- priorModules]
+      priorData = Map.fromList [(checkedModuleName checked, checkedModuleData checked) | checked <- priorModules]
       priorInstances = concatMap checkedModuleInstances priorModules
       unqualifiedClassIdentities = importedUnqualifiedClassIdentities priorExports (P.moduleImports mod0)
-      qualifiedPriorInstances =
-        concatMap
-          (qualifiedInstancesForImport priorExports priorInstances unqualifiedClassIdentities)
-          (P.moduleImports mod0)
+      visibleImportedInstances =
+        visibleInstancesForImports priorExports priorData priorInstances unqualifiedClassIdentities (P.moduleImports mod0)
   ensureDistinctImportAliases (P.moduleImports mod0)
   importScope <- buildImportScope priorExports (P.moduleImports mod0)
   localData <- buildLocalDataInfo mod0
@@ -230,7 +229,7 @@ checkModule priorModules mod0 = do
   valueScope <- liftEither =<< pure (addValues (scopeValues importScope) localValues)
   typeScope <- liftEither =<< pure (addTypes (scopeTypes importScope) localData)
   classScope <- liftEither =<< pure (addClasses (scopeClasses importScope) localClasses)
-  let scope0 = Scope valueScope typeScope classScope (scopeInstances importScope ++ priorInstances ++ qualifiedPriorInstances)
+  let scope0 = Scope valueScope typeScope classScope (scopeInstances importScope ++ visibleImportedInstances)
   validateLocalClassMethodConstraints scope0 mod0
   derivedInstances <- synthesizeDerivedInstances scope0 mod0
   instanceSkeletons <- buildInstanceSkeletons scope0 mod0 derivedInstances
@@ -500,8 +499,47 @@ instanceClassIdentity :: InstanceInfo -> ClassIdentity
 instanceClassIdentity instanceInfo =
   (instanceClassModule instanceInfo, unqualifiedName (instanceClassName instanceInfo))
 
-qualifiedInstancesForImport :: Map P.ModuleName ModuleExports -> [InstanceInfo] -> Set.Set ClassIdentity -> P.Import -> [InstanceInfo]
-qualifiedInstancesForImport priorExports priorInstances unqualifiedClassIdentities imp =
+visibleInstancesForImports ::
+  Map P.ModuleName ModuleExports ->
+  Map P.ModuleName (Map String DataInfo) ->
+  [InstanceInfo] ->
+  Set.Set ClassIdentity ->
+  [P.Import] ->
+  [InstanceInfo]
+visibleInstancesForImports priorExports priorData priorInstances unqualifiedClassIdentities =
+  distinctInstanceHeads . concatMap instancesForImport
+  where
+    instancesForImport imp =
+      unqualifiedInstancesForImport priorExports priorData priorInstances unqualifiedClassIdentities imp
+        ++ qualifiedInstancesForImport priorExports priorData priorInstances unqualifiedClassIdentities imp
+
+unqualifiedInstancesForImport ::
+  Map P.ModuleName ModuleExports ->
+  Map P.ModuleName (Map String DataInfo) ->
+  [InstanceInfo] ->
+  Set.Set ClassIdentity ->
+  P.Import ->
+  [InstanceInfo]
+unqualifiedInstancesForImport priorExports priorData priorInstances unqualifiedClassIdentities imp =
+  case Map.lookup (P.importModuleName imp) priorExports of
+    Nothing -> []
+    Just exports ->
+      let importClassIdentities = importUnqualifiedClassIdentitiesFor exports imp
+          unqualifiedTypeNames = importUnqualifiedTypeNames exports imp
+       in [ instanceInfo
+            | instanceInfo <- priorInstances,
+              instanceBelongsToModule (P.importModuleName imp) instanceInfo,
+              instanceVisibleForUnqualifiedImport priorData unqualifiedClassIdentities importClassIdentities unqualifiedTypeNames instanceInfo
+          ]
+
+qualifiedInstancesForImport ::
+  Map P.ModuleName ModuleExports ->
+  Map P.ModuleName (Map String DataInfo) ->
+  [InstanceInfo] ->
+  Set.Set ClassIdentity ->
+  P.Import ->
+  [InstanceInfo]
+qualifiedInstancesForImport priorExports priorData priorInstances unqualifiedClassIdentities imp =
   case P.importAlias imp of
     Nothing -> []
     Just alias ->
@@ -512,7 +550,7 @@ qualifiedInstancesForImport priorExports priorInstances unqualifiedClassIdentiti
                 [ instanceInfo
                   | instanceInfo <- priorInstances,
                     instanceBelongsToModule (P.importModuleName imp) instanceInfo,
-                    instanceVisibleForQualifiedImport exports instanceInfo
+                    instanceVisibleForQualifiedImport priorData exports instanceInfo
                 ]
               unqualifiedTypeNames = importExposedTypeNames imp
            in concatMap (qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassIdentities) importedInstances
@@ -527,15 +565,18 @@ importedUnqualifiedClassIdentities priorExports =
     importUnqualifiedClassIdentities imp =
       case Map.lookup (P.importModuleName imp) priorExports of
         Nothing -> Set.empty
-        Just exports ->
-          case (P.importAlias imp, P.importExposing imp) of
-            (Nothing, Nothing) ->
-              Set.fromList (map classIdentity (Map.elems (exportedClasses exports)))
-                `Set.union` overloadedMethodClassIdentities (Map.elems (exportedValues exports))
-            (_, Just items) -> Set.unions (map (importItemClassIdentities exports) items)
-            (Just _, Nothing) -> Set.empty
+        Just exports -> importUnqualifiedClassIdentitiesFor exports imp
 
-    importItemClassIdentities exports item =
+importUnqualifiedClassIdentitiesFor :: ModuleExports -> P.Import -> Set.Set ClassIdentity
+importUnqualifiedClassIdentitiesFor exports imp =
+  case (P.importAlias imp, P.importExposing imp) of
+    (Nothing, Nothing) ->
+      Set.fromList (map classIdentity (Map.elems (exportedClasses exports)))
+        `Set.union` overloadedMethodClassIdentities (Map.elems (exportedValues exports))
+    (_, Just items) -> Set.unions (map importItemClassIdentities items)
+    (Just _, Nothing) -> Set.empty
+  where
+    importItemClassIdentities item =
       case item of
         P.ExportType name
           | Just classInfo <- Map.lookup name (exportedClasses exports) -> Set.singleton (classIdentity classInfo)
@@ -547,6 +588,13 @@ importedUnqualifiedClassIdentities priorExports =
 
     overloadedMethodClassIdentities =
       Set.fromList . mapMaybe methodClassIdentity
+
+importUnqualifiedTypeNames :: ModuleExports -> P.Import -> Set.Set String
+importUnqualifiedTypeNames exports imp =
+  case (P.importAlias imp, P.importExposing imp) of
+    (Nothing, Nothing) -> Map.keysSet (exportedTypes exports)
+    (_, Just _) -> importExposedTypeNames imp
+    (Just _, Nothing) -> Set.empty
 
 importExposedTypeNames :: P.Import -> Set.Set String
 importExposedTypeNames imp =
@@ -560,10 +608,32 @@ importExposedTypeNames imp =
         P.ExportTypeWithConstructors name -> [name]
         P.ExportValue {} -> []
 
-instanceVisibleForQualifiedImport :: ModuleExports -> InstanceInfo -> Bool
-instanceVisibleForQualifiedImport exports instanceInfo =
-  instanceClassName instanceInfo `Map.member` exportedClasses exports
-    || srcTypeMentionsAny (Map.keysSet (exportedTypes exports)) (instanceHeadType instanceInfo)
+instanceVisibleForUnqualifiedImport ::
+  Map P.ModuleName (Map String DataInfo) ->
+  Set.Set ClassIdentity ->
+  Set.Set ClassIdentity ->
+  Set.Set String ->
+  InstanceInfo ->
+  Bool
+instanceVisibleForUnqualifiedImport priorData unqualifiedClassIdentities importClassIdentities unqualifiedTypeNames instanceInfo =
+  (classVisibleGlobally && originDataVisible && not (Set.null originDataMentions))
+    || (classVisibleThroughImport && Set.null originDataMentions)
+  where
+    identity = instanceClassIdentity instanceInfo
+    classVisibleGlobally = identity `Set.member` unqualifiedClassIdentities
+    classVisibleThroughImport = identity `Set.member` importClassIdentities
+    originDataMentions = instanceOriginDataMentions priorData instanceInfo
+    originDataVisible = originDataMentions `Set.isSubsetOf` unqualifiedTypeNames
+
+instanceVisibleForQualifiedImport :: Map P.ModuleName (Map String DataInfo) -> ModuleExports -> InstanceInfo -> Bool
+instanceVisibleForQualifiedImport priorData exports instanceInfo =
+  originDataVisible
+    && ( instanceClassName instanceInfo `Map.member` exportedClasses exports
+           || srcTypeMentionsAny exportedTypeNames (instanceHeadType instanceInfo)
+       )
+  where
+    exportedTypeNames = Map.keysSet (exportedTypes exports)
+    originDataVisible = instanceOriginDataMentions priorData instanceInfo `Set.isSubsetOf` exportedTypeNames
 
 srcTypeMentionsAny :: Set.Set String -> SrcType -> Bool
 srcTypeMentionsAny names ty =
@@ -637,6 +707,12 @@ instanceExportedTypeMentions exportedTypeNames instanceInfo =
           srcTypeMentionedNames exportedTypeNames (valueType valueInfo)
             : map (srcTypeMentionedNames exportedTypeNames . P.constraintType) (valueConstraints valueInfo)
         _ -> []
+
+instanceOriginDataMentions :: Map P.ModuleName (Map String DataInfo) -> InstanceInfo -> Set.Set String
+instanceOriginDataMentions priorData instanceInfo =
+  case Map.lookup (instanceOriginModule instanceInfo) priorData of
+    Nothing -> Set.empty
+    Just dataInfos -> instanceExportedTypeMentions (Map.keysSet dataInfos) instanceInfo
 
 srcTypeMentionedNames :: Set.Set String -> SrcType -> Set.Set String
 srcTypeMentionedNames names ty =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -1212,7 +1212,9 @@ buildInstanceSkeletons :: Scope -> P.Module -> [P.InstanceDecl] -> TcM [Instance
 buildInstanceSkeletons scope mod0 derived = do
   let instances0 = derived ++ explicitInstances mod0
   infos <- mapM toInstanceInfo instances0
-  ensureDistinctPlain (\(className0, ty) -> ProgramDuplicateInstance className0 ty) [(instanceClassName info, instanceHeadType info) | info <- infos]
+  case duplicateLocalInstances infos of
+    info : _ -> throwError (ProgramDuplicateInstance (instanceClassName info) (instanceHeadType info))
+    [] -> pure ()
   case duplicateExistingInstances infos of
     info : _ -> throwError (ProgramDuplicateInstance (instanceClassName info) (instanceHeadType info))
     [] -> pure ()
@@ -1272,27 +1274,36 @@ buildInstanceSkeletons scope mod0 derived = do
       [ (left, right)
         | (ix, left) <- zip [(0 :: Int) ..] infos,
           right <- drop (ix + 1) infos,
-          instanceClassName left == instanceClassName right,
+          sameInstanceClass left right,
           instanceHeadType left /= instanceHeadType right,
           instanceHeadsOverlap (instanceHeadType left) (instanceHeadType right)
+      ]
+
+    duplicateLocalInstances infos =
+      [ left
+        | (ix, left) <- zip [(0 :: Int) ..] infos,
+          right <- drop (ix + 1) infos,
+          sameInstanceHead left right
       ]
 
     duplicateExistingInstances infos =
       [ local
         | local <- infos,
           existing <- scopeInstances scope,
-          instanceClassName local == instanceClassName existing,
-          instanceHeadType local == instanceHeadType existing
+          sameInstanceHead local existing
       ]
 
     overlappingWithExistingInstances infos =
       [ (local, existing)
         | local <- infos,
           existing <- scopeInstances scope,
-          instanceClassName local == instanceClassName existing,
+          sameInstanceClass local existing,
           instanceHeadType local /= instanceHeadType existing,
           instanceHeadsOverlap (instanceHeadType local) (instanceHeadType existing)
       ]
+
+    sameInstanceClass left right =
+      instanceClassIdentity left == instanceClassIdentity right
 
     instanceHeadsOverlap left right =
       case
@@ -1419,8 +1430,9 @@ sanitizeType = \case
 
 checkInstance :: ElaborateScope -> Scope -> P.InstanceDecl -> TcM [CheckedBinding]
 checkInstance elaborateScope scope instDecl = do
+  classInfo <- lookupClassInfo scope (P.instanceDeclClass instDecl)
   instanceInfo <-
-    case findInstance scope (P.instanceDeclClass instDecl) (P.instanceDeclType instDecl) of
+    case findInstance scope classInfo (P.instanceDeclType instDecl) of
       Just info -> pure info
       Nothing -> throwError (ProgramNoMatchingInstance (P.instanceDeclClass instDecl) (P.instanceDeclType instDecl))
   forM (P.instanceDeclMethods instDecl) $ \methodDef -> do
@@ -1434,9 +1446,9 @@ checkInstance elaborateScope scope instDecl = do
           )
       _ -> throwError (ProgramUnexpectedInstanceMethod (P.instanceDeclClass instDecl) (P.methodDefName methodDef))
   where
-    findInstance scope0 className0 headTy =
+    findInstance scope0 classInfo headTy =
       find
-        (\info -> instanceClassName info == className0 && instanceHeadType info == headTy)
+        (\info -> instanceClassIdentity info == classIdentity classInfo && instanceHeadType info == headTy)
         (scopeInstances scope0)
 
 checkDef :: ElaborateScope -> Scope -> P.DefDecl -> TcM CheckedBinding

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -27,6 +27,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
@@ -205,7 +206,11 @@ checkModule :: [CheckedModule] -> P.Module -> TcM CheckedModule
 checkModule priorModules mod0 = do
   let priorExports = Map.fromList [(checkedModuleName checked, checkedModuleExports checked) | checked <- priorModules]
       priorInstances = concatMap checkedModuleInstances priorModules
-      qualifiedPriorInstances = concatMap (qualifiedInstancesForImport priorExports priorInstances) (P.moduleImports mod0)
+      unqualifiedClassNames = importedUnqualifiedClassNames priorExports (P.moduleImports mod0)
+      qualifiedPriorInstances =
+        concatMap
+          (qualifiedInstancesForImport priorExports priorInstances unqualifiedClassNames)
+          (P.moduleImports mod0)
   ensureDistinctImportAliases (P.moduleImports mod0)
   importScope <- buildImportScope priorExports (P.moduleImports mod0)
   localData <- buildLocalDataInfo mod0
@@ -478,8 +483,8 @@ unqualifyQualifiedName alias name =
       | prefix == alias ++ "." -> rest
     _ -> name
 
-qualifiedInstancesForImport :: Map P.ModuleName ModuleExports -> [InstanceInfo] -> P.Import -> [InstanceInfo]
-qualifiedInstancesForImport priorExports priorInstances imp =
+qualifiedInstancesForImport :: Map P.ModuleName ModuleExports -> [InstanceInfo] -> Set.Set String -> P.Import -> [InstanceInfo]
+qualifiedInstancesForImport priorExports priorInstances unqualifiedClassNames imp =
   case P.importAlias imp of
     Nothing -> []
     Just alias ->
@@ -493,7 +498,45 @@ qualifiedInstancesForImport priorExports priorInstances imp =
                     instanceVisibleForQualifiedImport exports instanceInfo
                 ]
               unqualifiedTypeNames = importExposedTypeNames imp
-           in concatMap (qualifiedInstanceVariants alias exports unqualifiedTypeNames) importedInstances
+           in concatMap (qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassNames) importedInstances
+
+importedUnqualifiedClassNames ::
+  Map P.ModuleName ModuleExports ->
+  [P.Import] ->
+  Set.Set String
+importedUnqualifiedClassNames priorExports =
+  Set.unions . map importUnqualifiedClassNames
+  where
+    importUnqualifiedClassNames imp =
+      case Map.lookup (P.importModuleName imp) priorExports of
+        Nothing -> Set.empty
+        Just exports ->
+          case (P.importAlias imp, P.importExposing imp) of
+            (Nothing, Nothing) ->
+              Map.keysSet (exportedClasses exports)
+                `Set.union` overloadedMethodClassNames (Map.elems (exportedValues exports))
+            (_, Just items) -> Set.unions (map (importItemClassNames exports) items)
+            (Just _, Nothing) -> Set.empty
+
+    importItemClassNames exports item =
+      case item of
+        P.ExportType name
+          | name `Map.member` exportedClasses exports -> Set.singleton name
+        P.ExportValue name ->
+          case Map.lookup name (exportedValues exports) of
+            Just OverloadedMethod {valueMethodInfo = methodInfo} -> Set.singleton (methodClassName methodInfo)
+            _ -> Set.empty
+        _ -> Set.empty
+
+    overloadedMethodClassNames =
+      Set.fromList
+        . map methodClassName
+        . mapMaybe overloadedMethodInfo
+
+    overloadedMethodInfo valueInfo =
+      case valueInfo of
+        OverloadedMethod {valueMethodInfo = methodInfo} -> Just methodInfo
+        _ -> Nothing
 
 importExposedTypeNames :: P.Import -> Set.Set String
 importExposedTypeNames imp =
@@ -525,8 +568,8 @@ srcTypeMentionsAny names ty =
     STMu _ body -> srcTypeMentionsAny names body
     STBottom -> False
 
-qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> Set.Set String -> InstanceInfo -> [InstanceInfo]
-qualifiedInstanceVariants alias exports unqualifiedTypeNames instanceInfo =
+qualifiedInstanceVariants :: P.ModuleName -> ModuleExports -> Set.Set String -> Set.Set String -> InstanceInfo -> [InstanceInfo]
+qualifiedInstanceVariants alias exports unqualifiedTypeNames unqualifiedClassNames instanceInfo =
   distinctInstanceHeads
     [ variant
       | variant <- fullQualifiedVariants ++ aliasHeadVariants,
@@ -534,7 +577,9 @@ qualifiedInstanceVariants alias exports unqualifiedTypeNames instanceInfo =
     ]
   where
     qualifiedInstance = qualifyInstance alias exports instanceInfo
-    aliasHeadNeeded = needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo
+    aliasHeadNeeded =
+      instanceClassName instanceInfo `Set.member` unqualifiedClassNames
+        && needsAliasHeadInstanceVariant exports unqualifiedTypeNames instanceInfo
     fullQualifiedVariants =
       [ qualifiedInstance
         | shouldEmitQualifiedInstanceVariant

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -978,27 +978,31 @@ synthesizeDerivedInstances scope mod0 = do
 
     validateEqDerivingField :: P.ClassName -> Scope -> P.DataDecl -> SrcType -> TcM ()
     validateEqDerivingField eqClassName validationScope dataDecl fieldTy
-      | eqTypeSatisfiable eqClassName validationScope dataDecl Set.empty fieldTy = pure ()
+      | constraintTypeSatisfiable eqClassName validationScope dataDecl Set.empty eqClassName fieldTy = pure ()
       | otherwise = throwError (ProgramDerivingMissingFieldInstance eqClassName fieldTy)
 
-    eqTypeSatisfiable eqClassName validationScope dataDecl seen fieldTy
-      | fieldCoveredByDerivedConstraints dataDecl fieldTy = True
+    constraintTypeSatisfiable derivedClassName validationScope dataDecl seen className0 fieldTy
+      | className0 == derivedClassName && fieldCoveredByDerivedConstraints dataDecl fieldTy = True
       | key `Set.member` seen = False
       | otherwise =
-          case resolveInstanceInfoWithSubst (scopeToElaborateScope validationScope) eqClassName fieldTy of
+          case resolveInstanceInfoWithSubst (scopeToElaborateScope validationScope) className0 fieldTy of
             Right (instanceInfo, subst) ->
               let seen' = Set.insert key seen
                in all
-                    (eqConstraintSatisfiable eqClassName validationScope dataDecl seen' . applyConstraintSubst subst)
+                    (constraintSatisfiable derivedClassName validationScope dataDecl seen' . applyConstraintSubst subst)
                     (instanceConstraints instanceInfo)
             Left _ -> False
       where
-        key = (eqClassName, show fieldTy)
+        key = (className0, show fieldTy)
 
-    eqConstraintSatisfiable eqClassName validationScope dataDecl seen constraint
-      | P.constraintClassName constraint == eqClassName =
-          eqTypeSatisfiable eqClassName validationScope dataDecl seen (P.constraintType constraint)
-      | otherwise = False
+    constraintSatisfiable derivedClassName validationScope dataDecl seen constraint =
+      constraintTypeSatisfiable
+        derivedClassName
+        validationScope
+        dataDecl
+        seen
+        (P.constraintClassName constraint)
+        (P.constraintType constraint)
 
     applyConstraintSubst subst constraint =
       constraint

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -768,41 +768,58 @@ constructorRuntimeBindingRecoverable ctor =
         STBottom -> Set.empty
 
 synthesizeDerivedInstances :: Scope -> P.Module -> TcM [P.InstanceDecl]
-synthesizeDerivedInstances scope mod0 = concat <$> mapM deriveForData (moduleDataDecls mod0)
+synthesizeDerivedInstances scope mod0 = do
+  candidates <- concat <$> mapM deriveForData (moduleDataDecls mod0)
+  let pendingInstances = map (pendingDerivedInstance . snd) candidates
+      validationScope = scope {scopeInstances = scopeInstances scope ++ pendingInstances}
+  mapM_ (validateEqDerivingFields validationScope . fst) candidates
+  pure (map snd candidates)
   where
     deriveForData dataDecl = do
       forM (P.dataDeclDeriving dataDecl) $ \className0 ->
         case className0 of
           "Eq" -> do
             _ <- lookupClassInfo scope className0
-            mapM_ (validateEqDerivingField dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
-            pure (mkEqInstance dataDecl)
+            pure (dataDecl, mkEqInstance dataDecl)
           other -> throwError (ProgramUnsupportedDeriving other)
+
+    pendingDerivedInstance instDecl =
+      InstanceInfo
+        { instanceClassName = P.instanceDeclClass instDecl,
+          instanceConstraints = P.instanceDeclConstraints instDecl,
+          instanceHeadType = P.instanceDeclType instDecl,
+          instanceMethods = Map.empty
+        }
 
     constructorFieldTypes ctor =
       fst (splitArrows (snd (splitForalls (P.constructorDeclType ctor))))
 
-    validateEqDerivingField dataDecl fieldTy
-      | eqTypeSatisfiable dataDecl Set.empty fieldTy = pure ()
+    validateEqDerivingFields :: Scope -> P.DataDecl -> TcM ()
+    validateEqDerivingFields validationScope dataDecl =
+      mapM_ (validateEqDerivingField validationScope dataDecl) (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
+
+    validateEqDerivingField :: Scope -> P.DataDecl -> SrcType -> TcM ()
+    validateEqDerivingField validationScope dataDecl fieldTy
+      | eqTypeSatisfiable validationScope dataDecl Set.empty fieldTy = pure ()
       | otherwise = throwError (ProgramDerivingMissingFieldInstance "Eq" fieldTy)
 
-    eqTypeSatisfiable dataDecl seen fieldTy
+    eqTypeSatisfiable validationScope dataDecl seen fieldTy
       | fieldCoveredByDerivedConstraints dataDecl fieldTy = True
       | key `Set.member` seen = False
       | otherwise =
-          case resolveInstanceInfoWithSubst (scopeToElaborateScope scope) "Eq" fieldTy of
+          case resolveInstanceInfoWithSubst (scopeToElaborateScope validationScope) "Eq" fieldTy of
             Right (instanceInfo, subst) ->
               let seen' = Set.insert key seen
                in all
-                    (eqConstraintSatisfiable dataDecl seen' . applyConstraintSubst subst)
+                    (eqConstraintSatisfiable validationScope dataDecl seen' . applyConstraintSubst subst)
                     (instanceConstraints instanceInfo)
             Left _ -> False
       where
         key = ("Eq", show fieldTy)
 
-    eqConstraintSatisfiable dataDecl seen constraint
+    eqConstraintSatisfiable validationScope dataDecl seen constraint
       | P.constraintClassName constraint == "Eq" =
-          eqTypeSatisfiable dataDecl seen (P.constraintType constraint)
+          eqTypeSatisfiable validationScope dataDecl seen (P.constraintType constraint)
       | otherwise = False
 
     applyConstraintSubst subst constraint =
@@ -981,12 +998,12 @@ buildInstanceSkeletons scope mod0 derived = do
       ]
 
     instanceHeadsOverlap left right =
-      case unifyOverlap Map.empty left right of
+      case unifyOverlap Map.empty (tagTypeVars "__overlap_left__" left) (tagTypeVars "__overlap_right__" right) of
         Just _ -> True
         Nothing -> False
 
     unifyOverlap subst left right =
-      case (left, right) of
+      case (applyOverlapSubst subst left, applyOverlapSubst subst right) of
         (STVar name, ty) -> bindOverlap name ty subst
         (ty, STVar name) -> bindOverlap name ty subst
         (STBase leftName, STBase rightName)
@@ -1004,10 +1021,54 @@ buildInstanceSkeletons scope mod0 derived = do
 
     bindOverlap name ty subst =
       case Map.lookup name subst of
-        Nothing -> Just (Map.insert name ty subst)
-        Just existing
-          | existing == ty -> Just subst
-          | otherwise -> Nothing
+        Just existing -> unifyOverlap subst existing ty
+        Nothing
+          | ty == STVar name -> Just subst
+          | name `Set.member` freeTypeVarsInType ty -> Nothing
+          | otherwise -> Just (Map.insert name ty subst)
+
+    applyOverlapSubst subst ty =
+      case ty of
+        STVar name ->
+          case Map.lookup name subst of
+            Just replacement -> applyOverlapSubst subst replacement
+            Nothing -> ty
+        STArrow dom cod -> STArrow (applyOverlapSubst subst dom) (applyOverlapSubst subst cod)
+        STCon name args -> STCon name (fmap (applyOverlapSubst subst) args)
+        STForall name mb body ->
+          STForall name (fmap (SrcBound . applyOverlapSubst subst . unSrcBound) mb) (applyOverlapSubst subst body)
+        STMu name body -> STMu name (applyOverlapSubst subst body)
+        STBase {} -> ty
+        STBottom -> STBottom
+
+    tagTypeVars prefix = go Map.empty
+      where
+        go env ty =
+          case ty of
+            STVar name -> STVar (Map.findWithDefault (prefix ++ name) name env)
+            STArrow dom cod -> STArrow (go env dom) (go env cod)
+            STCon name args -> STCon name (fmap (go env) args)
+            STForall name mb body ->
+              let tagged = prefix ++ name
+                  env' = Map.insert name tagged env
+               in STForall tagged (fmap (SrcBound . go env . unSrcBound) mb) (go env' body)
+            STMu name body ->
+              let tagged = prefix ++ name
+               in STMu tagged (go (Map.insert name tagged env) body)
+            STBase {} -> ty
+            STBottom -> STBottom
+
+    freeTypeVarsInType ty =
+      case ty of
+        STVar name -> Set.singleton name
+        STArrow dom cod -> freeTypeVarsInType dom `Set.union` freeTypeVarsInType cod
+        STCon _ args -> foldMap freeTypeVarsInType args
+        STForall name mb body ->
+          maybe Set.empty (freeTypeVarsInType . unSrcBound) mb
+            `Set.union` Set.delete name (freeTypeVarsInType body)
+        STMu name body -> Set.delete name (freeTypeVarsInType body)
+        STBase {} -> Set.empty
+        STBottom -> Set.empty
 
     substituteConstraint paramName headTy constraint =
       constraint

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -501,11 +501,7 @@ sameInstanceHead left right =
 
 instanceBelongsToModule :: P.ModuleName -> InstanceInfo -> Bool
 instanceBelongsToModule moduleName0 instanceInfo =
-  any belongs (Map.elems (instanceMethods instanceInfo))
-  where
-    belongs OrdinaryValue {valueOriginModule = origin} = origin == moduleName0
-    belongs ConstructorValue {valueOriginModule = origin} = origin == moduleName0
-    belongs OverloadedMethod {valueOriginModule = origin} = origin == moduleName0
+  instanceOriginModule instanceInfo == moduleName0
 
 qualifyInstance :: P.ModuleName -> ModuleExports -> InstanceInfo -> InstanceInfo
 qualifyInstance alias exports instanceInfo =
@@ -786,6 +782,7 @@ synthesizeDerivedInstances scope mod0 = do
     pendingDerivedInstance instDecl =
       InstanceInfo
         { instanceClassName = P.instanceDeclClass instDecl,
+          instanceOriginModule = P.moduleName mod0,
           instanceConstraints = P.instanceDeclConstraints instDecl,
           instanceHeadType = P.instanceDeclType instDecl,
           instanceMethods = Map.empty
@@ -987,6 +984,7 @@ buildInstanceSkeletons scope mod0 derived = do
       pure
         InstanceInfo
           { instanceClassName = P.instanceDeclClass instDecl,
+            instanceOriginModule = P.moduleName mod0,
             instanceConstraints = P.instanceDeclConstraints instDecl,
             instanceHeadType = P.instanceDeclType instDecl,
             instanceMethods = instanceMethodInfos

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -497,21 +497,28 @@ constraintCoveredByEvidence :: ElaborateScope -> P.ClassConstraint -> Bool
 constraintCoveredByEvidence scope constraint =
   case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
     Nothing -> False
-    Just classInfo ->
-      all
-        ( \methodInfo ->
-            case lookupEvidenceMethod scope (P.constraintClassName constraint) (P.constraintType constraint) (methodName methodInfo) of
-              Just _ -> True
-              Nothing -> False
-        )
-        (Map.elems (classMethods classInfo))
+    Just classInfo
+      | Map.null (classMethods classInfo) ->
+          zeroMethodConstraintCoveredByEvidence scope constraint
+      | otherwise ->
+          all
+            ( \methodInfo ->
+                case lookupEvidenceMethod scope (P.constraintClassName constraint) (P.constraintType constraint) (methodName methodInfo) of
+                  Just _ -> True
+                  Nothing -> False
+            )
+            (Map.elems (classMethods classInfo))
 
 deferConstraintEvidenceExprs :: ElaborateScope -> P.ClassConstraint -> ElaborateM [SurfaceExpr]
 deferConstraintEvidenceExprs scope constraint =
   case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
     Nothing -> throwError (ProgramUnknownClass (P.constraintClassName constraint))
-    Just classInfo ->
-      mapM (deferMethodEvidenceExpr scope (P.constraintType constraint)) (Map.elems (classMethods classInfo))
+    Just classInfo
+      | Map.null (classMethods classInfo) -> do
+          _ <- liftEitherElab (resolveInstanceInfo scope (P.constraintClassName constraint) (P.constraintType constraint))
+          pure []
+      | otherwise ->
+          mapM (deferMethodEvidenceExpr scope (P.constraintType constraint)) (Map.elems (classMethods classInfo))
 
 deferMethodEvidenceExpr :: ElaborateScope -> SrcType -> MethodInfo -> ElaborateM SurfaceExpr
 deferMethodEvidenceExpr scope classArgTy methodInfo = do
@@ -656,19 +663,36 @@ resolveConstraintEvidenceExpr scope seen constraint =
     Just classInfo -> do
       let key = (P.constraintClassName constraint, show (P.constraintType constraint))
       whenSeen key
-      mapM
-        ( \methodInfo ->
-            resolveMethodHeadExpr
-              scope
-              (Set.insert key seen)
-              methodInfo
-              (P.constraintType constraint)
-        )
-        (Map.elems (classMethods classInfo))
+      if Map.null (classMethods classInfo)
+        then do
+          if zeroMethodConstraintCoveredByEvidence scope constraint
+            then pure []
+            else do
+              _ <- liftEitherElab (resolveInstanceInfo scope (P.constraintClassName constraint) (P.constraintType constraint))
+              pure []
+        else
+          mapM
+            ( \methodInfo ->
+                resolveMethodHeadExpr
+                  scope
+                  (Set.insert key seen)
+                  methodInfo
+                  (P.constraintType constraint)
+            )
+            (Map.elems (classMethods classInfo))
   where
     whenSeen key =
       when (key `Set.member` seen) $
         throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
+
+zeroMethodConstraintCoveredByEvidence :: ElaborateScope -> P.ClassConstraint -> Bool
+zeroMethodConstraintCoveredByEvidence scope constraint =
+  any
+    ( \evidence ->
+        evidenceClassName evidence == P.constraintClassName constraint
+          && lowerType scope (evidenceType evidence) == lowerType scope (P.constraintType constraint)
+    )
+    (esEvidence scope)
 
 lookupEvidenceMethod :: ElaborateScope -> P.ClassName -> SrcType -> P.MethodName -> Maybe (String, SrcType)
 lookupEvidenceMethod scope className0 headTy methodName0 =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -311,8 +311,6 @@ compileExpr scope mbExpected expr = case expr of
   EVar name ->
     case Map.lookup name (esValues scope) of
       Just OverloadedMethod {} -> throwError (ProgramAmbiguousMethodUse name)
-      Just OrdinaryValue {valueConstraints = _ : _} ->
-        throwError (ProgramAmbiguousConstrainedValueUse name)
       Just valueInfo@OrdinaryValue {valueRuntimeName = runtimeName} -> do
         evidenceSurfaces <- valueEvidenceArgs scope valueInfo []
         pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -338,33 +338,37 @@ compileExpr scope mbExpected expr = case expr of
     if name `notElem` collectFreeValues Set.empty body && mbTy == Nothing
       then compileExpr scope mbExpected body
       else do
-        runtimeName <- freshRuntimeName name
         let recursive = mentionsFreeValue name rhs
-        provisionalTy <- case (recursive, mbTy) of
-          (True, Nothing) -> Just <$> freshTypeName
-          _ -> pure mbTy
-        selfScope <-
-          if recursive
-            then extendLocal scope name runtimeName provisionalTy
-            else pure scope
-        rhsExpr <- compileExpr selfScope provisionalTy rhs
-        bindingTy <- case mbTy of
-          Just ty -> pure (lowerType scope ty)
-          Nothing
-            | Just rhsTy <- explicitExprAnnotation rhs -> pure (lowerType scope rhsTy)
-            | Just rhsTy <- inferKnownExprType selfScope rhs -> pure (lowerType scope rhsTy)
-            | Just ty <- provisionalTy -> pure (lowerType scope ty)
-          Nothing -> freshTypeName
-        let rhsExpr' =
-              case mbTy of
-                Just ty -> surfaceAnn rhsExpr (lowerType scope ty)
-                Nothing ->
-                  case inferKnownExprType selfScope rhs of
+        case (recursive, mbTy, inlineImmediateLetUse name rhs body) of
+          (False, Nothing, Just inlined) ->
+            compileExpr scope mbExpected inlined
+          _ -> do
+            runtimeName <- freshRuntimeName name
+            provisionalTy <- case (recursive, mbTy) of
+              (True, Nothing) -> Just <$> freshTypeName
+              _ -> pure mbTy
+            selfScope <-
+              if recursive
+                then extendLocal scope name runtimeName provisionalTy
+                else pure scope
+            rhsExpr <- compileExpr selfScope provisionalTy rhs
+            bindingTy <- case mbTy of
+              Just ty -> pure (lowerType scope ty)
+              Nothing
+                | Just rhsTy <- explicitExprAnnotation rhs -> pure (lowerType scope rhsTy)
+                | Just rhsTy <- inferKnownExprType selfScope rhs -> pure (lowerType scope rhsTy)
+                | Just ty <- provisionalTy -> pure (lowerType scope ty)
+              Nothing -> freshTypeName
+            let rhsExpr' =
+                  case mbTy of
                     Just ty -> surfaceAnn rhsExpr (lowerType scope ty)
-                    Nothing -> rhsExpr
-        bodyScope <- extendLocalLowered scope name runtimeName bindingTy
-        bodyExpr <- compileExpr bodyScope mbExpected body
-        pure (surfaceLet runtimeName rhsExpr' bodyExpr)
+                    Nothing ->
+                      case inferKnownExprType selfScope rhs of
+                        Just ty -> surfaceAnn rhsExpr (lowerType scope ty)
+                        Nothing -> rhsExpr
+            bodyScope <- extendLocalLowered scope name runtimeName bindingTy
+            bodyExpr <- compileExpr bodyScope mbExpected body
+            pure (surfaceLet runtimeName rhsExpr' bodyExpr)
   EAnn inner annTy -> do
     innerExpr <- compileExpr scope (Just annTy) inner
     pure (surfaceAnn innerExpr (lowerType scope annTy))
@@ -380,8 +384,16 @@ compileApp scope mbExpected expr =
           compileValueApp scope mbExpected valueInfo args
     (headExpr, [arg])
       | Just expectedTy <- mbExpected -> do
-          headSurface <- compileExpr scope (Just (STArrow expectedTy expectedTy)) headExpr
-          argSurface <- compileExpr scope (Just expectedTy) arg
+          (expectedHeadTy, argSurface) <-
+            case inferKnownExprType scope arg of
+              Just argTy -> do
+                argSurface <- compileExpr scope (Just argTy) arg
+                pure (STArrow argTy expectedTy, argSurface)
+              Nothing -> do
+                argTy <- freshTypeName
+                argSurface <- compileExpr scope Nothing arg
+                pure (STArrow argTy expectedTy, argSurface)
+          headSurface <- compileExpr scope (Just expectedHeadTy) headExpr
           pure (surfaceApp headSurface argSurface)
     (headExpr, args) -> do
       headSurface <- compileExpr scope Nothing headExpr
@@ -455,8 +467,50 @@ valueEvidenceArgs scope OrdinaryValue {valueType = visibleTy, valueConstraints =
             case constraints of
               constraint : _ -> throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
               [] -> pure Map.empty
-      concat <$> mapM (resolveConstraintEvidenceExpr scope Set.empty . applyConstraintSubst subst) constraints
+      concat <$> mapM (constraintEvidenceArgExprs scope . applyConstraintSubst subst) constraints
 valueEvidenceArgs _ _ _ = pure []
+
+constraintEvidenceArgExprs :: ElaborateScope -> P.ClassConstraint -> ElaborateM [SurfaceExpr]
+constraintEvidenceArgExprs scope constraint
+  | shouldDeferConstraintEvidence scope constraint =
+      deferConstraintEvidenceExprs scope constraint
+  | otherwise =
+      resolveConstraintEvidenceExpr scope Set.empty constraint
+
+shouldDeferConstraintEvidence :: ElaborateScope -> P.ClassConstraint -> Bool
+shouldDeferConstraintEvidence scope constraint =
+  not (Set.null (freeTypeVarsSrcType (P.constraintType constraint)))
+    && not (constraintCoveredByEvidence scope constraint)
+
+constraintCoveredByEvidence :: ElaborateScope -> P.ClassConstraint -> Bool
+constraintCoveredByEvidence scope constraint =
+  case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
+    Nothing -> False
+    Just classInfo ->
+      all
+        ( \methodInfo ->
+            case lookupEvidenceMethod scope (P.constraintClassName constraint) (P.constraintType constraint) (methodName methodInfo) of
+              Just _ -> True
+              Nothing -> False
+        )
+        (Map.elems (classMethods classInfo))
+
+deferConstraintEvidenceExprs :: ElaborateScope -> P.ClassConstraint -> ElaborateM [SurfaceExpr]
+deferConstraintEvidenceExprs scope constraint =
+  case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
+    Nothing -> throwError (ProgramUnknownClass (P.constraintClassName constraint))
+    Just classInfo ->
+      mapM (deferMethodEvidenceExpr scope (P.constraintType constraint)) (Map.elems (classMethods classInfo))
+
+deferMethodEvidenceExpr :: ElaborateScope -> SrcType -> MethodInfo -> ElaborateM SurfaceExpr
+deferMethodEvidenceExpr scope classArgTy methodInfo = do
+  let methodTy =
+        stripVacuousSrcForalls $
+          specializeMethodType (methodType methodInfo) (methodParamName methodInfo) classArgTy
+      fullArity = methodFullArity methodInfo
+  placeholder <- deferMethodCall scope methodInfo fullArity methodTy
+  expanded <- etaExpandMissingArgs scope methodInfo methodTy 0 fullArity (surfaceVar placeholder)
+  pure (surfaceAnn expanded (lowerType scope methodTy))
 
 inferCallSubst :: ElaborateScope -> SrcType -> [P.Expr] -> Maybe (Map String SrcType)
 inferCallSubst scope visibleTy args = do
@@ -468,6 +522,25 @@ inferCallSubst scope visibleTy args = do
             Just actualTy <- [inferKnownExprType scope arg]
         ]
   foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty knownPairs
+
+inlineImmediateLetUse :: String -> P.Expr -> P.Expr -> Maybe P.Expr
+inlineImmediateLetUse bindingName rhs body =
+  let (headExpr, args) = collectApps body
+   in case (headExpr, args) of
+        (EVar name, _ : _)
+          | name == bindingName,
+            rhsConsumesAppliedArgs rhs (length args) ->
+              Just (foldl EApp rhs args)
+        _ -> Nothing
+
+rhsConsumesAppliedArgs :: P.Expr -> Int -> Bool
+rhsConsumesAppliedArgs _ 0 = True
+rhsConsumesAppliedArgs expr argCount =
+  case expr of
+    ELam param body ->
+      mentionsFreeValue (P.paramName param) body
+        && rhsConsumesAppliedArgs body (argCount - 1)
+    _ -> True
 
 isLocalOrdinaryValue :: ValueInfo -> Bool
 isLocalOrdinaryValue OrdinaryValue {valueOriginModule = "<local>"} = True

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -261,10 +261,13 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
         STArrow
         resultTy
         [ foldr
-            (\(name, mbBound) acc -> STForall name (fmap (SrcBound . lowerCtorArg subst (Just (dataName info)) selfTy) mbBound) acc)
-            (foldr STArrow resultTy (map (lowerCtorArg subst (Just (dataName info)) selfTy) (ctorArgs ctor)))
+            (\(name, mbBound) acc ->
+               STForall name (fmap (SrcBound . lowerCtorArg subst ownerIdentity selfTy) mbBound) acc
+            )
+            (foldr STArrow resultTy (map (lowerCtorArg subst ownerIdentity selfTy) (ctorArgs ctor)))
             (ctorForalls ctor)
           | ctor <- dataConstructors info
+          , let ownerIdentity = Just (dataIdentity info)
         ]
 
     lowerCtorArg subst currentData selfTy ty = case ty of
@@ -291,11 +294,12 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
     isCurrentDataAlias currentData name =
       case currentData of
         Nothing -> False
-        Just ownerName ->
-          name == ownerName
-            || case Map.lookup name dataTypes of
-              Just info -> dataName info == ownerName
-              Nothing -> False
+        Just ownerIdentity ->
+          case Map.lookup name dataTypes of
+            Just info -> dataIdentity info == ownerIdentity
+            Nothing -> name == ownerIdentity
+
+    dataIdentity info = dataModule info ++ "." ++ dataName info
 
 toListNE :: NonEmpty a -> [a]
 toListNE (x :| xs) = x : xs

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -550,12 +550,12 @@ resolveMethodHeadExpr scope seen methodInfo classArgTy =
     Nothing -> do
       (instanceInfo, subst) <- liftEitherElab (resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy)
       case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
-        Just OrdinaryValue {valueRuntimeName = runtimeName} -> do
+        Just OrdinaryValue {valueRuntimeName = runtimeName, valueConstraints = constraints} -> do
           evidenceArgs <-
             concat
               <$> mapM
                 (resolveConstraintEvidenceExpr scope seen . applyConstraintSubst subst)
-                (instanceConstraints instanceInfo)
+                constraints
           pure (foldl surfaceApp (surfaceVar runtimeName) evidenceArgs)
         _ -> throwError (ProgramUnknownMethod (methodName methodInfo))
 
@@ -827,12 +827,22 @@ compileCase :: ElaborateScope -> Maybe SrcType -> P.Expr -> [P.Alt] -> Elaborate
 compileCase scope mbExpected scrutinee alts = do
   case ctorOwners alts of
     [] -> do
-      let mbScrutineeTy =
-            case inferKnownExprType scope scrutinee of
+      let mbInferredScrutineeTy = inferKnownExprType scope scrutinee
+          mbAnnotationScrutineeTy = catchAllPatternAnnotationType alts
+          mbScrutineeTy =
+            case mbInferredScrutineeTy of
               Just knownTy -> Just knownTy
-              Nothing -> catchAllPatternAnnotationType alts
+              Nothing -> mbAnnotationScrutineeTy
+          annotateScrutinee =
+            case (mbInferredScrutineeTy, mbAnnotationScrutineeTy) of
+              (Nothing, Just annTy) -> Just annTy
+              _ -> Nothing
       mapM_ (\scrutineeTy -> mapM_ (validatePatternType scope scrutineeTy . P.altPattern) alts) mbScrutineeTy
-      scrutineeExpr <- compileExpr scope mbScrutineeTy scrutinee
+      scrutineeExpr0 <- compileExpr scope mbScrutineeTy scrutinee
+      let scrutineeExpr =
+            case annotateScrutinee of
+              Just annTy -> surfaceAnn scrutineeExpr0 (lowerType scope annTy)
+              Nothing -> scrutineeExpr0
       compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts
     owners -> do
       dataInfo <- requireSingleDataOwner scope owners
@@ -873,7 +883,13 @@ localIdentityScrutinee scope expr =
 compileCatchAllOnly :: ElaborateScope -> Maybe SrcType -> Maybe SrcType -> SurfaceExpr -> [P.Alt] -> ElaborateM SurfaceExpr
 compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts =
   case alts of
-    [P.Alt P.PatWildcard body] -> compileExpr scope mbExpected body
+    [P.Alt P.PatWildcard body] -> do
+      bodyExpr <- compileExpr scope mbExpected body
+      case mbScrutineeTy of
+        Just _ -> do
+          scrutineeName <- freshRuntimeName "case_scrutinee"
+          pure (surfaceLet scrutineeName scrutineeExpr bodyExpr)
+        Nothing -> pure bodyExpr
     [P.Alt (P.PatVar name) body] -> do
       runtimeName <- freshRuntimeName name
       scope' <- extendLocalLowered scope name runtimeName =<< freshTypeName

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -827,7 +827,10 @@ compileCase :: ElaborateScope -> Maybe SrcType -> P.Expr -> [P.Alt] -> Elaborate
 compileCase scope mbExpected scrutinee alts = do
   case ctorOwners alts of
     [] -> do
-      let mbScrutineeTy = inferKnownExprType scope scrutinee
+      let mbScrutineeTy =
+            case inferKnownExprType scope scrutinee of
+              Just knownTy -> Just knownTy
+              Nothing -> catchAllPatternAnnotationType alts
       mapM_ (\scrutineeTy -> mapM_ (validatePatternType scope scrutineeTy . P.altPattern) alts) mbScrutineeTy
       scrutineeExpr <- compileExpr scope mbScrutineeTy scrutinee
       compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts
@@ -985,6 +988,21 @@ ctorOwners = foldr go []
       P.PatCtor ctorName0 _ -> ctorName0 : acc
       P.PatAnn inner _ -> go (P.Alt inner (P.altExpr alt)) acc
       _ -> acc
+
+catchAllPatternAnnotationType :: [P.Alt] -> Maybe SrcType
+catchAllPatternAnnotationType alts =
+  case alts of
+    [P.Alt pattern0 _] -> patternAnnotationType pattern0
+    _ -> Nothing
+
+patternAnnotationType :: P.Pattern -> Maybe SrcType
+patternAnnotationType pattern0 =
+  case pattern0 of
+    P.PatAnn inner annTy ->
+      case patternAnnotationType inner of
+        Just innerTy -> Just innerTy
+        Nothing -> Just annTy
+    _ -> Nothing
 
 validatePatternType :: ElaborateScope -> SrcType -> P.Pattern -> ElaborateM ()
 validatePatternType scope expectedTy pattern0 =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -1268,7 +1268,7 @@ requireSingleDataOwner scope ctorNames0 = do
   case owners of
     [owner] ->
       case Map.lookup owner (esTypes scope) of
-        Just info -> pure info
+        Just info -> pure (info {dataName = owner})
         Nothing -> throwError (ProgramUnknownType owner)
     _ -> throwError (ProgramCaseOnNonDataType STBottom)
   where

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -508,7 +508,8 @@ compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} arg
               else argSurface
 
 compileValueApp scope mbExpected valueInfo args = do
-  argSurfaces <- mapM (compileExpr scope Nothing) args
+  let expectedArgTys = valueExpectedArgTypes valueInfo args
+  argSurfaces <- zipWithM compileValueArg (expectedArgTys ++ repeat Nothing) args
   evidenceSurfaces <- valueEvidenceArgs scope valueInfo args
   let headSurface =
         case valueInfo of
@@ -522,6 +523,33 @@ compileValueApp scope mbExpected valueInfo args = do
         isRecursiveResultType expectedTy || isRecursiveResultType (lowerType scope expectedTy) ->
           surfaceAnn applied (lowerType scope expectedTy)
     _ -> applied
+  where
+    compileValueArg (Just expectedTy) arg
+      | isPartialOverloadedMethodApp scope arg =
+          compileExpr scope (Just expectedTy) arg
+    compileValueArg _ arg =
+      compileExpr scope Nothing arg
+
+valueExpectedArgTypes :: ValueInfo -> [P.Expr] -> [Maybe SrcType]
+valueExpectedArgTypes valueInfo args =
+  let argTys =
+        case valueInfo of
+          OrdinaryValue {valueType = ty} ->
+            fst (splitArrows (snd (splitForalls ty)))
+          _ -> []
+   in map concreteExpectedTy (take (length args) argTys)
+  where
+    concreteExpectedTy ty
+      | Set.null (freeTypeVarsSrcType ty) = Just ty
+      | otherwise = Nothing
+
+isPartialOverloadedMethodApp :: ElaborateScope -> P.Expr -> Bool
+isPartialOverloadedMethodApp scope expr =
+  case collectApps expr of
+    (EVar name, args)
+      | Just OverloadedMethod {valueMethodInfo = methodInfo} <- Map.lookup name (esValues scope) ->
+          not (null args) && length args < methodFullArity methodInfo
+    _ -> False
 
 constructorExpectedArgTypes :: ElaborateScope -> ConstructorInfo -> [P.Expr] -> [SrcType]
 constructorExpectedArgTypes scope ctorInfo args =
@@ -601,7 +629,7 @@ deferMethodEvidenceExpr scope classArgTy methodInfo = do
           specializeMethodType (methodType methodInfo) (methodParamName methodInfo) classArgTy
       fullArity = methodFullArity methodInfo
   placeholder <- deferMethodCall scope methodInfo fullArity methodTy
-  expanded <- etaExpandMissingArgs scope methodInfo methodTy 0 fullArity (surfaceVar placeholder)
+  expanded <- etaExpandMissingArgs scope methodInfo methodTy Nothing 0 fullArity (surfaceVar placeholder)
   pure (surfaceAnn expanded (lowerType scope methodTy))
 
 inferCallSubst :: ElaborateScope -> SrcType -> [P.Expr] -> Maybe (Map String SrcType)
@@ -645,7 +673,7 @@ knownConstructorResultType scope ctorInfo args = do
   pure (Map.foldrWithKey substituteTypeVar (ctorResult ctorInfo) subst)
 
 compileMethodApp :: ElaborateScope -> Maybe SrcType -> MethodInfo -> [P.Expr] -> ElaborateM SurfaceExpr
-compileMethodApp scope _mbExpected methodInfo args
+compileMethodApp scope mbExpected methodInfo args
   | null args = throwError (ProgramAmbiguousMethodUse (methodName methodInfo))
   | otherwise = do
       let fullArity = methodFullArity methodInfo
@@ -665,21 +693,23 @@ compileMethodApp scope _mbExpected methodInfo args
           | shouldResolveMethodBeforeInference scope methodInfo classArgTy -> do
               methodHead <- resolveMethodHeadForCall scope Set.empty methodInfo classArgTy args
               let applied = foldl surfaceApp methodHead argSurfaces
-              expanded <- etaExpandMissingArgs scope methodInfo placeholderTy suppliedArity fullArity applied
-              pure $
-                case peelAppliedType placeholderTy suppliedArity of
-                  Just remainingTy
-                    | suppliedArity < fullArity -> surfaceAnn expanded (lowerType scope remainingTy)
-                  _ -> expanded
+              expanded <- etaExpandMissingArgs scope methodInfo placeholderTy mbExpected suppliedArity fullArity applied
+              pure (annotatePartialMethod expanded placeholderTy suppliedArity fullArity)
         _ -> do
           placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy
           let applied = foldl surfaceApp (surfaceVar placeholder) argSurfaces
-          expanded <- etaExpandMissingArgs scope methodInfo placeholderTy suppliedArity fullArity applied
-          pure $
-            case peelAppliedType placeholderTy suppliedArity of
-              Just remainingTy
-                | suppliedArity < fullArity -> surfaceAnn expanded (lowerType scope remainingTy)
-              _ -> expanded
+          expanded <- etaExpandMissingArgs scope methodInfo placeholderTy mbExpected suppliedArity fullArity applied
+          pure (annotatePartialMethod expanded placeholderTy suppliedArity fullArity)
+  where
+    annotatePartialMethod expanded placeholderTy suppliedArity fullArity
+      | suppliedArity < fullArity =
+          case mbExpected of
+            Just expectedTy -> surfaceAnn expanded (lowerType scope expectedTy)
+            Nothing ->
+              case peelAppliedType placeholderTy suppliedArity of
+                Just remainingTy -> surfaceAnn expanded (lowerType scope remainingTy)
+                Nothing -> expanded
+      | otherwise = expanded
 
 compileExpectedMethodArg :: ElaborateScope -> SrcType -> P.Expr -> ElaborateM SurfaceExpr
 compileExpectedMethodArg scope expectedTy expr =
@@ -839,17 +869,31 @@ applySrcSubst subst ty =
 liftEitherElab :: Either ProgramError a -> ElaborateM a
 liftEitherElab = either throwError pure
 
-etaExpandMissingArgs :: ElaborateScope -> MethodInfo -> SrcType -> Int -> Int -> SurfaceExpr -> ElaborateM SurfaceExpr
-etaExpandMissingArgs scope methodInfo methodTy suppliedArity fullArity applied = do
+etaExpandMissingArgs :: ElaborateScope -> MethodInfo -> SrcType -> Maybe SrcType -> Int -> Int -> SurfaceExpr -> ElaborateM SurfaceExpr
+etaExpandMissingArgs scope methodInfo methodTy mbExpected suppliedArity fullArity applied = do
   let missingArity = max 0 (fullArity - suppliedArity)
   if missingArity == 0
     then pure applied
     else do
       missingNames <- replicateM missingArity (freshRuntimeName (methodName methodInfo ++ "_arg"))
-      let missingTypes = drop suppliedArity (methodArgumentTypes methodTy)
+      let missingTypes = zipWith preferExpectedType methodMissingTypes (expectedMissingTypes ++ repeat Nothing)
           body = foldl surfaceApp applied (map surfaceVar missingNames)
       pure (foldr wrapMissingArg body (zip missingNames missingTypes))
   where
+    methodMissingTypes =
+      drop suppliedArity (methodArgumentTypes methodTy)
+
+    expectedMissingTypes =
+      case mbExpected of
+        Just expectedTy ->
+          map Just (fst (splitArrows (snd (splitForalls expectedTy))))
+        Nothing -> []
+
+    preferExpectedType methodTy0 (Just expectedTy)
+      | Set.null (freeTypeVarsSrcType expectedTy) = expectedTy
+      | otherwise = methodTy0
+    preferExpectedType methodTy0 Nothing = methodTy0
+
     wrapMissingArg (name, ty) body
       | Set.null (freeTypeVarsSrcType ty) = surfaceLamAnn name (lowerType scope ty) body
       | otherwise = surfaceLam name body

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -311,7 +311,11 @@ compileExpr scope mbExpected expr = case expr of
   EVar name ->
     case Map.lookup name (esValues scope) of
       Just OverloadedMethod {} -> throwError (ProgramAmbiguousMethodUse name)
-      Just OrdinaryValue {valueRuntimeName = runtimeName} -> pure (surfaceVar runtimeName)
+      Just OrdinaryValue {valueConstraints = _ : _} ->
+        throwError (ProgramAmbiguousConstrainedValueUse name)
+      Just valueInfo@OrdinaryValue {valueRuntimeName = runtimeName} -> do
+        evidenceSurfaces <- valueEvidenceArgs scope valueInfo []
+        pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
       Just ConstructorValue {valueCtorInfo = ctorInfo} -> do
         placeholder <- deferConstructorCall scope ctorInfo 0 mbExpected
         pure (surfaceVar placeholder)
@@ -457,7 +461,7 @@ constructorExpectedArgTypes scope ctorInfo args =
        in (subst', expectedTy : acc)
 
 valueEvidenceArgs :: ElaborateScope -> ValueInfo -> [P.Expr] -> ElaborateM [SurfaceExpr]
-valueEvidenceArgs scope OrdinaryValue {valueType = visibleTy, valueConstraints = constraints} args
+valueEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, valueType = visibleTy, valueConstraints = constraints} args
   | null constraints = pure []
   | otherwise = do
       subst <-
@@ -467,7 +471,14 @@ valueEvidenceArgs scope OrdinaryValue {valueType = visibleTy, valueConstraints =
             case constraints of
               constraint : _ -> throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
               [] -> pure Map.empty
-      concat <$> mapM (constraintEvidenceArgExprs scope . applyConstraintSubst subst) constraints
+      let specializedConstraints = map (applyConstraintSubst subst) constraints
+      if any usesLocalPolymorphicEvidence specializedConstraints
+        then throwError (ProgramAmbiguousConstrainedValueUse displayName)
+        else concat <$> mapM (constraintEvidenceArgExprs scope) specializedConstraints
+  where
+    usesLocalPolymorphicEvidence constraint =
+      not (Set.null (freeTypeVarsSrcType (P.constraintType constraint)))
+        && constraintCoveredByEvidence scope constraint
 valueEvidenceArgs _ _ _ = pure []
 
 constraintEvidenceArgExprs :: ElaborateScope -> P.ClassConstraint -> ElaborateM [SurfaceExpr]

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -17,6 +17,7 @@ module MLF.Frontend.Program.Elaborate
     freeTypeVarsSrcType,
     resolveInstanceInfo,
     resolveInstanceInfoWithSubst,
+    resolveMethodInstanceInfoWithSubst,
   )
 where
 
@@ -73,6 +74,8 @@ data ElaborateResult a = ElaborateResult
     elaborateResultDeferredObligations :: Map String DeferredProgramObligation,
     elaborateResultExternalTypes :: Map String SrcType
   }
+
+type ClassIdentity = (P.ModuleName, P.ClassName)
 
 runElaborateM :: ElaborateM a -> Either ProgramError (ElaborateResult a)
 runElaborateM action =
@@ -745,7 +748,7 @@ resolveMethodHeadExpr scope seen methodInfo classArgTy =
   case lookupEvidenceMethod scope (methodClassName methodInfo) classArgTy (methodName methodInfo) of
     Just (runtimeName, _) -> pure (surfaceVar runtimeName)
     Nothing -> do
-      (instanceInfo, subst) <- liftEitherElab (resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy)
+      (instanceInfo, subst) <- liftEitherElab (resolveMethodInstanceInfoWithSubst scope methodInfo classArgTy)
       case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
         Just OrdinaryValue {valueRuntimeName = runtimeName, valueConstraints = constraints} -> do
           let headVars = freeTypeVarsSrcType classArgTy
@@ -1522,6 +1525,33 @@ resolveInstanceInfo scope className0 headTy =
 
 resolveInstanceInfoWithSubst :: ElaborateScope -> P.ClassName -> SrcType -> Either ProgramError (InstanceInfo, Map String SrcType)
 resolveInstanceInfoWithSubst scope className0 headTy =
+  resolveInstanceInfoWithIdentity scope className0 expectedClassIdentity headTy
+  where
+    expectedClassIdentity = classInfoIdentity <$> Map.lookup className0 (esClasses scope)
+
+resolveMethodInstanceInfoWithSubst :: ElaborateScope -> MethodInfo -> SrcType -> Either ProgramError (InstanceInfo, Map String SrcType)
+resolveMethodInstanceInfoWithSubst scope methodInfo =
+  resolveInstanceInfoWithIdentity scope (methodClassName methodInfo) (Just (methodInfoClassIdentity methodInfo))
+
+classInfoIdentity :: ClassInfo -> ClassIdentity
+classInfoIdentity classInfo =
+  (classModule classInfo, unqualifiedName (className classInfo))
+
+methodInfoClassIdentity :: MethodInfo -> ClassIdentity
+methodInfoClassIdentity methodInfo =
+  (methodClassModule methodInfo, unqualifiedName (methodClassName methodInfo))
+
+unqualifiedName :: String -> String
+unqualifiedName =
+  reverse . takeWhile (/= '.') . reverse
+
+resolveInstanceInfoWithIdentity ::
+  ElaborateScope ->
+  P.ClassName ->
+  Maybe ClassIdentity ->
+  SrcType ->
+  Either ProgramError (InstanceInfo, Map String SrcType)
+resolveInstanceInfoWithIdentity scope className0 expectedClassIdentity headTy =
   case deduplicatedMatches of
     [(match, subst, _direct)] -> Right (match, subst)
     [] -> Left (ProgramNoMatchingInstance className0 headTy)
@@ -1532,44 +1562,17 @@ resolveInstanceInfoWithSubst scope className0 headTy =
     matches =
       [ (info, subst, direct)
         | info <- esInstances scope,
-          instanceClassName info == className0,
           instanceMatchesClassIdentity info,
           Just (subst, direct) <- [matchInstanceHead info]
       ]
-
-    expectedClassIdentity =
-      case Map.lookup className0 (esClasses scope) of
-        Just classInfo -> Just (classInfoIdentity classInfo)
-        Nothing -> overloadedMethodClassIdentity
 
     instanceMatchesClassIdentity info =
       case expectedClassIdentity of
         Just identity -> instanceInfoClassIdentity info == identity
         Nothing -> False
 
-    classInfoIdentity classInfo =
-      (classModule classInfo, unqualifiedName (className classInfo))
-
     instanceInfoClassIdentity info =
       (instanceClassModule info, unqualifiedName (instanceClassName info))
-
-    overloadedMethodClassIdentity =
-      methodValueClassIdentity
-        =<< find visibleMethodForClass (Map.elems (esValues scope))
-
-    visibleMethodForClass valueInfo =
-      case valueInfo of
-        OverloadedMethod {valueMethodInfo = methodInfo} -> methodClassName methodInfo == className0
-        _ -> False
-
-    methodValueClassIdentity valueInfo =
-      case valueInfo of
-        OverloadedMethod {valueMethodInfo = methodInfo} ->
-          Just (valueOriginModule valueInfo, unqualifiedName (methodClassName methodInfo))
-        _ -> Nothing
-
-    unqualifiedName =
-      reverse . takeWhile (/= '.') . reverse
 
     matchInstanceHead info =
       case matchTypes Map.empty (instanceHeadType info) headTy of
@@ -1586,7 +1589,7 @@ resolveInstanceInfoWithSubst scope className0 headTy =
 
     equivalentInstanceMatch (left, _, _) (right, _, _) =
       instanceOriginModule left == instanceOriginModule right
-        && instanceClassName left == instanceClassName right
+        && instanceInfoClassIdentity left == instanceInfoClassIdentity right
         && lowerType scope (instanceHeadType left) == lowerType scope (instanceHeadType right)
         && map lowerConstraint (instanceConstraints left) == map lowerConstraint (instanceConstraints right)
         && fmap methodRuntimeIdentity (instanceMethods left) == fmap methodRuntimeIdentity (instanceMethods right)

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -1533,8 +1533,43 @@ resolveInstanceInfoWithSubst scope className0 headTy =
       [ (info, subst, direct)
         | info <- esInstances scope,
           instanceClassName info == className0,
+          instanceMatchesClassIdentity info,
           Just (subst, direct) <- [matchInstanceHead info]
       ]
+
+    expectedClassIdentity =
+      case Map.lookup className0 (esClasses scope) of
+        Just classInfo -> Just (classInfoIdentity classInfo)
+        Nothing -> overloadedMethodClassIdentity
+
+    instanceMatchesClassIdentity info =
+      case expectedClassIdentity of
+        Just identity -> instanceInfoClassIdentity info == identity
+        Nothing -> False
+
+    classInfoIdentity classInfo =
+      (classModule classInfo, unqualifiedName (className classInfo))
+
+    instanceInfoClassIdentity info =
+      (instanceClassModule info, unqualifiedName (instanceClassName info))
+
+    overloadedMethodClassIdentity =
+      methodValueClassIdentity
+        =<< find visibleMethodForClass (Map.elems (esValues scope))
+
+    visibleMethodForClass valueInfo =
+      case valueInfo of
+        OverloadedMethod {valueMethodInfo = methodInfo} -> methodClassName methodInfo == className0
+        _ -> False
+
+    methodValueClassIdentity valueInfo =
+      case valueInfo of
+        OverloadedMethod {valueMethodInfo = methodInfo} ->
+          Just (valueOriginModule valueInfo, unqualifiedName (methodClassName methodInfo))
+        _ -> Nothing
+
+    unqualifiedName =
+      reverse . takeWhile (/= '.') . reverse
 
     matchInstanceHead info =
       case matchTypes Map.empty (instanceHeadType info) headTy of

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -563,7 +563,7 @@ shouldResolveMethodBeforeInference :: ElaborateScope -> MethodInfo -> SrcType ->
 shouldResolveMethodBeforeInference scope methodInfo classArgTy =
   case lookupEvidenceMethod scope (methodClassName methodInfo) classArgTy (methodName methodInfo) of
     Just _ -> True
-    Nothing -> not (Set.null (freeTypeVarsSrcType classArgTy))
+    Nothing -> False
 
 resolveConstraintEvidenceExpr :: ElaborateScope -> Set (P.ClassName, String) -> P.ClassConstraint -> ElaborateM [SurfaceExpr]
 resolveConstraintEvidenceExpr scope seen constraint =
@@ -892,7 +892,10 @@ compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts =
         Nothing -> pure bodyExpr
     [P.Alt (P.PatVar name) body] -> do
       runtimeName <- freshRuntimeName name
-      scope' <- extendLocalLowered scope name runtimeName =<< freshTypeName
+      scope' <-
+        case mbScrutineeTy of
+          Just scrutineeTy -> extendLocal scope name runtimeName (Just scrutineeTy)
+          Nothing -> extendLocalLowered scope name runtimeName =<< freshTypeName
       bodyExpr <- compileExpr scope' mbExpected body
       pure (surfaceLet runtimeName scrutineeExpr bodyExpr)
     [P.Alt (P.PatAnn inner _) body] -> compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr [P.Alt inner body]

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -5,22 +5,25 @@
 module MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
     elaborateScopeDataTypes,
+    elaborateScopeInstances,
     elaborateScopeRuntimeTypes,
     mkElaborateScope,
     lowerConstructorBinding,
+    lowerConstrainedExprBinding,
     lowerExprBinding,
     inferClassArgument,
     lowerType,
     matchTypes,
     freeTypeVarsSrcType,
     resolveInstanceInfo,
+    resolveInstanceInfoWithSubst,
   )
 where
 
-import Control.Monad (foldM, replicateM, zipWithM)
+import Control.Monad (foldM, replicateM, when, zipWithM)
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
 import Control.Monad.State.Strict (State, get, modify, runState)
-import Data.List (find, nub, sort)
+import Data.List (nub, sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -52,6 +55,8 @@ data ElaborateScope = ElaborateScope
   { esValues :: Map String ValueInfo,
     esRuntimeTypes :: Map String SrcType,
     esTypes :: Map String DataInfo,
+    esClasses :: Map String ClassInfo,
+    esEvidence :: [EvidenceInfo],
     esInstances :: [InstanceInfo]
   }
 
@@ -88,10 +93,10 @@ runElaborateM action =
                 elaborateResultExternalTypes = elaborateExternalTypes finalState
               }
 
-mkElaborateScope :: Map String ValueInfo -> Map String DataInfo -> [InstanceInfo] -> ElaborateScope
-mkElaborateScope values0 dataTypes instances0 =
+mkElaborateScope :: Map String ValueInfo -> Map String DataInfo -> Map String ClassInfo -> [InstanceInfo] -> ElaborateScope
+mkElaborateScope values0 dataTypes classes0 instances0 =
   ElaborateScope
-    { esValues = values0,
+    { esValues = values0 `Map.union` instanceRuntimeValues,
       esRuntimeTypes =
         Map.fromList
           [ (runtimeNameFor info, lowerTypeRaw dataTypes (valueTypeFor info))
@@ -105,6 +110,8 @@ mkElaborateScope values0 dataTypes instances0 =
                 shouldTrackRuntimeType methodInfo
             ],
       esTypes = dataTypes,
+      esClasses = classes0,
+      esEvidence = [],
       esInstances = instances0
     }
   where
@@ -115,9 +122,17 @@ mkElaborateScope values0 dataTypes instances0 =
     runtimeNameFor ConstructorValue {valueRuntimeName = runtimeName} = runtimeName
     runtimeNameFor OverloadedMethod {} = error "overloaded methods do not have runtime names"
 
-    valueTypeFor OrdinaryValue {valueType = ty} = ty
+    valueTypeFor OrdinaryValue {valueType = ty, valueConstraints = constraints} =
+      constrainedRuntimeTypeRaw dataTypes classes0 constraints ty
     valueTypeFor ConstructorValue {valueType = ty} = quantifyFreeTypeVars ty
     valueTypeFor OverloadedMethod {} = error "overloaded methods do not have concrete runtime types"
+
+    instanceRuntimeValues =
+      Map.fromList
+        [ (runtimeName, methodValue)
+          | instanceInfo <- instances0,
+            methodValue@OrdinaryValue {valueRuntimeName = runtimeName} <- Map.elems (instanceMethods instanceInfo)
+        ]
 
 elaborateScopeRuntimeTypes :: ElaborateScope -> Map String SrcType
 elaborateScopeRuntimeTypes = esRuntimeTypes
@@ -125,8 +140,30 @@ elaborateScopeRuntimeTypes = esRuntimeTypes
 elaborateScopeDataTypes :: ElaborateScope -> Map String DataInfo
 elaborateScopeDataTypes = esTypes
 
+elaborateScopeInstances :: ElaborateScope -> [InstanceInfo]
+elaborateScopeInstances = esInstances
+
 lowerType :: ElaborateScope -> SrcType -> SrcType
 lowerType scope = lowerTypeRaw (esTypes scope)
+
+constrainedRuntimeType :: ElaborateScope -> [P.ClassConstraint] -> SrcType -> SrcType
+constrainedRuntimeType scope =
+  constrainedRuntimeTypeRaw (esTypes scope) (esClasses scope)
+
+constrainedRuntimeTypeRaw :: Map String DataInfo -> Map String ClassInfo -> [P.ClassConstraint] -> SrcType -> SrcType
+constrainedRuntimeTypeRaw dataTypes classes0 constraints visibleTy =
+  let (foralls, bodyTy) = splitForalls visibleTy
+      evidenceTys = concatMap constraintEvidenceTypes constraints
+      runtimeBody = foldr STArrow bodyTy evidenceTys
+   in foldr (\(name, mb) acc -> STForall name (fmap SrcBound mb) acc) runtimeBody foralls
+  where
+    constraintEvidenceTypes constraint =
+      case Map.lookup (P.constraintClassName constraint) classes0 of
+        Nothing -> []
+        Just classInfo ->
+          [ lowerTypeRaw dataTypes (specializeMethodType (methodType methodInfo) (classParamName classInfo) (P.constraintType constraint))
+            | methodInfo <- Map.elems (classMethods classInfo)
+          ]
 
 lowerTypeRaw :: Map String DataInfo -> SrcType -> SrcType
 lowerTypeRaw dataTypes = lower Map.empty Nothing
@@ -217,6 +254,27 @@ lowerExprBinding scope runtimeName expectedTy exportedAsMain expr = do
         loweredBindingExportedAsMain = exportedAsMain
       }
 
+lowerConstrainedExprBinding :: ElaborateScope -> String -> [P.ClassConstraint] -> SrcType -> Bool -> P.Expr -> Either ProgramError LoweredBinding
+lowerConstrainedExprBinding scope runtimeName constraints visibleTy exportedAsMain expr = do
+  result <- runElaborateM $ do
+    (scopeWithEvidence, evidenceParams) <- extendConstraintEvidence scope constraints
+    let (_, bodyExpectedTy) = splitForalls visibleTy
+    bodyExpr <- compileExpr scopeWithEvidence (Just bodyExpectedTy) expr
+    pure (foldr wrapEvidence bodyExpr evidenceParams)
+  let expectedTy = constrainedRuntimeType scope constraints visibleTy
+  pure
+    LoweredBinding
+      { loweredBindingName = runtimeName,
+        loweredBindingExpectedType = lowerType scope expectedTy,
+        loweredBindingSurfaceExpr = elaborateResultValue result,
+        loweredBindingDeferredObligations = elaborateResultDeferredObligations result,
+        loweredBindingExternalTypes = elaborateResultExternalTypes result,
+        loweredBindingExportedAsMain = exportedAsMain
+      }
+  where
+    wrapEvidence (runtimeName0, evidenceTy) acc =
+      surfaceLamAnn runtimeName0 evidenceTy acc
+
 constructorSurfaceExpr :: ElaborateScope -> ConstructorInfo -> SurfaceExpr
 constructorSurfaceExpr scope ctorInfo =
   surfaceAnn (constructorSurfaceExprRaw scope ctorInfo) (lowerType scope (quantifyFreeTypeVars (ctorType ctorInfo)))
@@ -226,7 +284,7 @@ constructorSurfaceExprRaw scope ctorInfo =
   let argNames = ["$" ++ ctorName ctorInfo ++ "_arg" ++ show ix | ix <- [1 .. length (ctorArgs ctorInfo)]]
       handlerNames = ["$" ++ ctorName ctorInfo ++ "_k" ++ show ix | ix <- [1 .. length ctorOrder]]
       resultVar =
-        if any (not . null . ctorForalls) ctorOrder
+        if any (not . null . ctorForalls) ctorOrder || constructorOwnerHasParams
           then "$" ++ ctorOwningType ctorInfo ++ "_result"
           else "a"
       handlerTypes = map (\ctor -> handlerSurfaceType scope ctor (STVar resultVar)) ctorOrder
@@ -245,6 +303,8 @@ constructorSurfaceExprRaw scope ctorInfo =
   where
     ctorOrder =
       maybe [] dataConstructors (Map.lookup (ctorOwningType ctorInfo) (esTypes scope))
+    constructorOwnerHasParams =
+      maybe False (not . null . dataParams) (Map.lookup (ctorOwningType ctorInfo) (esTypes scope))
 
 compileExpr :: ElaborateScope -> Maybe SrcType -> P.Expr -> ElaborateM SurfaceExpr
 compileExpr scope mbExpected expr = case expr of
@@ -336,15 +396,19 @@ explicitExprAnnotation expr =
 
 compileValueApp :: ElaborateScope -> Maybe SrcType -> ValueInfo -> [P.Expr] -> ElaborateM SurfaceExpr
 compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} args = do
+  let expectedArgTys = constructorExpectedArgTypes scope ctorInfo args
   argSurfaces <-
-    zipWithM compileConstructorArg (take (length args) (ctorArgs ctorInfo)) args
+    zipWithM compileConstructorArg expectedArgTys args
   placeholder <- deferConstructorCall scope ctorInfo (length args) mbExpected
   pure (foldl surfaceApp (surfaceVar placeholder) argSurfaces)
   where
     compileConstructorArg expectedTy arg = do
       case inferKnownExprType scope arg of
-        Just knownTy ->
-          compileExpr scope (Just knownTy) arg
+        Just knownTy
+          | Set.null (freeTypeVarsSrcType knownTy) ->
+              compileExpr scope (Just knownTy) arg
+          | otherwise ->
+              compileExpr scope (Just expectedTy) arg
         Nothing -> do
           argSurface <- compileExpr scope Nothing arg
           pure $
@@ -354,17 +418,56 @@ compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} arg
 
 compileValueApp scope mbExpected valueInfo args = do
   argSurfaces <- mapM (compileExpr scope Nothing) args
+  evidenceSurfaces <- valueEvidenceArgs scope valueInfo args
   let headSurface =
         case valueInfo of
           OrdinaryValue {valueRuntimeName = runtimeName} -> surfaceVar runtimeName
           OverloadedMethod {} -> error "compileValueApp does not handle overloaded methods"
-      applied = foldl surfaceApp headSurface argSurfaces
+      headWithEvidence = foldl surfaceApp headSurface evidenceSurfaces
+      applied = foldl surfaceApp headWithEvidence argSurfaces
   pure $ case mbExpected of
     Just expectedTy
       | not (isLocalOrdinaryValue valueInfo),
         isRecursiveResultType expectedTy || isRecursiveResultType (lowerType scope expectedTy) ->
           surfaceAnn applied (lowerType scope expectedTy)
     _ -> applied
+
+constructorExpectedArgTypes :: ElaborateScope -> ConstructorInfo -> [P.Expr] -> [SrcType]
+constructorExpectedArgTypes scope ctorInfo args =
+  reverse (snd (foldl step (Map.empty, []) (zip (ctorArgs ctorInfo) args)))
+  where
+    step (subst, acc) (templateTy, arg) =
+      let expectedTy = specializeSrcType subst templateTy
+          subst' =
+            case inferKnownExprType scope arg >>= matchTypes subst templateTy of
+              Just matched -> matched
+              Nothing -> subst
+       in (subst', expectedTy : acc)
+
+valueEvidenceArgs :: ElaborateScope -> ValueInfo -> [P.Expr] -> ElaborateM [SurfaceExpr]
+valueEvidenceArgs scope OrdinaryValue {valueType = visibleTy, valueConstraints = constraints} args
+  | null constraints = pure []
+  | otherwise = do
+      subst <-
+        case inferCallSubst scope visibleTy args of
+          Just subst0 -> pure subst0
+          Nothing ->
+            case constraints of
+              constraint : _ -> throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
+              [] -> pure Map.empty
+      concat <$> mapM (resolveConstraintEvidenceExpr scope Set.empty . applyConstraintSubst subst) constraints
+valueEvidenceArgs _ _ _ = pure []
+
+inferCallSubst :: ElaborateScope -> SrcType -> [P.Expr] -> Maybe (Map String SrcType)
+inferCallSubst scope visibleTy args = do
+  let (_, bodyTy) = splitForalls visibleTy
+      (argTys, _) = splitArrows bodyTy
+      knownPairs =
+        [ (templateTy, actualTy)
+          | (templateTy, arg) <- zip argTys args,
+            Just actualTy <- [inferKnownExprType scope arg]
+        ]
+  foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty knownPairs
 
 isLocalOrdinaryValue :: ValueInfo -> Bool
 isLocalOrdinaryValue OrdinaryValue {valueOriginModule = "<local>"} = True
@@ -382,23 +485,36 @@ compileMethodApp scope _mbExpected methodInfo args
   | otherwise = do
       let fullArity = methodFullArity methodInfo
           suppliedArity = length args
+          knownClassArg = knownMethodClassArg scope methodInfo args
           placeholderTy = placeholderMethodType scope methodInfo args
           knownArgTys =
-            case knownMethodClassArg scope methodInfo args of
+            case knownClassArg of
               Just _ -> Just (take suppliedArity (methodArgumentTypes placeholderTy))
               Nothing -> Nothing
       argSurfaces <-
         case knownArgTys of
           Just argTys -> zipWithM (compileExpectedMethodArg scope) argTys args
           Nothing -> mapM (compileExpr scope Nothing) args
-      placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy
-      let applied = foldl surfaceApp (surfaceVar placeholder) argSurfaces
-      expanded <- etaExpandMissingArgs scope methodInfo placeholderTy suppliedArity fullArity applied
-      pure $
-        case peelAppliedType placeholderTy suppliedArity of
-          Just remainingTy
-            | suppliedArity < fullArity -> surfaceAnn expanded (lowerType scope remainingTy)
-          _ -> expanded
+      case knownClassArg of
+        Just classArgTy
+          | shouldResolveMethodBeforeInference scope methodInfo classArgTy -> do
+              methodHead <- resolveMethodHeadExpr scope Set.empty methodInfo classArgTy
+              let applied = foldl surfaceApp methodHead argSurfaces
+              expanded <- etaExpandMissingArgs scope methodInfo placeholderTy suppliedArity fullArity applied
+              pure $
+                case peelAppliedType placeholderTy suppliedArity of
+                  Just remainingTy
+                    | suppliedArity < fullArity -> surfaceAnn expanded (lowerType scope remainingTy)
+                  _ -> expanded
+        _ -> do
+          placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy
+          let applied = foldl surfaceApp (surfaceVar placeholder) argSurfaces
+          expanded <- etaExpandMissingArgs scope methodInfo placeholderTy suppliedArity fullArity applied
+          pure $
+            case peelAppliedType placeholderTy suppliedArity of
+              Just remainingTy
+                | suppliedArity < fullArity -> surfaceAnn expanded (lowerType scope remainingTy)
+              _ -> expanded
 
 compileExpectedMethodArg :: ElaborateScope -> SrcType -> P.Expr -> ElaborateM SurfaceExpr
 compileExpectedMethodArg scope expectedTy expr =
@@ -426,6 +542,73 @@ compileExpectedMethodArg scope expectedTy expr =
     _ -> do
       argExpr <- compileExpr scope Nothing expr
       pure (surfaceAnn argExpr (lowerType scope expectedTy))
+
+resolveMethodHeadExpr :: ElaborateScope -> Set (P.ClassName, String) -> MethodInfo -> SrcType -> ElaborateM SurfaceExpr
+resolveMethodHeadExpr scope seen methodInfo classArgTy =
+  case lookupEvidenceMethod scope (methodClassName methodInfo) classArgTy (methodName methodInfo) of
+    Just (runtimeName, _) -> pure (surfaceVar runtimeName)
+    Nothing -> do
+      (instanceInfo, subst) <- liftEitherElab (resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy)
+      case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
+        Just OrdinaryValue {valueRuntimeName = runtimeName} -> do
+          evidenceArgs <-
+            concat
+              <$> mapM
+                (resolveConstraintEvidenceExpr scope seen . applyConstraintSubst subst)
+                (instanceConstraints instanceInfo)
+          pure (foldl surfaceApp (surfaceVar runtimeName) evidenceArgs)
+        _ -> throwError (ProgramUnknownMethod (methodName methodInfo))
+
+shouldResolveMethodBeforeInference :: ElaborateScope -> MethodInfo -> SrcType -> Bool
+shouldResolveMethodBeforeInference scope methodInfo classArgTy =
+  case lookupEvidenceMethod scope (methodClassName methodInfo) classArgTy (methodName methodInfo) of
+    Just _ -> True
+    Nothing -> not (Set.null (freeTypeVarsSrcType classArgTy))
+
+resolveConstraintEvidenceExpr :: ElaborateScope -> Set (P.ClassName, String) -> P.ClassConstraint -> ElaborateM [SurfaceExpr]
+resolveConstraintEvidenceExpr scope seen constraint =
+  case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
+    Nothing -> throwError (ProgramUnknownClass (P.constraintClassName constraint))
+    Just classInfo -> do
+      let key = (P.constraintClassName constraint, show (P.constraintType constraint))
+      whenSeen key
+      mapM
+        ( \methodInfo ->
+            resolveMethodHeadExpr
+              scope
+              (Set.insert key seen)
+              methodInfo
+              (P.constraintType constraint)
+        )
+        (Map.elems (classMethods classInfo))
+  where
+    whenSeen key =
+      when (key `Set.member` seen) $
+        throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
+
+lookupEvidenceMethod :: ElaborateScope -> P.ClassName -> SrcType -> P.MethodName -> Maybe (String, SrcType)
+lookupEvidenceMethod scope className0 headTy methodName0 =
+  case
+    [ methodEvidence
+      | evidence <- esEvidence scope,
+        evidenceClassName evidence == className0,
+        lowerType scope (evidenceType evidence) == lowerType scope headTy,
+        Just methodEvidence <- [Map.lookup methodName0 (evidenceMethods evidence)]
+    ]
+  of
+    methodEvidence : _ -> Just methodEvidence
+    [] -> Nothing
+
+applyConstraintSubst :: Map String SrcType -> P.ClassConstraint -> P.ClassConstraint
+applyConstraintSubst subst constraint =
+  constraint {P.constraintType = applySrcSubst subst (P.constraintType constraint)}
+
+applySrcSubst :: Map String SrcType -> SrcType -> SrcType
+applySrcSubst subst ty =
+  Map.foldrWithKey substituteTypeVar ty subst
+
+liftEitherElab :: Either ProgramError a -> ElaborateM a
+liftEitherElab = either throwError pure
 
 etaExpandMissingArgs :: ElaborateScope -> MethodInfo -> SrcType -> Int -> Int -> SurfaceExpr -> ElaborateM SurfaceExpr
 etaExpandMissingArgs scope methodInfo methodTy suppliedArity fullArity applied = do
@@ -649,12 +832,7 @@ compileCase scope mbExpected scrutinee alts = do
     owners -> do
       dataInfo <- requireSingleDataOwner scope owners
       let headTy = dataHeadType dataInfo
-          ctorNames = [name | P.Alt (P.PatCtor name _) _ <- alts]
-          dupes = duplicates ctorNames
-      case dupes of
-        (dup : _) -> throwError (ProgramDuplicateCaseBranch dup)
-        [] -> pure ()
-      catchAll <- pure (findCatchAll alts)
+      validateOrderedPatterns alts
       (resultTy, _quantifyResult) <-
         case mbExpected of
           Just expectedTy -> pure (expectedTy, False)
@@ -666,7 +844,7 @@ compileCase scope mbExpected scrutinee alts = do
         Nothing -> do
           scrutineeExpr <- compileExpr scope (Just headTy) scrutinee
           let forceAnnotateHandlers = any (not . null . ctorForalls) (dataConstructors dataInfo)
-          handlers <- mapM (compileHandler scope scrutineeExpr resultTy headTy dataInfo alts catchAll forceAnnotateHandlers) (dataConstructors dataInfo)
+          handlers <- mapM (compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers) (dataConstructors dataInfo)
           placeholder <- deferCaseCall scope dataInfo resultTy
           pure (foldl surfaceApp (surfaceVar placeholder) (scrutineeExpr : handlers))
 
@@ -691,98 +869,164 @@ compileCatchAllOnly scope mbExpected scrutineeExpr alts =
       scope' <- extendLocalLowered scope name runtimeName =<< freshTypeName
       bodyExpr <- compileExpr scope' mbExpected body
       pure (surfaceLet runtimeName scrutineeExpr bodyExpr)
+    [P.Alt (P.PatAnn inner _) body] -> compileCatchAllOnly scope mbExpected scrutineeExpr [P.Alt inner body]
     _ -> throwError (ProgramCaseOnNonDataType STBottom)
 
-compileHandler :: ElaborateScope -> SurfaceExpr -> SrcType -> SrcType -> DataInfo -> [P.Alt] -> Maybe P.Alt -> Bool -> ConstructorInfo -> ElaborateM SurfaceExpr
-compileHandler scope scrutineeExpr resultTy headTy dataInfo alts catchAll forceAnnotateHandlers ctorInfo =
-  case findMatchingAlt ctorInfo of
-    Just alt -> compileMatchingAlt scope resultTy headTy forceAnnotateHandlers ctorInfo alt
-    Nothing ->
-      case catchAll of
-        Just alt -> compileCatchAllAlt scope scrutineeExpr resultTy forceAnnotateHandlers ctorInfo alt
-        Nothing -> throwError (ProgramNonExhaustiveCase missing)
-  where
-    missing = [ctorName ctor | ctor <- dataConstructors dataInfo, not (hasAlt ctor)]
-
-    hasAlt ctor =
-      any
-        ( \case
-            P.Alt (P.PatCtor ctorName0 _) _ -> ctorName0 == ctorName ctor
-            P.Alt P.PatVar {} _ -> True
-            P.Alt P.PatWildcard _ -> True
-        )
-        alts
-
-    findMatchingAlt ctor =
-      find
-        ( \case
-            P.Alt (P.PatCtor ctorName0 _) _ -> ctorName0 == ctorName ctor
-            _ -> False
-        )
-        alts
-
-compileMatchingAlt :: ElaborateScope -> SrcType -> SrcType -> Bool -> ConstructorInfo -> P.Alt -> ElaborateM SurfaceExpr
-compileMatchingAlt scope resultTy headTy forceAnnotateHandlers ctorInfo (P.Alt (P.PatCtor _ binders) body)
-  | length binders /= length (ctorArgs ctorInfo) = throwError (ProgramPatternConstructorMismatch (ctorName ctorInfo) headTy)
-  | otherwise = do
-      runtimeNames <- mapM freshRuntimeName binders
-      scope' <- foldM (\acc (srcName, runtimeName, argTy) -> extendLocal acc srcName runtimeName (Just argTy)) scope (zip3 binders runtimeNames (ctorArgs ctorInfo))
-      let resultTyElab = lowerType scope resultTy
-      bodyExpr <- compileExpr scope' (Just resultTy) body
-      let handlerBody =
-            foldr
-              (\(name, argTy) acc -> surfaceLamAnn name (lowerType scope argTy) acc)
-              bodyExpr
-              (zip runtimeNames (ctorArgs ctorInfo))
-      if not forceAnnotateHandlers && null (ctorForalls ctorInfo)
-        then pure handlerBody
-        else do
-          let handlerTy = handlerSurfaceType scope ctorInfo resultTyElab
-          pure (surfaceAnn handlerBody handlerTy)
-compileMatchingAlt _ _ headTy _ ctorInfo _ =
-  throwError (ProgramPatternConstructorMismatch (ctorName ctorInfo) headTy)
-
-compileCatchAllAlt :: ElaborateScope -> SurfaceExpr -> SrcType -> Bool -> ConstructorInfo -> P.Alt -> ElaborateM SurfaceExpr
-compileCatchAllAlt scope scrutineeExpr resultTy forceAnnotateHandlers ctorInfo alt = do
+compileHandler :: ElaborateScope -> SurfaceExpr -> SrcType -> DataInfo -> [P.Alt] -> Bool -> ConstructorInfo -> ElaborateM SurfaceExpr
+compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers ctorInfo = do
   runtimeNames <- mapM freshRuntimeName ["case" ++ show ix | ix <- [1 .. length (ctorArgs ctorInfo)]]
-  let lambdaBinders = zip runtimeNames (ctorArgs ctorInfo)
-  case P.altPattern alt of
-    P.PatWildcard -> do
-      let resultTyElab = lowerType scope resultTy
-      bodyExpr <- compileExpr scope (Just resultTy) (P.altExpr alt)
-      let handlerBody =
+  let topArgs = zip3 (map (const P.PatWildcard) (ctorArgs ctorInfo)) runtimeNames (ctorArgs ctorInfo)
+      candidates = matchingCandidates ctorInfo
+  bodyExpr <- compileCandidates topArgs candidates
+  let handlerBody =
+        foldr
+          (\(name, argTy) acc -> surfaceLamAnn name (lowerType scope argTy) acc)
+          bodyExpr
+          (zip runtimeNames (ctorArgs ctorInfo))
+  if not forceAnnotateHandlers && null (ctorForalls ctorInfo)
+    then pure handlerBody
+    else do
+      let handlerTy = handlerSurfaceType scope ctorInfo (lowerType scope resultTy)
+      pure (surfaceAnn handlerBody handlerTy)
+  where
+    matchingCandidates ctor =
+      filter (patternCouldMatchConstructor ctor . P.altPattern) alts
+
+    compileCandidates _ [] = throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
+    compileCandidates topArgs [alt] =
+      compileAltCandidate topArgs alt Nothing
+    compileCandidates topArgs (alt : rest) = do
+      fallback <- compileCandidates topArgs rest
+      compileAltCandidate topArgs alt (Just fallback)
+
+    compileAltCandidate topArgs (P.Alt pattern0 body) mbFallback =
+      case stripPatternAnn pattern0 of
+        P.PatWildcard -> compileExpr scope (Just resultTy) body
+        P.PatVar name -> do
+          scrutineeName <- freshRuntimeName name
+          scope' <- extendLocalLowered scope name scrutineeName (lowerType scope (dataHeadType dataInfo))
+          bodyExpr <- compileExpr scope' (Just resultTy) body
+          pure (surfaceLet scrutineeName scrutineeExpr bodyExpr)
+        P.PatCtor ctorName0 patterns
+          | ctorName0 == ctorName ctorInfo,
+            length patterns == length (ctorArgs ctorInfo) ->
+              compilePatternSequence scope (zip3 patterns (map middle topArgs) (ctorArgs ctorInfo)) body mbFallback
+          | ctorName0 == ctorName ctorInfo ->
+              throwError (ProgramPatternConstructorMismatch ctorName0 (dataHeadType dataInfo))
+          | otherwise ->
+              case mbFallback of
+                Just fallback -> pure fallback
+                Nothing -> throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
+        P.PatAnn inner _ -> compileAltCandidate topArgs (P.Alt inner body) mbFallback
+
+    middle (_, value, _) = value
+
+    compilePatternSequence scope0 [] body _ =
+      compileExpr scope0 (Just resultTy) body
+    compilePatternSequence scope0 ((pattern0, runtimeName, argTy) : rest) body mbFallback =
+      case stripPatternAnn pattern0 of
+        P.PatWildcard -> compilePatternSequence scope0 rest body mbFallback
+        P.PatVar sourceName -> do
+          scope' <- extendLocal scope0 sourceName runtimeName (Just argTy)
+          compilePatternSequence scope' rest body mbFallback
+        P.PatCtor nestedCtorName nestedPatterns -> do
+          nestedCtorInfo <- lookupConstructorInfo nestedCtorName
+          nestedDataInfo <- lookupDataInfo (ctorOwningType nestedCtorInfo)
+          if length nestedPatterns /= length (ctorArgs nestedCtorInfo)
+            then throwError (ProgramPatternConstructorMismatch nestedCtorName argTy)
+            else do
+              fallback <-
+                case mbFallback of
+                  Just fallback0 -> pure fallback0
+                  Nothing -> throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
+              nestedRuntimeNames <- mapM freshRuntimeName ["pat" ++ show ix | ix <- [1 .. length (ctorArgs nestedCtorInfo)]]
+              let forceNestedAnnotations = any (not . null . ctorForalls) (dataConstructors nestedDataInfo)
+              matchingBody <- compilePatternSequence scope0 (zip3 nestedPatterns nestedRuntimeNames (ctorArgs nestedCtorInfo) ++ rest) body mbFallback
+              handlers <- mapM (nestedHandler forceNestedAnnotations nestedCtorInfo nestedRuntimeNames matchingBody fallback) (dataConstructors nestedDataInfo)
+              placeholder <- deferCaseCall scope0 nestedDataInfo resultTy
+              pure (foldl surfaceApp (surfaceVar placeholder) (surfaceVar runtimeName : handlers))
+        P.PatAnn inner _ -> compilePatternSequence scope0 ((inner, runtimeName, argTy) : rest) body mbFallback
+
+    nestedHandler forceNestedAnnotations targetCtor nestedRuntimeNames matchingBody fallback ctor =
+      let argNames = if ctorName ctor == ctorName targetCtor then nestedRuntimeNames else ["unused" ++ show ix | ix <- [1 .. length (ctorArgs ctor)]]
+          selectedBody = if ctorName ctor == ctorName targetCtor then matchingBody else fallback
+          handlerBody =
             foldr
               (\(name, argTy) acc -> surfaceLamAnn name (lowerType scope argTy) acc)
-              bodyExpr
-              lambdaBinders
-      if not forceAnnotateHandlers && null (ctorForalls ctorInfo)
-        then pure handlerBody
-        else do
-          let handlerTy = handlerSurfaceType scope ctorInfo resultTyElab
-          pure (surfaceAnn handlerBody handlerTy)
-    P.PatVar name -> do
-      scrutineeName <- freshRuntimeName name
-      scope' <- extendLocalLowered scope name scrutineeName (lowerType scope (ctorResult ctorInfo))
-      let resultTyElab = lowerType scope resultTy
-      bodyExpr <- compileExpr scope' (Just resultTy) (P.altExpr alt)
-      let handlerBody =
-            foldr
-              (\(name', argTy) acc -> surfaceLamAnn name' (lowerType scope argTy) acc)
-              (surfaceLet scrutineeName scrutineeExpr bodyExpr)
-              lambdaBinders
-      if not forceAnnotateHandlers && null (ctorForalls ctorInfo)
-        then pure handlerBody
-        else do
-          let handlerTy = handlerSurfaceType scope ctorInfo resultTyElab
-          pure (surfaceAnn handlerBody handlerTy)
-    _ -> throwError (ProgramUnknownConstructor (ctorName ctorInfo))
+              selectedBody
+              (zip argNames (ctorArgs ctor))
+       in if not forceNestedAnnotations && null (ctorForalls ctor)
+            then pure handlerBody
+            else do
+              let handlerTy = handlerSurfaceType scope ctor (lowerType scope resultTy)
+              pure (surfaceAnn handlerBody handlerTy)
+
+    lookupConstructorInfo ctorName0 =
+      case Map.lookup ctorName0 (esValues scope) of
+        Just ConstructorValue {valueCtorInfo = ctorInfo0} -> pure ctorInfo0
+        _ -> throwError (ProgramUnknownConstructor ctorName0)
+
+    lookupDataInfo typeName =
+      case Map.lookup typeName (esTypes scope) of
+        Just info -> pure info
+        Nothing -> throwError (ProgramUnknownType typeName)
 
 ctorOwners :: [P.Alt] -> [String]
 ctorOwners = foldr go []
   where
     go alt acc = case P.altPattern alt of
       P.PatCtor ctorName0 _ -> ctorName0 : acc
+      P.PatAnn inner _ -> go (P.Alt inner (P.altExpr alt)) acc
       _ -> acc
+
+validateOrderedPatterns :: [P.Alt] -> ElaborateM ()
+validateOrderedPatterns = go Set.empty False
+  where
+    go _ _ [] = pure ()
+    go seen catchAllSeen (P.Alt pattern0 _ : rest)
+      | catchAllSeen =
+          throwError (ProgramDuplicateCaseBranch (maybe "_" id (topConstructorName pattern0)))
+      | isCatchAllPattern pattern0 =
+          go seen True rest
+      | Just ctorName0 <- flatCatchAllConstructor pattern0 =
+          if ctorName0 `Set.member` seen
+            then throwError (ProgramDuplicateCaseBranch ctorName0)
+            else go (Set.insert ctorName0 seen) False rest
+      | otherwise = go seen False rest
+
+topConstructorName :: P.Pattern -> Maybe String
+topConstructorName pattern0 =
+  case stripPatternAnn pattern0 of
+    P.PatCtor ctorName0 _ -> Just ctorName0
+    _ -> Nothing
+
+flatCatchAllConstructor :: P.Pattern -> Maybe String
+flatCatchAllConstructor pattern0 =
+  case stripPatternAnn pattern0 of
+    P.PatCtor ctorName0 patterns
+      | all isCatchAllPattern patterns -> Just ctorName0
+    _ -> Nothing
+
+isCatchAllPattern :: P.Pattern -> Bool
+isCatchAllPattern pattern0 =
+  case stripPatternAnn pattern0 of
+    P.PatWildcard -> True
+    P.PatVar {} -> True
+    _ -> False
+
+patternCouldMatchConstructor :: ConstructorInfo -> P.Pattern -> Bool
+patternCouldMatchConstructor ctorInfo pattern0 =
+  case stripPatternAnn pattern0 of
+    P.PatWildcard -> True
+    P.PatVar {} -> True
+    P.PatCtor ctorName0 _ -> ctorName0 == ctorName ctorInfo
+    P.PatAnn inner _ -> patternCouldMatchConstructor ctorInfo inner
+
+stripPatternAnn :: P.Pattern -> P.Pattern
+stripPatternAnn pattern0 =
+  case pattern0 of
+    P.PatAnn inner _ -> stripPatternAnn inner
+    _ -> pattern0
 
 requireSingleDataOwner :: ElaborateScope -> [String] -> ElaborateM DataInfo
 requireSingleDataOwner scope ctorNames0 = do
@@ -799,13 +1043,6 @@ requireSingleDataOwner scope ctorNames0 = do
       case Map.lookup ctorName0 (esValues scope) of
         Just ConstructorValue {valueCtorInfo = ctorInfo} -> pure ctorInfo
         _ -> throwError (ProgramUnknownConstructor ctorName0)
-
-findCatchAll :: [P.Alt] -> Maybe P.Alt
-findCatchAll = find isCatchAll
-  where
-    isCatchAll (P.Alt P.PatVar {} _) = True
-    isCatchAll (P.Alt P.PatWildcard _) = True
-    isCatchAll _ = False
 
 handlerSurfaceType :: ElaborateScope -> ConstructorInfo -> SrcType -> SrcType
 handlerSurfaceType scope ctorInfo resultTy =
@@ -851,14 +1088,29 @@ isRecursiveResultType ty =
 
 resolveInstanceInfo :: ElaborateScope -> P.ClassName -> SrcType -> Either ProgramError InstanceInfo
 resolveInstanceInfo scope className0 headTy =
-  case filter matches (esInstances scope) of
-    [info] -> Right info
+  fst <$> resolveInstanceInfoWithSubst scope className0 headTy
+
+resolveInstanceInfoWithSubst :: ElaborateScope -> P.ClassName -> SrcType -> Either ProgramError (InstanceInfo, Map String SrcType)
+resolveInstanceInfoWithSubst scope className0 headTy =
+  case matches of
+    [match] -> Right match
     [] -> Left (ProgramNoMatchingInstance className0 headTy)
     _ -> Left (ProgramNoMatchingInstance className0 headTy)
   where
-    matches info =
-      instanceClassName info == className0
-        && lowerType scope (instanceHeadType info) == lowerType scope headTy
+    matches =
+      [ (info, subst)
+        | info <- esInstances scope,
+          instanceClassName info == className0,
+          Just subst <- [matchInstanceHead info]
+      ]
+
+    matchInstanceHead info =
+      case matchTypes Map.empty (instanceHeadType info) headTy of
+        Just subst -> Just subst
+        Nothing ->
+          if lowerType scope (instanceHeadType info) == lowerType scope headTy
+            then Just Map.empty
+            else Nothing
 
 inferClassArgument :: SrcType -> String -> [SrcType] -> Maybe SrcType
 inferClassArgument methodTy classParam args =
@@ -934,6 +1186,42 @@ freeTypeVarsSrcType = go Set.empty
        in mbFvs `Set.union` go bound' body
     go bound (STMu name body) = go (Set.insert name bound) body
 
+extendConstraintEvidence :: ElaborateScope -> [P.ClassConstraint] -> ElaborateM (ElaborateScope, [(String, SrcType)])
+extendConstraintEvidence scope constraints = do
+  built <- mapM buildEvidence constraints
+  let evidenceInfos = concatMap fst built
+      params = concatMap snd built
+  let runtimeTypes = Map.fromList params
+  pure
+    ( scope
+        { esEvidence = evidenceInfos ++ esEvidence scope,
+          esRuntimeTypes = runtimeTypes `Map.union` esRuntimeTypes scope
+        },
+      params
+    )
+  where
+    buildEvidence constraint = do
+      classInfo <-
+        case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
+          Just info -> pure info
+          Nothing -> throwError (ProgramUnknownClass (P.constraintClassName constraint))
+      methodEntries <-
+        mapM
+          ( \methodInfo -> do
+              runtimeName <- freshRuntimeName ("evidence_" ++ P.constraintClassName constraint ++ "_" ++ methodName methodInfo)
+              let evidenceTy = lowerType scope (specializeMethodType (methodType methodInfo) (classParamName classInfo) (P.constraintType constraint))
+              pure (methodName methodInfo, (runtimeName, evidenceTy))
+          )
+          (Map.elems (classMethods classInfo))
+      let evidenceInfo =
+            EvidenceInfo
+              { evidenceClassName = P.constraintClassName constraint,
+                evidenceType = P.constraintType constraint,
+                evidenceMethods = Map.fromList methodEntries
+              }
+          params = map snd methodEntries
+      pure ([evidenceInfo], params)
+
 extendLocal :: ElaborateScope -> String -> String -> Maybe SrcType -> ElaborateM ElaborateScope
 extendLocal scope sourceName runtimeName mbTy = do
   case mbTy of
@@ -956,6 +1244,7 @@ extendLocalLoweredPure scope sourceName runtimeName loweredTy =
             { valueDisplayName = sourceName,
               valueRuntimeName = runtimeName,
               valueType = loweredTy,
+              valueConstraints = [],
               valueOriginModule = "<local>"
             }
           (esValues scope),
@@ -972,6 +1261,7 @@ extendLocalSourceTypePure scope sourceName runtimeName sourceTy =
             { valueDisplayName = sourceName,
               valueRuntimeName = runtimeName,
               valueType = sourceTy,
+              valueConstraints = [],
               valueOriginModule = "<local>"
             }
           (esValues scope),
@@ -1003,9 +1293,10 @@ collectFreeValues bound expr = case expr of
       collectFreeValues (Set.union bound (Set.fromList (patternBinders pattern0))) body
 
     patternBinders = \case
-      P.PatCtor _ binders -> binders
+      P.PatCtor _ patterns -> concatMap patternBinders patterns
       P.PatVar name -> [name]
       P.PatWildcard -> []
+      P.PatAnn inner _ -> patternBinders inner
 
 collectApps :: P.Expr -> (P.Expr, [P.Expr])
 collectApps = go []
@@ -1013,8 +1304,6 @@ collectApps = go []
     go acc (EApp fun arg) = go (arg : acc) fun
     go acc headExpr = (headExpr, acc)
 
-duplicates :: (Eq a) => [a] -> [a]
-duplicates xs = [x | x <- nub xs, length (filter (== x) xs) > 1]
 
 freshRuntimeName :: String -> ElaborateM String
 freshRuntimeName base = do

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -20,10 +20,10 @@ module MLF.Frontend.Program.Elaborate
   )
 where
 
-import Control.Monad (foldM, replicateM, when, zipWithM)
+import Control.Monad ((>=>), foldM, replicateM, when, zipWithM)
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
 import Control.Monad.State.Strict (State, get, modify, runState)
-import Data.List (nub, sort)
+import Data.List (find, sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -378,10 +378,12 @@ constructorSurfaceExprRaw scope ctorInfo =
           (zip argNames (ctorArgs ctorInfo))
    in lifted
   where
+    ownerInfo =
+      visibleDataInfo <$> resolveConstructorDataInfo scope ctorInfo
     ctorOrder =
-      maybe [] dataConstructors (Map.lookup (ctorOwningType ctorInfo) (esTypes scope))
+      maybe [] dataConstructors ownerInfo
     constructorOwnerHasParams =
-      maybe False (not . null . dataParams) (Map.lookup (ctorOwningType ctorInfo) (esTypes scope))
+      maybe False (not . null . dataParams) ownerInfo
 
 compileExpr :: ElaborateScope -> Maybe SrcType -> P.Expr -> ElaborateM SurfaceExpr
 compileExpr scope mbExpected expr = case expr of
@@ -1201,7 +1203,7 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
       pure (surfaceAnn handlerBody handlerTy)
   where
     matchingCandidates ctor =
-      filter (patternCouldMatchConstructor ctor . P.altPattern) alts
+      filter (patternCouldMatchConstructor scope ctor . P.altPattern) alts
 
     compileCandidates _ [] = throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
     compileCandidates topArgs [alt] =
@@ -1219,11 +1221,10 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
           bodyExpr <- compileExpr scope' (Just resultTy) body
           pure (surfaceLet scrutineeName scrutineeExpr bodyExpr)
         P.PatCtor ctorName0 patterns
-          | ctorName0 == ctorName ctorInfo,
-            length patterns == length (ctorArgs ctorInfo) ->
-              compilePatternSequence scope (zip3 patterns (map middle topArgs) (map third topArgs)) body mbFallback
-          | ctorName0 == ctorName ctorInfo ->
-              throwError (ProgramPatternConstructorMismatch ctorName0 (dataHeadType dataInfo))
+          | constructorNameMatches scope ctorName0 ctorInfo ->
+              if length patterns == length (ctorArgs ctorInfo)
+                then compilePatternSequence scope (zip3 patterns (map middle topArgs) (map third topArgs)) body mbFallback
+                else throwError (ProgramPatternConstructorMismatch ctorName0 (dataHeadType dataInfo))
           | otherwise ->
               case mbFallback of
                 Just fallback -> pure fallback
@@ -1242,8 +1243,8 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
           scope' <- extendLocal scope0 sourceName runtimeName (Just argTy)
           compilePatternSequence scope' rest body mbFallback
         P.PatCtor nestedCtorName nestedPatterns -> do
-          nestedCtorInfo <- lookupConstructorInfo nestedCtorName
-          nestedDataInfo <- lookupDataInfo (ctorOwningType nestedCtorInfo)
+          nestedCtorInfo <- lookupConstructorInfo scope nestedCtorName
+          nestedDataInfo <- lookupDataInfoForConstructor scope nestedCtorInfo
           if length nestedPatterns /= length (ctorArgs nestedCtorInfo)
             then throwError (ProgramPatternConstructorMismatch nestedCtorName argTy)
             else do
@@ -1264,14 +1265,15 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
         P.PatAnn inner annTy -> compilePatternSequence scope0 ((inner, runtimeName, annTy) : rest) body mbFallback
 
     nestedPatternNeedsFallback nestedDataInfo targetCtor =
-      any ((/= ctorName targetCtor) . ctorName) (dataConstructors nestedDataInfo)
+      any (not . sameConstructorInfo targetCtor) (dataConstructors nestedDataInfo)
 
     nestedHandler forceNestedAnnotations nestedScrutineeTy targetCtor nestedRuntimeNames matchingBody mbFallback ctor =
       let ctorArgTys = specializeConstructorArgsForScrutinee nestedScrutineeTy ctor
           specializedCtor = ctor {ctorArgs = ctorArgTys}
-          argNames = if ctorName ctor == ctorName targetCtor then nestedRuntimeNames else ["unused" ++ show ix | ix <- [1 .. length ctorArgTys]]
+          targetSelected = sameConstructorInfo ctor targetCtor
+          argNames = if targetSelected then nestedRuntimeNames else ["unused" ++ show ix | ix <- [1 .. length ctorArgTys]]
           selectedBody =
-            case (ctorName ctor == ctorName targetCtor, mbFallback) of
+            case (targetSelected, mbFallback) of
               (True, _) -> matchingBody
               (False, Just fallback) -> fallback
               (False, Nothing) -> matchingBody
@@ -1290,16 +1292,6 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
       case matchTypes Map.empty (ctorResult ctor) actualScrutineeTy of
         Just subst -> map (specializeSrcType subst) (ctorArgs ctor)
         Nothing -> ctorArgs ctor
-
-    lookupConstructorInfo ctorName0 =
-      case Map.lookup ctorName0 (esValues scope) of
-        Just ConstructorValue {valueCtorInfo = ctorInfo0} -> pure ctorInfo0
-        _ -> throwError (ProgramUnknownConstructor ctorName0)
-
-    lookupDataInfo typeName =
-      case Map.lookup typeName (esTypes scope) of
-        Just info -> pure info
-        Nothing -> throwError (ProgramUnknownType typeName)
 
 ctorOwners :: [P.Alt] -> [String]
 ctorOwners = foldr go []
@@ -1333,7 +1325,7 @@ validatePatternType scope expectedTy pattern0 =
       validatePatternAnnotation scope expectedTy annTy
       validatePatternType scope annTy inner
     P.PatCtor ctorName0 patterns -> do
-      ctorInfo <- lookupConstructorInfo ctorName0
+      ctorInfo <- lookupConstructorInfo scope ctorName0
       subst <-
         case matchPatternTypes (ctorResult ctorInfo) expectedTy of
           Just subst0 -> pure subst0
@@ -1347,11 +1339,6 @@ validatePatternType scope expectedTy pattern0 =
             )
             (zip patterns (ctorArgs ctorInfo))
   where
-    lookupConstructorInfo ctorName0 =
-      case Map.lookup ctorName0 (esValues scope) of
-        Just ConstructorValue {valueCtorInfo = ctorInfo} -> pure ctorInfo
-        _ -> throwError (ProgramUnknownConstructor ctorName0)
-
     matchPatternTypes template actual =
       case matchTypes Map.empty template actual of
         Just subst -> Just subst
@@ -1408,13 +1395,13 @@ isCatchAllPattern pattern0 =
     P.PatVar {} -> True
     _ -> False
 
-patternCouldMatchConstructor :: ConstructorInfo -> P.Pattern -> Bool
-patternCouldMatchConstructor ctorInfo pattern0 =
+patternCouldMatchConstructor :: ElaborateScope -> ConstructorInfo -> P.Pattern -> Bool
+patternCouldMatchConstructor scope ctorInfo pattern0 =
   case stripPatternAnn pattern0 of
     P.PatWildcard -> True
     P.PatVar {} -> True
-    P.PatCtor ctorName0 _ -> ctorName0 == ctorName ctorInfo
-    P.PatAnn inner _ -> patternCouldMatchConstructor ctorInfo inner
+    P.PatCtor ctorName0 _ -> constructorNameMatches scope ctorName0 ctorInfo
+    P.PatAnn inner _ -> patternCouldMatchConstructor scope ctorInfo inner
 
 stripPatternAnn :: P.Pattern -> P.Pattern
 stripPatternAnn pattern0 =
@@ -1424,19 +1411,68 @@ stripPatternAnn pattern0 =
 
 requireSingleDataOwner :: ElaborateScope -> [String] -> ElaborateM DataInfo
 requireSingleDataOwner scope ctorNames0 = do
-  ctors <- mapM lookupCtor ctorNames0
-  let owners = nub (map ctorOwningType ctors)
+  owners <- mapM (lookupConstructorInfo scope >=> lookupResolvedDataInfo) ctorNames0
   case owners of
-    [owner] ->
-      case Map.lookup owner (esTypes scope) of
-        Just info -> pure (info {dataName = owner})
-        Nothing -> throwError (ProgramUnknownType owner)
-    _ -> throwError (ProgramCaseOnNonDataType STBottom)
+    [] -> throwError (ProgramCaseOnNonDataType STBottom)
+    owner : rest
+      | all (sameDataInfo owner) rest -> pure (visibleDataInfo owner)
+      | otherwise -> throwError (ProgramCaseOnNonDataType STBottom)
   where
-    lookupCtor ctorName0 =
-      case Map.lookup ctorName0 (esValues scope) of
-        Just ConstructorValue {valueCtorInfo = ctorInfo} -> pure ctorInfo
-        _ -> throwError (ProgramUnknownConstructor ctorName0)
+    lookupResolvedDataInfo ctorInfo =
+      case resolveConstructorDataInfo scope ctorInfo of
+        Just resolved -> pure resolved
+        Nothing -> throwError (ProgramUnknownType (ctorOwningType ctorInfo))
+
+lookupConstructorInfo :: ElaborateScope -> String -> ElaborateM ConstructorInfo
+lookupConstructorInfo scope ctorName0 =
+  case lookupConstructorInfoMaybe scope ctorName0 of
+    Just ctorInfo -> pure ctorInfo
+    Nothing -> throwError (ProgramUnknownConstructor ctorName0)
+
+lookupConstructorInfoMaybe :: ElaborateScope -> String -> Maybe ConstructorInfo
+lookupConstructorInfoMaybe scope ctorName0 =
+  case Map.lookup ctorName0 (esValues scope) of
+    Just ConstructorValue {valueCtorInfo = ctorInfo} -> Just ctorInfo
+    _ -> Nothing
+
+lookupDataInfoForConstructor :: ElaborateScope -> ConstructorInfo -> ElaborateM DataInfo
+lookupDataInfoForConstructor scope ctorInfo =
+  case resolveConstructorDataInfo scope ctorInfo of
+    Just resolved -> pure (visibleDataInfo resolved)
+    Nothing -> throwError (ProgramUnknownType (ctorOwningType ctorInfo))
+
+resolveConstructorDataInfo :: ElaborateScope -> ConstructorInfo -> Maybe (String, DataInfo)
+resolveConstructorDataInfo scope ctorInfo =
+  case Map.lookup (ctorOwningType ctorInfo) (esTypes scope) of
+    Just info
+      | constructorBelongsToDataInfo ctorInfo info ->
+          Just (ctorOwningType ctorInfo, info)
+    _ ->
+      find
+        (constructorBelongsToDataInfo ctorInfo . snd)
+        (Map.toList (esTypes scope))
+
+visibleDataInfo :: (String, DataInfo) -> DataInfo
+visibleDataInfo (visibleName, info) =
+  info {dataName = visibleName}
+
+sameDataInfo :: (String, DataInfo) -> (String, DataInfo) -> Bool
+sameDataInfo (_, left) (_, right) =
+  dataModule left == dataModule right && dataName left == dataName right
+
+constructorBelongsToDataInfo :: ConstructorInfo -> DataInfo -> Bool
+constructorBelongsToDataInfo ctorInfo =
+  any (sameConstructorInfo ctorInfo) . dataConstructors
+
+constructorNameMatches :: ElaborateScope -> String -> ConstructorInfo -> Bool
+constructorNameMatches scope ctorName0 ctorInfo =
+  case lookupConstructorInfoMaybe scope ctorName0 of
+    Just namedCtor -> sameConstructorInfo namedCtor ctorInfo
+    Nothing -> False
+
+sameConstructorInfo :: ConstructorInfo -> ConstructorInfo -> Bool
+sameConstructorInfo left right =
+  ctorRuntimeName left == ctorRuntimeName right
 
 handlerSurfaceType :: ElaborateScope -> ConstructorInfo -> SrcType -> SrcType
 handlerSurfaceType scope ctorInfo resultTy =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -23,7 +23,7 @@ where
 import Control.Monad ((>=>), foldM, replicateM, when, zipWithM)
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
 import Control.Monad.State.Strict (State, get, modify, runState)
-import Data.List (find, sort)
+import Data.List (find, partition, sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -1522,25 +1522,53 @@ resolveInstanceInfo scope className0 headTy =
 
 resolveInstanceInfoWithSubst :: ElaborateScope -> P.ClassName -> SrcType -> Either ProgramError (InstanceInfo, Map String SrcType)
 resolveInstanceInfoWithSubst scope className0 headTy =
-  case matches of
-    [match] -> Right match
+  case deduplicatedMatches of
+    [(match, subst, _direct)] -> Right (match, subst)
     [] -> Left (ProgramNoMatchingInstance className0 headTy)
     _ -> Left (ProgramNoMatchingInstance className0 headTy)
   where
+    deduplicatedMatches = deduplicateEquivalentMatches matches
+
     matches =
-      [ (info, subst)
+      [ (info, subst, direct)
         | info <- esInstances scope,
           instanceClassName info == className0,
-          Just subst <- [matchInstanceHead info]
+          Just (subst, direct) <- [matchInstanceHead info]
       ]
 
     matchInstanceHead info =
       case matchTypes Map.empty (instanceHeadType info) headTy of
-        Just subst -> Just subst
+        Just subst -> Just (subst, True)
         Nothing ->
           if lowerType scope (instanceHeadType info) == lowerType scope headTy
-            then Just Map.empty
+            then Just (Map.empty, False)
             else Nothing
+
+    deduplicateEquivalentMatches [] = []
+    deduplicateEquivalentMatches (match : rest) =
+      let (equivalent, different) = partition (equivalentInstanceMatch match) rest
+       in foldl preferredInstanceMatch match equivalent : deduplicateEquivalentMatches different
+
+    equivalentInstanceMatch (left, _, _) (right, _, _) =
+      instanceOriginModule left == instanceOriginModule right
+        && instanceClassName left == instanceClassName right
+        && lowerType scope (instanceHeadType left) == lowerType scope (instanceHeadType right)
+        && map lowerConstraint (instanceConstraints left) == map lowerConstraint (instanceConstraints right)
+        && fmap methodRuntimeIdentity (instanceMethods left) == fmap methodRuntimeIdentity (instanceMethods right)
+
+    lowerConstraint constraint =
+      constraint {P.constraintType = lowerType scope (P.constraintType constraint)}
+
+    methodRuntimeIdentity valueInfo =
+      case valueInfo of
+        OrdinaryValue {valueRuntimeName = runtimeName} -> runtimeName
+        ConstructorValue {valueRuntimeName = runtimeName} -> runtimeName
+        OverloadedMethod {valueMethodInfo = methodInfo} -> methodRuntimeBase methodInfo
+
+    preferredInstanceMatch left@(_, leftSubst, leftDirect) right@(_, rightSubst, rightDirect)
+      | rightDirect && not leftDirect = right
+      | rightDirect == leftDirect && Map.size rightSubst > Map.size leftSubst = right
+      | otherwise = left
 
 inferClassArgument :: SrcType -> String -> [SrcType] -> Maybe SrcType
 inferClassArgument methodTy classParam args =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -824,13 +824,12 @@ specializeSrcType subst ty = case ty of
     | otherwise -> STMu name (specializeSrcType subst body)
   STBottom -> STBottom
 
-deferCaseCall :: ElaborateScope -> DataInfo -> SrcType -> ElaborateM String
-deferCaseCall scope dataInfo resultTy = do
+deferCaseCall :: ElaborateScope -> DataInfo -> SrcType -> SrcType -> ElaborateM String
+deferCaseCall scope dataInfo scrutineeTy resultTy = do
   placeholder <- freshDeferredCaseName (dataName dataInfo)
-  let headTy = dataHeadType dataInfo
-      resultTyElab = lowerType scope resultTy
+  let resultTyElab = lowerType scope resultTy
       handlerTys = replicate (length (dataConstructors dataInfo)) STBottom
-      placeholderTy = foldr STArrow resultTyElab (lowerType scope headTy : handlerTys)
+      placeholderTy = foldr STArrow resultTyElab (lowerType scope scrutineeTy : handlerTys)
       deferred =
         DeferredCaseCall
           { deferredCasePlaceholder = placeholder,
@@ -979,8 +978,8 @@ compileCase scope mbExpected scrutinee alts = do
         Nothing -> do
           scrutineeExpr <- compileExpr scope (Just scrutineeTy) scrutinee
           let forceAnnotateHandlers = any (not . null . ctorForalls) (dataConstructors dataInfo)
-          handlers <- mapM (compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers) (dataConstructors dataInfo)
-          placeholder <- deferCaseCall scope dataInfo resultTy
+          handlers <- mapM (compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnotateHandlers) (dataConstructors dataInfo)
+          placeholder <- deferCaseCall scope dataInfo scrutineeTy resultTy
           pure (foldl surfaceApp (surfaceVar placeholder) (scrutineeExpr : handlers))
 
 localIdentityScrutinee :: ElaborateScope -> P.Expr -> Maybe P.Expr
@@ -1016,21 +1015,23 @@ compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts =
     [P.Alt (P.PatAnn inner _) body] -> compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr [P.Alt inner body]
     _ -> throwError (ProgramCaseOnNonDataType STBottom)
 
-compileHandler :: ElaborateScope -> SurfaceExpr -> SrcType -> DataInfo -> [P.Alt] -> Bool -> ConstructorInfo -> ElaborateM SurfaceExpr
-compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers ctorInfo = do
-  runtimeNames <- mapM freshRuntimeName ["case" ++ show ix | ix <- [1 .. length (ctorArgs ctorInfo)]]
-  let topArgs = zip3 (map (const P.PatWildcard) (ctorArgs ctorInfo)) runtimeNames (ctorArgs ctorInfo)
+compileHandler :: ElaborateScope -> SurfaceExpr -> SrcType -> SrcType -> DataInfo -> [P.Alt] -> Bool -> ConstructorInfo -> ElaborateM SurfaceExpr
+compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnotateHandlers ctorInfo = do
+  let ctorArgTys = specializeConstructorArgsForScrutinee scrutineeTy ctorInfo
+      specializedCtorInfo = ctorInfo {ctorArgs = ctorArgTys}
+  runtimeNames <- mapM freshRuntimeName ["case" ++ show ix | ix <- [1 .. length ctorArgTys]]
+  let topArgs = zip3 (map (const P.PatWildcard) ctorArgTys) runtimeNames ctorArgTys
       candidates = matchingCandidates ctorInfo
   bodyExpr <- compileCandidates topArgs candidates
   let handlerBody =
         foldr
           (\(name, argTy) acc -> surfaceLamAnn name (lowerType scope argTy) acc)
           bodyExpr
-          (zip runtimeNames (ctorArgs ctorInfo))
+          (zip runtimeNames ctorArgTys)
   if not forceAnnotateHandlers && null (ctorForalls ctorInfo)
     then pure handlerBody
     else do
-      let handlerTy = handlerSurfaceType scope ctorInfo (lowerType scope resultTy)
+      let handlerTy = handlerSurfaceType scope specializedCtorInfo (lowerType scope resultTy)
       pure (surfaceAnn handlerBody handlerTy)
   where
     matchingCandidates ctor =
@@ -1048,13 +1049,13 @@ compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers 
         P.PatWildcard -> compileExpr scope (Just resultTy) body
         P.PatVar name -> do
           scrutineeName <- freshRuntimeName name
-          scope' <- extendLocalLowered scope name scrutineeName (lowerType scope (dataHeadType dataInfo))
+          scope' <- extendLocalLowered scope name scrutineeName (lowerType scope scrutineeTy)
           bodyExpr <- compileExpr scope' (Just resultTy) body
           pure (surfaceLet scrutineeName scrutineeExpr bodyExpr)
         P.PatCtor ctorName0 patterns
           | ctorName0 == ctorName ctorInfo,
             length patterns == length (ctorArgs ctorInfo) ->
-              compilePatternSequence scope (zip3 patterns (map middle topArgs) (ctorArgs ctorInfo)) body mbFallback
+              compilePatternSequence scope (zip3 patterns (map middle topArgs) (map third topArgs)) body mbFallback
           | ctorName0 == ctorName ctorInfo ->
               throwError (ProgramPatternConstructorMismatch ctorName0 (dataHeadType dataInfo))
           | otherwise ->
@@ -1064,6 +1065,7 @@ compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers 
         P.PatAnn inner _ -> compileAltCandidate topArgs (P.Alt inner body) mbFallback
 
     middle (_, value, _) = value
+    third (_, _, value) = value
 
     compilePatternSequence scope0 [] body _ =
       compileExpr scope0 (Just resultTy) body
@@ -1085,25 +1087,33 @@ compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers 
                   Nothing -> throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
               nestedRuntimeNames <- mapM freshRuntimeName ["pat" ++ show ix | ix <- [1 .. length (ctorArgs nestedCtorInfo)]]
               let forceNestedAnnotations = any (not . null . ctorForalls) (dataConstructors nestedDataInfo)
-              matchingBody <- compilePatternSequence scope0 (zip3 nestedPatterns nestedRuntimeNames (ctorArgs nestedCtorInfo) ++ rest) body mbFallback
-              handlers <- mapM (nestedHandler forceNestedAnnotations nestedCtorInfo nestedRuntimeNames matchingBody fallback) (dataConstructors nestedDataInfo)
-              placeholder <- deferCaseCall scope0 nestedDataInfo resultTy
+                  nestedArgTys = specializeConstructorArgsForScrutinee argTy nestedCtorInfo
+              matchingBody <- compilePatternSequence scope0 (zip3 nestedPatterns nestedRuntimeNames nestedArgTys ++ rest) body mbFallback
+              handlers <- mapM (nestedHandler forceNestedAnnotations argTy nestedCtorInfo nestedRuntimeNames matchingBody fallback) (dataConstructors nestedDataInfo)
+              placeholder <- deferCaseCall scope0 nestedDataInfo argTy resultTy
               pure (foldl surfaceApp (surfaceVar placeholder) (surfaceVar runtimeName : handlers))
         P.PatAnn inner _ -> compilePatternSequence scope0 ((inner, runtimeName, argTy) : rest) body mbFallback
 
-    nestedHandler forceNestedAnnotations targetCtor nestedRuntimeNames matchingBody fallback ctor =
-      let argNames = if ctorName ctor == ctorName targetCtor then nestedRuntimeNames else ["unused" ++ show ix | ix <- [1 .. length (ctorArgs ctor)]]
+    nestedHandler forceNestedAnnotations nestedScrutineeTy targetCtor nestedRuntimeNames matchingBody fallback ctor =
+      let ctorArgTys = specializeConstructorArgsForScrutinee nestedScrutineeTy ctor
+          specializedCtor = ctor {ctorArgs = ctorArgTys}
+          argNames = if ctorName ctor == ctorName targetCtor then nestedRuntimeNames else ["unused" ++ show ix | ix <- [1 .. length ctorArgTys]]
           selectedBody = if ctorName ctor == ctorName targetCtor then matchingBody else fallback
           handlerBody =
             foldr
               (\(name, argTy) acc -> surfaceLamAnn name (lowerType scope argTy) acc)
               selectedBody
-              (zip argNames (ctorArgs ctor))
+              (zip argNames ctorArgTys)
        in if not forceNestedAnnotations && null (ctorForalls ctor)
             then pure handlerBody
             else do
-              let handlerTy = handlerSurfaceType scope ctor (lowerType scope resultTy)
+              let handlerTy = handlerSurfaceType scope specializedCtor (lowerType scope resultTy)
               pure (surfaceAnn handlerBody handlerTy)
+
+    specializeConstructorArgsForScrutinee actualScrutineeTy ctor =
+      case matchTypes Map.empty (ctorResult ctor) actualScrutineeTy of
+        Just subst -> map (specializeSrcType subst) (ctorArgs ctor)
+        Nothing -> ctorArgs ctor
 
     lookupConstructorInfo ctorName0 =
       case Map.lookup ctorName0 (esValues scope) of

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -210,13 +210,13 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
       STVar name -> Map.findWithDefault ty name subst
       STArrow dom cod -> STArrow (lowerCtorArg subst currentData selfTy dom) (lowerCtorArg subst currentData selfTy cod)
       STBase name
-        | Just name == currentData -> selfTy
+        | isCurrentDataAlias currentData name -> selfTy
         | otherwise ->
             case Map.lookup name dataTypes of
               Just info -> encodeDataType subst info []
               Nothing -> STBase name
       STCon name args
-        | Just name == currentData -> selfTy
+        | isCurrentDataAlias currentData name -> selfTy
         | otherwise ->
             case Map.lookup name dataTypes of
               Just info -> encodeDataType subst info (map (lowerCtorArg subst currentData selfTy) (toListNE args))
@@ -226,6 +226,15 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
          in STForall name (fmap (SrcBound . lowerCtorArg subst' currentData selfTy . unSrcBound) mb) (lowerCtorArg subst' currentData selfTy body)
       STMu name body -> STMu name (lowerCtorArg (Map.delete name subst) currentData selfTy body)
       STBottom -> STBottom
+
+    isCurrentDataAlias currentData name =
+      case currentData of
+        Nothing -> False
+        Just ownerName ->
+          name == ownerName
+            || case Map.lookup name dataTypes of
+              Just info -> dataName info == ownerName
+              Nothing -> False
 
 toListNE :: NonEmpty a -> [a]
 toListNE (x :| xs) = x : xs

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -184,9 +184,47 @@ constrainedRuntimeTypeRaw dataTypes classes0 constraints visibleTy =
       case Map.lookup (P.constraintClassName constraint) classes0 of
         Nothing -> []
         Just classInfo ->
-          [ lowerTypeRaw dataTypes (specializeMethodType (methodType methodInfo) (classParamName classInfo) (P.constraintType constraint))
+          [ lowerTypeRaw dataTypes (methodEvidenceSourceTypeRaw dataTypes classes0 classInfo (P.constraintType constraint) methodInfo)
             | methodInfo <- Map.elems (classMethods classInfo)
           ]
+
+methodEvidenceSourceType :: ElaborateScope -> ClassInfo -> SrcType -> MethodInfo -> SrcType
+methodEvidenceSourceType scope =
+  methodEvidenceSourceTypeRaw (esTypes scope) (esClasses scope)
+
+methodEvidenceSourceTypeRaw :: Map String DataInfo -> Map String ClassInfo -> ClassInfo -> SrcType -> MethodInfo -> SrcType
+methodEvidenceSourceTypeRaw dataTypes classes0 classInfo classArgTy methodInfo =
+  let specializedMethodTy =
+        specializeMethodType (methodType methodInfo) (classParamName classInfo) classArgTy
+      specializedConstraints =
+        map
+          (specializeConstraintType (classParamName classInfo) classArgTy)
+          (methodConstraints methodInfo)
+      headVars = freeTypeVarsSrcType classArgTy
+      deferredConstraints =
+        filter (not . constraintDeterminedByTypeVars headVars) specializedConstraints
+      evidenceVisibleTy =
+        quantifyMethodLocalVars headVars specializedConstraints specializedMethodTy
+   in constrainedRuntimeTypeRaw dataTypes classes0 deferredConstraints evidenceVisibleTy
+
+specializeConstraintType :: String -> SrcType -> P.ClassConstraint -> P.ClassConstraint
+specializeConstraintType paramName headTy constraint =
+  constraint {P.constraintType = substituteTypeVar paramName headTy (P.constraintType constraint)}
+
+constraintDeterminedByTypeVars :: Set String -> P.ClassConstraint -> Bool
+constraintDeterminedByTypeVars typeVars constraint =
+  freeTypeVarsSrcType (P.constraintType constraint) `Set.isSubsetOf` typeVars
+
+quantifyMethodLocalVars :: Set String -> [P.ClassConstraint] -> SrcType -> SrcType
+quantifyMethodLocalVars headVars constraints ty =
+  let (foralls, _) = splitForalls ty
+      alreadyQuantified = Set.fromList (map fst foralls)
+      constraintVars = foldMap (freeTypeVarsSrcType . P.constraintType) constraints
+      localVars =
+        (freeTypeVarsSrcType ty `Set.union` constraintVars)
+          Set.\\ headVars
+          Set.\\ alreadyQuantified
+   in foldr (\name acc -> STForall name Nothing acc) ty (sort (Set.toList localVars))
 
 lowerTypeRaw :: Map String DataInfo -> SrcType -> SrcType
 lowerTypeRaw dataTypes = lower Map.empty Nothing
@@ -621,7 +659,7 @@ compileMethodApp scope _mbExpected methodInfo args
       case knownClassArg of
         Just classArgTy
           | shouldResolveMethodBeforeInference scope methodInfo classArgTy -> do
-              methodHead <- resolveMethodHeadExpr scope Set.empty methodInfo classArgTy
+              methodHead <- resolveMethodHeadForCall scope Set.empty methodInfo classArgTy args
               let applied = foldl surfaceApp methodHead argSurfaces
               expanded <- etaExpandMissingArgs scope methodInfo placeholderTy suppliedArity fullArity applied
               pure $
@@ -674,13 +712,52 @@ resolveMethodHeadExpr scope seen methodInfo classArgTy =
       (instanceInfo, subst) <- liftEitherElab (resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy)
       case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
         Just OrdinaryValue {valueRuntimeName = runtimeName, valueConstraints = constraints} -> do
+          let headVars = freeTypeVarsSrcType classArgTy
+              eagerConstraints =
+                filter
+                  (constraintDeterminedByTypeVars headVars)
+                  (map (applyConstraintSubst subst) constraints)
           evidenceArgs <-
             concat
               <$> mapM
-                (resolveConstraintEvidenceExpr scope seen . applyConstraintSubst subst)
-                constraints
+                (resolveConstraintEvidenceExpr scope seen)
+                eagerConstraints
           pure (foldl surfaceApp (surfaceVar runtimeName) evidenceArgs)
         _ -> throwError (ProgramUnknownMethod (methodName methodInfo))
+
+resolveMethodHeadForCall :: ElaborateScope -> Set (P.ClassName, String) -> MethodInfo -> SrcType -> [P.Expr] -> ElaborateM SurfaceExpr
+resolveMethodHeadForCall scope seen methodInfo classArgTy args =
+  case lookupEvidenceMethod scope (methodClassName methodInfo) classArgTy (methodName methodInfo) of
+    Just (runtimeName, _) -> do
+      evidenceArgs <- methodLocalEvidenceArgsForCall scope methodInfo classArgTy args
+      pure (foldl surfaceApp (surfaceVar runtimeName) evidenceArgs)
+    Nothing -> resolveMethodHeadExpr scope seen methodInfo classArgTy
+
+methodLocalEvidenceArgsForCall :: ElaborateScope -> MethodInfo -> SrcType -> [P.Expr] -> ElaborateM [SurfaceExpr]
+methodLocalEvidenceArgsForCall scope methodInfo classArgTy args = do
+  subst <-
+    case inferMethodCallSubst scope methodInfo classArgTy args of
+      Just subst0 -> pure subst0
+      Nothing -> pure Map.empty
+  let headVars = freeTypeVarsSrcType classArgTy
+      methodLocalConstraints =
+        filter
+          (not . constraintDeterminedByTypeVars headVars)
+          (map (specializeConstraintType (methodParamName methodInfo) classArgTy) (methodConstraints methodInfo))
+      specializedConstraints = map (applyConstraintSubst subst) methodLocalConstraints
+  concat <$> mapM (constraintEvidenceArgExprs scope) specializedConstraints
+
+inferMethodCallSubst :: ElaborateScope -> MethodInfo -> SrcType -> [P.Expr] -> Maybe (Map String SrcType)
+inferMethodCallSubst scope methodInfo classArgTy args = do
+  let specializedMethodTy = specializeMethodType (methodType methodInfo) (methodParamName methodInfo) classArgTy
+      (_, bodyTy) = splitForalls specializedMethodTy
+      (paramTys, _) = splitArrows bodyTy
+      knownPairs =
+        [ (templateTy, actualTy)
+          | (templateTy, arg) <- zip paramTys args,
+            Just actualTy <- [inferKnownExprType scope arg]
+        ]
+  foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty knownPairs
 
 shouldResolveMethodBeforeInference :: ElaborateScope -> MethodInfo -> SrcType -> Bool
 shouldResolveMethodBeforeInference scope methodInfo classArgTy =
@@ -1468,7 +1545,7 @@ extendConstraintEvidence scope constraints = do
         mapM
           ( \methodInfo -> do
               runtimeName <- freshRuntimeName ("evidence_" ++ P.constraintClassName constraint ++ "_" ++ methodName methodInfo)
-              let evidenceTy = lowerType scope (specializeMethodType (methodType methodInfo) (classParamName classInfo) (P.constraintType constraint))
+              let evidenceTy = lowerType scope (methodEvidenceSourceType scope classInfo (P.constraintType constraint) methodInfo)
               pure (methodName methodInfo, (runtimeName, evidenceTy))
           )
           (Map.elems (classMethods classInfo))

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -1170,7 +1170,7 @@ validatePatternType scope expectedTy pattern0 =
     P.PatVar {} -> pure ()
     P.PatAnn inner annTy -> do
       validatePatternAnnotation scope expectedTy annTy
-      validatePatternType scope expectedTy inner
+      validatePatternType scope annTy inner
     P.PatCtor ctorName0 patterns -> do
       ctorInfo <- lookupConstructorInfo ctorName0
       subst <-

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -827,12 +827,19 @@ compileCase :: ElaborateScope -> Maybe SrcType -> P.Expr -> [P.Alt] -> Elaborate
 compileCase scope mbExpected scrutinee alts = do
   case ctorOwners alts of
     [] -> do
-      scrutineeExpr <- compileExpr scope Nothing scrutinee
-      compileCatchAllOnly scope mbExpected scrutineeExpr alts
+      let mbScrutineeTy = inferKnownExprType scope scrutinee
+      mapM_ (\scrutineeTy -> mapM_ (validatePatternType scope scrutineeTy . P.altPattern) alts) mbScrutineeTy
+      scrutineeExpr <- compileExpr scope mbScrutineeTy scrutinee
+      compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts
     owners -> do
       dataInfo <- requireSingleDataOwner scope owners
       let headTy = dataHeadType dataInfo
+          scrutineeTy =
+            case inferKnownExprType scope scrutinee of
+              Just knownTy -> knownTy
+              Nothing -> headTy
       validateOrderedPatterns alts
+      mapM_ (validatePatternType scope scrutineeTy . P.altPattern) alts
       (resultTy, _quantifyResult) <-
         case mbExpected of
           Just expectedTy -> pure (expectedTy, False)
@@ -842,7 +849,7 @@ compileCase scope mbExpected scrutinee alts = do
       case localIdentityScrutinee scope scrutinee of
         Just inner -> compileCase scope mbExpected inner alts
         Nothing -> do
-          scrutineeExpr <- compileExpr scope (Just headTy) scrutinee
+          scrutineeExpr <- compileExpr scope (Just scrutineeTy) scrutinee
           let forceAnnotateHandlers = any (not . null . ctorForalls) (dataConstructors dataInfo)
           handlers <- mapM (compileHandler scope scrutineeExpr resultTy dataInfo alts forceAnnotateHandlers) (dataConstructors dataInfo)
           placeholder <- deferCaseCall scope dataInfo resultTy
@@ -860,8 +867,8 @@ localIdentityScrutinee scope expr =
           Just arg
     _ -> Nothing
 
-compileCatchAllOnly :: ElaborateScope -> Maybe SrcType -> SurfaceExpr -> [P.Alt] -> ElaborateM SurfaceExpr
-compileCatchAllOnly scope mbExpected scrutineeExpr alts =
+compileCatchAllOnly :: ElaborateScope -> Maybe SrcType -> Maybe SrcType -> SurfaceExpr -> [P.Alt] -> ElaborateM SurfaceExpr
+compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts =
   case alts of
     [P.Alt P.PatWildcard body] -> compileExpr scope mbExpected body
     [P.Alt (P.PatVar name) body] -> do
@@ -869,7 +876,7 @@ compileCatchAllOnly scope mbExpected scrutineeExpr alts =
       scope' <- extendLocalLowered scope name runtimeName =<< freshTypeName
       bodyExpr <- compileExpr scope' mbExpected body
       pure (surfaceLet runtimeName scrutineeExpr bodyExpr)
-    [P.Alt (P.PatAnn inner _) body] -> compileCatchAllOnly scope mbExpected scrutineeExpr [P.Alt inner body]
+    [P.Alt (P.PatAnn inner _) body] -> compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr [P.Alt inner body]
     _ -> throwError (ProgramCaseOnNonDataType STBottom)
 
 compileHandler :: ElaborateScope -> SurfaceExpr -> SrcType -> DataInfo -> [P.Alt] -> Bool -> ConstructorInfo -> ElaborateM SurfaceExpr
@@ -979,6 +986,54 @@ ctorOwners = foldr go []
       P.PatAnn inner _ -> go (P.Alt inner (P.altExpr alt)) acc
       _ -> acc
 
+validatePatternType :: ElaborateScope -> SrcType -> P.Pattern -> ElaborateM ()
+validatePatternType scope expectedTy pattern0 =
+  case pattern0 of
+    P.PatWildcard -> pure ()
+    P.PatVar {} -> pure ()
+    P.PatAnn inner annTy -> do
+      validatePatternAnnotation scope expectedTy annTy
+      validatePatternType scope expectedTy inner
+    P.PatCtor ctorName0 patterns -> do
+      ctorInfo <- lookupConstructorInfo ctorName0
+      subst <-
+        case matchPatternTypes (ctorResult ctorInfo) expectedTy of
+          Just subst0 -> pure subst0
+          Nothing -> throwError (ProgramPatternConstructorMismatch ctorName0 expectedTy)
+      if length patterns /= length (ctorArgs ctorInfo)
+        then throwError (ProgramPatternConstructorMismatch ctorName0 expectedTy)
+        else
+          mapM_
+            ( \(nestedPattern, argTy) ->
+                validatePatternType scope (specializeSrcType subst argTy) nestedPattern
+            )
+            (zip patterns (ctorArgs ctorInfo))
+  where
+    lookupConstructorInfo ctorName0 =
+      case Map.lookup ctorName0 (esValues scope) of
+        Just ConstructorValue {valueCtorInfo = ctorInfo} -> pure ctorInfo
+        _ -> throwError (ProgramUnknownConstructor ctorName0)
+
+    matchPatternTypes template actual =
+      case matchTypes Map.empty template actual of
+        Just subst -> Just subst
+        Nothing ->
+          case matchTypes Map.empty actual template of
+            Just subst -> Just subst
+            Nothing
+              | lowerType scope template == lowerType scope actual -> Just Map.empty
+            Nothing -> Nothing
+
+validatePatternAnnotation :: ElaborateScope -> SrcType -> SrcType -> ElaborateM ()
+validatePatternAnnotation scope expectedTy annTy =
+  when (not (patternAnnotationCompatible expectedTy annTy)) $
+    throwError (ProgramTypeMismatch annTy expectedTy)
+  where
+    patternAnnotationCompatible left right =
+      lowerType scope left == lowerType scope right
+        || matchTypes Map.empty left right /= Nothing
+        || matchTypes Map.empty right left /= Nothing
+
 validateOrderedPatterns :: [P.Alt] -> ElaborateM ()
 validateOrderedPatterns = go Set.empty False
   where
@@ -988,10 +1043,11 @@ validateOrderedPatterns = go Set.empty False
           throwError (ProgramDuplicateCaseBranch (maybe "_" id (topConstructorName pattern0)))
       | isCatchAllPattern pattern0 =
           go seen True rest
+      | Just ctorName0 <- topConstructorName pattern0,
+        ctorName0 `Set.member` seen =
+          throwError (ProgramDuplicateCaseBranch ctorName0)
       | Just ctorName0 <- flatCatchAllConstructor pattern0 =
-          if ctorName0 `Set.member` seen
-            then throwError (ProgramDuplicateCaseBranch ctorName0)
-            else go (Set.insert ctorName0 seen) False rest
+          go (Set.insert ctorName0 seen) False rest
       | otherwise = go seen False rest
 
 topConstructorName :: P.Pattern -> Maybe String

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -1188,7 +1188,7 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
     compilePatternSequence scope0 [] body _ =
       compileExpr scope0 (Just resultTy) body
     compilePatternSequence scope0 ((pattern0, runtimeName, argTy) : rest) body mbFallback =
-      case stripPatternAnn pattern0 of
+      case pattern0 of
         P.PatWildcard -> compilePatternSequence scope0 rest body mbFallback
         P.PatVar sourceName -> do
           scope' <- extendLocal scope0 sourceName runtimeName (Just argTy)
@@ -1199,24 +1199,34 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
           if length nestedPatterns /= length (ctorArgs nestedCtorInfo)
             then throwError (ProgramPatternConstructorMismatch nestedCtorName argTy)
             else do
-              fallback <-
-                case mbFallback of
-                  Just fallback0 -> pure fallback0
-                  Nothing -> throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
               nestedRuntimeNames <- mapM freshRuntimeName ["pat" ++ show ix | ix <- [1 .. length (ctorArgs nestedCtorInfo)]]
               let forceNestedAnnotations = any (not . null . ctorForalls) (dataConstructors nestedDataInfo)
                   nestedArgTys = specializeConstructorArgsForScrutinee argTy nestedCtorInfo
               matchingBody <- compilePatternSequence scope0 (zip3 nestedPatterns nestedRuntimeNames nestedArgTys ++ rest) body mbFallback
+              fallback <-
+                case mbFallback of
+                  Just fallback0 -> pure (Just fallback0)
+                  Nothing
+                    | nestedPatternNeedsFallback nestedDataInfo nestedCtorInfo ->
+                        throwError (ProgramNonExhaustiveCase [ctorName ctorInfo])
+                  Nothing -> pure Nothing
               handlers <- mapM (nestedHandler forceNestedAnnotations argTy nestedCtorInfo nestedRuntimeNames matchingBody fallback) (dataConstructors nestedDataInfo)
               placeholder <- deferCaseCall scope0 nestedDataInfo argTy resultTy
               pure (foldl surfaceApp (surfaceVar placeholder) (surfaceVar runtimeName : handlers))
-        P.PatAnn inner _ -> compilePatternSequence scope0 ((inner, runtimeName, argTy) : rest) body mbFallback
+        P.PatAnn inner annTy -> compilePatternSequence scope0 ((inner, runtimeName, annTy) : rest) body mbFallback
 
-    nestedHandler forceNestedAnnotations nestedScrutineeTy targetCtor nestedRuntimeNames matchingBody fallback ctor =
+    nestedPatternNeedsFallback nestedDataInfo targetCtor =
+      any ((/= ctorName targetCtor) . ctorName) (dataConstructors nestedDataInfo)
+
+    nestedHandler forceNestedAnnotations nestedScrutineeTy targetCtor nestedRuntimeNames matchingBody mbFallback ctor =
       let ctorArgTys = specializeConstructorArgsForScrutinee nestedScrutineeTy ctor
           specializedCtor = ctor {ctorArgs = ctorArgTys}
           argNames = if ctorName ctor == ctorName targetCtor then nestedRuntimeNames else ["unused" ++ show ix | ix <- [1 .. length ctorArgTys]]
-          selectedBody = if ctorName ctor == ctorName targetCtor then matchingBody else fallback
+          selectedBody =
+            case (ctorName ctor == ctorName targetCtor, mbFallback) of
+              (True, _) -> matchingBody
+              (False, Just fallback) -> fallback
+              (False, Nothing) -> matchingBody
           handlerBody =
             foldr
               (\(name, argTy) acc -> surfaceLamAnn name (lowerType scope argTy) acc)

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -1006,11 +1006,19 @@ compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts =
   case alts of
     [P.Alt P.PatWildcard body] -> do
       bodyExpr <- compileExpr scope mbExpected body
+      scrutineeName <- freshRuntimeName "case_scrutinee"
       case mbScrutineeTy of
-        Just _ -> do
-          scrutineeName <- freshRuntimeName "case_scrutinee"
-          pure (surfaceLet scrutineeName scrutineeExpr bodyExpr)
-        Nothing -> pure bodyExpr
+        Just _ -> pure (surfaceLet scrutineeName scrutineeExpr bodyExpr)
+        Nothing -> do
+          -- Keep the scrutinee binding referenced so eMLF infers its own scheme
+          -- while the strict let still preserves evaluation before the body.
+          forceName <- freshRuntimeName "case_scrutinee_force"
+          pure
+            ( surfaceLet
+                scrutineeName
+                scrutineeExpr
+                (surfaceLet forceName (surfaceVar scrutineeName) bodyExpr)
+            )
     [P.Alt (P.PatVar name) body] -> do
       runtimeName <- freshRuntimeName name
       scope' <-

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -521,9 +521,8 @@ deferConstraintEvidenceExprs scope constraint =
   case Map.lookup (P.constraintClassName constraint) (esClasses scope) of
     Nothing -> throwError (ProgramUnknownClass (P.constraintClassName constraint))
     Just classInfo
-      | Map.null (classMethods classInfo) -> do
-          _ <- liftEitherElab (resolveInstanceInfo scope (P.constraintClassName constraint) (P.constraintType constraint))
-          pure []
+      | Map.null (classMethods classInfo) ->
+          resolveZeroMethodEvidenceExpr scope Set.empty constraint
       | otherwise ->
           mapM (deferMethodEvidenceExpr scope (P.constraintType constraint)) (Map.elems (classMethods classInfo))
 
@@ -671,12 +670,7 @@ resolveConstraintEvidenceExpr scope seen constraint =
       let key = (P.constraintClassName constraint, show (P.constraintType constraint))
       whenSeen key
       if Map.null (classMethods classInfo)
-        then do
-          if zeroMethodConstraintCoveredByEvidence scope constraint
-            then pure []
-            else do
-              _ <- liftEitherElab (resolveInstanceInfo scope (P.constraintClassName constraint) (P.constraintType constraint))
-              pure []
+        then resolveZeroMethodEvidenceExpr scope seen constraint
         else
           mapM
             ( \methodInfo ->
@@ -691,6 +685,19 @@ resolveConstraintEvidenceExpr scope seen constraint =
     whenSeen key =
       when (key `Set.member` seen) $
         throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
+
+resolveZeroMethodEvidenceExpr :: ElaborateScope -> Set (P.ClassName, String) -> P.ClassConstraint -> ElaborateM [SurfaceExpr]
+resolveZeroMethodEvidenceExpr scope seen constraint
+  | zeroMethodConstraintCoveredByEvidence scope constraint = pure []
+  | otherwise = do
+      let key = (P.constraintClassName constraint, show (P.constraintType constraint))
+      (instanceInfo, subst) <- liftEitherElab (resolveInstanceInfoWithSubst scope (P.constraintClassName constraint) (P.constraintType constraint))
+      _ <-
+        concat
+          <$> mapM
+            (resolveConstraintEvidenceExpr scope (Set.insert key seen) . applyConstraintSubst subst)
+            (instanceConstraints instanceInfo)
+      pure []
 
 zeroMethodConstraintCoveredByEvidence :: ElaborateScope -> P.ClassConstraint -> Bool
 zeroMethodConstraintCoveredByEvidence scope constraint =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -146,6 +146,29 @@ elaborateScopeInstances = esInstances
 lowerType :: ElaborateScope -> SrcType -> SrcType
 lowerType scope = lowerTypeRaw (esTypes scope)
 
+canonicalSourceType :: ElaborateScope -> SrcType -> SrcType
+canonicalSourceType scope = canonical
+  where
+    canonical ty =
+      case ty of
+        STVar {} -> ty
+        STBase name ->
+          case Map.lookup name (esTypes scope) of
+            Just info -> STBase (qualifiedDataName info)
+            Nothing -> ty
+        STCon name args ->
+          let args' = fmap canonical args
+           in case Map.lookup name (esTypes scope) of
+                Just info -> STCon (qualifiedDataName info) args'
+                Nothing -> STCon name args'
+        STArrow dom cod -> STArrow (canonical dom) (canonical cod)
+        STForall name mb body ->
+          STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)
+        STMu name body -> STMu name (canonical body)
+        STBottom -> STBottom
+
+    qualifiedDataName info = dataModule info ++ "." ++ dataName info
+
 constrainedRuntimeType :: ElaborateScope -> [P.ClassConstraint] -> SrcType -> SrcType
 constrainedRuntimeType scope =
   constrainedRuntimeTypeRaw (esTypes scope) (esClasses scope)
@@ -243,6 +266,7 @@ lowerConstructorBinding :: ElaborateScope -> ConstructorInfo -> LoweredBinding
 lowerConstructorBinding scope ctorInfo =
   LoweredBinding
     { loweredBindingName = ctorRuntimeName ctorInfo,
+      loweredBindingSourceType = canonicalSourceType scope (quantifyFreeTypeVars (ctorType ctorInfo)),
       loweredBindingExpectedType = lowerType scope (quantifyFreeTypeVars (ctorType ctorInfo)),
       loweredBindingSurfaceExpr = constructorSurfaceExpr scope ctorInfo,
       loweredBindingDeferredObligations = Map.empty,
@@ -256,6 +280,7 @@ lowerExprBinding scope runtimeName expectedTy exportedAsMain expr = do
   pure
     LoweredBinding
       { loweredBindingName = runtimeName,
+        loweredBindingSourceType = canonicalSourceType scope expectedTy,
         loweredBindingExpectedType = lowerType scope expectedTy,
         loweredBindingSurfaceExpr = elaborateResultValue result,
         loweredBindingDeferredObligations = elaborateResultDeferredObligations result,
@@ -274,6 +299,7 @@ lowerConstrainedExprBinding scope runtimeName constraints visibleTy exportedAsMa
   pure
     LoweredBinding
       { loweredBindingName = runtimeName,
+        loweredBindingSourceType = canonicalSourceType scope visibleTy,
         loweredBindingExpectedType = lowerType scope expectedTy,
         loweredBindingSurfaceExpr = elaborateResultValue result,
         loweredBindingDeferredObligations = elaborateResultDeferredObligations result,

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -619,12 +619,13 @@ resolveDeferredCases scope deferredCases = go
         _ -> Left (ProgramCaseOnNonDataType STBottom)
 
     validateCaseScrutineeType dataInfo scrutineeTy =
-      case scrutineeTy of
-        STBase name
-          | name == dataName dataInfo -> Right ()
-        STCon name _
-          | name == dataName dataInfo -> Right ()
-        other -> Left (ProgramCaseOnNonDataType other)
+      let validHeadNames = Set.fromList (dataInfoHeadNames scope dataInfo)
+       in case scrutineeTy of
+            STBase name
+              | name `Set.member` validHeadNames -> Right ()
+            STCon name _
+              | name `Set.member` validHeadNames -> Right ()
+            other -> Left (ProgramCaseOnNonDataType other)
 
     inferDeferredArgType env arg =
       case typeCheckWithEnv env arg of
@@ -839,6 +840,19 @@ deferredPlaceholderHeadWithInsts = go []
         X.ETyInst inner _ -> go insts inner
         _ -> Nothing
 
+dataInfoHeadNames :: ElaborateScope -> DataInfo -> [String]
+dataInfoHeadNames scope info =
+  dataName info
+    : [ name
+        | (name, candidate) <- Map.toList (elaborateScopeDataTypes scope),
+          name /= dataName info,
+          sameDataIdentity candidate info
+      ]
+  where
+    sameDataIdentity left right =
+      dataModule left == dataModule right
+        && dataName left == dataName right
+
 {- Note [recoverSourceType]
 
 When the eMLF pipeline infers a type, it returns raw Church-encoded μ forms
@@ -888,30 +902,40 @@ matchDataInfoEncoding = matchDataInfoEncodingWith id
 
 matchDataInfoEncodingWith :: (SrcType -> SrcType) -> ElaborateScope -> DataInfo -> SrcType -> Maybe (SrcType, Map String SrcType)
 matchDataInfoEncodingWith recover scope info ty =
-  let params = dataParams info
-      templateHead =
-        case params of
-          [] -> STBase (dataName info)
-          p : ps -> STCon (dataName info) (STVar p :| map STVar ps)
-      loweredTemplate = lowerType scope templateHead
-      matchTemplate template =
-        matchRecoverType (Set.fromList params) Map.empty Map.empty template ty
-      matched =
-        case matchTemplate loweredTemplate of
-          Just subst -> Just subst
-          Nothing ->
-            case loweredTemplate of
-              STMu _ body -> matchTemplate body
-              _ -> Nothing
-   in case matched of
-        Just subst ->
-          let recoveredArgs = map (\param -> recover (Map.findWithDefault (STVar param) param subst)) params
-              recoveredHead =
-                case recoveredArgs of
-                  [] -> STBase (dataName info)
-                  arg : args -> STCon (dataName info) (arg :| args)
-           in Just (recoveredHead, subst)
-        Nothing -> Nothing
+  firstMatch (dataInfoHeadNames scope info)
+  where
+    params = dataParams info
+
+    firstMatch [] = Nothing
+    firstMatch (headName : rest) =
+      case matchHeadName headName of
+        Just matched -> Just matched
+        Nothing -> firstMatch rest
+
+    matchHeadName headName =
+      let templateHead =
+            case params of
+              [] -> STBase headName
+              p : ps -> STCon headName (STVar p :| map STVar ps)
+          loweredTemplate = lowerType scope templateHead
+          matchTemplate template =
+            matchRecoverType (Set.fromList params) Map.empty Map.empty template ty
+          matched =
+            case matchTemplate loweredTemplate of
+              Just subst -> Just subst
+              Nothing ->
+                case loweredTemplate of
+                  STMu _ body -> matchTemplate body
+                  _ -> Nothing
+       in case matched of
+            Just subst ->
+              let recoveredArgs = map (\param -> recover (Map.findWithDefault (STVar param) param subst)) params
+                  recoveredHead =
+                    case recoveredArgs of
+                      [] -> STBase headName
+                      arg : args -> STCon headName (arg :| args)
+               in Just (recoveredHead, subst)
+            Nothing -> Nothing
 
 matchRecoverType ::
   Set String ->

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -39,6 +39,7 @@ import MLF.Frontend.Program.Elaborate
     lowerType,
     matchTypes,
     resolveInstanceInfoWithSubst,
+    resolveMethodInstanceInfoWithSubst,
   )
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
@@ -724,7 +725,7 @@ resolveDeferredMethods scope deferredMethods = go
             case inferClassArgument (lowerType scope (methodType methodInfo)) (methodParamName methodInfo) argTypes of
               Just ty -> Right ty
               Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
-          (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy
+          (instanceInfo, subst) <- resolveMethodInstanceInfoWithSubst scope methodInfo classArgTy
           methodValue <- concreteMethodValue instanceInfo methodInfo
           methodSubst <-
             case inferMethodArgumentSubst methodInfo classArgTy subst argTypes of

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -730,7 +730,11 @@ resolveDeferredMethods scope deferredMethods = go
             case inferMethodArgumentSubst methodInfo classArgTy subst argTypes of
               Just subst' -> Right subst'
               Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
-          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty (map (applyConstraintSubst methodSubst) (methodValueConstraints methodValue))
+          let eagerConstraints =
+                filter
+                  constraintGround
+                  (map (applyConstraintSubst methodSubst) (methodValueConstraints methodValue))
+          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
           let methodHead = instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
@@ -796,6 +800,10 @@ resolveConstraintEvidenceTerm scope seen constraint = do
 constraintDeterminedByTypeVars :: Set String -> P.ClassConstraint -> Bool
 constraintDeterminedByTypeVars typeVars constraint =
   freeTypeVarsSrcType (P.constraintType constraint) `Set.isSubsetOf` typeVars
+
+constraintGround :: P.ClassConstraint -> Bool
+constraintGround constraint =
+  Set.null (freeTypeVarsSrcType (P.constraintType constraint))
 
 methodValueConstraints :: ValueInfo -> [P.ClassConstraint]
 methodValueConstraints OrdinaryValue {valueConstraints = constraints} = constraints

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -804,17 +804,24 @@ methodValueConstraints _ = []
 instantiateMethodValue :: ElaborateScope -> Map String SrcType -> ValueInfo -> ElabTerm
 instantiateMethodValue scope subst OrdinaryValue {valueRuntimeName = runtimeName, valueType = visibleTy} =
   foldl
-    ( \term (name, _) ->
-        case Map.lookup name subst of
-          Just ty -> X.ETyInst term (X.InstApp (srcTypeToElabType (lowerType scope ty)))
-          Nothing -> term
-    )
+    X.ETyInst
     (X.EVar runtimeName)
-    (fst (splitForalls visibleTy))
+    (methodForallInstantiations scope subst (fst (splitForalls visibleTy)))
 instantiateMethodValue _ _ ConstructorValue {valueRuntimeName = runtimeName} =
   X.EVar runtimeName
 instantiateMethodValue _ _ OverloadedMethod {} =
   X.EVar "<overloaded-method>"
+
+methodForallInstantiations :: ElaborateScope -> Map String SrcType -> [(String, Maybe SrcType)] -> [X.Instantiation]
+methodForallInstantiations scope subst = go
+  where
+    go [] = []
+    go ((name, _) : rest) =
+      case Map.lookup name subst of
+        Just ty -> X.InstApp (srcTypeToElabType (lowerType scope ty)) : go rest
+        Nothing
+          | any ((`Map.member` subst) . fst) rest -> X.InstElim : go rest
+          | otherwise -> []
 
 applyConstraintSubst :: Map String SrcType -> P.ClassConstraint -> P.ClassConstraint
 applyConstraintSubst subst constraint =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -764,7 +764,17 @@ resolveConstraintEvidenceTerm scope seen constraint = do
     then Left (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
     else do
       (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (P.constraintClassName constraint) (P.constraintType constraint)
-      mapM (materializeMethodEvidence (Set.insert key seen) subst) (ordinaryInstanceMethods instanceInfo)
+      let seen' = Set.insert key seen
+          methodValues = ordinaryInstanceMethods instanceInfo
+      if null methodValues
+        then do
+          _ <-
+            resolveConstraintEvidenceTerms
+              scope
+              seen'
+              (map (applyConstraintSubst subst) (instanceConstraints instanceInfo))
+          Right []
+        else mapM (materializeMethodEvidence seen' subst) methodValues
   where
     ordinaryInstanceMethods instanceInfo =
       [valueInfo | valueInfo@OrdinaryValue {} <- Map.elems (instanceMethods instanceInfo)]

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -53,8 +53,10 @@ import MLF.Frontend.Program.Types
     MethodInfo (..),
     ProgramError (..),
     ValueInfo (..),
+    splitArrows,
     splitForalls,
     substituteTypeVar,
+    specializeMethodType,
   )
 import MLF.Frontend.Syntax (Expr (..), SrcBound (..), SrcTy (..), SrcType, SurfaceExpr)
 import qualified MLF.Frontend.Syntax.Program as P
@@ -722,8 +724,12 @@ resolveDeferredMethods scope deferredMethods = go
               Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
           (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy
           methodValue <- concreteMethodValue instanceInfo methodInfo
-          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty (map (applyConstraintSubst subst) (methodValueConstraints methodValue))
-          let methodHead = instantiateMethodValue scope subst methodValue
+          methodSubst <-
+            case inferMethodArgumentSubst methodInfo classArgTy subst argTypes of
+              Just subst' -> Right subst'
+              Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
+          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty (map (applyConstraintSubst methodSubst) (methodValueConstraints methodValue))
+          let methodHead = instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
     inferDeferredArgType env arg =
@@ -737,6 +743,15 @@ resolveDeferredMethods scope deferredMethods = go
       case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
         Just valueInfo@OrdinaryValue {} -> Right valueInfo
         _ -> Left (ProgramUnknownMethod (methodName methodInfo))
+
+    inferMethodArgumentSubst methodInfo classArgTy subst argTypes =
+      let specializedMethodTy = specializeMethodType (methodType methodInfo) (methodParamName methodInfo) classArgTy
+          (_, bodyTy) = splitForalls specializedMethodTy
+          (paramTys, _) = splitArrows bodyTy
+       in foldM
+            (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy)
+            subst
+            (zip paramTys argTypes)
 
 resolveConstraintEvidenceTerms :: ElaborateScope -> Set (P.ClassName, String) -> [P.ClassConstraint] -> Either ProgramError [ElabTerm]
 resolveConstraintEvidenceTerms scope seen constraints =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -218,6 +218,12 @@ runSurfacePipeline scope forceUnchecked deferredObligations externalTypes surfac
 
     externalBindingModeFor name =
       case Map.lookup name deferredObligations of
+        Just (DeferredMethod {}) ->
+          case Map.lookup name externalTypes of
+            Just ty
+              | not (Set.null (freeTypeVarsSrcTypeLocal ty)) ->
+                  ExternalBindingMonomorphic
+            _ -> ExternalBindingScheme
         Just (DeferredConstructor deferred) -> convertDeferredBindingMode (deferredConstructorBindingMode deferred)
         Just (DeferredCase {}) -> ExternalBindingMonomorphic
         _ -> ExternalBindingScheme
@@ -226,6 +232,22 @@ runSurfacePipeline scope forceUnchecked deferredObligations externalTypes surfac
       case mode of
         DeferredBindingScheme -> ExternalBindingScheme
         DeferredBindingMonomorphic -> ExternalBindingMonomorphic
+
+    freeTypeVarsSrcTypeLocal = go Set.empty
+      where
+        go boundVars ty =
+          case ty of
+            STVar name
+              | name `Set.member` boundVars -> Set.empty
+              | otherwise -> Set.singleton name
+            STArrow dom cod -> go boundVars dom `Set.union` go boundVars cod
+            STBase {} -> Set.empty
+            STCon _ args -> foldMap (go boundVars) args
+            STForall name mb body ->
+              maybe Set.empty (go boundVars . unSrcBound) mb
+                `Set.union` go (Set.insert name boundVars) body
+            STMu name body -> go (Set.insert name boundVars) body
+            STBottom -> Set.empty
 
 finalizeDeferredObligations ::
   ElaborateScope ->

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -34,6 +34,7 @@ import MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
     elaborateScopeDataTypes,
     elaborateScopeRuntimeTypes,
+    freeTypeVarsSrcType,
     inferClassArgument,
     lowerType,
     matchTypes,
@@ -775,18 +776,26 @@ resolveConstraintEvidenceTerm scope seen constraint = do
               seen'
               (map (applyConstraintSubst subst) (instanceConstraints instanceInfo))
           Right []
-        else mapM (materializeMethodEvidence seen' subst) methodValues
+        else mapM (materializeMethodEvidence (freeTypeVarsSrcType (P.constraintType constraint)) seen' subst) methodValues
   where
     ordinaryInstanceMethods instanceInfo =
       [valueInfo | valueInfo@OrdinaryValue {} <- Map.elems (instanceMethods instanceInfo)]
 
-    materializeMethodEvidence seen' subst valueInfo = do
+    materializeMethodEvidence headVars seen' subst valueInfo = do
+      let eagerConstraints =
+            filter
+              (constraintDeterminedByTypeVars headVars)
+              (map (applyConstraintSubst subst) (methodValueConstraints valueInfo))
       nestedEvidence <-
         resolveConstraintEvidenceTerms
           scope
           seen'
-          (map (applyConstraintSubst subst) (methodValueConstraints valueInfo))
+          eagerConstraints
       pure (foldl X.EApp (instantiateMethodValue scope subst valueInfo) nestedEvidence)
+
+constraintDeterminedByTypeVars :: Set String -> P.ClassConstraint -> Bool
+constraintDeterminedByTypeVars typeVars constraint =
+  freeTypeVarsSrcType (P.constraintType constraint) `Set.isSubsetOf` typeVars
 
 methodValueConstraints :: ValueInfo -> [P.ClassConstraint]
 methodValueConstraints OrdinaryValue {valueConstraints = constraints} = constraints

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -700,7 +700,7 @@ resolveDeferredMethods scope deferredMethods = go
               Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
           (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy
           methodValue <- concreteMethodValue instanceInfo methodInfo
-          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty (map (applyConstraintSubst subst) (instanceConstraints instanceInfo))
+          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty (map (applyConstraintSubst subst) (methodValueConstraints methodValue))
           let methodHead = instantiateMethodValue scope subst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
@@ -715,6 +715,9 @@ resolveDeferredMethods scope deferredMethods = go
       case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
         Just valueInfo@OrdinaryValue {} -> Right valueInfo
         _ -> Left (ProgramUnknownMethod (methodName methodInfo))
+
+    methodValueConstraints OrdinaryValue {valueConstraints = constraints} = constraints
+    methodValueConstraints _ = []
 
 resolveConstraintEvidenceTerms :: ElaborateScope -> Set (P.ClassName, String) -> [P.ClassConstraint] -> Either ProgramError [ElabTerm]
 resolveConstraintEvidenceTerms scope seen constraints =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -84,7 +84,7 @@ finalizeBinding scope lowered = do
       Right
         CheckedBinding
           { checkedBindingName = loweredBindingName lowered,
-            checkedBindingSourceType = loweredBindingExpectedType lowered,
+            checkedBindingSourceType = loweredBindingSourceType lowered,
             checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
             checkedBindingTerm = acceptedTerm,
             checkedBindingType = acceptedTy,
@@ -104,7 +104,7 @@ finalizeBinding scope lowered = do
           Right
             CheckedBinding
               { checkedBindingName = loweredBindingName lowered,
-                checkedBindingSourceType = loweredBindingExpectedType lowered,
+                checkedBindingSourceType = loweredBindingSourceType lowered,
                 checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
                 checkedBindingTerm = acceptedTerm,
                 checkedBindingType = acceptedTy,

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -716,9 +716,6 @@ resolveDeferredMethods scope deferredMethods = go
         Just valueInfo@OrdinaryValue {} -> Right valueInfo
         _ -> Left (ProgramUnknownMethod (methodName methodInfo))
 
-    methodValueConstraints OrdinaryValue {valueConstraints = constraints} = constraints
-    methodValueConstraints _ = []
-
 resolveConstraintEvidenceTerms :: ElaborateScope -> Set (P.ClassName, String) -> [P.ClassConstraint] -> Either ProgramError [ElabTerm]
 resolveConstraintEvidenceTerms scope seen constraints =
   concat <$> mapM (resolveConstraintEvidenceTerm scope seen) constraints
@@ -730,12 +727,22 @@ resolveConstraintEvidenceTerm scope seen constraint = do
     then Left (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
     else do
       (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (P.constraintClassName constraint) (P.constraintType constraint)
-      let nestedConstraints = map (applyConstraintSubst subst) (instanceConstraints instanceInfo)
-      nestedEvidence <- resolveConstraintEvidenceTerms scope (Set.insert key seen) nestedConstraints
-      pure
-        [ foldl X.EApp (instantiateMethodValue scope subst valueInfo) nestedEvidence
-          | valueInfo@OrdinaryValue {} <- Map.elems (instanceMethods instanceInfo)
-        ]
+      mapM (materializeMethodEvidence (Set.insert key seen) subst) (ordinaryInstanceMethods instanceInfo)
+  where
+    ordinaryInstanceMethods instanceInfo =
+      [valueInfo | valueInfo@OrdinaryValue {} <- Map.elems (instanceMethods instanceInfo)]
+
+    materializeMethodEvidence seen' subst valueInfo = do
+      nestedEvidence <-
+        resolveConstraintEvidenceTerms
+          scope
+          seen'
+          (map (applyConstraintSubst subst) (methodValueConstraints valueInfo))
+      pure (foldl X.EApp (instantiateMethodValue scope subst valueInfo) nestedEvidence)
+
+methodValueConstraints :: ValueInfo -> [P.ClassConstraint]
+methodValueConstraints OrdinaryValue {valueConstraints = constraints} = constraints
+methodValueConstraints _ = []
 
 instantiateMethodValue :: ElaborateScope -> Map String SrcType -> ValueInfo -> ElabTerm
 instantiateMethodValue scope subst OrdinaryValue {valueRuntimeName = runtimeName, valueType = visibleTy} =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -2,11 +2,12 @@
 
 module MLF.Frontend.Program.Finalize
   ( finalizeBinding,
+    recoverSourceType,
   )
 where
 
 import Control.Monad (foldM)
-import Data.List (sort)
+import Data.List (isPrefixOf, sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -36,7 +37,7 @@ import MLF.Frontend.Program.Elaborate
     inferClassArgument,
     lowerType,
     matchTypes,
-    resolveInstanceInfo,
+    resolveInstanceInfoWithSubst,
   )
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
@@ -52,8 +53,11 @@ import MLF.Frontend.Program.Types
     MethodInfo (..),
     ProgramError (..),
     ValueInfo (..),
+    splitForalls,
+    substituteTypeVar,
   )
 import MLF.Frontend.Syntax (Expr (..), SrcBound (..), SrcTy (..), SrcType, SurfaceExpr)
+import qualified MLF.Frontend.Syntax.Program as P
 import MLF.Reify.TypeOps (alphaEqType, churchAwareEqType, freeTypeVarsType)
 
 finalizeBinding :: ElaborateScope -> LoweredBinding -> Either ProgramError CheckedBinding
@@ -66,16 +70,22 @@ finalizeBinding scope lowered = do
       (loweredBindingExternalTypes lowered)
       (loweredBindingSurfaceExpr lowered)
   (term, actualTy) <-
-    finalizeDeferredObligations scope (loweredBindingDeferredObligations lowered) tcEnv term0 actualTy0
-  if constructorBindingNeedsUnchecked scope (loweredBindingName lowered)
+    finalizeDeferredObligations scope (loweredBindingDeferredObligations lowered) tcEnv term0 actualTy0 (loweredBindingExpectedType lowered)
+  let isUncheckedConstructor = constructorBindingNeedsUnchecked scope (loweredBindingName lowered)
+      acceptedTerm = repairConstructorBindingTerm scope (loweredBindingName lowered) term
+      acceptedTy =
+        if isUncheckedConstructor
+          then srcTypeToElabType (loweredBindingExpectedType lowered)
+          else actualTy
+  if isUncheckedConstructor
     then
       Right
         CheckedBinding
           { checkedBindingName = loweredBindingName lowered,
             checkedBindingSourceType = loweredBindingExpectedType lowered,
             checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
-            checkedBindingTerm = term,
-            checkedBindingType = actualTy,
+            checkedBindingTerm = acceptedTerm,
+            checkedBindingType = acceptedTy,
             checkedBindingExportedAsMain = loweredBindingExportedAsMain lowered
           }
     else do
@@ -94,8 +104,8 @@ finalizeBinding scope lowered = do
               { checkedBindingName = loweredBindingName lowered,
                 checkedBindingSourceType = loweredBindingExpectedType lowered,
                 checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
-                checkedBindingTerm = term,
-                checkedBindingType = actualTy,
+                checkedBindingTerm = acceptedTerm,
+                checkedBindingType = acceptedTy,
                 checkedBindingExportedAsMain = loweredBindingExportedAsMain lowered
               }
         else Left (ProgramTypeMismatch recoveredActualSrcTy (loweredBindingExpectedType lowered))
@@ -103,10 +113,78 @@ finalizeBinding scope lowered = do
 constructorBindingNeedsUnchecked :: ElaborateScope -> String -> Bool
 constructorBindingNeedsUnchecked scope runtimeName =
   or
-    [ ctorRuntimeName ctor == runtimeName && not (null (ctorForalls ctor))
+    [ ctorRuntimeName ctor == runtimeName
+        && (not (null (ctorForalls ctor)) || not (null (dataParams dataInfo)))
       | dataInfo <- Map.elems (elaborateScopeDataTypes scope),
         ctor <- dataConstructors dataInfo
     ]
+
+repairConstructorBindingTerm :: ElaborateScope -> String -> ElabTerm -> ElabTerm
+repairConstructorBindingTerm scope runtimeName term =
+  case lookupConstructorRuntime scope runtimeName of
+    Just (dataInfo, ctor)
+      | not (null (dataParams dataInfo)) ->
+          moveConstructorResultAbs (dataName dataInfo) (length (ctorArgs ctor)) term
+    _ -> term
+
+lookupConstructorRuntime :: ElaborateScope -> String -> Maybe (DataInfo, ConstructorInfo)
+lookupConstructorRuntime scope runtimeName =
+  case
+    [ (dataInfo, ctor)
+      | dataInfo <- Map.elems (elaborateScopeDataTypes scope),
+        ctor <- dataConstructors dataInfo,
+        ctorRuntimeName ctor == runtimeName
+    ]
+  of
+    match : _ -> Just match
+    [] -> Nothing
+
+data TypeAbsInfo = TypeAbsInfo
+  { typeAbsName :: String,
+    typeAbsBound :: Maybe X.BoundType
+  }
+
+data TermLamInfo = TermLamInfo String ElabType
+
+data ConstructorSpineItem
+  = SpineTypeAbs TypeAbsInfo
+  | SpineLam TermLamInfo
+
+moveConstructorResultAbs :: String -> Int -> ElabTerm -> ElabTerm
+moveConstructorResultAbs typeName argCount term =
+  let (spine, body) = collectConstructorSpine term
+      typeAbs = [info | SpineTypeAbs info <- spine]
+      lams = [info | SpineLam info <- spine]
+      (resultAbs, otherAbs) = partitionResultAbs typeAbs
+      (argLams, handlerLams) = splitAt argCount lams
+   in wrapTypeAbs otherAbs (wrapLams argLams (wrapTypeAbs resultAbs (wrapLams handlerLams body)))
+  where
+    resultPrefix = "$" ++ typeName ++ "_result"
+
+    partitionResultAbs =
+      foldr
+        ( \absInfo (results, others) ->
+            if resultPrefix `isPrefixOf` typeAbsName absInfo
+              then (absInfo : results, others)
+              else (results, absInfo : others)
+        )
+        ([], [])
+
+collectConstructorSpine :: ElabTerm -> ([ConstructorSpineItem], ElabTerm)
+collectConstructorSpine = go []
+  where
+    go acc = \case
+      X.ETyAbs name mb body -> go (acc ++ [SpineTypeAbs (TypeAbsInfo name mb)]) body
+      X.ELam name ty body -> go (acc ++ [SpineLam (TermLamInfo name ty)]) body
+      other -> (acc, other)
+
+wrapTypeAbs :: [TypeAbsInfo] -> ElabTerm -> ElabTerm
+wrapTypeAbs infos body =
+  foldr (\TypeAbsInfo {typeAbsName = name, typeAbsBound = mb} acc -> X.ETyAbs name mb acc) body infos
+
+wrapLams :: [TermLamInfo] -> ElabTerm -> ElabTerm
+wrapLams infos body =
+  foldr (\(TermLamInfo name ty) acc -> X.ELam name ty acc) body infos
 
 runSurfacePipeline :: ElaborateScope -> Bool -> Map String DeferredProgramObligation -> Map String SrcType -> SurfaceExpr -> Either ProgramError PipelineElabDetailedResult
 runSurfacePipeline scope forceUnchecked deferredObligations externalTypes surfaceExpr = do
@@ -155,10 +233,11 @@ finalizeDeferredObligations ::
   Env ->
   ElabTerm ->
   ElabType ->
+  SrcType ->
   Either ProgramError (ElabTerm, ElabType)
-finalizeDeferredObligations _ deferredObligations _ term inferredTy
+finalizeDeferredObligations _ deferredObligations _ term inferredTy _
   | Map.null deferredObligations = Right (term, inferredTy)
-finalizeDeferredObligations scope deferredObligations tcEnv term _ = do
+finalizeDeferredObligations scope deferredObligations tcEnv term _ _ = do
   let rewriteEnv = extendTypeCheckEnvWithRuntimeScope scope tcEnv
       constructorObligations = Map.mapMaybe onlyConstructor deferredObligations
       caseObligations = Map.mapMaybe onlyCase deferredObligations
@@ -168,11 +247,10 @@ finalizeDeferredObligations scope deferredObligations tcEnv term _ = do
   methodsRewritten <- resolveDeferredMethods scope methodObligations caseRewriteEnv casesRewritten
   rewritten <- refreshLetSchemes caseRewriteEnv methodsRewritten
   rewrittenTy <-
-    fmap (inlineTypeEnvBounds caseRewriteEnv) $
-      either
-      (Left . ProgramPipelineError . ("deferred program obligation rewrite failed type check: " ++) . show)
-      Right
-      (typeCheckWithEnv caseRewriteEnv rewritten)
+    case typeCheckWithEnv caseRewriteEnv rewritten of
+      Right ty -> Right (inlineTypeEnvBounds caseRewriteEnv ty)
+      Left err ->
+        Left (ProgramPipelineError ("deferred program obligation rewrite failed type check: " ++ show err))
   Right (rewritten, rewrittenTy)
   where
     onlyConstructor = \case
@@ -408,7 +486,15 @@ resolveDeferredConstructors scope env deferredConstructors = go env
               (zip visibleArgTemplates argTypes)
           of
             Just subst -> subst
-            Nothing -> fst substFromHead
+            Nothing ->
+              case
+                foldM
+                  (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy)
+                  (deferredConstructorInitialSubst deferred)
+                  (zip visibleArgTemplates argTypes)
+              of
+                Just subst -> subst
+                Nothing -> fst substFromHead
       let substFinal =
             case matchTypes substFromArgs (deferredConstructorOccurrenceType deferred) occurrenceTy of
               Just subst -> subst
@@ -612,9 +698,11 @@ resolveDeferredMethods scope deferredMethods = go
             case inferClassArgument (lowerType scope (methodType methodInfo)) (methodParamName methodInfo) argTypes of
               Just ty -> Right ty
               Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
-          instanceInfo <- resolveInstanceInfo scope (methodClassName methodInfo) classArgTy
-          runtimeName <- concreteMethodRuntimeName instanceInfo methodInfo
-          Right (foldl X.EApp (X.EVar runtimeName) args)
+          (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (methodClassName methodInfo) classArgTy
+          methodValue <- concreteMethodValue instanceInfo methodInfo
+          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty (map (applyConstraintSubst subst) (instanceConstraints instanceInfo))
+          let methodHead = instantiateMethodValue scope subst methodValue
+          Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
     inferDeferredArgType env arg =
       case typeCheckWithEnv env arg of
@@ -623,10 +711,51 @@ resolveDeferredMethods scope deferredMethods = go
         Left err ->
           Left (ProgramPipelineError ("deferred method argument type check failed: " ++ show err))
 
-    concreteMethodRuntimeName instanceInfo methodInfo =
+    concreteMethodValue instanceInfo methodInfo =
       case Map.lookup (methodName methodInfo) (instanceMethods instanceInfo) of
-        Just OrdinaryValue {valueRuntimeName = runtimeName} -> Right runtimeName
+        Just valueInfo@OrdinaryValue {} -> Right valueInfo
         _ -> Left (ProgramUnknownMethod (methodName methodInfo))
+
+resolveConstraintEvidenceTerms :: ElaborateScope -> Set (P.ClassName, String) -> [P.ClassConstraint] -> Either ProgramError [ElabTerm]
+resolveConstraintEvidenceTerms scope seen constraints =
+  concat <$> mapM (resolveConstraintEvidenceTerm scope seen) constraints
+
+resolveConstraintEvidenceTerm :: ElaborateScope -> Set (P.ClassName, String) -> P.ClassConstraint -> Either ProgramError [ElabTerm]
+resolveConstraintEvidenceTerm scope seen constraint = do
+  let key = (P.constraintClassName constraint, show (P.constraintType constraint))
+  if key `Set.member` seen
+    then Left (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
+    else do
+      (instanceInfo, subst) <- resolveInstanceInfoWithSubst scope (P.constraintClassName constraint) (P.constraintType constraint)
+      let nestedConstraints = map (applyConstraintSubst subst) (instanceConstraints instanceInfo)
+      nestedEvidence <- resolveConstraintEvidenceTerms scope (Set.insert key seen) nestedConstraints
+      pure
+        [ foldl X.EApp (instantiateMethodValue scope subst valueInfo) nestedEvidence
+          | valueInfo@OrdinaryValue {} <- Map.elems (instanceMethods instanceInfo)
+        ]
+
+instantiateMethodValue :: ElaborateScope -> Map String SrcType -> ValueInfo -> ElabTerm
+instantiateMethodValue scope subst OrdinaryValue {valueRuntimeName = runtimeName, valueType = visibleTy} =
+  foldl
+    ( \term (name, _) ->
+        case Map.lookup name subst of
+          Just ty -> X.ETyInst term (X.InstApp (srcTypeToElabType (lowerType scope ty)))
+          Nothing -> term
+    )
+    (X.EVar runtimeName)
+    (fst (splitForalls visibleTy))
+instantiateMethodValue _ _ ConstructorValue {valueRuntimeName = runtimeName} =
+  X.EVar runtimeName
+instantiateMethodValue _ _ OverloadedMethod {} =
+  X.EVar "<overloaded-method>"
+
+applyConstraintSubst :: Map String SrcType -> P.ClassConstraint -> P.ClassConstraint
+applyConstraintSubst subst constraint =
+  constraint {P.constraintType = applySrcSubst subst (P.constraintType constraint)}
+
+applySrcSubst :: Map String SrcType -> SrcType -> SrcType
+applySrcSubst subst ty =
+  Map.foldrWithKey substituteTypeVar ty subst
 
 collectElabApps :: ElabTerm -> (ElabTerm, [ElabTerm])
 collectElabApps = go []
@@ -742,7 +871,6 @@ matchRecoverType params subst renames template actual =
       | Just actualName <- Map.lookup name renames ->
           case actual of
             STVar name' | name' == actualName -> Just subst
-            STVar name' -> Just (Map.insert name' (STVar actualName) subst)
             _ -> Nothing
       | otherwise ->
           case actual of

--- a/src/MLF/Frontend/Program/Prelude.hs
+++ b/src/MLF/Frontend/Program/Prelude.hs
@@ -1,0 +1,61 @@
+module MLF.Frontend.Program.Prelude
+  ( preludeSource,
+    preludeProgram,
+    preludeLocatedProgram,
+    withPrelude,
+    withPreludeLocated,
+  )
+where
+
+import MLF.Frontend.Parse.Program (parseLocatedProgramWithFile)
+import qualified MLF.Frontend.Syntax.Program as P
+
+preludeSource :: String
+preludeSource =
+  unlines
+    [ "module Prelude export (Nat(..), Option(..), List(..), Eq, eq, and, id) {",
+      "  class Eq a {",
+      "    eq : a -> a -> Bool;",
+      "  }",
+      "",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat",
+      "    deriving Eq;",
+      "",
+      "  data Option a =",
+      "      None : Option a",
+      "    | Some : a -> Option a",
+      "    deriving Eq;",
+      "",
+      "  data List a =",
+      "      Nil : List a",
+      "    | Cons : a -> List a -> List a",
+      "    deriving Eq;",
+      "",
+      "  def and : Bool -> Bool -> Bool = \\left \\right __mlfp_and left right;",
+      "  def id : forall a. a -> a = \\x x;",
+      "}"
+    ]
+
+preludeLocatedProgram :: P.LocatedProgram
+preludeLocatedProgram =
+  case parseLocatedProgramWithFile "<mlfp-prelude>" preludeSource of
+    Right program -> program
+    Left err -> error ("internal Prelude failed to parse: " ++ show err)
+
+preludeProgram :: P.Program
+preludeProgram = P.locatedProgram preludeLocatedProgram
+
+withPrelude :: P.Program -> P.Program
+withPrelude program =
+  P.Program (P.programModules preludeProgram ++ P.programModules program)
+
+withPreludeLocated :: P.LocatedProgram -> P.LocatedProgram
+withPreludeLocated program =
+  P.LocatedProgram
+    { P.locatedProgram = withPrelude (P.locatedProgram program),
+      P.locatedProgramSpans =
+        P.locatedProgramSpans program
+          `P.appendProgramSpanIndex` P.locatedProgramSpans preludeLocatedProgram
+    }

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -1,30 +1,46 @@
+{-# LANGUAGE GADTs #-}
+
 module MLF.Frontend.Program.Run
   ( Value (..),
     runProgram,
+    runLocatedProgram,
     prettyValue,
   )
 where
 
+import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
 import MLF.Elab.Pipeline (ElabTerm (..), Pretty (..), Ty (..), freeTypeVarsType, normalize, schemeFromType, typeCheck)
-import MLF.Frontend.Program.Check (checkProgram)
+import MLF.Frontend.Program.Check (checkLocatedProgram, checkProgram)
+import MLF.Frontend.Program.Elaborate (ElaborateScope, mkElaborateScope)
+import MLF.Frontend.Program.Finalize (recoverSourceType)
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
     CheckedModule (..),
     CheckedProgram (..),
+    ConstructorInfo (..),
+    DataInfo (..),
+    ProgramDiagnostic,
     ProgramError (..),
   )
-import MLF.Frontend.Syntax (Lit (..))
+import MLF.Frontend.Syntax (Lit (..), SrcBound (..), SrcTy (..), SrcType)
 import qualified MLF.Frontend.Syntax.Program as ProgramSyntax
 
 data Value
   = VLit Lit
+  | VData String [Value]
   | VTerm ElabTerm
   deriving (Eq, Show)
 
 runProgram :: ProgramSyntax.Program -> Either ProgramError Value
 runProgram program = do
   checked <- checkProgram program
-  pure (toValue (normalizeProgramTerm (programMainTerm checked)))
+  pure (toValueWithProgram checked (normalizeProgramTerm (programMainTerm checked)))
+
+runLocatedProgram :: ProgramSyntax.LocatedProgram -> Either ProgramDiagnostic Value
+runLocatedProgram located = do
+  checked <- checkLocatedProgram located
+  pure (toValueWithProgram checked (normalizeProgramTerm (programMainTerm checked)))
 
 programMainTerm :: CheckedProgram -> ElabTerm
 programMainTerm checked =
@@ -82,8 +98,17 @@ stripUnusedTopTyAbs term = case term of
   EUnroll body -> EUnroll (stripUnusedTopTyAbs body)
   _ -> term
 
+toValueWithProgram :: CheckedProgram -> ElabTerm -> Value
+toValueWithProgram checked term =
+  case mainSourceType checked >>= \srcTy -> decodeSourceValue checked srcTy term of
+    Just value -> value
+    Nothing ->
+      case decodeAnyData checked term of
+        Just value -> value
+        Nothing -> toValue term
+
 toValue :: ElabTerm -> Value
-toValue term = case term of
+toValue term = case stripRuntimeWrappers term of
   ELit lit -> VLit lit
   other -> VTerm other
 
@@ -92,4 +117,150 @@ prettyValue value = case value of
   VLit (LInt i) -> show i
   VLit (LBool b) -> if b then "true" else "false"
   VLit (LString s) -> show s
+  VData ctor [] -> ctor
+  VData ctor args -> unwords (ctor : map prettyValueArg args)
   VTerm term -> pretty term
+
+prettyValueArg :: Value -> String
+prettyValueArg value = case value of
+  VData _ (_ : _) -> "(" ++ prettyValue value ++ ")"
+  _ -> prettyValue value
+
+mainSourceType :: CheckedProgram -> Maybe SrcType
+mainSourceType checked =
+  case
+    [ checkedBindingSourceType binding
+      | checkedModule <- checkedProgramModules checked,
+        binding <- checkedModuleBindings checkedModule,
+        checkedBindingName binding == checkedProgramMain checked
+    ]
+  of
+    ty : _ -> Just (recoverSourceType (programElaborateScope checked) ty)
+    [] -> Nothing
+
+programElaborateScope :: CheckedProgram -> ElaborateScope
+programElaborateScope checked =
+  mkElaborateScope Map.empty (Map.fromList [(dataName info, info) | info <- allDataInfos checked]) Map.empty []
+
+decodeSourceValue :: CheckedProgram -> SrcType -> ElabTerm -> Maybe Value
+decodeSourceValue checked srcTy term =
+  case lookupDataInfoForType checked srcTy of
+    Just dataInfo -> decodeChurchData checked dataInfo (dataTypeSubst dataInfo srcTy) term
+    Nothing ->
+      case stripRuntimeWrappers term of
+        ELit lit -> Just (VLit lit)
+        _ -> Nothing
+
+lookupDataInfoForType :: CheckedProgram -> SrcType -> Maybe DataInfo
+lookupDataInfoForType checked srcTy =
+  case srcTy of
+    STBase name -> lookupDataInfoByName checked name
+    STCon name _ -> lookupDataInfoByName checked name
+    _ -> Nothing
+
+lookupDataInfoByName :: CheckedProgram -> String -> Maybe DataInfo
+lookupDataInfoByName checked name =
+  case
+    [ dataInfo
+      | checkedModule <- checkedProgramModules checked,
+        dataInfo <- map snd (Map.toList (checkedModuleData checkedModule)),
+        dataName dataInfo == name
+    ]
+  of
+    dataInfo : _ -> Just dataInfo
+    [] -> Nothing
+
+allDataInfos :: CheckedProgram -> [DataInfo]
+allDataInfos checked =
+  [ dataInfo
+    | checkedModule <- checkedProgramModules checked,
+      dataInfo <- map snd (Map.toList (checkedModuleData checkedModule))
+  ]
+
+decodeAnyData :: CheckedProgram -> ElabTerm -> Maybe Value
+decodeAnyData checked term =
+  case [value | dataInfo <- allDataInfos checked, Just value <- [decodeChurchData checked dataInfo Map.empty term]] of
+    value : _ -> Just value
+    [] -> Nothing
+
+decodeChurchData :: CheckedProgram -> DataInfo -> Map.Map String SrcType -> ElabTerm -> Maybe Value
+decodeChurchData checked dataInfo subst term = do
+  let stripped = stripRuntimeWrappers term
+      (handlerNames, body) = collectLeadingLams stripped
+      constructors = dataConstructors dataInfo
+  if length handlerNames < length constructors
+    then Nothing
+    else do
+      let activeHandlers = take (length constructors) handlerNames
+          (headTerm, args) = collectElabApps (stripRuntimeWrappers body)
+      selectedHandler <- case headTerm of
+        EVar name -> Just name
+        _ -> Nothing
+      ctorInfo <- lookupByHandler activeHandlers constructors selectedHandler
+      if length args /= length (ctorArgs ctorInfo)
+        then Nothing
+        else Just (VData (ctorName ctorInfo) (zipWith (decodeArg checked) (map (substDataParams subst) (ctorArgs ctorInfo)) args))
+
+dataTypeSubst :: DataInfo -> SrcType -> Map.Map String SrcType
+dataTypeSubst dataInfo srcTy =
+  case (dataParams dataInfo, srcTy) of
+    ([], STBase name)
+      | name == dataName dataInfo -> Map.empty
+    (params, STCon name args)
+      | name == dataName dataInfo && length params == length args ->
+          Map.fromList (zip params (toList args))
+    _ -> Map.empty
+
+substDataParams :: Map.Map String SrcType -> SrcType -> SrcType
+substDataParams subst ty =
+  case ty of
+    STVar name -> Map.findWithDefault ty name subst
+    STArrow dom cod -> STArrow (substDataParams subst dom) (substDataParams subst cod)
+    STBase {} -> ty
+    STCon name args -> STCon name (fmap (substDataParams subst) args)
+    STForall name mb body ->
+      let subst' = Map.delete name subst
+       in STForall name (fmap (SrcBound . substDataParams subst' . unSrcBound) mb) (substDataParams subst' body)
+    STMu name body ->
+      STMu name (substDataParams (Map.delete name subst) body)
+    STBottom -> STBottom
+
+decodeArg :: CheckedProgram -> SrcType -> ElabTerm -> Value
+decodeArg checked srcTy term =
+  case decodeSourceValue checked srcTy term of
+    Just value -> value
+    Nothing ->
+      case decodeAnyData checked term of
+        Just value -> value
+        Nothing -> toValue term
+
+lookupByHandler :: [String] -> [ConstructorInfo] -> String -> Maybe ConstructorInfo
+lookupByHandler handlerNames constructors selected =
+  case [ctor | (handlerName, ctor) <- zip handlerNames constructors, handlerName == selected] of
+    ctor : _ -> Just ctor
+    [] -> Nothing
+
+collectLeadingLams :: ElabTerm -> ([String], ElabTerm)
+collectLeadingLams = go []
+  where
+    go acc term =
+      case stripRuntimeWrappers term of
+        ELam name _ body -> go (acc ++ [name]) body
+        other -> (acc, other)
+
+collectElabApps :: ElabTerm -> (ElabTerm, [ElabTerm])
+collectElabApps = go []
+  where
+    go acc term =
+      case stripRuntimeWrappers term of
+        EApp fun arg -> go (stripRuntimeWrappers arg : acc) fun
+        other -> (other, acc)
+
+stripRuntimeWrappers :: ElabTerm -> ElabTerm
+stripRuntimeWrappers term =
+  case term of
+    ETyAbs _ _ body -> stripRuntimeWrappers body
+    ETyInst inner _ -> stripRuntimeWrappers inner
+    ERoll _ body -> stripRuntimeWrappers body
+    EUnroll body -> stripRuntimeWrappers body
+    _ -> term

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -154,7 +154,7 @@ recoverMainSourceType checked ty =
 
 programElaborateScope :: CheckedProgram -> ElaborateScope
 programElaborateScope checked =
-  mkElaborateScope Map.empty (Map.fromList [(dataName info, info) | info <- allDataInfos checked]) Map.empty []
+  mkElaborateScope Map.empty (Map.fromList [(qualifiedDataName info, info) | info <- allDataInfos checked]) Map.empty []
 
 decodeSourceValue :: CheckedProgram -> SrcType -> ElabTerm -> Maybe Value
 decodeSourceValue checked srcTy term =
@@ -188,21 +188,22 @@ sourceTypeIsData checked srcTy =
 
 lookupDataInfosByName :: CheckedProgram -> String -> [DataInfo]
 lookupDataInfosByName checked name =
-  case exactMatches of
-    [] -> [dataInfo | dataInfo <- infos, dataTypeHeadMatches dataInfo name]
-    _ -> exactMatches
-  where
-    infos = allDataInfos checked
-    exactMatches = [dataInfo | dataInfo <- infos, dataName dataInfo == name]
+  [ dataInfo
+    | dataInfo <- allDataInfos checked,
+      dataTypeHeadMatches dataInfo name
+  ]
 
 dataTypeHeadMatches :: DataInfo -> String -> Bool
 dataTypeHeadMatches dataInfo name =
-  dataName dataInfo == name
-    || dataName dataInfo == unqualifiedSourceHead name
+  if isQualifiedSourceHead name
+    then qualifiedDataName dataInfo == name
+    else dataName dataInfo == name
 
-unqualifiedSourceHead :: String -> String
-unqualifiedSourceHead =
-  reverse . takeWhile (/= '.') . reverse
+isQualifiedSourceHead :: String -> Bool
+isQualifiedSourceHead = elem '.'
+
+qualifiedDataName :: DataInfo -> String
+qualifiedDataName dataInfo = dataModule dataInfo ++ "." ++ dataName dataInfo
 
 allDataInfos :: CheckedProgram -> [DataInfo]
 allDataInfos checked =
@@ -233,7 +234,9 @@ decodeChurchData checked dataInfo subst term = do
       ctorInfo <- lookupByHandler activeHandlers constructors selectedHandler
       if length args /= length (ctorArgs ctorInfo)
         then Nothing
-        else Just (VData (ctorName ctorInfo) (zipWith (decodeArg checked) (map (substDataParams subst) (ctorArgs ctorInfo)) args))
+        else
+          let argTypes = map (canonicalFieldType checked dataInfo . substDataParams subst) (ctorArgs ctorInfo)
+           in Just (VData (ctorName ctorInfo) (zipWith (decodeArg checked) argTypes args))
 
 dataTypeSubst :: DataInfo -> SrcType -> Map.Map String SrcType
 dataTypeSubst dataInfo srcTy =
@@ -258,6 +261,39 @@ substDataParams subst ty =
     STMu name body ->
       STMu name (substDataParams (Map.delete name subst) body)
     STBottom -> STBottom
+
+canonicalFieldType :: CheckedProgram -> DataInfo -> SrcType -> SrcType
+canonicalFieldType checked ownerInfo = canonical
+  where
+    canonical ty =
+      case ty of
+        STVar {} -> ty
+        STBase name ->
+          case lookupDataInfoInModule checked (dataModule ownerInfo) name of
+            Just info -> STBase (qualifiedDataName info)
+            Nothing -> ty
+        STCon name args ->
+          let args' = fmap canonical args
+           in case lookupDataInfoInModule checked (dataModule ownerInfo) name of
+                Just info -> STCon (qualifiedDataName info) args'
+                Nothing -> STCon name args'
+        STArrow dom cod -> STArrow (canonical dom) (canonical cod)
+        STForall name mb body ->
+          STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)
+        STMu name body -> STMu name (canonical body)
+        STBottom -> STBottom
+
+lookupDataInfoInModule :: CheckedProgram -> ProgramSyntax.ModuleName -> String -> Maybe DataInfo
+lookupDataInfoInModule checked moduleName0 name =
+  case
+    [ dataInfo
+      | dataInfo <- allDataInfos checked,
+        dataModule dataInfo == moduleName0,
+        dataName dataInfo == name
+    ]
+  of
+    dataInfo : _ -> Just dataInfo
+    [] -> Nothing
 
 decodeArg :: CheckedProgram -> SrcType -> ElabTerm -> Value
 decodeArg checked srcTy term =

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -249,10 +249,12 @@ decodeArg :: CheckedProgram -> SrcType -> ElabTerm -> Value
 decodeArg checked srcTy term =
   case decodeSourceValue checked srcTy term of
     Just value -> value
-    Nothing ->
-      case decodeAnyData checked term of
-        Just value -> value
-        Nothing -> toValue term
+    Nothing
+      | sourceTypeIsData checked srcTy ->
+          case decodeAnyData checked term of
+            Just value -> value
+            Nothing -> toValue term
+      | otherwise -> toValue term
 
 lookupByHandler :: [String] -> [ConstructorInfo] -> String -> Maybe ConstructorInfo
 lookupByHandler handlerNames constructors selected =

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -100,8 +100,16 @@ stripUnusedTopTyAbs term = case term of
 
 toValueWithProgram :: CheckedProgram -> ElabTerm -> Value
 toValueWithProgram checked term =
-  case mainSourceType checked >>= \srcTy -> decodeSourceValue checked srcTy term of
-    Just value -> value
+  case mainSourceType checked of
+    Just srcTy ->
+      case decodeSourceValue checked srcTy term of
+        Just value -> value
+        Nothing
+          | sourceTypeIsData checked srcTy ->
+              case decodeAnyData checked term of
+                Just value -> value
+                Nothing -> toValue term
+          | otherwise -> toValue term
     Nothing ->
       case decodeAnyData checked term of
         Just value -> value
@@ -135,8 +143,14 @@ mainSourceType checked =
         checkedBindingName binding == checkedProgramMain checked
     ]
   of
-    ty : _ -> Just (recoverSourceType (programElaborateScope checked) ty)
+    ty : _ -> Just (recoverMainSourceType checked ty)
     [] -> Nothing
+
+recoverMainSourceType :: CheckedProgram -> SrcType -> SrcType
+recoverMainSourceType checked ty =
+  case ty of
+    STArrow {} -> ty
+    _ -> recoverSourceType (programElaborateScope checked) ty
 
 programElaborateScope :: CheckedProgram -> ElaborateScope
 programElaborateScope checked =
@@ -157,6 +171,12 @@ lookupDataInfoForType checked srcTy =
     STBase name -> lookupDataInfoByName checked name
     STCon name _ -> lookupDataInfoByName checked name
     _ -> Nothing
+
+sourceTypeIsData :: CheckedProgram -> SrcType -> Bool
+sourceTypeIsData checked srcTy =
+  case lookupDataInfoForType checked srcTy of
+    Just _ -> True
+    Nothing -> False
 
 lookupDataInfoByName :: CheckedProgram -> String -> Maybe DataInfo
 lookupDataInfoByName checked name =

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -158,37 +158,51 @@ programElaborateScope checked =
 
 decodeSourceValue :: CheckedProgram -> SrcType -> ElabTerm -> Maybe Value
 decodeSourceValue checked srcTy term =
-  case lookupDataInfoForType checked srcTy of
-    Just dataInfo -> decodeChurchData checked dataInfo (dataTypeSubst dataInfo srcTy) term
-    Nothing ->
+  case lookupDataInfosForType checked srcTy of
+    [] ->
       case stripRuntimeWrappers term of
         ELit lit -> Just (VLit lit)
         _ -> Nothing
+    dataInfos ->
+      firstJust
+        [ decodeChurchData checked dataInfo (dataTypeSubst dataInfo srcTy) term
+          | dataInfo <- dataInfos
+        ]
 
-lookupDataInfoForType :: CheckedProgram -> SrcType -> Maybe DataInfo
-lookupDataInfoForType checked srcTy =
+firstJust :: [Maybe a] -> Maybe a
+firstJust values =
+  case [value | Just value <- values] of
+    value : _ -> Just value
+    [] -> Nothing
+
+lookupDataInfosForType :: CheckedProgram -> SrcType -> [DataInfo]
+lookupDataInfosForType checked srcTy =
   case srcTy of
-    STBase name -> lookupDataInfoByName checked name
-    STCon name _ -> lookupDataInfoByName checked name
-    _ -> Nothing
+    STBase name -> lookupDataInfosByName checked name
+    STCon name _ -> lookupDataInfosByName checked name
+    _ -> []
 
 sourceTypeIsData :: CheckedProgram -> SrcType -> Bool
 sourceTypeIsData checked srcTy =
-  case lookupDataInfoForType checked srcTy of
-    Just _ -> True
-    Nothing -> False
+  not (null (lookupDataInfosForType checked srcTy))
 
-lookupDataInfoByName :: CheckedProgram -> String -> Maybe DataInfo
-lookupDataInfoByName checked name =
-  case
-    [ dataInfo
-      | checkedModule <- checkedProgramModules checked,
-        dataInfo <- map snd (Map.toList (checkedModuleData checkedModule)),
-        dataName dataInfo == name
-    ]
-  of
-    dataInfo : _ -> Just dataInfo
-    [] -> Nothing
+lookupDataInfosByName :: CheckedProgram -> String -> [DataInfo]
+lookupDataInfosByName checked name =
+  case exactMatches of
+    [] -> [dataInfo | dataInfo <- infos, dataTypeHeadMatches dataInfo name]
+    _ -> exactMatches
+  where
+    infos = allDataInfos checked
+    exactMatches = [dataInfo | dataInfo <- infos, dataName dataInfo == name]
+
+dataTypeHeadMatches :: DataInfo -> String -> Bool
+dataTypeHeadMatches dataInfo name =
+  dataName dataInfo == name
+    || dataName dataInfo == unqualifiedSourceHead name
+
+unqualifiedSourceHead :: String -> String
+unqualifiedSourceHead =
+  reverse . takeWhile (/= '.') . reverse
 
 allDataInfos :: CheckedProgram -> [DataInfo]
 allDataInfos checked =
@@ -225,9 +239,9 @@ dataTypeSubst :: DataInfo -> SrcType -> Map.Map String SrcType
 dataTypeSubst dataInfo srcTy =
   case (dataParams dataInfo, srcTy) of
     ([], STBase name)
-      | name == dataName dataInfo -> Map.empty
+      | dataTypeHeadMatches dataInfo name -> Map.empty
     (params, STCon name args)
-      | name == dataName dataInfo && length params == length args ->
+      | dataTypeHeadMatches dataInfo name && length params == length args ->
           Map.fromList (zip params (toList args))
     _ -> Map.empty
 

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -123,8 +123,8 @@ spanForError :: ProgramError -> P.ProgramSpanIndex -> Maybe P.SourceSpan
 spanForError err index =
   case err of
     ProgramDuplicateModule name -> Map.lookup name (P.spanModules index)
-    ProgramUnknownImportModule name -> Map.lookup name (P.spanModules index)
-    ProgramImportNotExported _ name -> lookupAnyName name index
+    ProgramUnknownImportModule name -> firstSpan name (P.spanImports index) <|> Map.lookup name (P.spanModules index)
+    ProgramImportNotExported _ name -> firstSpan name (P.spanImportItems index) <|> lookupAnyName name index
     ProgramInvalidExport name -> lookupAnyName name index
     ProgramExportNotLocal name -> lookupAnyName name index
     ProgramDuplicateVisibleName name -> lookupAnyName name index
@@ -133,7 +133,7 @@ spanForError err index =
     ProgramDuplicateClass name -> firstSpan name (P.spanClasses index)
     ProgramDuplicateValue name -> firstSpan name (P.spanValues index)
     ProgramDuplicateMethod name -> firstSpan name (P.spanValues index)
-    ProgramDuplicateImportAlias name -> Map.lookup name (P.spanModules index)
+    ProgramDuplicateImportAlias name -> firstSpan name (P.spanImportAliases index) <|> Map.lookup name (P.spanModules index)
     ProgramOverlappingInstance className0 _ _ -> firstSpan className0 (P.spanClasses index)
     ProgramUnknownValue name -> lookupAnyName name index
     ProgramUnknownConstructor name -> firstSpan name (P.spanConstructors index)

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -368,6 +368,7 @@ data ModuleExports = ModuleExports
 
 data LoweredBinding = LoweredBinding
   { loweredBindingName :: String,
+    loweredBindingSourceType :: SrcType,
     loweredBindingExpectedType :: SrcType,
     loweredBindingSurfaceExpr :: SurfaceExpr,
     loweredBindingDeferredObligations :: Map String DeferredProgramObligation,

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -134,6 +134,7 @@ spanForError err index =
     ProgramDuplicateValue name -> firstSpan name (P.spanValues index)
     ProgramDuplicateMethod name -> firstSpan name (P.spanValues index)
     ProgramDuplicateImportAlias name -> firstSpan name (P.spanImportAliases index) <|> Map.lookup name (P.spanModules index)
+    ProgramDuplicateInstance className0 _ -> firstSpan className0 (P.spanClasses index)
     ProgramOverlappingInstance className0 _ _ -> firstSpan className0 (P.spanClasses index)
     ProgramUnknownValue name -> lookupAnyName name index
     ProgramUnknownConstructor name -> firstSpan name (P.spanConstructors index)

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -69,6 +69,7 @@ data ProgramError
   | ProgramUnexpectedInstanceMethod P.ClassName P.MethodName
   | ProgramNoMatchingInstance P.ClassName SrcType
   | ProgramAmbiguousMethodUse P.MethodName
+  | ProgramAmbiguousConstrainedValueUse String
   | ProgramAmbiguousConstructorUse P.ConstructorName
   | ProgramExpectedFunction SrcType
   | ProgramTypeMismatch SrcType SrcType
@@ -147,6 +148,7 @@ spanForError err index =
     ProgramUnexpectedInstanceMethod _ methodName0 -> firstSpan methodName0 (P.spanValues index)
     ProgramNoMatchingInstance className0 _ -> firstSpan className0 (P.spanClasses index)
     ProgramAmbiguousMethodUse methodName0 -> firstSpan methodName0 (P.spanValues index)
+    ProgramAmbiguousConstrainedValueUse valueName -> firstSpan valueName (P.spanValues index)
     ProgramAmbiguousConstructorUse ctor -> firstSpan ctor (P.spanConstructors index)
     ProgramPatternConstructorMismatch ctor _ -> firstSpan ctor (P.spanConstructors index)
     ProgramNonExhaustiveCase (ctor : _) -> firstSpan ctor (P.spanConstructors index)
@@ -199,6 +201,7 @@ programErrorMessage err =
     ProgramUnexpectedInstanceMethod className0 methodName0 -> "instance for `" ++ className0 ++ "` defines unexpected method `" ++ methodName0 ++ "`"
     ProgramNoMatchingInstance className0 ty -> "no matching instance for `" ++ className0 ++ " " ++ show ty ++ "`"
     ProgramAmbiguousMethodUse methodName0 -> "ambiguous overloaded method use `" ++ methodName0 ++ "`"
+    ProgramAmbiguousConstrainedValueUse valueName -> "ambiguous constrained value use `" ++ valueName ++ "`"
     ProgramAmbiguousConstructorUse ctor -> "ambiguous constructor use `" ++ ctor ++ "`"
     ProgramExpectedFunction ty -> "expected a function, got `" ++ show ty ++ "`"
     ProgramTypeMismatch actual expected -> "type mismatch: expected `" ++ show expected ++ "`, got `" ++ show actual ++ "`"
@@ -217,6 +220,8 @@ programErrorHints err =
       ["add an explicit result type annotation, for example `" ++ ctor ++ " : <Type>`"]
     ProgramAmbiguousMethodUse methodName0 ->
       ["apply `" ++ methodName0 ++ "` to enough arguments or add an annotation that fixes the instance type"]
+    ProgramAmbiguousConstrainedValueUse valueName ->
+      ["use `" ++ valueName ++ "` at a concrete instance type; generic constrained value aliases are not supported yet"]
     ProgramNoMatchingInstance className0 ty ->
       ["define or import an instance for `" ++ className0 ++ " " ++ show ty ++ "`"]
     ProgramDerivingMissingFieldInstance className0 ty ->

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -305,6 +305,7 @@ data ValueInfo
 
 data InstanceInfo = InstanceInfo
   { instanceClassName :: P.ClassName,
+    instanceOriginModule :: P.ModuleName,
     instanceConstraints :: [P.ClassConstraint],
     instanceHeadType :: SrcType,
     instanceMethods :: Map P.MethodName ValueInfo

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -266,6 +266,7 @@ data DataInfo = DataInfo
 
 data MethodInfo = MethodInfo
   { methodClassName :: P.ClassName,
+    methodClassModule :: P.ModuleName,
     methodName :: P.MethodName,
     methodRuntimeBase :: String,
     methodType :: SrcType,

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -306,6 +306,7 @@ data ValueInfo
 
 data InstanceInfo = InstanceInfo
   { instanceClassName :: P.ClassName,
+    instanceClassModule :: P.ModuleName,
     instanceOriginModule :: P.ModuleName,
     instanceConstraints :: [P.ClassConstraint],
     instanceHeadType :: SrcType,

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -125,8 +125,8 @@ spanForError err index =
     ProgramDuplicateModule name -> Map.lookup name (P.spanModules index)
     ProgramUnknownImportModule name -> firstSpan name (P.spanImports index) <|> Map.lookup name (P.spanModules index)
     ProgramImportNotExported _ name -> firstSpan name (P.spanImportItems index) <|> lookupAnyName name index
-    ProgramInvalidExport name -> lookupAnyName name index
-    ProgramExportNotLocal name -> lookupAnyName name index
+    ProgramInvalidExport name -> firstSpan name (P.spanExportItems index) <|> lookupAnyName name index
+    ProgramExportNotLocal name -> firstSpan name (P.spanExportItems index) <|> lookupAnyName name index
     ProgramDuplicateVisibleName name -> lookupAnyName name index
     ProgramDuplicateType name -> firstSpan name (P.spanTypes index)
     ProgramDuplicateConstructor name -> firstSpan name (P.spanConstructors index)

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -3,6 +3,10 @@
 
 module MLF.Frontend.Program.Types
   ( ProgramError (..),
+    ProgramDiagnostic (..),
+    diagnosticForProgramError,
+    renderProgramDiagnostic,
+    EvidenceInfo (..),
     ConstructorInfo (..),
     DataInfo (..),
     MethodInfo (..),
@@ -24,10 +28,14 @@ module MLF.Frontend.Program.Types
     splitArrows,
     substituteTypeVar,
     specializeMethodType,
+    constrainedVisibleType,
   )
 where
 
+import Control.Applicative ((<|>))
+import Data.Foldable (toList)
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import MLF.Elab.Types (ElabTerm, ElabType)
 import MLF.Frontend.Syntax (SrcBound (..), SrcTy (..), SrcType, SurfaceExpr)
 import qualified MLF.Frontend.Syntax.Program as P
@@ -45,7 +53,9 @@ data ProgramError
   | ProgramDuplicateClass String
   | ProgramDuplicateValue String
   | ProgramDuplicateMethod String
+  | ProgramDuplicateImportAlias P.ModuleName
   | ProgramDuplicateInstance P.ClassName SrcType
+  | ProgramOverlappingInstance P.ClassName SrcType SrcType
   | ProgramUnknownValue String
   | ProgramUnknownConstructor String
   | ProgramUnknownType String
@@ -54,6 +64,7 @@ data ProgramError
   | ProgramInvalidConstructorResult P.ConstructorName SrcType P.TypeName
   | ProgramUnsupportedDeriving P.ClassName
   | ProgramDerivingRequiresNullaryType P.TypeName
+  | ProgramDerivingMissingFieldInstance P.ClassName SrcType
   | ProgramMissingInstanceMethod P.ClassName P.MethodName
   | ProgramUnexpectedInstanceMethod P.ClassName P.MethodName
   | ProgramNoMatchingInstance P.ClassName SrcType
@@ -68,6 +79,163 @@ data ProgramError
   | ProgramPipelineError String
   | ProgramMainNotFound
   | ProgramMultipleMainDefinitions [String]
+  deriving (Eq, Show)
+
+data ProgramDiagnostic = ProgramDiagnostic
+  { diagnosticError :: ProgramError,
+    diagnosticSpan :: Maybe P.SourceSpan,
+    diagnosticMessage :: String,
+    diagnosticHints :: [String]
+  }
+  deriving (Eq, Show)
+
+diagnosticForProgramError :: Maybe P.LocatedProgram -> ProgramError -> ProgramDiagnostic
+diagnosticForProgramError mbLocated err =
+  ProgramDiagnostic
+    { diagnosticError = err,
+      diagnosticSpan = mbLocated >>= spanForError err . P.locatedProgramSpans,
+      diagnosticMessage = programErrorMessage err,
+      diagnosticHints = programErrorHints err
+    }
+
+renderProgramDiagnostic :: ProgramDiagnostic -> String
+renderProgramDiagnostic diagnostic =
+  unlines $
+    header
+      ++ ["error: " ++ diagnosticMessage diagnostic]
+      ++ map ("hint: " ++) (diagnosticHints diagnostic)
+  where
+    header =
+      case diagnosticSpan diagnostic of
+        Just span0 -> [renderSourceSpan span0]
+        Nothing -> []
+
+renderSourceSpan :: P.SourceSpan -> String
+renderSourceSpan span0 =
+  P.sourceFile span0
+    ++ ":"
+    ++ show (P.sourceLine (P.sourceStart span0))
+    ++ ":"
+    ++ show (P.sourceColumn (P.sourceStart span0))
+
+spanForError :: ProgramError -> P.ProgramSpanIndex -> Maybe P.SourceSpan
+spanForError err index =
+  case err of
+    ProgramDuplicateModule name -> Map.lookup name (P.spanModules index)
+    ProgramUnknownImportModule name -> Map.lookup name (P.spanModules index)
+    ProgramImportNotExported _ name -> lookupAnyName name index
+    ProgramInvalidExport name -> lookupAnyName name index
+    ProgramExportNotLocal name -> lookupAnyName name index
+    ProgramDuplicateVisibleName name -> lookupAnyName name index
+    ProgramDuplicateType name -> firstSpan name (P.spanTypes index)
+    ProgramDuplicateConstructor name -> firstSpan name (P.spanConstructors index)
+    ProgramDuplicateClass name -> firstSpan name (P.spanClasses index)
+    ProgramDuplicateValue name -> firstSpan name (P.spanValues index)
+    ProgramDuplicateMethod name -> firstSpan name (P.spanValues index)
+    ProgramDuplicateImportAlias name -> Map.lookup name (P.spanModules index)
+    ProgramOverlappingInstance className0 _ _ -> firstSpan className0 (P.spanClasses index)
+    ProgramUnknownValue name -> lookupAnyName name index
+    ProgramUnknownConstructor name -> firstSpan name (P.spanConstructors index)
+    ProgramUnknownType name -> firstSpan name (P.spanTypes index)
+    ProgramUnknownClass name -> firstSpan name (P.spanClasses index)
+    ProgramUnknownMethod name -> firstSpan name (P.spanValues index)
+    ProgramInvalidConstructorResult ctor _ _ -> firstSpan ctor (P.spanConstructors index)
+    ProgramUnsupportedDeriving className0 -> firstSpan className0 (P.spanClasses index)
+    ProgramDerivingRequiresNullaryType typeName -> firstSpan typeName (P.spanTypes index)
+    ProgramDerivingMissingFieldInstance className0 _ -> firstSpan className0 (P.spanClasses index)
+    ProgramMissingInstanceMethod _ methodName0 -> firstSpan methodName0 (P.spanValues index)
+    ProgramUnexpectedInstanceMethod _ methodName0 -> firstSpan methodName0 (P.spanValues index)
+    ProgramNoMatchingInstance className0 _ -> firstSpan className0 (P.spanClasses index)
+    ProgramAmbiguousMethodUse methodName0 -> firstSpan methodName0 (P.spanValues index)
+    ProgramAmbiguousConstructorUse ctor -> firstSpan ctor (P.spanConstructors index)
+    ProgramPatternConstructorMismatch ctor _ -> firstSpan ctor (P.spanConstructors index)
+    ProgramNonExhaustiveCase (ctor : _) -> firstSpan ctor (P.spanConstructors index)
+    ProgramDuplicateCaseBranch ctor -> firstSpan ctor (P.spanConstructors index)
+    _ -> Nothing
+
+firstSpan :: String -> Map String [P.SourceSpan] -> Maybe P.SourceSpan
+firstSpan name spans = do
+  matches <- Map.lookup name spans
+  case matches of
+    span0 : _ -> Just span0
+    [] -> Nothing
+
+lookupAnyName :: String -> P.ProgramSpanIndex -> Maybe P.SourceSpan
+lookupAnyName name index =
+  firstSpan name (P.spanValues index)
+    <|> firstSpan name (P.spanConstructors index)
+    <|> firstSpan name (P.spanTypes index)
+    <|> firstSpan name (P.spanClasses index)
+    <|> Map.lookup name (P.spanModules index)
+
+programErrorMessage :: ProgramError -> String
+programErrorMessage err =
+  case err of
+    ProgramDuplicateModule name -> "duplicate module `" ++ name ++ "`"
+    ProgramUnknownImportModule name -> "unknown imported module `" ++ name ++ "`"
+    ProgramImportNotExported moduleName name -> "module `" ++ moduleName ++ "` does not export `" ++ name ++ "`"
+    ProgramImportCycle modules0 -> "module import cycle: " ++ show modules0
+    ProgramInvalidExport name -> "invalid export `" ++ name ++ "`"
+    ProgramExportNotLocal name -> "export is not local: `" ++ name ++ "`"
+    ProgramDuplicateVisibleName name -> "duplicate visible name `" ++ name ++ "`"
+    ProgramDuplicateType name -> "duplicate type `" ++ name ++ "`"
+    ProgramDuplicateConstructor name -> "duplicate constructor `" ++ name ++ "`"
+    ProgramDuplicateClass name -> "duplicate class `" ++ name ++ "`"
+    ProgramDuplicateValue name -> "duplicate value `" ++ name ++ "`"
+    ProgramDuplicateMethod name -> "duplicate method `" ++ name ++ "`"
+    ProgramDuplicateImportAlias name -> "duplicate import alias `" ++ name ++ "`"
+    ProgramDuplicateInstance className0 ty -> "duplicate instance `" ++ className0 ++ " " ++ show ty ++ "`"
+    ProgramOverlappingInstance className0 left right -> "overlapping instances for `" ++ className0 ++ "`: `" ++ show left ++ "` overlaps `" ++ show right ++ "`"
+    ProgramUnknownValue name -> "unknown value `" ++ name ++ "`"
+    ProgramUnknownConstructor name -> "unknown constructor `" ++ name ++ "`"
+    ProgramUnknownType name -> "unknown type `" ++ name ++ "`"
+    ProgramUnknownClass name -> "unknown class `" ++ name ++ "`"
+    ProgramUnknownMethod name -> "unknown method `" ++ name ++ "`"
+    ProgramInvalidConstructorResult ctor resultTy owner -> "constructor `" ++ ctor ++ "` returns `" ++ show resultTy ++ "` instead of owning type `" ++ owner ++ "`"
+    ProgramUnsupportedDeriving className0 -> "unsupported deriving class `" ++ className0 ++ "`"
+    ProgramDerivingRequiresNullaryType typeName -> "deriving currently requires a nullary type, but `" ++ typeName ++ "` has parameters"
+    ProgramDerivingMissingFieldInstance className0 ty -> "cannot derive `" ++ className0 ++ "` because field type `" ++ show ty ++ "` has no matching instance or constraint"
+    ProgramMissingInstanceMethod className0 methodName0 -> "instance for `" ++ className0 ++ "` is missing method `" ++ methodName0 ++ "`"
+    ProgramUnexpectedInstanceMethod className0 methodName0 -> "instance for `" ++ className0 ++ "` defines unexpected method `" ++ methodName0 ++ "`"
+    ProgramNoMatchingInstance className0 ty -> "no matching instance for `" ++ className0 ++ " " ++ show ty ++ "`"
+    ProgramAmbiguousMethodUse methodName0 -> "ambiguous overloaded method use `" ++ methodName0 ++ "`"
+    ProgramAmbiguousConstructorUse ctor -> "ambiguous constructor use `" ++ ctor ++ "`"
+    ProgramExpectedFunction ty -> "expected a function, got `" ++ show ty ++ "`"
+    ProgramTypeMismatch actual expected -> "type mismatch: expected `" ++ show expected ++ "`, got `" ++ show actual ++ "`"
+    ProgramCaseOnNonDataType ty -> "case scrutinee is not a data type: `" ++ show ty ++ "`"
+    ProgramNonExhaustiveCase ctors -> "non-exhaustive case; missing constructors " ++ show ctors
+    ProgramDuplicateCaseBranch ctor -> "unreachable or duplicate case branch for constructor `" ++ ctor ++ "`"
+    ProgramPatternConstructorMismatch ctor ty -> "pattern for constructor `" ++ ctor ++ "` does not match expected type `" ++ show ty ++ "`"
+    ProgramPipelineError msg -> "pipeline error: " ++ msg
+    ProgramMainNotFound -> "main is not defined"
+    ProgramMultipleMainDefinitions names -> "multiple main definitions: " ++ show names
+
+programErrorHints :: ProgramError -> [String]
+programErrorHints err =
+  case err of
+    ProgramAmbiguousConstructorUse ctor ->
+      ["add an explicit result type annotation, for example `" ++ ctor ++ " : <Type>`"]
+    ProgramAmbiguousMethodUse methodName0 ->
+      ["apply `" ++ methodName0 ++ "` to enough arguments or add an annotation that fixes the instance type"]
+    ProgramNoMatchingInstance className0 ty ->
+      ["define or import an instance for `" ++ className0 ++ " " ++ show ty ++ "`"]
+    ProgramDerivingMissingFieldInstance className0 ty ->
+      ["add a `" ++ className0 ++ " " ++ show ty ++ "` instance or add a type parameter constraint through deriving"]
+    ProgramTypeMismatch {} ->
+      ["check the nearest annotation; `.mlfp` uses eMLF inference before resolving program obligations"]
+    ProgramPatternConstructorMismatch {} ->
+      ["check the constructor arity and the data type being matched"]
+    ProgramNonExhaustiveCase {} ->
+      ["add missing constructor branches or a final wildcard branch"]
+    ProgramImportNotExported {} ->
+      ["export the name from the source module or remove it from the import exposing list"]
+    _ -> []
+
+data EvidenceInfo = EvidenceInfo
+  { evidenceClassName :: P.ClassName,
+    evidenceType :: SrcType,
+    evidenceMethods :: Map P.MethodName (String, SrcType)
+  }
   deriving (Eq, Show)
 
 data ConstructorInfo = ConstructorInfo
@@ -95,6 +263,7 @@ data MethodInfo = MethodInfo
     methodName :: P.MethodName,
     methodRuntimeBase :: String,
     methodType :: SrcType,
+    methodConstraints :: [P.ClassConstraint],
     methodParamName :: String
   }
   deriving (Eq, Show)
@@ -112,6 +281,7 @@ data ValueInfo
       { valueDisplayName :: String,
         valueRuntimeName :: String,
         valueType :: SrcType,
+        valueConstraints :: [P.ClassConstraint],
         valueOriginModule :: P.ModuleName
       }
   | ConstructorValue
@@ -130,6 +300,7 @@ data ValueInfo
 
 data InstanceInfo = InstanceInfo
   { instanceClassName :: P.ClassName,
+    instanceConstraints :: [P.ClassConstraint],
     instanceHeadType :: SrcType,
     instanceMethods :: Map P.MethodName ValueInfo
   }
@@ -262,3 +433,28 @@ specializeMethodType methodTy paramName headTy =
   let (foralls, body) = splitForalls methodTy
       rebuilt = foldr (\(name, mb) acc -> STForall name (fmap SrcBound mb) acc) (substituteTypeVar paramName headTy body) foralls
    in rebuilt
+
+constrainedVisibleType :: P.ConstrainedType -> SrcType
+constrainedVisibleType constrained
+  | null (P.constrainedConstraints constrained) = P.constrainedBody constrained
+  | otherwise =
+      quantifyFreeVars
+        (P.constrainedBody constrained)
+        (foldMap constraintFreeVars (P.constrainedConstraints constrained) `mappend` freeVars (P.constrainedBody constrained))
+  where
+    quantifyFreeVars ty vars =
+      foldr forallNoBound ty (Map.keys (Map.fromList [(var, ()) | var <- vars]))
+
+    forallNoBound name acc = STForall name Nothing acc
+
+    constraintFreeVars constraint = freeVars (P.constraintType constraint)
+
+    freeVars ty = case ty of
+      STVar name -> [name]
+      STArrow dom cod -> freeVars dom ++ freeVars cod
+      STBase {} -> []
+      STCon _ args -> concatMap freeVars (toList args)
+      STForall name mb body ->
+        filter (/= name) (maybe [] (freeVars . unSrcBound) mb ++ freeVars body)
+      STMu name body -> filter (/= name) (freeVars body)
+      STBottom -> []

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -146,7 +146,7 @@ spanForError err index =
     ProgramDerivingMissingFieldInstance className0 _ -> firstSpan className0 (P.spanClasses index)
     ProgramMissingInstanceMethod _ methodName0 -> firstSpan methodName0 (P.spanValues index)
     ProgramUnexpectedInstanceMethod _ methodName0 -> firstSpan methodName0 (P.spanValues index)
-    ProgramNoMatchingInstance className0 _ -> firstSpan className0 (P.spanClasses index)
+    ProgramNoMatchingInstance {} -> Nothing
     ProgramAmbiguousMethodUse methodName0 -> firstSpan methodName0 (P.spanValues index)
     ProgramAmbiguousConstrainedValueUse valueName -> firstSpan valueName (P.spanValues index)
     ProgramAmbiguousConstructorUse ctor -> firstSpan ctor (P.spanConstructors index)

--- a/src/MLF/Frontend/Syntax/Program.hs
+++ b/src/MLF/Frontend/Syntax/Program.hs
@@ -6,10 +6,19 @@ module MLF.Frontend.Syntax.Program
     , ClassName
     , MethodName
     , ValueName
+    , SourcePosition (..)
+    , SourceSpan (..)
+    , ProgramSpanIndex (..)
+    , LocatedProgram (..)
+    , emptyProgramSpanIndex
+    , appendProgramSpanIndex
     , Program (..)
     , Module (..)
     , ExportItem (..)
     , Import (..)
+    , ClassConstraint (..)
+    , ConstrainedType (..)
+    , unconstrainedType
     , Decl (..)
     , ClassDecl (..)
     , MethodSig (..)
@@ -24,6 +33,8 @@ module MLF.Frontend.Syntax.Program
     , Pattern (..)
     ) where
 
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import MLF.Frontend.Syntax (Lit (..), SrcType)
 
 type ModuleName = String
@@ -37,6 +48,54 @@ type ClassName = String
 type MethodName = String
 
 type ValueName = String
+
+data SourcePosition = SourcePosition
+    { sourceLine :: Int
+    , sourceColumn :: Int
+    }
+    deriving (Eq, Ord, Show)
+
+data SourceSpan = SourceSpan
+    { sourceFile :: FilePath
+    , sourceStart :: SourcePosition
+    , sourceEnd :: SourcePosition
+    }
+    deriving (Eq, Ord, Show)
+
+data ProgramSpanIndex = ProgramSpanIndex
+    { spanModules :: Map ModuleName SourceSpan
+    , spanValues :: Map ValueName [SourceSpan]
+    , spanTypes :: Map TypeName [SourceSpan]
+    , spanConstructors :: Map ConstructorName [SourceSpan]
+    , spanClasses :: Map ClassName [SourceSpan]
+    }
+    deriving (Eq, Show)
+
+data LocatedProgram = LocatedProgram
+    { locatedProgram :: Program
+    , locatedProgramSpans :: ProgramSpanIndex
+    }
+    deriving (Eq, Show)
+
+emptyProgramSpanIndex :: ProgramSpanIndex
+emptyProgramSpanIndex =
+    ProgramSpanIndex
+        { spanModules = Map.empty
+        , spanValues = Map.empty
+        , spanTypes = Map.empty
+        , spanConstructors = Map.empty
+        , spanClasses = Map.empty
+        }
+
+appendProgramSpanIndex :: ProgramSpanIndex -> ProgramSpanIndex -> ProgramSpanIndex
+appendProgramSpanIndex left right =
+    ProgramSpanIndex
+        { spanModules = spanModules left `Map.union` spanModules right
+        , spanValues = Map.unionWith (++) (spanValues left) (spanValues right)
+        , spanTypes = Map.unionWith (++) (spanTypes left) (spanTypes right)
+        , spanConstructors = Map.unionWith (++) (spanConstructors left) (spanConstructors right)
+        , spanClasses = Map.unionWith (++) (spanClasses left) (spanClasses right)
+        }
 
 newtype Program = Program
     { programModules :: [Module]
@@ -59,9 +118,25 @@ data ExportItem
 
 data Import = Import
     { importModuleName :: ModuleName
+    , importAlias :: Maybe ModuleName
     , importExposing :: Maybe [ExportItem]
     }
     deriving (Eq, Show)
+
+data ClassConstraint = ClassConstraint
+    { constraintClassName :: ClassName
+    , constraintType :: SrcType
+    }
+    deriving (Eq, Show)
+
+data ConstrainedType = ConstrainedType
+    { constrainedConstraints :: [ClassConstraint]
+    , constrainedBody :: SrcType
+    }
+    deriving (Eq, Show)
+
+unconstrainedType :: SrcType -> ConstrainedType
+unconstrainedType = ConstrainedType []
 
 data Decl
     = DeclClass ClassDecl
@@ -79,12 +154,13 @@ data ClassDecl = ClassDecl
 
 data MethodSig = MethodSig
     { methodSigName :: MethodName
-    , methodSigType :: SrcType
+    , methodSigType :: ConstrainedType
     }
     deriving (Eq, Show)
 
 data InstanceDecl = InstanceDecl
-    { instanceDeclClass :: ClassName
+    { instanceDeclConstraints :: [ClassConstraint]
+    , instanceDeclClass :: ClassName
     , instanceDeclType :: SrcType
     , instanceDeclMethods :: [MethodDef]
     }
@@ -112,7 +188,7 @@ data ConstructorDecl = ConstructorDecl
 
 data DefDecl = DefDecl
     { defDeclName :: ValueName
-    , defDeclType :: SrcType
+    , defDeclType :: ConstrainedType
     , defDeclExpr :: Expr
     }
     deriving (Eq, Show)
@@ -140,7 +216,8 @@ data Alt = Alt
     deriving (Eq, Show)
 
 data Pattern
-    = PatCtor ConstructorName [ValueName]
+    = PatCtor ConstructorName [Pattern]
     | PatVar ValueName
     | PatWildcard
+    | PatAnn Pattern SrcType
     deriving (Eq, Show)

--- a/src/MLF/Frontend/Syntax/Program.hs
+++ b/src/MLF/Frontend/Syntax/Program.hs
@@ -64,6 +64,9 @@ data SourceSpan = SourceSpan
 
 data ProgramSpanIndex = ProgramSpanIndex
     { spanModules :: Map ModuleName SourceSpan
+    , spanImports :: Map ModuleName [SourceSpan]
+    , spanImportAliases :: Map ModuleName [SourceSpan]
+    , spanImportItems :: Map String [SourceSpan]
     , spanValues :: Map ValueName [SourceSpan]
     , spanTypes :: Map TypeName [SourceSpan]
     , spanConstructors :: Map ConstructorName [SourceSpan]
@@ -81,6 +84,9 @@ emptyProgramSpanIndex :: ProgramSpanIndex
 emptyProgramSpanIndex =
     ProgramSpanIndex
         { spanModules = Map.empty
+        , spanImports = Map.empty
+        , spanImportAliases = Map.empty
+        , spanImportItems = Map.empty
         , spanValues = Map.empty
         , spanTypes = Map.empty
         , spanConstructors = Map.empty
@@ -91,6 +97,9 @@ appendProgramSpanIndex :: ProgramSpanIndex -> ProgramSpanIndex -> ProgramSpanInd
 appendProgramSpanIndex left right =
     ProgramSpanIndex
         { spanModules = spanModules left `Map.union` spanModules right
+        , spanImports = Map.unionWith (++) (spanImports left) (spanImports right)
+        , spanImportAliases = Map.unionWith (++) (spanImportAliases left) (spanImportAliases right)
+        , spanImportItems = Map.unionWith (++) (spanImportItems left) (spanImportItems right)
         , spanValues = Map.unionWith (++) (spanValues left) (spanValues right)
         , spanTypes = Map.unionWith (++) (spanTypes left) (spanTypes right)
         , spanConstructors = Map.unionWith (++) (spanConstructors left) (spanConstructors right)

--- a/src/MLF/Frontend/Syntax/Program.hs
+++ b/src/MLF/Frontend/Syntax/Program.hs
@@ -67,6 +67,7 @@ data ProgramSpanIndex = ProgramSpanIndex
     , spanImports :: Map ModuleName [SourceSpan]
     , spanImportAliases :: Map ModuleName [SourceSpan]
     , spanImportItems :: Map String [SourceSpan]
+    , spanExportItems :: Map String [SourceSpan]
     , spanValues :: Map ValueName [SourceSpan]
     , spanTypes :: Map TypeName [SourceSpan]
     , spanConstructors :: Map ConstructorName [SourceSpan]
@@ -87,6 +88,7 @@ emptyProgramSpanIndex =
         , spanImports = Map.empty
         , spanImportAliases = Map.empty
         , spanImportItems = Map.empty
+        , spanExportItems = Map.empty
         , spanValues = Map.empty
         , spanTypes = Map.empty
         , spanConstructors = Map.empty
@@ -100,6 +102,7 @@ appendProgramSpanIndex left right =
         , spanImports = Map.unionWith (++) (spanImports left) (spanImports right)
         , spanImportAliases = Map.unionWith (++) (spanImportAliases left) (spanImportAliases right)
         , spanImportItems = Map.unionWith (++) (spanImportItems left) (spanImportItems right)
+        , spanExportItems = Map.unionWith (++) (spanExportItems left) (spanExportItems right)
         , spanValues = Map.unionWith (++) (spanValues left) (spanValues right)
         , spanTypes = Map.unionWith (++) (spanTypes left) (spanTypes right)
         , spanConstructors = Map.unionWith (++) (spanConstructors left) (spanConstructors right)

--- a/src/MLF/Program/CLI.hs
+++ b/src/MLF/Program/CLI.hs
@@ -7,13 +7,15 @@ import Control.Exception (IOException, try)
 import Data.Bifunctor (first)
 
 import MLF.Frontend.Parse.Program
-    ( parseRawProgram
+    ( parseLocatedProgramWithFile
     , renderProgramParseError
     )
 import MLF.Frontend.Program.Run
     ( prettyValue
-    , runProgram
+    , runLocatedProgram
     )
+import MLF.Frontend.Program.Prelude (withPreludeLocated)
+import MLF.Frontend.Program.Types (renderProgramDiagnostic)
 
 programCliUsage :: String
 programCliUsage =
@@ -30,5 +32,5 @@ runProgramFile path = do
     fileResult <- try (readFile path) :: IO (Either IOException String)
     pure $ do
         source <- first show fileResult
-        program <- first renderProgramParseError (parseRawProgram source)
-        first show (prettyValue <$> runProgram program)
+        program <- first renderProgramParseError (parseLocatedProgramWithFile path source)
+        first renderProgramDiagnostic (prettyValue <$> runLocatedProgram (withPreludeLocated program))

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,40 +1,38 @@
 # Task Plan
 
 ## Summary
-Goal: implement deferred `.mlfp` program obligations, including constructor
-obligations that carry constructor-local `forall` evidence, so program-owned
-features resolve after eMLF inference without widening public eMLF syntax or
-adding a direct `.mlfp -> ElabTerm` route.
+Goal: make `.mlfp` a more usable source language while preserving the shared
+eMLF/xMLF pipeline boundary. Implement additive diagnostics, a language
+reference, nested/ordered patterns, explicit prelude support, readable ADT
+runtime values, and the first typeclass/module ergonomics slice
+without adding a second `.mlfp -> ElabTerm` authority path.
 
 ## Current Phase
-Completed: constructor-local `forall` evidence is carried in deferred constructor obligations and all source constructor uses lower through placeholders.
+Complete.
 
 ## Phases
-1. Discovery and obligation design. - completed
-2. Refactor `.mlfp` lowering/finalization for deferred program obligations. - completed
-3. Move pending rows to strict matrix and add negative guards. - completed
-4. Run focused validation and repair failures. - completed
-5. Run full validation and update docs. - completed
-6. Add constructor-local `forall` evidence and defer all source constructor uses. - completed
+1. Discovery and planning refresh. - completed
+2. Add located parsing and user-facing diagnostics. - completed
+3. Upgrade patterns to nested/ordered lowering. - completed
+4. Add language reference and readable example programs. - completed
+5. Add explicit prelude support and ADT value rendering. - completed
+6. Add constrained typeclass/deriving and module ergonomics slice. - completed
+7. Run focused and full validation. - completed
 
 ## Decisions Made
 | Decision | Rationale |
 |----------|-----------|
-| Keep public eMLF parser/API unchanged | User plan and repo invariants require `.mlfp`-internal obligations only |
-| Preserve existing Church ADT runtime representation | Current recursive ADT/program runtime depends on this encoding |
-| Use post-eMLF finalization as the dispatch point | Matches the existing deferred overload path and lets eMLF infer terms first |
-| Defer every source constructor occurrence | Constructor placeholders now carry expected-type seeds, constructor-local forall binders, and runtime instantiation order so GADT, existential, nullary, and ordinary constructors all finalize after eMLF inference |
-| Preserve public pipeline APIs while adding internal external binding modes | `.mlfp` needs monomorphic constructor placeholders without exposing new public eMLF APIs |
-| Use an unchecked internal detailed pipeline only for program obligations/generated constructor-forall bindings | Program placeholders may not typecheck until finalization rewrites them; public eMLF APIs still keep the normal typecheck guard |
-| Skip generated runtime bindings for constructor-local foralls with no recoverable evidence | Such constructors cannot be instantiated safely; source occurrences fail later with `ProgramAmbiguousConstructorUse` |
+| Keep public raw eMLF unchanged | User plan and repo invariants reserve language features for `.mlfp` |
+| Keep current unlocated APIs | Additive APIs let existing equality tests continue while CLI can use richer diagnostics |
+| Preserve Church runtime representation | Existing constructor/case lowering and runtime tests depend on it |
+| Compile nested patterns to existing case/deferred-case machinery | Avoids adding a runtime pattern primitive or direct `.mlfp -> ElabTerm` path |
+| Make the prelude explicit-import in v1 | Avoids surprising user namespace collisions |
+| Keep constraints and qualified names as `.mlfp`-owned source semantics | Public raw eMLF remains thesis-facing and unchanged |
+| Keep derived recursive Eq monomorphic internally | Avoids re-inferring a polymorphic schema instance from hidden evidence during recursive field comparison |
 
 ## Errors Encountered
 | Error | Attempt | Resolution |
 |-------|---------|------------|
-| Installed `haskell-pro` path from `AGENTS.md` is missing | 1 | Follow repo formatting conventions directly |
-| Planning skill relative path under worktree was absent | 1 | Read installed skill at `/Users/ares/.codex/skills/planning-with-files/SKILL.md` |
-| Recursive overloaded method calls hit locked-node failures when resolved through synthetic local wrappers or reannotated pattern variables | 2 | Finalize instance method bodies as their runtime binding, defer overloaded runtime resolution, and leave pattern-bound recursive fields unannotated |
-| All-deferred constructor placeholders exposed recursive μ types as external schemes and hit locked-node failures | 6 | Added internal external binding modes and made constructor/case placeholders inference-local while retaining concrete types for finalization/typecheck |
-| Direct deferred cases applied handlers to data-typed placeholders and clashed with μ encodings | 6 | Lower deferred cases as placeholder applications and rewrite them after constructor finalization |
-| Generated constructor-local forall runtime bindings could fail before source ambiguity was checked | 6 | Route recoverable generated bindings through the unchecked internal path and skip unrecoverable generated bindings |
-| Repository guard expected the older scheme-only detailed pipeline marker | 6 | Guard now requires the internal external-binding detailed/unchecked entrypoints plus the final post-rewrite typecheck |
+| `/Users/ares/.agents/skills/haskell-pro/SKILL.md` missing | 1 | Follow existing repo Haskell style directly |
+| Concurrent `cabal run` probes collided on `package.conf.inplace` | 1 | Avoid parallel Cabal invocations; run build/test commands sequentially |
+| Recursive parameterized `List` deriving exposed constructor quantifier ordering issues | 1 | Repair parameterized constructor runtime spines and use monomorphic local self for generated recursive Eq |

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -686,6 +686,27 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "checks constrained method use from specialized parameterized case binder"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (C, c, Box(..), f, main) {"
+                , "  class C a {"
+                , "    c : a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  def f : C Int => Box Int -> Bool = \\x case x of {"
+                , "    Box n -> c n"
+                , "  };"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs deferred method with method-level type variable constraint"
         ( InlineProgram $
             unlines
@@ -1218,6 +1239,38 @@ emlfBoundaryMatrix =
                 ]
         )
         (ExpectRunValue "Zero")
+    , ProgramMatrixCase
+        "runs distinct instances whose qualified heads would sanitize alike"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (B(..)) {"
+                , "  data B ="
+                , "      B : Int -> B;"
+                , "}"
+                , ""
+                , "module Main export (Eq, A_B(..), eq, main) {"
+                , "  import Core as A;"
+                , ""
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data A_B ="
+                , "      A_B : A_B;"
+                , ""
+                , "  instance Eq A.B {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance Eq A_B {"
+                , "    eq = \\left \\right false;"
+                , "  }"
+                , ""
+                , "  def main : Bool = eq (A.B 1) (A.B 2);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
     , ProgramMatrixCase
         "rejects qualified access to hidden constructors"
         ( InlineProgram $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -381,14 +381,14 @@ emlfBoundaryMatrix =
                 , "    | Succ : Nat -> Nat;"
                 , ""
                 , "  def main : Bool ="
-                , "    let f = \\x -> case x of {"
+                , "    let f = \\x case x of {"
                 , "      (_ : Int) -> true"
                 , "    } in"
                 , "    f Zero;"
                 , "}"
                 ]
         )
-        (ExpectCheckFailureContaining "ProgramTypeMismatch")
+        (ExpectCheckFailureContaining "ProgramPipelineError")
     , ProgramMatrixCase
         "rejects branches after catch-all as unreachable"
         ( InlineProgram $
@@ -606,7 +606,7 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
-        "runs class method with method-level Eq constraint"
+        "runs deferred class method with method-level Eq constraint"
         ( InlineProgram $
             unlines
                 [ "module Main export (Eq, ShowEq, Nat(..), eq, showEq, main) {"
@@ -627,7 +627,35 @@ emlfBoundaryMatrix =
                 , "    showEq = \\x \\y eq x y;"
                 , "  }"
                 , ""
-                , "  def main : Bool = showEq Zero Zero;"
+                , "  def main : Bool = showEq ((\\x x) Zero) Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs constrained helper through method-level evidence constraints"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, ShowEq, Nat(..), eq, showEq, sameShow, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  class ShowEq a {"
+                , "    showEq : Eq a => a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  instance ShowEq Nat {"
+                , "    showEq = \\x \\y eq x y;"
+                , "  }"
+                , ""
+                , "  def sameShow : ShowEq a => a -> a -> Bool = \\x \\y showEq x y;"
+                , "  def main : Bool = sameShow Zero Zero;"
                 , "}"
                 ]
         )
@@ -1167,6 +1195,21 @@ spec = do
                         ]
             program <- requireParsed programText
             (prettyValue <$> runProgram program) `shouldBe` Right "Some (Succ Zero)"
+
+        it "does not decode non-data main values through fallback ADT decoding" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Token(..), main) {"
+                        , "  data Token ="
+                        , "      Token : Token;"
+                        , ""
+                        , "  def main : Bool -> Bool = \\x x;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            case prettyValue <$> runProgram program of
+                Right rendered -> rendered `shouldSatisfy` (/= "Token")
+                Left err -> expectationFailure ("unexpected program failure: " ++ show err)
 
     describe "MLF.Program performance baseline" $ do
         it "evaluates a recursive Nat equality example at representative depth" $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -723,6 +723,27 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Marker\"")
     , ProgramMatrixCase
+        "runs qualified zero-method class instance through aliased import"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Marker) {"
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  instance Marker Bool {"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , ""
+                , "  def needsMarker : C.Marker Bool => Bool -> Bool = \\x x;"
+                , "  def main : Bool = needsMarker true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs deferred class method with method-level Eq constraint"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -917,6 +917,36 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Marker\"")
     , ProgramMatrixCase
+        "rejects method signature constraint with unknown class"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (C, main) {"
+                , "  class C a {"
+                , "    m : Missing a => a -> a;"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramUnknownClass \"Missing\"")
+    , ProgramMatrixCase
+        "rejects zero-method instance constraint with unknown class"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Marker, main) {"
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  instance Missing a => Marker a {"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramUnknownClass \"Missing\"")
+    , ProgramMatrixCase
         "rejects zero-method class instance when prerequisite is missing"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -304,6 +304,92 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs ordered nested constructor patterns"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Succ (Succ Zero) of {"
+                , "    Succ Zero -> false;"
+                , "    Succ (Succ n) -> true;"
+                , "    _ -> false"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs wildcard fallthrough after constructor patterns"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Zero of {"
+                , "    Succ _ -> false;"
+                , "    _ -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs pattern annotations"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Succ Zero of {"
+                , "    Zero -> false;"
+                , "    Succ (n : Nat) -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "rejects branches after catch-all as unreachable"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Zero of {"
+                , "    _ -> true;"
+                , "    Zero -> false"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDuplicateCaseBranch \"Zero\"")
+    , ProgramMatrixCase
+        "rejects non-exhaustive nested constructor patterns"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Succ Zero of {"
+                , "    Zero -> false;"
+                , "    Succ (Succ n) -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNonExhaustiveCase [\"Succ\"]")
+    , ProgramMatrixCase
         "constructor argument inferred as first-class polymorphic value should run"
         ( InlineProgram $
             unlines
@@ -447,6 +533,281 @@ emlfBoundaryMatrix =
                 ]
         )
         (ExpectCheckFailureContaining "ProgramAmbiguousConstructorUse \"Hidden\"")
+    , ProgramMatrixCase
+        "runs constrained helper through hidden Eq evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), eq, same, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;"
+                , "  def main : Bool = same Zero Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "rejects constrained helper call without a satisfiable instance"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), Box(..), eq, same, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;"
+                , "  def main : Bool = same (Box Zero) (Box Zero);"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\" (STCon \"Box\"")
+    , ProgramMatrixCase
+        "runs explicit constrained parameterized Eq instance"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), Option(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  data Option a ="
+                , "      None : Option a"
+                , "    | Some : a -> Option a;"
+                , ""
+                , "  instance Eq a => Eq (Option a) {"
+                , "    eq = \\left \\right case left of {"
+                , "      None -> case right of {"
+                , "        None -> true;"
+                , "        Some _ -> false"
+                , "      };"
+                , "      Some l -> case right of {"
+                , "        None -> false;"
+                , "        Some r -> eq l r"
+                , "      }"
+                , "    };"
+                , "  }"
+                , ""
+                , "  def main : Bool = eq (Some (Some Zero)) (Some (Some Zero));"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "rejects overlapping parameterized and concrete instance heads"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), Box(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  instance Eq a => Eq (Box a) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance Eq (Box Nat) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
+    , ProgramMatrixCase
+        "runs parameterized deriving Eq for Option"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), Option(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  data Option a ="
+                , "      None : Option a"
+                , "    | Some : a -> Option a"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool ="
+                , "    eq (Some Zero) (Some Zero);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs parameterized deriving Eq for recursive List"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), List(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  data List a ="
+                , "      Nil : List a"
+                , "    | Cons : a -> List a -> List a"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool ="
+                , "    eq (Cons Zero (Cons (Succ Zero) Nil)) (Cons Zero (Cons (Succ Zero) Nil));"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "rejects parameterized deriving when a field has no Eq evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Bad(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Bad a ="
+                , "      Bad : (a -> a) -> Bad a"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDerivingMissingFieldInstance \"Eq\"")
+    , ProgramMatrixCase
+        "runs qualified import with alias-only value and constructor access"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Nat(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , "  def main : Bool = C.eq C.Zero C.Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs aliased import with exposed method and qualified constructors"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Nat(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C exposing (eq);"
+                , "  def main : Bool = eq C.Zero C.Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs qualified type name in annotation"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Nat(..)) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , "  def main : C.Nat = C.Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "Zero")
+    , ProgramMatrixCase
+        "rejects qualified access to hidden constructors"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Nat) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , "  def main : C.Nat = C.Zero;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramUnknownValue \"C.Zero\"")
+    , ProgramMatrixCase
+        "rejects duplicate import aliases in one module"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (main) {"
+                , "  def main : Bool = true;"
+                , "}"
+                , ""
+                , "module Other export (main) {"
+                , "  def main : Bool = false;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , "  import Other as C;"
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDuplicateImportAlias \"C\"")
     ]
 
 spec :: Spec
@@ -461,6 +822,32 @@ spec = do
         it "runs a frozen sample file by path" $ do
             runProgramFile "test/programs/recursive-adt/plain-recursive-nat.mlfp"
                 `shouldReturn` Right "true"
+
+        it "prepends the built-in Prelude for explicit imports" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Nat(..), Option(..));"
+                        , "  def main : Option Nat = Some Zero;"
+                        , "}"
+                        ]
+            (prettyValue <$> runLocatedProgram (withPreludeLocated located)) `shouldBe` Right "Some Zero"
+
+        it "rejects a user module named Prelude when the built-in Prelude is active" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Prelude export () {"
+                        , "}"
+                        , ""
+                        , "module Main export (main) {"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            runLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                ((== ProgramDuplicateModule "Prelude") . diagnosticError)
+                (const False)
 
     describe "MLF.Program diagnostics" $ do
         it "rejects importing constructors from an abstract type export" $ do
@@ -634,6 +1021,45 @@ spec = do
             program <- requireParsed programText
             checkProgram program `shouldSatisfy` isRight
 
+        it "renders located diagnostics with a mechanically justified hint" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Option(..), main) {"
+                        , "  data Option a ="
+                        , "      None : Option a"
+                        , "    | Some : a -> Option a;"
+                        , ""
+                        , "  def main : Bool = let ignore = \\x true in ignore None;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "ambiguous.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    let rendered = renderProgramDiagnostic diagnostic
+                    rendered `shouldSatisfy` isInfixOf "ambiguous.mlfp:3:7"
+                    rendered `shouldSatisfy` isInfixOf "error: ambiguous constructor use `None`"
+                    rendered `shouldSatisfy` isInfixOf "hint: add an explicit result type annotation"
+                Right _ -> expectationFailure "expected ambiguous constructor diagnostic"
+
+    describe "MLF.Program runtime value rendering" $ do
+        it "renders closed ADT values with source constructor syntax" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Nat(..), Option(..), main) {"
+                        , "  data Nat ="
+                        , "      Zero : Nat"
+                        , "    | Succ : Nat -> Nat;"
+                        , ""
+                        , "  data Option a ="
+                        , "      None : Option a"
+                        , "    | Some : a -> Option a;"
+                        , ""
+                        , "  def main : Option Nat = Some (Succ Zero);"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            (prettyValue <$> runProgram program) `shouldBe` Right "Some (Succ Zero)"
+
     describe "MLF.Program performance baseline" $ do
         it "evaluates a recursive Nat equality example at representative depth" $ do
             let depth = (24 :: Int)
@@ -713,5 +1139,14 @@ spec = do
 requireParsed :: String -> IO Program
 requireParsed input =
     case parseRawProgram input of
+        Left err -> expectationFailure (renderProgramParseError err) >> fail "parse failed"
+        Right program -> pure program
+
+requireLocated :: String -> IO LocatedProgram
+requireLocated = requireLocatedWithFile "<test>"
+
+requireLocatedWithFile :: FilePath -> String -> IO LocatedProgram
+requireLocatedWithFile path input =
+    case parseLocatedProgramWithFile path input of
         Left err -> expectationFailure (renderProgramParseError err) >> fail "parse failed"
         Right program -> pure program

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1344,6 +1344,28 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs aliased import exposing a type without duplicate alias-head instance matches"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Nat(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C exposing (Nat(..), eq);"
+                , "  def main : Bool = eq C.Zero C.Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs aliased instance head when class is imported from another module"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -692,6 +692,37 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs zero-method class constraint with matching instance"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Marker, needsMarker, main) {"
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  instance Marker Bool {"
+                , "  }"
+                , ""
+                , "  def needsMarker : Marker Bool => Bool -> Bool = \\x x;"
+                , "  def main : Bool = needsMarker true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "rejects zero-method class constraint without matching instance"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Marker, needsMarker, main) {"
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  def needsMarker : Marker Bool => Bool -> Bool = \\x x;"
+                , "  def main : Bool = needsMarker true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Marker\"")
+    , ProgramMatrixCase
         "runs deferred class method with method-level Eq constraint"
         ( InlineProgram $
             unlines
@@ -910,6 +941,25 @@ emlfBoundaryMatrix =
                 , ""
                 , "  def main : Bool ="
                 , "    eq (Some Zero) (Some Zero);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs parameterized deriving Eq for phantom parameter without Eq constraint"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Phantom(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Phantom a ="
+                , "      Phantom : Phantom a"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool ="
+                , "    eq (Phantom : Phantom (Bool -> Bool)) (Phantom : Phantom (Bool -> Bool));"
                 , "}"
                 ]
         )

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2043,6 +2043,24 @@ spec = do
                         `shouldSatisfy` isInfixOf "error: no matching instance for `Eq STBase \"Nat\"`"
                 Right _ -> expectationFailure "expected missing instance diagnostic"
 
+        it "renders unknown instance class diagnostics at the instance head" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  instance Missing Bool {"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "unknown-instance-class.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    diagnosticError diagnostic `shouldBe` ProgramUnknownClass "Missing"
+                    renderProgramDiagnostic diagnostic
+                        `shouldSatisfy` isInfixOf "unknown-instance-class.mlfp:2:12"
+                Right _ -> expectationFailure "expected unknown instance class diagnostic"
+
         it "renders duplicate instance diagnostics with a class span" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1744,6 +1744,26 @@ spec = do
             program <- requireParsed programText
             (prettyValue <$> runProgram program) `shouldBe` Right "Some (Succ Zero)"
 
+        it "renders qualified ADT main annotations with source constructor syntax" $ do
+            let programText =
+                    unlines
+                        [ "module Core export (Nat(..), Option(..)) {"
+                        , "  data Nat ="
+                        , "      Zero : Nat;"
+                        , ""
+                        , "  data Option a ="
+                        , "      None : Option a"
+                        , "    | Some : a -> Option a;"
+                        , "}"
+                        , ""
+                        , "module Main export (main) {"
+                        , "  import Core as A;"
+                        , "  def main : A.Option A.Nat = A.Some A.Zero;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            (prettyValue <$> runProgram program) `shouldBe` Right "Some Zero"
+
         it "does not decode non-data main values through fallback ADT decoding" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1341,6 +1341,24 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Zero")
     , ProgramMatrixCase
+        "runs alias-only qualified case over imported ADT"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Box(..)) {"
+                , "  data Box ="
+                , "      Box : Box;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , "  def main : Bool = case C.Box of {"
+                , "    C.Box -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs exposed constructor with qualified alias type identity"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1566,6 +1566,22 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Zero")
     , ProgramMatrixCase
+        "runs qualified constructor from implicit default export"
+        ( InlineProgram $
+            unlines
+                [ "module Core {"
+                , "  data Token ="
+                , "      Token : Token;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C;"
+                , "  def main : C.Token = C.Token;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "Token")
+    , ProgramMatrixCase
         "runs alias-only qualified case over imported ADT"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1513,6 +1513,36 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs local class instance for alias-only imported type"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Token(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Token ="
+                , "      Token : Token"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (Eq, eq, main) {"
+                , "  import Core as C;"
+                , ""
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq C.Token {"
+                , "    eq = \\left \\right false;"
+                , "  }"
+                , ""
+                , "  def main : Bool = eq C.Token C.Token;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "false")
+    , ProgramMatrixCase
         "runs alias-only qualified deriving Eq"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1713,6 +1713,38 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\" (STBase \"C.Token\")")
     , ProgramMatrixCase
+        "rejects unimported prior private instance for same-named local class"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (hidden) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Token ="
+                , "      Token : Token;"
+                , ""
+                , "  instance Eq Token {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def hidden : Bool = true;"
+                , "}"
+                , ""
+                , "module Main export (Eq, Token(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Token ="
+                , "      Token : Token;"
+                , ""
+                , "  def main : Bool = eq Token Token;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\" (STBase \"Token\")")
+    , ProgramMatrixCase
         "runs aliased exposing type without duplicate instance heads"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -796,6 +796,24 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs deferred method when only a later forall binder is inferred"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Pick, pick, main) {"
+                , "  class Pick a {"
+                , "    pick : forall ghost. forall b. a -> b -> b;"
+                , "  }"
+                , ""
+                , "  instance Pick Bool {"
+                , "    pick = let impl : forall ghost. forall b. Bool -> b -> b = \\flag \\value value in impl;"
+                , "  }"
+                , ""
+                , "  def main : Bool = pick true false;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "false")
+    , ProgramMatrixCase
         "runs constrained helper with method-local evidence fixed by call args"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1202,6 +1202,23 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Zero")
     , ProgramMatrixCase
+        "runs exposed constructor with qualified alias type identity"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Nat(..)) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C exposing (Nat(..));"
+                , "  def main : C.Nat = Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "Zero")
+    , ProgramMatrixCase
         "rejects qualified access to hidden constructors"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1584,6 +1584,28 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "keeps imported same-name ADT fields distinct from local recursion"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (T(..)) {"
+                , "  data T ="
+                , "      External : T;"
+                , "}"
+                , ""
+                , "module Main export (T(..), main) {"
+                , "  import Core as A;"
+                , ""
+                , "  data T ="
+                , "      Wrap : A.T -> T;"
+                , ""
+                , "  def main : Bool = case Wrap A.External of {"
+                , "    Wrap _ -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs exposed constructor with qualified alias type identity"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -393,6 +393,26 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramTypeMismatch (STBase \"Bool\") (STBase \"Nat\")")
     , ProgramMatrixCase
+        "rejects nested constructor patterns that violate their annotation"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), Box(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  def main : Bool ="
+                , "    let f = \\x case x of {"
+                , "      Box (Zero : Bool) -> true"
+                , "    } in"
+                , "    f (Box Zero);"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramTypeMismatch (STBase \"Bool\") (STBase \"Nat\")")
+    , ProgramMatrixCase
         "rejects catch-all pattern annotations when scrutinee type is inferred later"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1725,6 +1725,65 @@ spec = do
                     rendered `shouldSatisfy` isInfixOf "hint: add an explicit result type annotation"
                 Right _ -> expectationFailure "expected ambiguous constructor diagnostic"
 
+        it "renders unknown import diagnostics at the import site" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Missing;"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "missing-import.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    let rendered = renderProgramDiagnostic diagnostic
+                    rendered `shouldSatisfy` isInfixOf "missing-import.mlfp:2:10"
+                    rendered `shouldSatisfy` isInfixOf "error: unknown imported module `Missing`"
+                Right _ -> expectationFailure "expected unknown import diagnostic"
+
+        it "renders duplicate import alias diagnostics at the alias site" $ do
+            let programText =
+                    unlines
+                        [ "module A export () {"
+                        , "}"
+                        , "module B export () {"
+                        , "}"
+                        , "module Main export (main) {"
+                        , "  import A as C;"
+                        , "  import B as C;"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "duplicate-alias.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    let rendered = renderProgramDiagnostic diagnostic
+                    rendered `shouldSatisfy` \text ->
+                        "duplicate-alias.mlfp:6:15" `isInfixOf` text
+                            || "duplicate-alias.mlfp:7:15" `isInfixOf` text
+                    rendered `shouldSatisfy` isInfixOf "error: duplicate import alias `C`"
+                Right _ -> expectationFailure "expected duplicate import alias diagnostic"
+
+        it "renders import visibility diagnostics at the exposing item" $ do
+            let programText =
+                    unlines
+                        [ "module Hidden export () {"
+                        , "  data Nat ="
+                        , "      Zero : Nat;"
+                        , "}"
+                        , "module Main export (main) {"
+                        , "  import Hidden exposing (Nat);"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "hidden-import.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    let rendered = renderProgramDiagnostic diagnostic
+                    rendered `shouldSatisfy` isInfixOf "hidden-import.mlfp:6:27"
+                    rendered `shouldSatisfy` isInfixOf "error: module `Hidden` does not export `Nat`"
+                Right _ -> expectationFailure "expected import visibility diagnostic"
+
     describe "MLF.Program runtime value rendering" $ do
         it "renders closed ADT values with source constructor syntax" $ do
             let programText =

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1463,6 +1463,33 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs aliased exposing type without duplicate instance heads"
+        ( InlineProgram $
+            unlines
+                [ "module Classes export (Eq, eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Core export (Foo(..)) {"
+                , "  import Classes exposing (Eq, eq);"
+                , ""
+                , "  data Foo ="
+                , "      Foo : Foo"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Classes exposing (Eq, eq);"
+                , "  import Core as A exposing (Foo(..));"
+                , ""
+                , "  def main : Bool = eq A.Foo A.Foo;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs qualified type name in annotation"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -377,6 +377,49 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs exhaustive nested constructor pattern without fallback"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Unit(..), Wrap(..), main) {"
+                , "  data Unit ="
+                , "      Unit : Unit;"
+                , ""
+                , "  data Wrap ="
+                , "      Wrap : Unit -> Wrap;"
+                , ""
+                , "  def main : Bool = case Wrap Unit of {"
+                , "    Wrap Unit -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "uses nested pattern annotations to type binders"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), Box(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  def main : Bool ="
+                , "    let useBox = \\box case box of {"
+                , "      Box (n : Nat) -> eq n n"
+                , "    } in"
+                , "    useBox (Box Zero);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "rejects mismatched pattern annotations"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -753,6 +753,33 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs constrained helper with method-local evidence fixed by call args"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Mix, eq, mix, callMix, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  class Mix a {"
+                , "    mix : Eq b => a -> b -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Mix Bool {"
+                , "    mix = \\x \\y eq y y;"
+                , "  }"
+                , ""
+                , "  def callMix : Mix Bool => Bool -> Bool -> Bool = \\x \\y mix x y;"
+                , "  def main : Bool = callMix true true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs zero-method class constraint with matching instance"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -588,6 +588,33 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs class method with method-level Eq constraint"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, ShowEq, Nat(..), eq, showEq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  class ShowEq a {"
+                , "    showEq : Eq a => a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  instance ShowEq Nat {"
+                , "    showEq = \\x \\y eq x y;"
+                , "  }"
+                , ""
+                , "  def main : Bool = showEq Zero Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "rejects constrained helper call without a satisfiable instance"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1681,6 +1681,38 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "rejects alias-head instance for same-named private class"
+        ( InlineProgram $
+            unlines
+                [ "module Classes export (Eq, eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Core export (Token(..)) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Token ="
+                , "      Token : Token;"
+                , ""
+                , "  instance Eq Token {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Classes exposing (Eq, eq);"
+                , "  import Core as C;"
+                , ""
+                , "  def main : Bool = eq C.Token C.Token;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\" (STBase \"C.Token\")")
+    , ProgramMatrixCase
         "runs aliased exposing type without duplicate instance heads"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -891,6 +891,27 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs aliased import exposing a closed-type instance without duplicate matches"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    eq = \\x \\y true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C exposing (eq);"
+                , "  def main : Bool = eq 1 1;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs qualified type name in annotation"
         ( InlineProgram $
             unlines
@@ -1209,6 +1230,24 @@ spec = do
             program <- requireParsed programText
             case prettyValue <$> runProgram program of
                 Right rendered -> rendered `shouldSatisfy` (/= "Token")
+                Left err -> expectationFailure ("unexpected program failure: " ++ show err)
+
+        it "does not decode typed non-data constructor fields through fallback ADT decoding" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Token(..), Holder(..), main) {"
+                        , "  data Token ="
+                        , "      Token : Token;"
+                        , ""
+                        , "  data Holder ="
+                        , "      Holder : (Bool -> Bool) -> Holder;"
+                        , ""
+                        , "  def main : Holder = Holder (\\(x : Bool) x);"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            case prettyValue <$> runProgram program of
+                Right rendered -> rendered `shouldSatisfy` (/= "Holder Token")
                 Left err -> expectationFailure ("unexpected program failure: " ++ show err)
 
     describe "MLF.Program performance baseline" $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2129,6 +2129,21 @@ spec = do
                     rendered `shouldSatisfy` isInfixOf "error: module `Hidden` does not export `Nat`"
                 Right _ -> expectationFailure "expected import visibility diagnostic"
 
+        it "renders export visibility diagnostics at the module export item" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (missing) {"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "missing-export.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    diagnosticError diagnostic `shouldBe` ProgramExportNotLocal "missing"
+                    renderProgramDiagnostic diagnostic
+                        `shouldSatisfy` isInfixOf "missing-export.mlfp:1:21"
+                Right _ -> expectationFailure "expected export visibility diagnostic"
+
         it "does not report missing-instance diagnostics at class declarations" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1324,6 +1324,33 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs aliased instance head when class is imported from another module"
+        ( InlineProgram $
+            unlines
+                [ "module Classes export (Eq, eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Core export (Foo(..)) {"
+                , "  import Classes exposing (Eq, eq);"
+                , ""
+                , "  data Foo ="
+                , "      Foo : Foo"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Classes exposing (Eq, eq);"
+                , "  import Core as A;"
+                , ""
+                , "  def main : Bool = eq A.Foo A.Foo;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs qualified type name in annotation"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -847,6 +847,55 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramDerivingMissingFieldInstance \"Eq\"")
     , ProgramMatrixCase
+        "rejects parameterized deriving when transitive field constraints lack Eq evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Option(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Option a ="
+                , "      None : Option a"
+                , "    | Some : a -> Option a"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (Bad(..), main) {"
+                , "  import Core exposing (Eq, Option(..), eq);"
+                , ""
+                , "  data Bad a ="
+                , "      Bad : Option (a -> a) -> Bad a"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDerivingMissingFieldInstance \"Eq\"")
+    , ProgramMatrixCase
+        "rejects non-regular recursive deriving fields"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, List(..), Weird(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data List a ="
+                , "      Nil : List a"
+                , "    | Cons : a -> List a -> List a;"
+                , ""
+                , "  data Weird a ="
+                , "      Weird : Weird (List a) -> Weird a"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDerivingMissingFieldInstance \"Eq\"")
+    , ProgramMatrixCase
         "runs qualified import with alias-only value and constructor access"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1888,6 +1888,28 @@ spec = do
             program <- requireParsed programText
             (prettyValue <$> runProgram program) `shouldBe` Right "Some Zero"
 
+        it "uses qualified ADT heads to disambiguate runtime decoding" $ do
+            let programText =
+                    unlines
+                        [ "module A export (Bit(..)) {"
+                        , "  data Bit ="
+                        , "      ABit : Bit;"
+                        , "}"
+                        , ""
+                        , "module B export (Bit(..)) {"
+                        , "  data Bit ="
+                        , "      BBit : Bit;"
+                        , "}"
+                        , ""
+                        , "module Main export (main) {"
+                        , "  import A as L;"
+                        , "  import B as R;"
+                        , "  def main : R.Bit = R.BBit;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            (prettyValue <$> runProgram program) `shouldBe` Right "BBit"
+
         it "does not decode non-data main values through fallback ADT decoding" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -750,6 +750,34 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs zero-method class instance after resolving prerequisites"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Marker, Nat(..), eq, needsMarker, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  instance Eq Nat {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance Eq a => Marker a {"
+                , "  }"
+                , ""
+                , "  def needsMarker : Marker Nat => Bool -> Bool = \\x x;"
+                , "  def main : Bool = needsMarker true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "rejects zero-method class constraint without matching instance"
         ( InlineProgram $
             unlines
@@ -763,6 +791,30 @@ emlfBoundaryMatrix =
                 ]
         )
         (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Marker\"")
+    , ProgramMatrixCase
+        "rejects zero-method class instance when prerequisite is missing"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Marker, Nat(..), eq, needsMarker, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  instance Eq a => Marker a {"
+                , "  }"
+                , ""
+                , "  def needsMarker : Marker Nat => Bool -> Bool = \\x x;"
+                , "  def main : Bool = needsMarker true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\"")
     , ProgramMatrixCase
         "runs qualified zero-method class instance through aliased import"
         ( InlineProgram $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -372,6 +372,24 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramTypeMismatch (STBase \"Bool\") (STBase \"Nat\")")
     , ProgramMatrixCase
+        "rejects catch-all pattern annotations when scrutinee type is inferred later"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool ="
+                , "    let f = \\x -> case x of {"
+                , "      (_ : Int) -> true"
+                , "    } in"
+                , "    f Zero;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramTypeMismatch")
+    , ProgramMatrixCase
         "rejects branches after catch-all as unreachable"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -627,6 +627,26 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "rejects constrained helper alias through local hidden Eq evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, eq, same, alias, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;"
+                , "  def alias : Eq a => a -> a -> Bool = same;"
+                , "  def main : Bool = alias true true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramAmbiguousConstrainedValueUse \"same\"")
+    , ProgramMatrixCase
         "runs constrained helper after local lambda inference"
         ( InlineProgram $
             unlines
@@ -641,6 +661,32 @@ emlfBoundaryMatrix =
                 , ""
                 , "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;"
                 , "  def main : Bool = let f = \\x same x x in f true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs deferred method with method-level type variable constraint"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Mix, eq, mix, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  class Mix a {"
+                , "    mix : Eq b => a -> b -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Mix Bool {"
+                , "    mix = \\x \\y eq y y;"
+                , "  }"
+                , ""
+                , "  def main : Bool = mix true true;"
                 , "}"
                 ]
         )

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1575,6 +1575,29 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "deduplicates equivalent instances from mixed unqualified and aliased imports"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Nat(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core exposing (Eq, Nat(..), eq);"
+                , "  import Core as C;"
+                , "  def main : Bool = eq C.Zero C.Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs local class instance for alias-only imported type"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -356,6 +356,22 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "rejects mismatched pattern annotations"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Zero of {"
+                , "    (_ : Bool) -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramTypeMismatch (STBase \"Bool\") (STBase \"Nat\")")
+    , ProgramMatrixCase
         "rejects branches after catch-all as unreachable"
         ( InlineProgram $
             unlines
@@ -372,6 +388,24 @@ emlfBoundaryMatrix =
                 ]
         )
         (ExpectCheckFailureContaining "ProgramDuplicateCaseBranch \"Zero\"")
+    , ProgramMatrixCase
+        "rejects branches after constructor-local catch-all as unreachable"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Nat(..), main) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  def main : Bool = case Succ Zero of {"
+                , "    Succ _ -> true;"
+                , "    Succ Zero -> false;"
+                , "    _ -> false"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDuplicateCaseBranch \"Succ\"")
     , ProgramMatrixCase
         "rejects non-exhaustive nested constructor patterns"
         ( InlineProgram $
@@ -634,6 +668,35 @@ emlfBoundaryMatrix =
                 , "  }"
                 , ""
                 , "  instance Eq (Box Nat) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
+    , ProgramMatrixCase
+        "rejects local instance overlapping an imported schema"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Box(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  instance Eq a => Eq (Box a) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core exposing (Eq, Box(..), eq);"
+                , ""
+                , "  instance Eq (Box Bool) {"
                 , "    eq = \\left \\right true;"
                 , "  }"
                 , ""

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1334,6 +1334,41 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs deriving Eq when field instance has non-Eq prerequisite"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Ord, BoxInt(..), eq) {"
+                , "  class Eq item {"
+                , "    eq : item -> item -> Bool;"
+                , "  }"
+                , ""
+                , "  class Ord item {"
+                , "  }"
+                , ""
+                , "  instance Ord Int {"
+                , "  }"
+                , ""
+                , "  data BoxInt ="
+                , "      MkBoxInt : Int -> BoxInt;"
+                , ""
+                , "  instance Ord Int => Eq BoxInt {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (UsesBox(..), main) {"
+                , "  import Core exposing (Eq, Ord, BoxInt(..), eq);"
+                , ""
+                , "  data UsesBox ="
+                , "      UsesBox : BoxInt -> UsesBox"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool = eq (UsesBox (MkBoxInt 1)) (UsesBox (MkBoxInt 2));"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs parameterized deriving Eq for recursive List"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -409,7 +409,7 @@ emlfBoundaryMatrix =
                 , "}"
                 ]
         )
-        (ExpectCheckFailureContaining "ProgramPipelineError")
+        (ExpectCheckFailureContaining "ProgramTypeMismatch (STBase \"Int\") (STBase \"Nat\")")
     , ProgramMatrixCase
         "rejects branches after catch-all as unreachable"
         ( InlineProgram $
@@ -622,6 +622,25 @@ emlfBoundaryMatrix =
                 , ""
                 , "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;"
                 , "  def main : Bool = same Zero Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs constrained helper after local lambda inference"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, eq, same, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;"
+                , "  def main : Bool = let f = \\x same x x in f true;"
                 , "}"
                 ]
         )

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1295,6 +1295,36 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
     , ProgramMatrixCase
+        "rejects alias-equivalent duplicate class instance heads"
+        ( InlineProgram $
+            unlines
+                [ "module Classes export (Eq, eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Classes exposing (Eq, eq);"
+                , "  import Classes as P;"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  instance Eq Nat {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance P.Eq Nat {"
+                , "    eq = \\left \\right false;"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramDuplicateInstance")
+    , ProgramMatrixCase
         "runs parameterized deriving Eq for Option"
         ( InlineProgram $
             unlines
@@ -1810,6 +1840,47 @@ emlfBoundaryMatrix =
                 ]
         )
         (ExpectRunValue "false")
+    , ProgramMatrixCase
+        "runs local same-named class instance beside hidden method-only imports"
+        ( InlineProgram $
+            unlines
+                [ "module A export (z) {"
+                , "  class Eq a {"
+                , "    z : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    z = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module B export (a) {"
+                , "  class Eq a {"
+                , "    a : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    a = \\left \\right false;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (Eq, eq, main) {"
+                , "  import A exposing (z);"
+                , "  import B exposing (a);"
+                , ""
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = eq 1 1;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
     , ProgramMatrixCase
         "runs aliased exposing type without duplicate instance heads"
         ( InlineProgram $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -779,6 +779,31 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
     , ProgramMatrixCase
+        "rejects overlapping instance heads after alpha-renaming variables"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Pair(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Pair a b ="
+                , "      Pair : a -> b -> Pair a b;"
+                , ""
+                , "  instance Eq (Pair a a) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance Eq (Pair a b) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
+    , ProgramMatrixCase
         "runs parameterized deriving Eq for Option"
         ( InlineProgram $
             unlines
@@ -799,6 +824,28 @@ emlfBoundaryMatrix =
                 , ""
                 , "  def main : Bool ="
                 , "    eq (Some Zero) (Some Zero);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "runs same-module deriving through pending derived field instances"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, B(..), A(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data B ="
+                , "      MkB : B"
+                , "    deriving Eq;"
+                , ""
+                , "  data A ="
+                , "      MkA : B -> A"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool = eq (MkA MkB) (MkA MkB);"
                 , "}"
                 ]
         )

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -216,6 +216,27 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs overloaded method dispatch on pattern-bound variable"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Nat(..), eq, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat"
+                , "    deriving Eq;"
+                , ""
+                , "  def main : Bool = case Zero of {"
+                , "    n -> eq n n"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "rejects bare overloaded method use"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2170,6 +2170,25 @@ spec = do
                         `shouldSatisfy` isInfixOf "unknown-instance-class.mlfp:2:12"
                 Right _ -> expectationFailure "expected unknown instance class diagnostic"
 
+        it "renders unknown method constraint class diagnostics at the constraint site" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (C, main) {"
+                        , "  class C a {"
+                        , "    m : Missing a => a -> a;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "unknown-method-constraint.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    diagnosticError diagnostic `shouldBe` ProgramUnknownClass "Missing"
+                    renderProgramDiagnostic diagnostic
+                        `shouldSatisfy` isInfixOf "unknown-method-constraint.mlfp:3:9"
+                Right _ -> expectationFailure "expected unknown method constraint diagnostic"
+
         it "renders duplicate instance diagnostics with a class span" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1826,6 +1826,29 @@ spec = do
                     rendered `shouldSatisfy` isInfixOf "error: module `Hidden` does not export `Nat`"
                 Right _ -> expectationFailure "expected import visibility diagnostic"
 
+        it "does not report missing-instance diagnostics at class declarations" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Eq, Nat(..), eq, main) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , ""
+                        , "  data Nat ="
+                        , "      Zero : Nat;"
+                        , ""
+                        , "  def main : Bool = eq Zero Zero;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "missing-instance.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    diagnosticError diagnostic `shouldBe` ProgramNoMatchingInstance "Eq" (STBase "Nat")
+                    diagnosticSpan diagnostic `shouldBe` Nothing
+                    renderProgramDiagnostic diagnostic
+                        `shouldSatisfy` isInfixOf "error: no matching instance for `Eq STBase \"Nat\"`"
+                Right _ -> expectationFailure "expected missing instance diagnostic"
+
     describe "MLF.Program runtime value rendering" $ do
         it "renders closed ADT values with source constructor syntax" $ do
             let programText =

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1745,6 +1745,72 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\" (STBase \"Token\")")
     , ProgramMatrixCase
+        "keeps hidden same-named class instances across method-only imports"
+        ( InlineProgram $
+            unlines
+                [ "module A export (z) {"
+                , "  class Eq a {"
+                , "    z : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    z = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module B export (a) {"
+                , "  class Eq a {"
+                , "    a : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    a = \\left \\right false;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import A exposing (z);"
+                , "  import B exposing (a);"
+                , ""
+                , "  def main : Bool = a 1 1;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "false")
+    , ProgramMatrixCase
+        "resolves method-only import by selected hidden class identity"
+        ( InlineProgram $
+            unlines
+                [ "module A export (eqA) {"
+                , "  class Eq a {"
+                , "    eqA : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Int {"
+                , "    eqA = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module B export (eqB) {"
+                , "  class Eq a {"
+                , "    eqB : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eqB = \\left \\right false;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import A exposing (eqA);"
+                , "  import B exposing (eqB);"
+                , ""
+                , "  def main : Bool = eqB true false;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "false")
+    , ProgramMatrixCase
         "runs aliased exposing type without duplicate instance heads"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1775,6 +1775,26 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Zero")
     , ProgramMatrixCase
+        "runs mixed exposed and qualified alias constructors in one case"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Nat(..)) {"
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core as C exposing (Nat(..));"
+                , "  def main : Bool = case C.Succ Zero of {"
+                , "    Zero -> false;"
+                , "    C.Succ _ -> true"
+                , "  };"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs distinct instances whose qualified heads would sanitize alike"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -796,6 +796,33 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs partial deferred method after method-local evidence is fixed by application"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Mix, eq, mix, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  class Mix a {"
+                , "    mix : Eq b => a -> b -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Mix Bool {"
+                , "    mix = \\x \\y eq y y;"
+                , "  }"
+                , ""
+                , "  def applyBool : (Bool -> Bool) -> Bool = \\f f true;"
+                , "  def main : Bool = applyBool (mix true);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs deferred method when only a later forall binder is inferred"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -647,6 +647,26 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramAmbiguousConstrainedValueUse \"same\"")
     , ProgramMatrixCase
+        "runs ground constrained helper alias with resolved evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, eq, sameBool, alias, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def sameBool : Eq Bool => Bool -> Bool -> Bool = \\x \\y eq x y;"
+                , "  def alias : Bool -> Bool -> Bool = sameBool;"
+                , "  def main : Bool = alias true true;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs constrained helper after local lambda inference"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1221,6 +1221,35 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
     , ProgramMatrixCase
+        "rejects alias-equivalent overlapping instance heads"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Nat(..)) {"
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , "}"
+                , ""
+                , "module Main export (Eq, eq, main) {"
+                , "  import Core as A exposing (Nat(..));"
+                , ""
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Nat {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance Eq A.Nat {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
+    , ProgramMatrixCase
         "runs parameterized deriving Eq for Option"
         ( InlineProgram $
             unlines
@@ -1975,6 +2004,33 @@ spec = do
                     renderProgramDiagnostic diagnostic
                         `shouldSatisfy` isInfixOf "error: no matching instance for `Eq STBase \"Nat\"`"
                 Right _ -> expectationFailure "expected missing instance diagnostic"
+
+        it "renders duplicate instance diagnostics with a class span" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Eq, eq, main) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , ""
+                        , "  instance Eq Bool {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , ""
+                        , "  instance Eq Bool {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            located <- requireLocatedWithFile "duplicate-instance.mlfp" programText
+            case checkLocatedProgram located of
+                Left diagnostic -> do
+                    diagnosticError diagnostic `shouldBe` ProgramDuplicateInstance "Eq" (STBase "Bool")
+                    renderProgramDiagnostic diagnostic
+                        `shouldSatisfy` isInfixOf "duplicate-instance.mlfp:2:3"
+                Right _ -> expectationFailure "expected duplicate instance diagnostic"
 
     describe "MLF.Program runtime value rendering" $ do
         it "renders closed ADT values with source constructor syntax" $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1495,6 +1495,32 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs alias-only qualified deriving Eq"
+        ( InlineProgram $
+            unlines
+                [ "module Classes export (Eq, eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\x \\y true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Classes as P;"
+                , ""
+                , "  data Box ="
+                , "      Box : Bool -> Box"
+                , "    deriving P.Eq;"
+                , ""
+                , "  def main : Bool = P.eq (Box true) (Box false);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "runs aliased instance head when class is imported from another module"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -778,6 +778,41 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "runs deferred method after resolving zero-method prerequisites"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Marker, Uses, Nat(..), eq, uses, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  class Uses a {"
+                , "    uses : Marker a => a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  instance Eq Nat {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  instance Eq a => Marker a {"
+                , "  }"
+                , ""
+                , "  instance Uses Nat {"
+                , "    uses = \\x true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = uses Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
         "rejects zero-method class constraint without matching instance"
         ( InlineProgram $
             unlines
@@ -811,6 +846,37 @@ emlfBoundaryMatrix =
                 , ""
                 , "  def needsMarker : Marker Nat => Bool -> Bool = \\x x;"
                 , "  def main : Bool = needsMarker true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramNoMatchingInstance \"Eq\"")
+    , ProgramMatrixCase
+        "rejects deferred method when zero-method prerequisite is missing"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Marker, Uses, Nat(..), eq, uses, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  class Marker a {"
+                , "  }"
+                , ""
+                , "  class Uses a {"
+                , "    uses : Marker a => a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  instance Eq a => Marker a {"
+                , "  }"
+                , ""
+                , "  instance Uses Nat {"
+                , "    uses = \\x true;"
+                , "  }"
+                , ""
+                , "  def main : Bool = uses Zero;"
                 , "}"
                 ]
         )
@@ -1488,6 +1554,27 @@ spec = do
                         ]
             program <- requireParsed programText
             checkProgram program `shouldBe` Left (ProgramNonExhaustiveCase ["Succ"])
+
+        it "preserves wildcard-only case scrutinee evaluation without a known source type" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  def main : Bool = case ((\\x x) true) of {"
+                        , "    _ -> true"
+                        , "  };"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            case checkProgram program of
+                Right checked ->
+                    unlines
+                        [ show (checkedBindingSurfaceExpr binding)
+                        | checkedModule <- checkedProgramModules checked
+                        , binding <- checkedModuleBindings checkedModule
+                        , checkedBindingExportedAsMain binding
+                        ]
+                        `shouldSatisfy` isInfixOf "$case_scrutinee"
+                Left err -> expectationFailure ("checkProgram failed: " ++ show err)
 
         it "rejects constructor arity mismatches as pattern errors" $ do
             let programText =


### PR DESCRIPTION
## Summary

- Add `.mlfp` constrained types for definitions, class methods, and instance declarations, lowering constraints to hidden runtime method evidence while keeping raw eMLF unchanged.
- Extend instance resolution for constrained schemas such as `Eq a => Eq (Option a)`, reject overlapping heads by unification, and add parameterized `deriving Eq` including recursive `List a`.
- Add qualified and aliased imports, expand the explicit Prelude, and document the updated language surface.

## Validation

- `cabal test mlf2-test --test-show-details=direct --test-options='--match "parameterized deriving Eq for recursive List"'`
- `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'` — 88 examples, 0 failures
- `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program eMLF"'` — 51 examples, 0 failures
- `cabal build all && cabal test` — 1637 examples, 0 failures
- `git diff --check`

Closes #14
