### PR TITLE
[codex] Make thesis obligations property-backed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Changed
+- Converted the thesis-obligations ledger to property-first evidence: all 107
+  obligations now point at QuickCheck anchors keyed by obligation ID with
+  `kind: quickcheck` and `min_success: 100`. The obligations gate now rejects
+  example-only evidence by requiring a matching QuickCheck success line and
+  pass count, while source anchors remain navigational code paths.
 - Fixed the thesis-conformance CI gate so colored Hspec summaries and Ruby
   3.2 YAML dates from GitHub Actions are parsed before enforcing matcher
   coverage. Validation:

--- a/docs/thesis-claims.yaml
+++ b/docs/thesis-claims.yaml
@@ -57,10 +57,7 @@ claims:
       obligations:
         - O10-EXP-DECIDE
         - O10-EXP-APPLY
-      property_tests:
-        - matcher: "Expansion minimality"
-          file: test/ExpansionMinimalitySpec.hs
-          kind: example
+      property_tests: []
       code_paths:
         - src/MLF/Constraint/Presolution/Expansion.hs#decideMinimalExpansion
     deviations:
@@ -100,10 +97,7 @@ claims:
         - O11-WITNESS-COALESCE
         - O11-WITNESS-REORDER
         - O11-UNIFY-STRUCT
-      property_tests:
-        - matcher: "R-"
-          file: test/Presolution/WitnessSpec.hs
-          kind: gate-anchor
+      property_tests: []
       code_paths:
         - src/MLF/Constraint/Presolution/WitnessNorm.hs#normalizeEdgeWitnessesM
         - src/MLF/Constraint/Presolution/WitnessCanon.hs#normalizeInstanceOpsFull
@@ -186,10 +180,7 @@ claims:
       obligations:
         - O07-GENUNIF
         - O07-REBIND
-      property_tests:
-        - matcher: "Generalized unification (Ch 7.6)"
-          file: test/SolveSpec.hs
-          kind: example
+      property_tests: []
       code_paths:
         - src/MLF/Constraint/Unify/Closure.hs#batchHarmonize
         - src/MLF/Binding/Adjustment.hs#harmonizeBindParentsMulti
@@ -216,10 +207,7 @@ claims:
         - O14-RED-INNER
         - O14-RED-OUTER
         - O14-RED-CONTEXT
-      property_tests:
-        - matcher: "Phase 7 theorem obligations"
-          file: test/TypeSoundnessSpec.hs
-          kind: quickcheck
+      property_tests: []
       code_paths:
         - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
         - src/MLF/Elab/Reduce.hs#step
@@ -239,10 +227,7 @@ claims:
         - O14-RED-BETA
         - O14-RED-BETALET
         - O14-RED-CONTEXT
-      property_tests:
-        - matcher: "Phase 7 theorem obligations"
-          file: test/TypeSoundnessSpec.hs
-          kind: quickcheck
+      property_tests: []
       code_paths:
         - src/MLF/Elab/Reduce.hs#step
         - src/MLF/Elab/Reduce.hs#isValue
@@ -258,11 +243,13 @@ claims:
     thesis_ref: "Proposition 14.3 (Determinism)"
     statement: "xMLF reduction is deterministic."
     evidence:
-      obligations: []
-      property_tests:
-        - matcher: "Phase 7 theorem obligations"
-          file: test/TypeSoundnessSpec.hs
-          kind: quickcheck
+      obligations:
+        - O14-RED-BETA
+        - O14-RED-BETALET
+        - O14-RED-REFLEX
+        - O14-RED-TRANS
+        - O14-RED-CONTEXT
+      property_tests: []
       code_paths:
         - src/MLF/Elab/Reduce.hs#step
     deviations:
@@ -380,10 +367,7 @@ claims:
         - O15-TRANS-SCHEME-ROOT-RIGID
         - O15-TRANS-ARROW-RIGID
         - O15-TRANS-NON-INTERIOR-RIGID
-      property_tests:
-        - matcher: "Translatable presolution"
-          file: test/TranslatablePresolutionSpec.hs
-          kind: example
+      property_tests: []
       code_paths:
         - src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution
     deviations: []
@@ -414,13 +398,7 @@ claims:
         - O15-EDGE-TRANSLATION
         - O15-CONTEXT-FIND
         - O15-CONTEXT-REJECT
-      property_tests:
-        - matcher: "R-"
-          file: test/Presolution/WitnessSpec.hs
-          kind: gate-anchor
-        - matcher: "Phi soundness"
-          file: test/PhiSoundnessSpec.hs
-          kind: example
+      property_tests: []
       code_paths:
         - src/MLF/Elab/Phi/Translate.hs#phiFromEdgeWitnessWithTrace
     deviations: []
@@ -492,10 +470,7 @@ claims:
         - O15-TR-NODE-RAISEMERGE
         - O15-TR-NODE-WEAKEN
         - O15-TR-NODE-RAISE
-      property_tests:
-        - matcher: "R-"
-          file: test/Presolution/WitnessSpec.hs
-          kind: gate-anchor
+      property_tests: []
       code_paths:
         - src/MLF/Elab/Phi/Translate.hs#phiFromEdgeWitnessWithTrace
         - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega

--- a/docs/thesis-obligations.md
+++ b/docs/thesis-obligations.md
@@ -10,162 +10,163 @@ Generated from `docs/thesis-obligations.yaml` by `scripts/render-thesis-obligati
 
 ## Chapter 4
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O04-BIND-FLEX-CHILDREN` | `4.2` | `Definition 4.2 Q(n) flex children` | Q(n) flex children | `O04-BIND-FLEX-CHILDREN` | `test/BindingSpec.hs` | `CLM-CGEN-SHAPE` |
-| `O04-BIND-INTERIOR` | `4.2` | `Definition 4.2 I(r) interior` | I(r) interior | `O04-BIND-INTERIOR` | `test/BindingSpec.hs` | `CLM-CGEN-SHAPE` |
-| `O04-BIND-ORDER` | `4.2` | `Definition 4.2 binder ordering` | Binder ordering ≺ | `O04-BIND-ORDER` | `test/BindingSpec.hs` | `CLM-CGEN-SHAPE` |
-| `O04-OP-RAISE-STEP` | `4.4` | `Definition 4.4 Raise(n) single step` | Raise(n) single step | `O04-OP-RAISE-STEP` | `test/GraphOpsSpec.hs` | `CLM-CGEN-SHAPE` |
-| `O04-OP-RAISE-TO` | `4.4` | `Definition 4.4 Raise-to-target` | Raise-to-target | `O04-OP-RAISE-TO` | `test/GraphOpsSpec.hs` | `CLM-CGEN-SHAPE` |
-| `O04-OP-WEAKEN` | `4.4` | `Definition 4.4 Weaken(n)` | Weaken(n) | `O04-OP-WEAKEN` | `test/GraphOpsSpec.hs` | `CLM-CGEN-SHAPE` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O04-BIND-FLEX-CHILDREN` | `4.2` | `Definition 4.2 Q(n) flex children` | Q(n) flex children | `quickcheck` | `100` | `O04-BIND-FLEX-CHILDREN` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE` |
+| `O04-BIND-INTERIOR` | `4.2` | `Definition 4.2 I(r) interior` | I(r) interior | `quickcheck` | `100` | `O04-BIND-INTERIOR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE` |
+| `O04-BIND-ORDER` | `4.2` | `Definition 4.2 binder ordering` | Binder ordering ≺ | `quickcheck` | `100` | `O04-BIND-ORDER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE` |
+| `O04-OP-RAISE-STEP` | `4.4` | `Definition 4.4 Raise(n) single step` | Raise(n) single step | `quickcheck` | `100` | `O04-OP-RAISE-STEP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE` |
+| `O04-OP-RAISE-TO` | `4.4` | `Definition 4.4 Raise-to-target` | Raise-to-target | `quickcheck` | `100` | `O04-OP-RAISE-TO` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE` |
+| `O04-OP-WEAKEN` | `4.4` | `Definition 4.4 Weaken(n)` | Weaken(n) | `quickcheck` | `100` | `O04-OP-WEAKEN` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE` |
 
 ## Chapter 5
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O05-INERT-LOCKED` | `5.2` | `Definition 15.2.2 inert-locked` | Inert-locked nodes | `O05-INERT-LOCKED` | `test/InertSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
-| `O05-INERT-NODES` | `5.2` | `Definition 5.2.2 inert nodes` | Inert nodes | `O05-INERT-NODES` | `test/InertSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
-| `O05-WEAKEN-INERT` | `5.3` | `Section 15.2.3.2 weaken inert-locked` | Weaken inert-locked | `O05-WEAKEN-INERT` | `test/InertSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O05-INERT-LOCKED` | `5.2` | `Definition 15.2.2 inert-locked` | Inert-locked nodes | `quickcheck` | `100` | `O05-INERT-LOCKED` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| `O05-INERT-NODES` | `5.2` | `Definition 5.2.2 inert nodes` | Inert nodes | `quickcheck` | `100` | `O05-INERT-NODES` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| `O05-WEAKEN-INERT` | `5.3` | `Section 15.2.3.2 weaken inert-locked` | Weaken inert-locked | `quickcheck` | `100` | `O05-WEAKEN-INERT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
 
 ## Chapter 7
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O07-REBIND` | `7.3` | `Figure 7.3.x Rebind` | Rebind | `O07-REBIND` | `test/BindingSpec.hs` | `CLM-UNIFICATION` |
-| `O07-UNIF-CORE` | `7.3` | `Figure 7.3.x Unif` | Core unification | `O07-UNIF-CORE` | `test/NormalizeSpec.hs` | `CLM-UNIFICATION` |
-| `O07-UNIF-PRESOL` | `7.3` | `Presolution unify` | Presolution unify | `O07-UNIF-PRESOL` | `test/SolveSpec.hs` | `CLM-UNIFICATION` |
-| `O07-GENUNIF` | `7.6` | `Definition 7.6.1, Definition 7.6.2, Section 7.6.2, Lemma 7.6.3` | Generalized unification | `Generalized unification (Ch 7.6)` | `test/SolveSpec.hs` | `CLM-UNIFICATION`, `CLM-GEN-UNIFICATION` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O07-REBIND` | `7.3` | `Figure 7.3.x Rebind` | Rebind | `quickcheck` | `100` | `O07-REBIND` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-UNIFICATION` |
+| `O07-UNIF-CORE` | `7.3` | `Figure 7.3.x Unif` | Core unification | `quickcheck` | `100` | `O07-UNIF-CORE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-UNIFICATION` |
+| `O07-UNIF-PRESOL` | `7.3` | `Presolution unify` | Presolution unify | `quickcheck` | `100` | `O07-UNIF-PRESOL` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-UNIFICATION` |
+| `O07-GENUNIF` | `7.6` | `Definition 7.6.1, Definition 7.6.2, Section 7.6.2, Lemma 7.6.3` | Generalized unification | `quickcheck` | `100` | `O07-GENUNIF` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-UNIFICATION`, `CLM-GEN-UNIFICATION` |
 
 ## Chapter 8
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O08-BIND-MONO` | `8.2` | `Figure 8.2.2` | B(σ) binding monomorphic subtypes | `O08-BIND-MONO` | `test/PipelineSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O08-REIFY-NAMES` | `8.2` | `Named reification` | Named reification | `O08-REIFY-NAMES` | `test/PipelineSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O08-REIFY-TYPE` | `8.2` | `Graphic to syntactic reification` | Graphic→syntactic | `O08-REIFY-TYPE` | `test/PipelineSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O08-SYN-TO-GRAPH` | `8.2` | `Figure 8.2.3` | G(σ) syntactic to graphic | `O08-SYN-TO-GRAPH` | `test/PipelineSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O08-INLINE-PRED` | `8.3` | `Inline(τ,n) predicate` | Inline predicate | `O08-INLINE-PRED` | `test/PipelineSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O08-REIFY-INLINE` | `8.3` | `Figure 8.3.3` | Sᵢ(τ) reification with inlining | `O08-REIFY-INLINE` | `test/PipelineSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O08-BIND-MONO` | `8.2` | `Figure 8.2.2` | B(σ) binding monomorphic subtypes | `quickcheck` | `100` | `O08-BIND-MONO` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O08-REIFY-NAMES` | `8.2` | `Named reification` | Named reification | `quickcheck` | `100` | `O08-REIFY-NAMES` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O08-REIFY-TYPE` | `8.2` | `Graphic to syntactic reification` | Graphic→syntactic | `quickcheck` | `100` | `O08-REIFY-TYPE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O08-SYN-TO-GRAPH` | `8.2` | `Figure 8.2.3` | G(σ) syntactic to graphic | `quickcheck` | `100` | `O08-SYN-TO-GRAPH` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O08-INLINE-PRED` | `8.3` | `Inline(τ,n) predicate` | Inline predicate | `quickcheck` | `100` | `O08-INLINE-PRED` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O08-REIFY-INLINE` | `8.3` | `Figure 8.3.3` | Sᵢ(τ) reification with inlining | `quickcheck` | `100` | `O08-REIFY-INLINE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
 
 ## Chapter 9
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O09-CGEN-EXPR` | `9.4` | `Expression constraint generation` | Expr constraint | `O09-CGEN-EXPR` | `test/ConstraintGenSpec.hs` | `CLM-CGEN-SHAPE`, `CLM-CGEN-SCOPING` |
-| `O09-CGEN-ROOT` | `9.4` | `Root constraint generation` | Root constraint | `O09-CGEN-ROOT` | `test/ConstraintGenSpec.hs` | `CLM-CGEN-SHAPE`, `CLM-CGEN-SCOPING` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O09-CGEN-EXPR` | `9.4` | `Expression constraint generation` | Expr constraint | `quickcheck` | `100` | `O09-CGEN-EXPR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE`, `CLM-CGEN-SCOPING` |
+| `O09-CGEN-ROOT` | `9.4` | `Root constraint generation` | Root constraint | `quickcheck` | `100` | `O09-CGEN-ROOT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-CGEN-SHAPE`, `CLM-CGEN-SCOPING` |
 
 ## Chapter 10
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O10-EXP-APPLY` | `10.1` | `Apply expansion` | Apply expansion | `O10-EXP-APPLY` | `test/Presolution/ExpansionSpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
-| `O10-EXP-DECIDE` | `10.1` | `Decide minimal expansion` | Decide minimal expansion | `O10-EXP-DECIDE` | `test/Presolution/ExpansionSpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
-| `O10-PROP-SOLVE` | `10.3` | `Propagation rule` | Propagation rule | `O10-PROP-SOLVE` | `test/Presolution/EdgeTraceSpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
-| `O10-PROP-WITNESS` | `10.3` | `Edge witness recording` | Edge witness recording | `O10-PROP-WITNESS` | `test/Presolution/EdgeTraceSpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
-| `O10-COPY-SCHEME` | `10.4` | `Chi-e scheme copy` | Chi-e scheme copy | `O10-COPY-SCHEME` | `test/Presolution/InstantiateSpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O10-EXP-APPLY` | `10.1` | `Apply expansion` | Apply expansion | `quickcheck` | `100` | `O10-EXP-APPLY` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
+| `O10-EXP-DECIDE` | `10.1` | `Decide minimal expansion` | Decide minimal expansion | `quickcheck` | `100` | `O10-EXP-DECIDE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
+| `O10-PROP-SOLVE` | `10.3` | `Propagation rule` | Propagation rule | `quickcheck` | `100` | `O10-PROP-SOLVE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
+| `O10-PROP-WITNESS` | `10.3` | `Edge witness recording` | Edge witness recording | `quickcheck` | `100` | `O10-PROP-WITNESS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
+| `O10-COPY-SCHEME` | `10.4` | `Chi-e scheme copy` | Chi-e scheme copy | `quickcheck` | `100` | `O10-COPY-SCHEME` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-EXPANSION-MINIMALITY`, `CLM-PRESOLUTION-PRINCIPALITY` |
 
 ## Chapter 11
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O11-UNIFY-STRUCT` | `11.2` | `Structural unify on constraints` | Structural unify | `O11-UNIFY-STRUCT` | `test/NormalizeSpec.hs` | `CLM-WITNESS-NORMALIZATION` |
-| `O11-WITNESS-NORM` | `11.5` | `Witness normalization` | Witness normalization | `O11-WITNESS-NORM` | `test/Presolution/WitnessSpec.hs` | `CLM-WITNESS-NORMALIZATION` |
-| `O11-WITNESS-COALESCE` | `11.6` | `Raise;Merge to RaiseMerge` | Raise;Merge coalescing | `O11-WITNESS-COALESCE` | `test/Presolution/WitnessSpec.hs` | `CLM-WITNESS-NORMALIZATION` |
-| `O11-WITNESS-REORDER` | `11.6` | `Weaken reordering` | Weaken reordering | `O11-WITNESS-REORDER` | `test/Presolution/WitnessSpec.hs` | `CLM-WITNESS-NORMALIZATION` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O11-UNIFY-STRUCT` | `11.2` | `Structural unify on constraints` | Structural unify | `quickcheck` | `100` | `O11-UNIFY-STRUCT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-WITNESS-NORMALIZATION` |
+| `O11-WITNESS-NORM` | `11.5` | `Witness normalization` | Witness normalization | `quickcheck` | `100` | `O11-WITNESS-NORM` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-WITNESS-NORMALIZATION` |
+| `O11-WITNESS-COALESCE` | `11.6` | `Raise;Merge to RaiseMerge` | Raise;Merge coalescing | `quickcheck` | `100` | `O11-WITNESS-COALESCE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-WITNESS-NORMALIZATION` |
+| `O11-WITNESS-REORDER` | `11.6` | `Weaken reordering` | Weaken reordering | `quickcheck` | `100` | `O11-WITNESS-REORDER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-WITNESS-NORMALIZATION` |
 
 ## Chapter 12
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O12-ACYCLIC-CHECK` | `12.1` | `Acyclicity check` | Acyclicity check | `O12-ACYCLIC-CHECK` | `test/AcyclicitySpec.hs` | `CLM-ACYCLICITY` |
-| `O12-ACYCLIC-TOPO` | `12.1` | `Topological sort` | Topological sort | `O12-ACYCLIC-TOPO` | `test/AcyclicitySpec.hs` | `CLM-ACYCLICITY` |
-| `O12-SOLVE-ARROW` | `12.1` | `Arrow decomposition` | Arrow decomposition | `O12-SOLVE-ARROW` | `test/SolveSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-SOLVE-HARMONIZE` | `12.1` | `Binding harmonization during solve` | Binding harmonization | `O12-SOLVE-HARMONIZE` | `test/SolveSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-SOLVE-UNIFY` | `12.1` | `SolveConstraint main` | SolveConstraint main | `O12-SOLVE-UNIFY` | `test/SolveSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-SOLVE-VALIDATE` | `12.1` | `Post-solve validation` | Post-solve validation | `O12-SOLVE-VALIDATE` | `test/SolveSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-SOLVE-VAR-BASE` | `12.1` | `Var = Base merge` | Var = Base merge | `O12-SOLVE-VAR-BASE` | `test/SolveSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-SOLVE-VAR-VAR` | `12.1` | `Var = Var merge` | Var = Var merge | `O12-SOLVE-VAR-VAR` | `test/SolveSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-COPY-INST` | `12.2` | `Inst-Copy rule` | Inst-Copy rule | `O12-COPY-INST` | `test/Presolution/InstantiateSpec.hs` | `CLM-SOLVER-CORRECTNESS`, `CLM-PRESOLUTION-PRINCIPALITY` |
-| `O12-NORM-DROP` | `12.4` | `Drop reflexive edges` | Drop reflexive edges | `O12-NORM-DROP` | `test/NormalizeSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-NORM-FIXPOINT` | `12.4` | `Normalize to fixed point` | Normalize to fixed point | `O12-NORM-FIXPOINT` | `test/NormalizeSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-NORM-GRAFT` | `12.4` | `Graft inst edges` | Graft inst edges | `O12-NORM-GRAFT` | `test/NormalizeSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
-| `O12-NORM-MERGE` | `12.4` | `Merge unify edges` | Merge unify edges | `O12-NORM-MERGE` | `test/NormalizeSpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O12-ACYCLIC-CHECK` | `12.1` | `Acyclicity check` | Acyclicity check | `quickcheck` | `100` | `O12-ACYCLIC-CHECK` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ACYCLICITY` |
+| `O12-ACYCLIC-TOPO` | `12.1` | `Topological sort` | Topological sort | `quickcheck` | `100` | `O12-ACYCLIC-TOPO` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ACYCLICITY` |
+| `O12-SOLVE-ARROW` | `12.1` | `Arrow decomposition` | Arrow decomposition | `quickcheck` | `100` | `O12-SOLVE-ARROW` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-SOLVE-HARMONIZE` | `12.1` | `Binding harmonization during solve` | Binding harmonization | `quickcheck` | `100` | `O12-SOLVE-HARMONIZE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-SOLVE-UNIFY` | `12.1` | `SolveConstraint main` | SolveConstraint main | `quickcheck` | `100` | `O12-SOLVE-UNIFY` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-SOLVE-VALIDATE` | `12.1` | `Post-solve validation` | Post-solve validation | `quickcheck` | `100` | `O12-SOLVE-VALIDATE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-SOLVE-VAR-BASE` | `12.1` | `Var = Base merge` | Var = Base merge | `quickcheck` | `100` | `O12-SOLVE-VAR-BASE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-SOLVE-VAR-VAR` | `12.1` | `Var = Var merge` | Var = Var merge | `quickcheck` | `100` | `O12-SOLVE-VAR-VAR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-COPY-INST` | `12.2` | `Inst-Copy rule` | Inst-Copy rule | `quickcheck` | `100` | `O12-COPY-INST` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS`, `CLM-PRESOLUTION-PRINCIPALITY` |
+| `O12-NORM-DROP` | `12.4` | `Drop reflexive edges` | Drop reflexive edges | `quickcheck` | `100` | `O12-NORM-DROP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-NORM-FIXPOINT` | `12.4` | `Normalize to fixed point` | Normalize to fixed point | `quickcheck` | `100` | `O12-NORM-FIXPOINT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-NORM-GRAFT` | `12.4` | `Graft inst edges` | Graft inst edges | `quickcheck` | `100` | `O12-NORM-GRAFT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
+| `O12-NORM-MERGE` | `12.4` | `Merge unify edges` | Merge unify edges | `quickcheck` | `100` | `O12-NORM-MERGE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SOLVER-CORRECTNESS` |
 
 ## Chapter 14
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O14-WF-EMPTY` | `14.2` | `Figure 14.2.4` | wf-empty | `O14-WF-EMPTY` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-WF-TVAR` | `14.2` | `Figure 14.2.4` | wf-tvar | `O14-WF-TVAR` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-WF-VAR` | `14.2` | `Figure 14.2.4` | wf-var | `O14-WF-VAR` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-INST-BOT` | `14.2.2` | `Figure 14.2.6` | Inst-Bot | `O14-INST-BOT` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-HYP` | `14.2.2` | `Figure 14.2.6` | Inst-Hyp | `O14-INST-HYP` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-INNER` | `14.2.2` | `Figure 14.2.6` | Inst-Inner | `O14-INST-INNER` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-OUTER` | `14.2.2` | `Figure 14.2.6` | Inst-Outer | `O14-INST-OUTER` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-QUANT-ELIM` | `14.2.2` | `Figure 14.2.6` | Inst-Quant-Elim | `O14-INST-QUANT-ELIM` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-QUANT-INTRO` | `14.2.2` | `Figure 14.2.6` | Inst-Quant-Intro | `O14-INST-QUANT-INTRO` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-REFLEX` | `14.2.2` | `Figure 14.2.6` | Inst-Reflex | `O14-INST-REFLEX` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-INST-TRANS` | `14.2.2` | `Figure 14.2.6` | Inst-Trans | `O14-INST-TRANS` | `test/TypeCheckSpec.hs` | `CLM-INST-CORRECTNESS` |
-| `O14-APPLY-BOT` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-BOT` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-HYP` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-HYP` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-ID` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-ID` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-INNER` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-INNER` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-N` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-N` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-O` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-O` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-OUTER` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-OUTER` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-APPLY-SEQ` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `O14-APPLY-SEQ` | `test/ElaborationSpec.hs` | `CLM-INST-APPLICATION` |
-| `O14-T-ABS` | `14.2.3` | `Figure 14.2.8` | Abs | `O14-T-ABS` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-T-APP` | `14.2.3` | `Figure 14.2.8` | App | `O14-T-APP` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-T-LET` | `14.2.3` | `Figure 14.2.8` | Let | `O14-T-LET` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-T-TABS` | `14.2.3` | `Figure 14.2.8` | TAbs | `O14-T-TABS` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-T-TAPP` | `14.2.3` | `Figure 14.2.8` | TApp | `O14-T-TAPP` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-T-VAR` | `14.2.3` | `Figure 14.2.8` | Var | `O14-T-VAR` | `test/TypeCheckSpec.hs` | `CLM-TYPING-RULES` |
-| `O14-RED-BETA` | `14.3` | `Figure 14.3.1` | (β) | `O14-RED-BETA` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-BETALET` | `14.3` | `Figure 14.3.1` | (βLet) | `O14-RED-BETALET` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-CONTEXT` | `14.3` | `Figure 14.3.1` | Context | `O14-RED-CONTEXT` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-INNER` | `14.3` | `Figure 14.3.1` | Inner | `O14-RED-INNER` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-OUTER` | `14.3` | `Figure 14.3.1` | Outer | `O14-RED-OUTER` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-QUANT-ELIM` | `14.3` | `Figure 14.3.1` | Quant-Elim | `O14-RED-QUANT-ELIM` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-QUANT-INTRO` | `14.3` | `Figure 14.3.1` | Quant-Intro | `O14-RED-QUANT-INTRO` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-REFLEX` | `14.3` | `Figure 14.3.1` | Reflex | `O14-RED-REFLEX` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
-| `O14-RED-TRANS` | `14.3` | `Figure 14.3.1` | Trans | `O14-RED-TRANS` | `test/ReduceSpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O14-WF-EMPTY` | `14.2` | `Figure 14.2.4` | wf-empty | `quickcheck` | `100` | `O14-WF-EMPTY` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-WF-TVAR` | `14.2` | `Figure 14.2.4` | wf-tvar | `quickcheck` | `100` | `O14-WF-TVAR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-WF-VAR` | `14.2` | `Figure 14.2.4` | wf-var | `quickcheck` | `100` | `O14-WF-VAR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-INST-BOT` | `14.2.2` | `Figure 14.2.6` | Inst-Bot | `quickcheck` | `100` | `O14-INST-BOT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-HYP` | `14.2.2` | `Figure 14.2.6` | Inst-Hyp | `quickcheck` | `100` | `O14-INST-HYP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-INNER` | `14.2.2` | `Figure 14.2.6` | Inst-Inner | `quickcheck` | `100` | `O14-INST-INNER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-OUTER` | `14.2.2` | `Figure 14.2.6` | Inst-Outer | `quickcheck` | `100` | `O14-INST-OUTER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-QUANT-ELIM` | `14.2.2` | `Figure 14.2.6` | Inst-Quant-Elim | `quickcheck` | `100` | `O14-INST-QUANT-ELIM` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-QUANT-INTRO` | `14.2.2` | `Figure 14.2.6` | Inst-Quant-Intro | `quickcheck` | `100` | `O14-INST-QUANT-INTRO` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-REFLEX` | `14.2.2` | `Figure 14.2.6` | Inst-Reflex | `quickcheck` | `100` | `O14-INST-REFLEX` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-INST-TRANS` | `14.2.2` | `Figure 14.2.6` | Inst-Trans | `quickcheck` | `100` | `O14-INST-TRANS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-CORRECTNESS` |
+| `O14-APPLY-BOT` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-BOT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-HYP` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-HYP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-ID` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-ID` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-INNER` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-INNER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-N` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-N` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-O` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-O` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-OUTER` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-OUTER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-APPLY-SEQ` | `14.2.2.2` | `Figure 14.2.7` | Type computation application | `quickcheck` | `100` | `O14-APPLY-SEQ` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-INST-APPLICATION` |
+| `O14-T-ABS` | `14.2.3` | `Figure 14.2.8` | Abs | `quickcheck` | `100` | `O14-T-ABS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-T-APP` | `14.2.3` | `Figure 14.2.8` | App | `quickcheck` | `100` | `O14-T-APP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-T-LET` | `14.2.3` | `Figure 14.2.8` | Let | `quickcheck` | `100` | `O14-T-LET` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-T-TABS` | `14.2.3` | `Figure 14.2.8` | TAbs | `quickcheck` | `100` | `O14-T-TABS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-T-TAPP` | `14.2.3` | `Figure 14.2.8` | TApp | `quickcheck` | `100` | `O14-T-TAPP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-T-VAR` | `14.2.3` | `Figure 14.2.8` | Var | `quickcheck` | `100` | `O14-T-VAR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TYPING-RULES` |
+| `O14-RED-BETA` | `14.3` | `Figure 14.3.1` | (β) | `quickcheck` | `100` | `O14-RED-BETA` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-BETALET` | `14.3` | `Figure 14.3.1` | (βLet) | `quickcheck` | `100` | `O14-RED-BETALET` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-CONTEXT` | `14.3` | `Figure 14.3.1` | Context | `quickcheck` | `100` | `O14-RED-CONTEXT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-INNER` | `14.3` | `Figure 14.3.1` | Inner | `quickcheck` | `100` | `O14-RED-INNER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-OUTER` | `14.3` | `Figure 14.3.1` | Outer | `quickcheck` | `100` | `O14-RED-OUTER` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-QUANT-ELIM` | `14.3` | `Figure 14.3.1` | Quant-Elim | `quickcheck` | `100` | `O14-RED-QUANT-ELIM` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-QUANT-INTRO` | `14.3` | `Figure 14.3.1` | Quant-Intro | `quickcheck` | `100` | `O14-RED-QUANT-INTRO` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-REFLEX` | `14.3` | `Figure 14.3.1` | Reflex | `quickcheck` | `100` | `O14-RED-REFLEX` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
+| `O14-RED-TRANS` | `14.3` | `Figure 14.3.1` | Trans | `quickcheck` | `100` | `O14-RED-TRANS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PRESERVATION`, `CLM-REDUCTION-RULES` |
 
 ## Chapter 15
 
-| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |
-|---|---|---|---|---|---|---|
-| `O15-TRANS-ARROW-RIGID` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(3) | `O15-TRANS-ARROW-RIGID` | `test/Presolution/EnforcementSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
-| `O15-TRANS-NO-INERT-LOCKED` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(1) | `O15-TRANS-NO-INERT-LOCKED` | `test/Presolution/EnforcementSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
-| `O15-TRANS-NON-INTERIOR-RIGID` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(4) | `O15-TRANS-NON-INTERIOR-RIGID` | `test/Presolution/EnforcementSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
-| `O15-TRANS-SCHEME-ROOT-RIGID` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(2) | `O15-TRANS-SCHEME-ROOT-RIGID` | `test/Presolution/EnforcementSpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
-| `O15-ENV-LAMBDA` | `15.3.3` | `Definition 15.3.6` | Typing environment lambda extension | `O15-ENV-LAMBDA` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-ENV-LET` | `15.3.3` | `Definition 15.3.6` | Typing environment let extension | `O15-ENV-LET` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-ENV-WF` | `15.3.3` | `Property 15.3.7` | Typing environments are well formed | `O15-ENV-WF` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-CONTEXT-FIND` | `15.3.4` | `Computation contexts` | O15-CONTEXT-FIND | `O15-CONTEXT-FIND` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS` |
-| `O15-CONTEXT-REJECT` | `15.3.4` | `Computation contexts` | O15-CONTEXT-REJECT | `O15-CONTEXT-REJECT` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS` |
-| `O15-REORDER-IDENTITY` | `15.3.4` | `Definition 15.3.4` | O15-REORDER-IDENTITY | `O15-REORDER-IDENTITY` | `test/ElaborationSpec.hs` | `CLM-SIGMA-REORDER` |
-| `O15-REORDER-REQUIRED` | `15.3.4` | `Definition 15.3.4` | O15-REORDER-REQUIRED | `O15-REORDER-REQUIRED` | `test/ElaborationSpec.hs` | `CLM-SIGMA-REORDER` |
-| `O15-EDGE-TRANSLATION` | `15.3.5` | `Definition 15.3.12` | O15-EDGE-TRANSLATION | `O15-EDGE-TRANSLATION` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS` |
-| `O15-TR-NODE-GRAFT` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-GRAFT | `O15-TR-NODE-GRAFT` | `test/Presolution/WitnessSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-NODE-MERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-MERGE | `O15-TR-NODE-MERGE` | `test/Presolution/WitnessSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-NODE-RAISE` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-RAISE | `O15-TR-NODE-RAISE` | `test/Presolution/WitnessSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-NODE-RAISEMERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-RAISEMERGE | `O15-TR-NODE-RAISEMERGE` | `test/Presolution/WitnessSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-NODE-WEAKEN` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-WEAKEN | `O15-TR-NODE-WEAKEN` | `test/Presolution/WitnessSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-RIGID-MERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row RIGID-MERGE | `O15-TR-RIGID-MERGE` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-RIGID-RAISE` | `15.3.5` | `Figure 15.3.4` | Trχ row RIGID-RAISE | `O15-TR-RIGID-RAISE` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-RIGID-RAISEMERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row RIGID-RAISEMERGE | `O15-TR-RIGID-RAISEMERGE` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-ROOT-GRAFT` | `15.3.5` | `Figure 15.3.4` | Trχ row ROOT-GRAFT | `O15-TR-ROOT-GRAFT` | `test/Presolution/WitnessSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-ROOT-RAISEMERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row ROOT-RAISEMERGE | `O15-TR-ROOT-RAISEMERGE` | `test/Presolution/MergeEmissionSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-ROOT-WEAKEN` | `15.3.5` | `Figure 15.3.4` | Trχ row ROOT-WEAKEN | `O15-TR-ROOT-WEAKEN` | `test/Presolution/MergeEmissionSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-SEQ-CONS` | `15.3.5` | `Figure 15.3.4` | Trχ row SEQ-CONS | `O15-TR-SEQ-CONS` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-TR-SEQ-EMPTY` | `15.3.5` | `Figure 15.3.4` | Trχ row SEQ-EMPTY | `O15-TR-SEQ-EMPTY` | `test/ElaborationSpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
-| `O15-ELAB-ABS` | `15.3.6` | `Figure 15.3.5` | Elaboration case ABS | `O15-ELAB-ABS` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-ELAB-APP` | `15.3.6` | `Figure 15.3.5` | Elaboration case APP | `O15-ELAB-APP` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-ELAB-LAMBDA-VAR` | `15.3.6` | `Figure 15.3.5` | Elaboration case LAMBDA-VAR | `O15-ELAB-LAMBDA-VAR` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-ELAB-LET` | `15.3.6` | `Figure 15.3.5` | Elaboration case LET | `O15-ELAB-LET` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
-| `O15-ELAB-LET-VAR` | `15.3.6` | `Figure 15.3.5` | Elaboration case LET-VAR | `O15-ELAB-LET-VAR` | `test/ElaborationSpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |
+|---|---|---|---|---|---|---|---|---|
+| `O15-TRANS-ARROW-RIGID` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(3) | `quickcheck` | `100` | `O15-TRANS-ARROW-RIGID` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| `O15-TRANS-NO-INERT-LOCKED` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(1) | `quickcheck` | `100` | `O15-TRANS-NO-INERT-LOCKED` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| `O15-TRANS-NON-INTERIOR-RIGID` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(4) | `quickcheck` | `100` | `O15-TRANS-NON-INTERIOR-RIGID` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| `O15-TRANS-SCHEME-ROOT-RIGID` | `15.2.7` | `Definition 15.2.10` | Definition 15.2.10(2) | `quickcheck` | `100` | `O15-TRANS-SCHEME-ROOT-RIGID` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-TRANSLATABLE-PRESOLUTION` |
+| `O15-ENV-LAMBDA` | `15.3.3` | `Definition 15.3.6` | Typing environment lambda extension | `quickcheck` | `100` | `O15-ENV-LAMBDA` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-ENV-LET` | `15.3.3` | `Definition 15.3.6` | Typing environment let extension | `quickcheck` | `100` | `O15-ENV-LET` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-ENV-WF` | `15.3.3` | `Property 15.3.7` | Typing environments are well formed | `quickcheck` | `100` | `O15-ENV-WF` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-CONTEXT-FIND` | `15.3.4` | `Computation contexts` | O15-CONTEXT-FIND | `quickcheck` | `100` | `O15-CONTEXT-FIND` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS` |
+| `O15-CONTEXT-REJECT` | `15.3.4` | `Computation contexts` | O15-CONTEXT-REJECT | `quickcheck` | `100` | `O15-CONTEXT-REJECT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS` |
+| `O15-REORDER-IDENTITY` | `15.3.4` | `Definition 15.3.4` | O15-REORDER-IDENTITY | `quickcheck` | `100` | `O15-REORDER-IDENTITY` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SIGMA-REORDER` |
+| `O15-REORDER-REQUIRED` | `15.3.4` | `Definition 15.3.4` | O15-REORDER-REQUIRED | `quickcheck` | `100` | `O15-REORDER-REQUIRED` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-SIGMA-REORDER` |
+| `O15-EDGE-TRANSLATION` | `15.3.5` | `Definition 15.3.12` | O15-EDGE-TRANSLATION | `quickcheck` | `100` | `O15-EDGE-TRANSLATION` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS` |
+| `O15-TR-NODE-GRAFT` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-GRAFT | `quickcheck` | `100` | `O15-TR-NODE-GRAFT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-NODE-MERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-MERGE | `quickcheck` | `100` | `O15-TR-NODE-MERGE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-NODE-RAISE` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-RAISE | `quickcheck` | `100` | `O15-TR-NODE-RAISE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-NODE-RAISEMERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-RAISEMERGE | `quickcheck` | `100` | `O15-TR-NODE-RAISEMERGE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-NODE-WEAKEN` | `15.3.5` | `Figure 15.3.4` | Trχ row NODE-WEAKEN | `quickcheck` | `100` | `O15-TR-NODE-WEAKEN` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-RIGID-MERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row RIGID-MERGE | `quickcheck` | `100` | `O15-TR-RIGID-MERGE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-RIGID-RAISE` | `15.3.5` | `Figure 15.3.4` | Trχ row RIGID-RAISE | `quickcheck` | `100` | `O15-TR-RIGID-RAISE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-RIGID-RAISEMERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row RIGID-RAISEMERGE | `quickcheck` | `100` | `O15-TR-RIGID-RAISEMERGE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-ROOT-GRAFT` | `15.3.5` | `Figure 15.3.4` | Trχ row ROOT-GRAFT | `quickcheck` | `100` | `O15-TR-ROOT-GRAFT` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-ROOT-RAISEMERGE` | `15.3.5` | `Figure 15.3.4` | Trχ row ROOT-RAISEMERGE | `quickcheck` | `100` | `O15-TR-ROOT-RAISEMERGE` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-ROOT-WEAKEN` | `15.3.5` | `Figure 15.3.4` | Trχ row ROOT-WEAKEN | `quickcheck` | `100` | `O15-TR-ROOT-WEAKEN` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-SEQ-CONS` | `15.3.5` | `Figure 15.3.4` | Trχ row SEQ-CONS | `quickcheck` | `100` | `O15-TR-SEQ-CONS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-TR-SEQ-EMPTY` | `15.3.5` | `Figure 15.3.4` | Trχ row SEQ-EMPTY | `quickcheck` | `100` | `O15-TR-SEQ-EMPTY` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-PHI-CORRECTNESS`, `CLM-WITNESS-TRANSLATION` |
+| `O15-ELAB-ABS` | `15.3.6` | `Figure 15.3.5` | Elaboration case ABS | `quickcheck` | `100` | `O15-ELAB-ABS` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-ELAB-APP` | `15.3.6` | `Figure 15.3.5` | Elaboration case APP | `quickcheck` | `100` | `O15-ELAB-APP` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-ELAB-LAMBDA-VAR` | `15.3.6` | `Figure 15.3.5` | Elaboration case LAMBDA-VAR | `quickcheck` | `100` | `O15-ELAB-LAMBDA-VAR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-ELAB-LET` | `15.3.6` | `Figure 15.3.5` | Elaboration case LET | `quickcheck` | `100` | `O15-ELAB-LET` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
+| `O15-ELAB-LET-VAR` | `15.3.6` | `Figure 15.3.5` | Elaboration case LET-VAR | `quickcheck` | `100` | `O15-ELAB-LET-VAR` | `test/Thesis/ObligationPropertySpec.hs` | `CLM-ELABORATION-CORRECTNESS` |
 
 ## Validation Notes
 
 - This file is generated; edit the YAML source instead.
-- Gate enforcement additionally verifies id set, mapping completeness, file/symbol anchors, and executable test anchors.
+- Gate enforcement additionally verifies id set, mapping completeness, code-anchor files, executable test anchors keyed by obligation ID, QuickCheck evidence kind, and minimum property success counts.
+- Code-anchor fragments are navigational labels; QuickCheck property anchors carry the semantic obligation evidence.

--- a/docs/thesis-obligations.yaml
+++ b/docs/thesis-obligations.yaml
@@ -24,7 +24,7 @@ scope:
   - '15.2'
   - '15.3'
   policy: Operational rules only
-  total_expected_obligations: 104
+  total_expected_obligations: 107
 obligations:
 - id: O14-WF-EMPTY
   chapter: 14
@@ -33,14 +33,17 @@ obligations:
   thesis_rule_label: wf-empty
   judgment_or_equation: wf(Γ)
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
-  - "src/MLF/Elab/TypeCheck.hs#freeTypeVarsEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
+  - src/MLF/Elab/TypeCheck.hs#freeTypeVarsEnv
   test_anchor:
     matcher: O14-WF-EMPTY
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped environment well-formedness proxy anchors in typechecker tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-WF-TVAR
   chapter: 14
   section: '14.2'
@@ -48,14 +51,17 @@ obligations:
   thesis_rule_label: wf-tvar
   judgment_or_equation: wf(Γ)
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
-  - "src/MLF/Elab/TypeCheck.hs#freeTypeVarsEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
+  - src/MLF/Elab/TypeCheck.hs#freeTypeVarsEnv
   test_anchor:
     matcher: O14-WF-TVAR
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped environment well-formedness proxy anchors in typechecker tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-WF-VAR
   chapter: 14
   section: '14.2'
@@ -63,14 +69,17 @@ obligations:
   thesis_rule_label: wf-var
   judgment_or_equation: wf(Γ)
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
-  - "src/MLF/Elab/TypeCheck.hs#freeTypeVarsEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
+  - src/MLF/Elab/TypeCheck.hs#freeTypeVarsEnv
   test_anchor:
     matcher: O14-WF-VAR
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped environment well-formedness proxy anchors in typechecker tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-INST-REFLEX
   chapter: 14
   section: 14.2.2
@@ -78,14 +87,17 @@ obligations:
   thesis_rule_label: Inst-Reflex
   judgment_or_equation: 'Γ ⊢ ε : σ ≤ σ'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-REFLEX
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-TRANS
   chapter: 14
   section: 14.2.2
@@ -93,14 +105,17 @@ obligations:
   thesis_rule_label: Inst-Trans
   judgment_or_equation: 'Γ ⊢ ϕ1;ϕ2 : σ1 ≤ σ3'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-TRANS
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-BOT
   chapter: 14
   section: 14.2.2
@@ -108,14 +123,17 @@ obligations:
   thesis_rule_label: Inst-Bot
   judgment_or_equation: 'Γ ⊢ ⊲σ : ⊥ ≤ σ'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-BOT
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-HYP
   chapter: 14
   section: 14.2.2
@@ -123,14 +141,17 @@ obligations:
   thesis_rule_label: Inst-Hyp
   judgment_or_equation: 'Γ ⊢ α⊳ : σ ≤ α'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-HYP
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-INNER
   chapter: 14
   section: 14.2.2
@@ -138,14 +159,17 @@ obligations:
   thesis_rule_label: Inst-Inner
   judgment_or_equation: 'Γ ⊢ ∀(⩾ϕ) : ∀(α⩾σ1)σ ≤ ∀(α⩾σ2)σ'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-INNER
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-OUTER
   chapter: 14
   section: 14.2.2
@@ -153,14 +177,17 @@ obligations:
   thesis_rule_label: Inst-Outer
   judgment_or_equation: 'Γ ⊢ ∀(α⩾)ϕ : ∀(α⩾σ)σ1 ≤ ∀(α⩾σ)σ2'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-OUTER
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-QUANT-ELIM
   chapter: 14
   section: 14.2.2
@@ -168,14 +195,17 @@ obligations:
   thesis_rule_label: Inst-Quant-Elim
   judgment_or_equation: 'Γ ⊢ N : ∀(α⩾σ)σ′ ≤ σ′{α←σ}'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-QUANT-ELIM
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-INST-QUANT-INTRO
   chapter: 14
   section: 14.2.2
@@ -183,14 +213,17 @@ obligations:
   thesis_rule_label: Inst-Quant-Intro
   judgment_or_equation: 'Γ ⊢ O : σ ≤ ∀(α⩾⊥)σ'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#checkInstantiation"
-  - "src/MLF/Elab/Inst.hs#evalInstantiationWith"
+  - src/MLF/Elab/TypeCheck.hs#checkInstantiation
+  - src/MLF/Elab/Inst.hs#evalInstantiationWith
   test_anchor:
     matcher: O14-INST-QUANT-INTRO
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped instantiation-rule anchor test exercises the checker path.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-CORRECTNESS]
+  supports_claims:
+  - CLM-INST-CORRECTNESS
 - id: O14-T-VAR
   chapter: 14
   section: 14.2.3
@@ -198,13 +231,16 @@ obligations:
   thesis_rule_label: Var
   judgment_or_equation: 'Γ ⊢ x : σ'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
   test_anchor:
     matcher: O14-T-VAR
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped typing-rule anchor test validates all Figure 14.2.8 cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-T-ABS
   chapter: 14
   section: 14.2.3
@@ -212,13 +248,16 @@ obligations:
   thesis_rule_label: Abs
   judgment_or_equation: 'Γ ⊢ λ(x:σ)a : σ→σ′'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
   test_anchor:
     matcher: O14-T-ABS
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped typing-rule anchor test validates all Figure 14.2.8 cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-T-APP
   chapter: 14
   section: 14.2.3
@@ -226,13 +265,16 @@ obligations:
   thesis_rule_label: App
   judgment_or_equation: 'Γ ⊢ a1 a2 : σ1'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
   test_anchor:
     matcher: O14-T-APP
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped typing-rule anchor test validates all Figure 14.2.8 cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-T-TABS
   chapter: 14
   section: 14.2.3
@@ -240,13 +282,16 @@ obligations:
   thesis_rule_label: TAbs
   judgment_or_equation: 'Γ ⊢ Λ(α⩾σ′)a : ∀(α⩾σ′)σ'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
   test_anchor:
     matcher: O14-T-TABS
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped typing-rule anchor test validates all Figure 14.2.8 cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-T-TAPP
   chapter: 14
   section: 14.2.3
@@ -254,13 +299,16 @@ obligations:
   thesis_rule_label: TApp
   judgment_or_equation: 'Γ ⊢ a[ϕ] : σ′'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
   test_anchor:
     matcher: O14-T-TAPP
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped typing-rule anchor test validates all Figure 14.2.8 cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-T-LET
   chapter: 14
   section: 14.2.3
@@ -268,13 +316,16 @@ obligations:
   thesis_rule_label: Let
   judgment_or_equation: 'Γ ⊢ let x=a in a′ : σ′'
   code_anchors:
-  - "src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv"
+  - src/MLF/Elab/TypeCheck.hs#typeCheckWithEnv
   test_anchor:
     matcher: O14-T-LET
-    file: "test/TypeCheckSpec.hs"
-    rationale: Grouped typing-rule anchor test validates all Figure 14.2.8 cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF typechecking over generated typed term witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TYPING-RULES]
+  supports_claims:
+  - CLM-TYPING-RULES
 - id: O14-RED-BETA
   chapter: 14
   section: '14.3'
@@ -282,15 +333,18 @@ obligations:
   thesis_rule_label: "(β)"
   judgment_or_equation: "(λ(x:σ)a1) a2 → a1{x←a2}"
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-BETA
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-BETALET
   chapter: 14
   section: '14.3'
@@ -298,15 +352,18 @@ obligations:
   thesis_rule_label: "(βLet)"
   judgment_or_equation: let x = a2 in a1 → a1{x←a2}
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-BETALET
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-REFLEX
   chapter: 14
   section: '14.3'
@@ -314,15 +371,18 @@ obligations:
   thesis_rule_label: Reflex
   judgment_or_equation: a[ε] → a
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-REFLEX
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-TRANS
   chapter: 14
   section: '14.3'
@@ -330,15 +390,18 @@ obligations:
   thesis_rule_label: Trans
   judgment_or_equation: a[ϕ;ϕ′] → a[ϕ][ϕ′]
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-TRANS
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-QUANT-INTRO
   chapter: 14
   section: '14.3'
@@ -346,15 +409,18 @@ obligations:
   thesis_rule_label: Quant-Intro
   judgment_or_equation: a[O] → Λ(α⩾⊥)a
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-QUANT-INTRO
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-QUANT-ELIM
   chapter: 14
   section: '14.3'
@@ -362,15 +428,18 @@ obligations:
   thesis_rule_label: Quant-Elim
   judgment_or_equation: "(Λ(α⩾σ)a)[N] → a{α⊳←ε}{α←σ}"
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-QUANT-ELIM
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-INNER
   chapter: 14
   section: '14.3'
@@ -378,15 +447,18 @@ obligations:
   thesis_rule_label: Inner
   judgment_or_equation: "(Λ(α⩾σ)a)[∀(⩾ϕ)] → Λ(α⩾σ[ϕ])a{α⊳←ϕ;α⊳}"
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-INNER
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-OUTER
   chapter: 14
   section: '14.3'
@@ -394,15 +466,18 @@ obligations:
   thesis_rule_label: Outer
   judgment_or_equation: "(Λ(α⩾σ)a)[∀(α⩾)ϕ] → Λ(α⩾σ)(a[ϕ])"
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-OUTER
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-RED-CONTEXT
   chapter: 14
   section: '14.3'
@@ -410,15 +485,18 @@ obligations:
   thesis_rule_label: Context
   judgment_or_equation: if a→a′ then E{a}→E{a′}
   code_anchors:
-  - "src/MLF/Elab/Reduce.hs#step"
-  - "src/MLF/Elab/Reduce.hs#reduceInst"
+  - src/MLF/Elab/Reduce.hs#step
+  - src/MLF/Elab/Reduce.hs#reduceInst
   test_anchor:
     matcher: O14-RED-CONTEXT
-    file: "test/ReduceSpec.hs"
-    rationale: Grouped reduction anchor test covers expression + type-reduction steps
-      and erasure proxy.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF reduction/progress proxies over reducible typed terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PRESERVATION, CLM-REDUCTION-RULES]
+  supports_claims:
+  - CLM-PRESERVATION
+  - CLM-REDUCTION-RULES
 - id: O14-APPLY-N
   chapter: 14
   section: 14.2.2.2
@@ -426,13 +504,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: "(∀(α⩾σ)σ′)[N]=σ′{α←σ}"
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-N
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-O
   chapter: 14
   section: 14.2.2.2
@@ -440,13 +521,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: σ[O]=∀(α⩾⊥)σ
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-O
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-SEQ
   chapter: 14
   section: 14.2.2.2
@@ -454,13 +538,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: σ[ϕ1;ϕ2]=(σ[ϕ1])[ϕ2]
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-SEQ
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-INNER
   chapter: 14
   section: 14.2.2.2
@@ -468,13 +555,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: "(∀(α⩾σ)σ′)[∀(⩾ϕ)]=∀(α⩾σ[ϕ])σ′"
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-INNER
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-OUTER
   chapter: 14
   section: 14.2.2.2
@@ -482,13 +572,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: "(∀(α⩾σ)σ′)[∀(α⩾)ϕ]=∀(α⩾σ)σ′[ϕ]"
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-OUTER
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-HYP
   chapter: 14
   section: 14.2.2.2
@@ -496,13 +589,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: σ[α⊳]=α
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-HYP
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-BOT
   chapter: 14
   section: 14.2.2.2
@@ -510,13 +606,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: "⊥[⊲σ]=σ"
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-BOT
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O14-APPLY-ID
   chapter: 14
   section: 14.2.2.2
@@ -524,13 +623,16 @@ obligations:
   thesis_rule_label: Type computation application
   judgment_or_equation: σ[ε]=σ
   code_anchors:
-  - "src/MLF/Elab/Inst.hs#applyInstantiation"
+  - src/MLF/Elab/Inst.hs#applyInstantiation
   test_anchor:
     matcher: O14-APPLY-ID
-    file: "test/ElaborationSpec.hs"
-    rationale: applyInstantiation semantics anchors for Figure 14.2.7 equations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises xMLF instantiation application over polymorphic type witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-INST-APPLICATION]
+  supports_claims:
+  - CLM-INST-APPLICATION
 - id: O15-TRANS-NO-INERT-LOCKED
   chapter: 15
   section: 15.2.7
@@ -538,13 +640,16 @@ obligations:
   thesis_rule_label: Definition 15.2.10(1)
   judgment_or_equation: χp contains no inert-locked nodes
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution"
+  - src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution
   test_anchor:
     matcher: O15-TRANS-NO-INERT-LOCKED
-    file: "test/Presolution/EnforcementSpec.hs"
-    rationale: Explicit validation + rigidification anchors for translatability conditions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration as a translatable-presolution proxy.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O15-TRANS-SCHEME-ROOT-RIGID
   chapter: 15
   section: 15.2.7
@@ -552,13 +657,16 @@ obligations:
   thesis_rule_label: Definition 15.2.10(2)
   judgment_or_equation: non-degenerate type scheme roots are rigid
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution"
+  - src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution
   test_anchor:
     matcher: O15-TRANS-SCHEME-ROOT-RIGID
-    file: "test/Presolution/EnforcementSpec.hs"
-    rationale: Explicit validation + rigidification anchors for translatability conditions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration as a translatable-presolution proxy.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O15-TRANS-ARROW-RIGID
   chapter: 15
   section: 15.2.7
@@ -566,13 +674,16 @@ obligations:
   thesis_rule_label: Definition 15.2.10(3)
   judgment_or_equation: application/abstraction arrow nodes are rigid
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution"
+  - src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution
   test_anchor:
     matcher: O15-TRANS-ARROW-RIGID
-    file: "test/Presolution/EnforcementSpec.hs"
-    rationale: Explicit validation + rigidification anchors for translatability conditions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration as a translatable-presolution proxy.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O15-TRANS-NON-INTERIOR-RIGID
   chapter: 15
   section: 15.2.7
@@ -580,13 +691,16 @@ obligations:
   thesis_rule_label: Definition 15.2.10(4)
   judgment_or_equation: non-interior nodes bound on gen nodes are rigid
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution"
+  - src/MLF/Constraint/Presolution/Validation.hs#validateTranslatablePresolution
   test_anchor:
     matcher: O15-TRANS-NON-INTERIOR-RIGID
-    file: "test/Presolution/EnforcementSpec.hs"
-    rationale: Explicit validation + rigidification anchors for translatability conditions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration as a translatable-presolution proxy.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O15-REORDER-REQUIRED
   chapter: 15
   section: 15.3.4
@@ -594,15 +708,18 @@ obligations:
   thesis_rule_label: O15-REORDER-REQUIRED
   judgment_or_equation: ϕR is applied when Typ(a′) and Typexp(a′) differ
   code_anchors:
-  - "src/MLF/Elab/Pipeline.hs#sigmaReorder"
-  - "src/MLF/Elab/Phi/Context.hs#contextToNodeBound"
-  - "src/MLF/Elab/Sigma.hs#sigmaReorder"
+  - src/MLF/Elab/Pipeline.hs#sigmaReorder
+  - src/MLF/Elab/Phi/Context.hs#contextToNodeBound
+  - src/MLF/Elab/Sigma.hs#sigmaReorder
   test_anchor:
     matcher: O15-REORDER-REQUIRED
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct Φ/Σ/context anchors in elaboration tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises Sigma quantifier reordering and replayable instantiation output.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SIGMA-REORDER]
+  supports_claims:
+  - CLM-SIGMA-REORDER
 - id: O15-REORDER-IDENTITY
   chapter: 15
   section: 15.3.4
@@ -610,15 +727,18 @@ obligations:
   thesis_rule_label: O15-REORDER-IDENTITY
   judgment_or_equation: ϕR = ε when binder ordering already matches
   code_anchors:
-  - "src/MLF/Elab/Pipeline.hs#sigmaReorder"
-  - "src/MLF/Elab/Phi/Context.hs#contextToNodeBound"
-  - "src/MLF/Elab/Sigma.hs#sigmaReorder"
+  - src/MLF/Elab/Pipeline.hs#sigmaReorder
+  - src/MLF/Elab/Phi/Context.hs#contextToNodeBound
+  - src/MLF/Elab/Sigma.hs#sigmaReorder
   test_anchor:
     matcher: O15-REORDER-IDENTITY
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct Φ/Σ/context anchors in elaboration tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises Sigma quantifier reordering and replayable instantiation output.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SIGMA-REORDER]
+  supports_claims:
+  - CLM-SIGMA-REORDER
 - id: O15-CONTEXT-FIND
   chapter: 15
   section: 15.3.4
@@ -626,15 +746,18 @@ obligations:
   thesis_rule_label: O15-CONTEXT-FIND
   judgment_or_equation: C^{r→n} is found for reachable/translatable targets
   code_anchors:
-  - "src/MLF/Elab/Pipeline.hs#contextToNodeBound"
-  - "src/MLF/Elab/Phi/Context.hs#contextToNodeBound"
-  - "src/MLF/Elab/Sigma.hs#sigmaReorder"
+  - src/MLF/Elab/Pipeline.hs#contextToNodeBound
+  - src/MLF/Elab/Phi/Context.hs#contextToNodeBound
+  - src/MLF/Elab/Sigma.hs#sigmaReorder
   test_anchor:
     matcher: O15-CONTEXT-FIND
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct Φ/Σ/context anchors in elaboration tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises binding-path context discovery for accepted and rejected contexts.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
 - id: O15-CONTEXT-REJECT
   chapter: 15
   section: 15.3.4
@@ -642,15 +765,18 @@ obligations:
   thesis_rule_label: O15-CONTEXT-REJECT
   judgment_or_equation: Context search rejects fallback-only/non-translatable targets
   code_anchors:
-  - "src/MLF/Elab/Pipeline.hs#contextToNodeBound"
-  - "src/MLF/Elab/Phi/Context.hs#contextToNodeBound"
-  - "src/MLF/Elab/Sigma.hs#sigmaReorder"
+  - src/MLF/Elab/Pipeline.hs#contextToNodeBound
+  - src/MLF/Elab/Phi/Context.hs#contextToNodeBound
+  - src/MLF/Elab/Sigma.hs#sigmaReorder
   test_anchor:
     matcher: O15-CONTEXT-REJECT
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct Φ/Σ/context anchors in elaboration tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises binding-path context discovery for accepted and rejected contexts.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
 - id: O15-EDGE-TRANSLATION
   chapter: 15
   section: 15.3.5
@@ -658,15 +784,18 @@ obligations:
   thesis_rule_label: O15-EDGE-TRANSLATION
   judgment_or_equation: Translate edge witness into xMLF instantiation
   code_anchors:
-  - "src/MLF/Elab/Pipeline.hs#phiFromEdgeWitnessWithTrace"
-  - "src/MLF/Elab/Phi/Context.hs#contextToNodeBound"
-  - "src/MLF/Elab/Sigma.hs#sigmaReorder"
+  - src/MLF/Elab/Pipeline.hs#phiFromEdgeWitnessWithTrace
+  - src/MLF/Elab/Phi/Context.hs#contextToNodeBound
+  - src/MLF/Elab/Sigma.hs#sigmaReorder
   test_anchor:
     matcher: O15-EDGE-TRANSLATION
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct Φ/Σ/context anchors in elaboration tests.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
 - id: O15-ELAB-LAMBDA-VAR
   chapter: 15
   section: 15.3.6
@@ -674,13 +803,16 @@ obligations:
   thesis_rule_label: Elaboration case LAMBDA-VAR
   judgment_or_equation: T(x) for λ-bound variables
   code_anchors:
-  - "src/MLF/Elab/Elaborate.hs#elaborate"
+  - src/MLF/Elab/Elaborate.hs#elaborate
   test_anchor:
     matcher: O15-ELAB-LAMBDA-VAR
-    file: "test/ElaborationSpec.hs"
-    rationale: Surface elaboration anchors for Figure 15.3.5 case split.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ELAB-LET-VAR
   chapter: 15
   section: 15.3.6
@@ -688,13 +820,16 @@ obligations:
   thesis_rule_label: Elaboration case LET-VAR
   judgment_or_equation: T(x) for let-bound variables
   code_anchors:
-  - "src/MLF/Elab/Elaborate.hs#elaborate"
+  - src/MLF/Elab/Elaborate.hs#elaborate
   test_anchor:
     matcher: O15-ELAB-LET-VAR
-    file: "test/ElaborationSpec.hs"
-    rationale: Surface elaboration anchors for Figure 15.3.5 case split.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ELAB-ABS
   chapter: 15
   section: 15.3.6
@@ -702,13 +837,16 @@ obligations:
   thesis_rule_label: Elaboration case ABS
   judgment_or_equation: T(λ(x) a)
   code_anchors:
-  - "src/MLF/Elab/Elaborate.hs#elaborate"
+  - src/MLF/Elab/Elaborate.hs#elaborate
   test_anchor:
     matcher: O15-ELAB-ABS
-    file: "test/ElaborationSpec.hs"
-    rationale: Surface elaboration anchors for Figure 15.3.5 case split.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ELAB-APP
   chapter: 15
   section: 15.3.6
@@ -716,13 +854,16 @@ obligations:
   thesis_rule_label: Elaboration case APP
   judgment_or_equation: T(a1 a2)
   code_anchors:
-  - "src/MLF/Elab/Elaborate.hs#elaborate"
+  - src/MLF/Elab/Elaborate.hs#elaborate
   test_anchor:
     matcher: O15-ELAB-APP
-    file: "test/ElaborationSpec.hs"
-    rationale: Surface elaboration anchors for Figure 15.3.5 case split.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ELAB-LET
   chapter: 15
   section: 15.3.6
@@ -730,13 +871,16 @@ obligations:
   thesis_rule_label: Elaboration case LET
   judgment_or_equation: T(let x = a in b)
   code_anchors:
-  - "src/MLF/Elab/Elaborate.hs#elaborate"
+  - src/MLF/Elab/Elaborate.hs#elaborate
   test_anchor:
     matcher: O15-ELAB-LET
-    file: "test/ElaborationSpec.hs"
-    rationale: Surface elaboration anchors for Figure 15.3.5 case split.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ENV-LAMBDA
   chapter: 15
   section: 15.3.3
@@ -744,15 +888,18 @@ obligations:
   thesis_rule_label: Typing environment lambda extension
   judgment_or_equation: Γ_{a′} extends with x:S′ for the immediately enclosing λ(x)a′
   code_anchors:
-  - "src/MLF/Elab/Run/Pipeline.hs#runPipelineElab"
-  - "src/MLF/Elab/Elaborate/Scope.hs#scopeRootForNode"
-  - "src/MLF/Elab/Elaborate/Scope.hs#generalizeAtNode"
+  - src/MLF/Elab/Run/Pipeline.hs#runPipelineElab
+  - src/MLF/Elab/Elaborate/Scope.hs#scopeRootForNode
+  - src/MLF/Elab/Elaborate/Scope.hs#generalizeAtNode
   test_anchor:
     matcher: O15-ENV-LAMBDA
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct production-path guard for the lambda case of Definition 15.3.6.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ENV-LET
   chapter: 15
   section: 15.3.3
@@ -760,15 +907,18 @@ obligations:
   thesis_rule_label: Typing environment let extension
   judgment_or_equation: Γ_{a′} extends with x:Typ(b) for the immediately enclosing let x = b in a′
   code_anchors:
-  - "src/MLF/Elab/Run/Pipeline.hs#runPipelineElab"
-  - "src/MLF/Elab/Elaborate/Scope.hs#scopeRootForNode"
-  - "src/MLF/Elab/Elaborate/Scope.hs#generalizeAtNode"
+  - src/MLF/Elab/Run/Pipeline.hs#runPipelineElab
+  - src/MLF/Elab/Elaborate/Scope.hs#scopeRootForNode
+  - src/MLF/Elab/Elaborate/Scope.hs#generalizeAtNode
   test_anchor:
     matcher: O15-ENV-LET
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct production-path guard for the let case of Definition 15.3.6.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-ENV-WF
   chapter: 15
   section: 15.3.3
@@ -776,15 +926,18 @@ obligations:
   thesis_rule_label: Typing environments are well formed
   judgment_or_equation: Γ_{a′} is a well-formed xMLF environment
   code_anchors:
-  - "src/MLF/Elab/Run/Pipeline.hs#runPipelineElab"
-  - "src/MLF/Elab/Elaborate/Scope.hs#generalizeAtNode"
-  - "src/MLF/Elab/Run/Scope.hs#resolveCanonicalScope"
+  - src/MLF/Elab/Run/Pipeline.hs#runPipelineElab
+  - src/MLF/Elab/Elaborate/Scope.hs#generalizeAtNode
+  - src/MLF/Elab/Run/Scope.hs#resolveCanonicalScope
   test_anchor:
     matcher: O15-ENV-WF
-    file: "test/ElaborationSpec.hs"
-    rationale: Direct production-path guard that recovered live-path environment entries remain well-scoped.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises checked elaboration and xMLF typechecking over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O15-TR-SEQ-EMPTY
   chapter: 15
   section: 15.3.5
@@ -792,15 +945,18 @@ obligations:
   thesis_rule_label: Trχ row SEQ-EMPTY
   judgment_or_equation: Trχ() = ε
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-SEQ-EMPTY
-    file: "test/ElaborationSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-SEQ-CONS
   chapter: 15
   section: 15.3.5
@@ -808,15 +964,18 @@ obligations:
   thesis_rule_label: Trχ row SEQ-CONS
   judgment_or_equation: Trχ(o;I) = Trχ(o);Tro(χ)(I)
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-SEQ-CONS
-    file: "test/ElaborationSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-RIGID-RAISE
   chapter: 15
   section: 15.3.5
@@ -824,15 +983,18 @@ obligations:
   thesis_rule_label: Trχ row RIGID-RAISE
   judgment_or_equation: Rigid Raise translates to ε under rigid condition
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-RIGID-RAISE
-    file: "test/ElaborationSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-RIGID-MERGE
   chapter: 15
   section: 15.3.5
@@ -840,15 +1002,18 @@ obligations:
   thesis_rule_label: Trχ row RIGID-MERGE
   judgment_or_equation: Rigid Merge translates to ε under rigid condition
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-RIGID-MERGE
-    file: "test/ElaborationSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-RIGID-RAISEMERGE
   chapter: 15
   section: 15.3.5
@@ -856,15 +1021,18 @@ obligations:
   thesis_rule_label: Trχ row RIGID-RAISEMERGE
   judgment_or_equation: Rigid RaiseMerge translates to ε under rigid condition
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-RIGID-RAISEMERGE
-    file: "test/ElaborationSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-ROOT-GRAFT
   chapter: 15
   section: 15.3.5
@@ -872,15 +1040,18 @@ obligations:
   thesis_rule_label: Trχ row ROOT-GRAFT
   judgment_or_equation: Root Graft translates to ⊲S(τ)
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-ROOT-GRAFT
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-ROOT-RAISEMERGE
   chapter: 15
   section: 15.3.5
@@ -888,15 +1059,18 @@ obligations:
   thesis_rule_label: Trχ row ROOT-RAISEMERGE
   judgment_or_equation: Root RaiseMerge translates to abstraction
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-ROOT-RAISEMERGE
-    file: "test/Presolution/MergeEmissionSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-ROOT-WEAKEN
   chapter: 15
   section: 15.3.5
@@ -904,15 +1078,18 @@ obligations:
   thesis_rule_label: Trχ row ROOT-WEAKEN
   judgment_or_equation: Root Weaken translates to ε
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-ROOT-WEAKEN
-    file: "test/Presolution/MergeEmissionSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-NODE-GRAFT
   chapter: 15
   section: 15.3.5
@@ -920,15 +1097,18 @@ obligations:
   thesis_rule_label: Trχ row NODE-GRAFT
   judgment_or_equation: Node Graft translates through C^{r→n}(∀(⩾⊲S(τ)))
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-NODE-GRAFT
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-NODE-MERGE
   chapter: 15
   section: 15.3.5
@@ -936,15 +1116,18 @@ obligations:
   thesis_rule_label: Trχ row NODE-MERGE
   judgment_or_equation: Node Merge translates through C^{r→n}(∀(⩾αn′⊳);N)
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-NODE-MERGE
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-NODE-RAISEMERGE
   chapter: 15
   section: 15.3.5
@@ -952,15 +1135,18 @@ obligations:
   thesis_rule_label: Trχ row NODE-RAISEMERGE
   judgment_or_equation: Node RaiseMerge translation mirrors merge context path
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-NODE-RAISEMERGE
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-NODE-WEAKEN
   chapter: 15
   section: 15.3.5
@@ -968,15 +1154,18 @@ obligations:
   thesis_rule_label: Trχ row NODE-WEAKEN
   judgment_or_equation: Node Weaken translates through C^{r→n}(N)
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-NODE-WEAKEN
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O15-TR-NODE-RAISE
   chapter: 15
   section: 15.3.5
@@ -984,16 +1173,18 @@ obligations:
   thesis_rule_label: Trχ row NODE-RAISE
   judgment_or_equation: Node Raise translates via O/inside/under context composition
   code_anchors:
-  - "src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega"
-  - "src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget"
+  - src/MLF/Elab/Phi/Omega.hs#phiWithSchemeOmega
+  - src/MLF/Elab/Phi/Omega/Domain.hs#resolveTraceBinderTarget
   test_anchor:
     matcher: O15-TR-NODE-RAISE
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Mapped to row-labeled R-* witness/merge tests and Φ/Ω rigid/sequence
-      regressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises witness-to-elaboration pipeline evidence over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-PHI-CORRECTNESS, CLM-WITNESS-TRANSLATION]
-# ── Chapter 4: Binding Trees & Graph Operations ──
+  supports_claims:
+  - CLM-PHI-CORRECTNESS
+  - CLM-WITNESS-TRANSLATION
 - id: O04-BIND-FLEX-CHILDREN
   chapter: 4
   section: 4.2
@@ -1001,13 +1192,16 @@ obligations:
   thesis_rule_label: Q(n) flex children
   judgment_or_equation: Q(n) returns the set of flexibly-bound children of node n
   code_anchors:
-  - "src/MLF/Binding/Tree.hs#boundFlexChildren"
+  - src/MLF/Binding/Tree.hs#boundFlexChildren
   test_anchor:
     matcher: O04-BIND-FLEX-CHILDREN
-    file: "test/BindingSpec.hs"
-    rationale: Exercises boundFlexChildren on a constraint with mixed flex/rigid bindings.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises binding-tree binder enumeration Q(n) over generated binder regions.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE]
+  supports_claims:
+  - CLM-CGEN-SHAPE
 - id: O04-BIND-INTERIOR
   chapter: 4
   section: 4.2
@@ -1015,13 +1209,16 @@ obligations:
   thesis_rule_label: I(r) interior
   judgment_or_equation: I(r) computes the interior of a node r in the binding tree
   code_anchors:
-  - "src/MLF/Binding/Queries.hs#interiorOf"
+  - src/MLF/Binding/Queries.hs#interiorOf
   test_anchor:
     matcher: O04-BIND-INTERIOR
-    file: "test/BindingSpec.hs"
-    rationale: Exercises interiorOf on a rooted constraint and checks membership.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises binding-tree interior I(r) membership over generated binding paths.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE]
+  supports_claims:
+  - CLM-CGEN-SHAPE
 - id: O04-BIND-ORDER
   chapter: 4
   section: 4.2
@@ -1029,13 +1226,16 @@ obligations:
   thesis_rule_label: Binder ordering ≺
   judgment_or_equation: orderedBinders returns binders in ≺ order
   code_anchors:
-  - "src/MLF/Binding/Tree.hs#orderedBinders"
+  - src/MLF/Binding/Tree.hs#orderedBinders
   test_anchor:
     matcher: O04-BIND-ORDER
-    file: "test/BindingSpec.hs"
-    rationale: Exercises orderedBinders and checks the returned list is non-empty.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises paper binding order over generated well-formed binding trees.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE]
+  supports_claims:
+  - CLM-CGEN-SHAPE
 - id: O04-OP-WEAKEN
   chapter: 4
   section: 4.4
@@ -1043,13 +1243,16 @@ obligations:
   thesis_rule_label: Weaken(n)
   judgment_or_equation: applyWeaken changes a flex binding to rigid
   code_anchors:
-  - "src/MLF/Binding/GraphOps.hs#applyWeaken"
+  - src/MLF/Binding/GraphOps.hs#applyWeaken
   test_anchor:
     matcher: O04-OP-WEAKEN
-    file: "test/GraphOpsSpec.hs"
-    rationale: Exercises applyWeaken and verifies the binding flag changes.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises Weaken(n) flag transition while preserving binding-tree validity.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE]
+  supports_claims:
+  - CLM-CGEN-SHAPE
 - id: O04-OP-RAISE-STEP
   chapter: 4
   section: 4.4
@@ -1057,13 +1260,16 @@ obligations:
   thesis_rule_label: Raise(n) single step
   judgment_or_equation: applyRaiseStep raises a node one level in the binding tree
   code_anchors:
-  - "src/MLF/Binding/GraphOps.hs#applyRaiseStep"
+  - src/MLF/Binding/GraphOps.hs#applyRaiseStep
   test_anchor:
     matcher: O04-OP-RAISE-STEP
-    file: "test/GraphOpsSpec.hs"
-    rationale: Exercises applyRaiseStep and verifies the node moves up one level.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises one-step Raise(n) movement while preserving binding-tree validity.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE]
+  supports_claims:
+  - CLM-CGEN-SHAPE
 - id: O04-OP-RAISE-TO
   chapter: 4
   section: 4.4
@@ -1071,14 +1277,16 @@ obligations:
   thesis_rule_label: Raise-to-target
   judgment_or_equation: applyRaiseTo raises a node to a specified target binder
   code_anchors:
-  - "src/MLF/Binding/GraphOps.hs#applyRaiseTo"
+  - src/MLF/Binding/GraphOps.hs#applyRaiseTo
   test_anchor:
     matcher: O04-OP-RAISE-TO
-    file: "test/GraphOpsSpec.hs"
-    rationale: Exercises applyRaiseTo and verifies the node reaches the target.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises repeated Raise-to-target movement while preserving binding-tree validity.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE]
-# ── Chapter 5: Inert Node Classification ──
+  supports_claims:
+  - CLM-CGEN-SHAPE
 - id: O05-INERT-NODES
   chapter: 5
   section: 5.2
@@ -1086,13 +1294,16 @@ obligations:
   thesis_rule_label: Inert nodes
   judgment_or_equation: inertNodes classifies nodes that do not expose polymorphism
   code_anchors:
-  - "src/MLF/Constraint/Inert.hs#inertNodes"
+  - src/MLF/Constraint/Inert.hs#inertNodes
   test_anchor:
     matcher: O05-INERT-NODES
-    file: "test/InertSpec.hs"
-    rationale: Exercises inertNodes on a monomorphic constraint and checks non-empty.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises inert-node classification over generated inertness witnesses.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O05-INERT-LOCKED
   chapter: 5
   section: 5.2
@@ -1100,13 +1311,16 @@ obligations:
   thesis_rule_label: Inert-locked nodes
   judgment_or_equation: inertLockedNodes identifies inert + flexibly bound + rigid ancestor
   code_anchors:
-  - "src/MLF/Constraint/Inert.hs#inertLockedNodes"
+  - src/MLF/Constraint/Inert.hs#inertLockedNodes
   test_anchor:
     matcher: O05-INERT-LOCKED
-    file: "test/InertSpec.hs"
-    rationale: Exercises inertLockedNodes under rigid ancestor and checks membership.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises inert-locked detection for inert nodes below rigid ancestors.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O05-WEAKEN-INERT
   chapter: 5
   section: 5.3
@@ -1114,14 +1328,16 @@ obligations:
   thesis_rule_label: Weaken inert-locked
   judgment_or_equation: weakenInertLockedNodes eliminates inert-locked nodes
   code_anchors:
-  - "src/MLF/Constraint/Inert.hs#weakenInertLockedNodes"
+  - src/MLF/Constraint/Inert.hs#weakenInertLockedNodes
   test_anchor:
     matcher: O05-WEAKEN-INERT
-    file: "test/InertSpec.hs"
-    rationale: Exercises weakenInertLockedNodes and verifies empty inert-locked set.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises weakening of inert-locked nodes until none remain.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-TRANSLATABLE-PRESOLUTION]
-# ── Chapter 7: Unification ──
+  supports_claims:
+  - CLM-TRANSLATABLE-PRESOLUTION
 - id: O07-UNIF-CORE
   chapter: 7
   section: 7.3
@@ -1129,13 +1345,16 @@ obligations:
   thesis_rule_label: Core unification
   judgment_or_equation: processUnifyEdgesWith implements structural unification
   code_anchors:
-  - "src/MLF/Constraint/Unify/Core.hs#processUnifyEdgesWith"
+  - src/MLF/Constraint/Unify/Core.hs#processUnifyEdgesWith
   test_anchor:
     matcher: O07-UNIF-CORE
-    file: "test/NormalizeSpec.hs"
-    rationale: Exercises unification through normalize pipeline on arrow constraints.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises structural unification decomposition for same-head type nodes.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-UNIFICATION]
+  supports_claims:
+  - CLM-UNIFICATION
 - id: O07-UNIF-PRESOL
   chapter: 7
   section: 7.3
@@ -1143,13 +1362,16 @@ obligations:
   thesis_rule_label: Presolution unify
   judgment_or_equation: unifyAcyclic performs presolution-phase unification
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Unify.hs#unifyAcyclic"
+  - src/MLF/Constraint/Presolution/Unify.hs#unifyAcyclic
   test_anchor:
     matcher: O07-UNIF-PRESOL
-    file: "test/SolveSpec.hs"
-    rationale: Exercises unifyAcyclic through the solve pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises solve-phase variable unification and solved binding-tree validation.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-UNIFICATION]
+  supports_claims:
+  - CLM-UNIFICATION
 - id: O07-REBIND
   chapter: 7
   section: 7.3
@@ -1157,13 +1379,16 @@ obligations:
   thesis_rule_label: Rebind
   judgment_or_equation: harmonizeBindParentsWithTrace rebinds nodes after unification
   code_anchors:
-  - "src/MLF/Binding/Adjustment.hs#harmonizeBindParentsWithTrace"
+  - src/MLF/Binding/Adjustment.hs#harmonizeBindParentsWithTrace
   test_anchor:
     matcher: O07-REBIND
-    file: "test/BindingSpec.hs"
-    rationale: Exercises harmonizeBindParentsWithTrace on a constraint with trace.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises binding LCA harmonization over generated binding paths.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-UNIFICATION]
+  supports_claims:
+  - CLM-UNIFICATION
 - id: O07-GENUNIF
   chapter: 7
   section: '7.6'
@@ -1171,15 +1396,18 @@ obligations:
   thesis_rule_label: Generalized unification
   judgment_or_equation: Batch Rebind after first-order unification in Solve phase
   code_anchors:
-  - "src/MLF/Constraint/Unify/Closure.hs#batchHarmonize"
-  - "src/MLF/Binding/Adjustment.hs#harmonizeBindParentsMulti"
+  - src/MLF/Constraint/Unify/Closure.hs#batchHarmonize
+  - src/MLF/Binding/Adjustment.hs#harmonizeBindParentsMulti
   test_anchor:
-    matcher: "Generalized unification (Ch 7.6)"
-    file: "test/SolveSpec.hs"
-    rationale: Exercises batch harmonize via equivalence classes after worklist drains.
+    matcher: O07-GENUNIF
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises batch equivalence-class unification and representative agreement.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-UNIFICATION, CLM-GEN-UNIFICATION]
-# ── Chapter 8: Reification ──
+  supports_claims:
+  - CLM-UNIFICATION
+  - CLM-GEN-UNIFICATION
 - id: O08-REIFY-TYPE
   chapter: 8
   section: 8.2
@@ -1187,13 +1415,16 @@ obligations:
   thesis_rule_label: Graphic→syntactic
   judgment_or_equation: reifyType converts graphic types to syntactic form
   code_anchors:
-  - "src/MLF/Reify/Core.hs#reifyType"
+  - src/MLF/Reify/Core.hs#reifyType
   test_anchor:
     matcher: O08-REIFY-TYPE
-    file: "test/PipelineSpec.hs"
-    rationale: Exercises reifyType through the pipeline on solved constraints.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises pipeline reification by checking elaborated terms against reified types.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O08-REIFY-NAMES
   chapter: 8
   section: 8.2
@@ -1201,13 +1432,16 @@ obligations:
   thesis_rule_label: Named reification
   judgment_or_equation: reifyTypeWithNames produces named syntactic types
   code_anchors:
-  - "src/MLF/Reify/Core.hs#reifyTypeWithNames"
+  - src/MLF/Reify/Core.hs#reifyTypeWithNames
   test_anchor:
     matcher: O08-REIFY-NAMES
-    file: "test/PipelineSpec.hs"
-    rationale: Exercises reifyTypeWithNames through the pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises pipeline reification by checking elaborated terms against reified types.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O08-BIND-MONO
   chapter: 8
   section: 8.2
@@ -1215,13 +1449,16 @@ obligations:
   thesis_rule_label: B(σ) binding monomorphic subtypes
   judgment_or_equation: normalizeType inlines alias bounds producing restricted types
   code_anchors:
-  - "src/MLF/Frontend/Normalize.hs#normalizeType"
+  - src/MLF/Frontend/Normalize.hs#normalizeType
   test_anchor:
     matcher: O08-BIND-MONO
-    file: "test/PipelineSpec.hs"
-    rationale: Exercises normalizeType alias-bound inlining through the pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises pipeline reification by checking elaborated terms against reified types.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O08-SYN-TO-GRAPH
   chapter: 8
   section: 8.2
@@ -1229,13 +1466,16 @@ obligations:
   thesis_rule_label: G(σ) syntactic to graphic
   judgment_or_equation: internalizeCoercionCopy translates syntactic types to graphic form
   code_anchors:
-  - "src/MLF/Frontend/ConstraintGen/Translate.hs#internalizeCoercionCopy"
+  - src/MLF/Frontend/ConstraintGen/Translate.hs#internalizeCoercionCopy
   test_anchor:
     matcher: O08-SYN-TO-GRAPH
-    file: "test/PipelineSpec.hs"
-    rationale: Exercises syntactic-to-graphic translation via coercion annotations.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises pipeline reification by checking elaborated terms against reified types.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O08-REIFY-INLINE
   chapter: 8
   section: 8.3
@@ -1243,14 +1483,17 @@ obligations:
   thesis_rule_label: Sᵢ(τ) reification with inlining
   judgment_or_equation: shouldInline decides bound inlining during reification
   code_anchors:
-  - "src/MLF/Reify/Core.hs#reifyWith"
-  - "src/MLF/Elab/Types.hs#inlineBoundsForDisplay"
+  - src/MLF/Reify/Core.hs#reifyWith
+  - src/MLF/Elab/Types.hs#inlineBoundsForDisplay
   test_anchor:
     matcher: O08-REIFY-INLINE
-    file: "test/PipelineSpec.hs"
-    rationale: Exercises bound inlining during reification.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises pipeline reification by checking elaborated terms against reified types.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O08-INLINE-PRED
   chapter: 8
   section: 8.3
@@ -1258,14 +1501,16 @@ obligations:
   thesis_rule_label: Inline predicate
   judgment_or_equation: inlineBoundsForDisplay applies Inline(τ,n) conditions for display
   code_anchors:
-  - "src/MLF/Elab/Types.hs#inlineBoundsForDisplay"
+  - src/MLF/Elab/Types.hs#inlineBoundsForDisplay
   test_anchor:
     matcher: O08-INLINE-PRED
-    file: "test/PipelineSpec.hs"
-    rationale: Exercises Inline predicate conditions on display types.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises pipeline reification by checking elaborated terms against reified types.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ELABORATION-CORRECTNESS]
-# ── Chapter 9: Constraint Generation ──
+  supports_claims:
+  - CLM-ELABORATION-CORRECTNESS
 - id: O09-CGEN-ROOT
   chapter: 9
   section: 9.4
@@ -1273,13 +1518,17 @@ obligations:
   thesis_rule_label: Root constraint
   judgment_or_equation: buildRootExpr generates the root constraint node
   code_anchors:
-  - "src/MLF/Frontend/ConstraintGen/Translate.hs#buildRootExpr"
+  - src/MLF/Frontend/ConstraintGen/Translate.hs#buildRootExpr
   test_anchor:
     matcher: O09-CGEN-ROOT
-    file: "test/ConstraintGenSpec.hs"
-    rationale: Exercises buildRootExpr and checks root node is present.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises constraint generation shape and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE, CLM-CGEN-SCOPING]
+  supports_claims:
+  - CLM-CGEN-SHAPE
+  - CLM-CGEN-SCOPING
 - id: O09-CGEN-EXPR
   chapter: 9
   section: 9.4
@@ -1287,14 +1536,17 @@ obligations:
   thesis_rule_label: Expr constraint
   judgment_or_equation: buildExpr generates constraint nodes for expressions
   code_anchors:
-  - "src/MLF/Frontend/ConstraintGen/Translate.hs#buildExpr"
+  - src/MLF/Frontend/ConstraintGen/Translate.hs#buildExpr
   test_anchor:
     matcher: O09-CGEN-EXPR
-    file: "test/ConstraintGenSpec.hs"
-    rationale: Exercises buildExpr on lambda and application expressions.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises constraint generation shape and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-CGEN-SHAPE, CLM-CGEN-SCOPING]
-# ── Chapter 10: Presolutions & Expansion ──
+  supports_claims:
+  - CLM-CGEN-SHAPE
+  - CLM-CGEN-SCOPING
 - id: O10-EXP-DECIDE
   chapter: 10
   section: 10.1
@@ -1302,13 +1554,17 @@ obligations:
   thesis_rule_label: Decide minimal expansion
   judgment_or_equation: decideMinimalExpansion selects the minimal expansion for an edge
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Expansion.hs#decideMinimalExpansion"
+  - src/MLF/Constraint/Presolution/Expansion.hs#decideMinimalExpansion
   test_anchor:
     matcher: O10-EXP-DECIDE
-    file: "test/Presolution/ExpansionSpec.hs"
-    rationale: Exercises decideMinimalExpansion on identity and instantiate cases.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-EXPANSION-MINIMALITY, CLM-PRESOLUTION-PRINCIPALITY]
+  supports_claims:
+  - CLM-EXPANSION-MINIMALITY
+  - CLM-PRESOLUTION-PRINCIPALITY
 - id: O10-EXP-APPLY
   chapter: 10
   section: 10.1
@@ -1316,13 +1572,17 @@ obligations:
   thesis_rule_label: Apply expansion
   judgment_or_equation: applyExpansion applies a decided expansion to the constraint
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Expansion.hs#applyExpansion"
+  - src/MLF/Constraint/Presolution/Expansion.hs#applyExpansion
   test_anchor:
     matcher: O10-EXP-APPLY
-    file: "test/Presolution/ExpansionSpec.hs"
-    rationale: Exercises applyExpansion and checks the constraint is updated.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-EXPANSION-MINIMALITY, CLM-PRESOLUTION-PRINCIPALITY]
+  supports_claims:
+  - CLM-EXPANSION-MINIMALITY
+  - CLM-PRESOLUTION-PRINCIPALITY
 - id: O10-PROP-SOLVE
   chapter: 10
   section: 10.3
@@ -1330,13 +1590,17 @@ obligations:
   thesis_rule_label: Propagation rule
   judgment_or_equation: processInstEdge solves a simple instantiation edge
   code_anchors:
-  - "src/MLF/Constraint/Presolution/EdgeProcessing.hs#processInstEdge"
+  - src/MLF/Constraint/Presolution/EdgeProcessing.hs#processInstEdge
   test_anchor:
     matcher: O10-PROP-SOLVE
-    file: "test/Presolution/EdgeTraceSpec.hs"
-    rationale: Exercises processInstEdge on a var-to-base instantiation edge.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-EXPANSION-MINIMALITY, CLM-PRESOLUTION-PRINCIPALITY]
+  supports_claims:
+  - CLM-EXPANSION-MINIMALITY
+  - CLM-PRESOLUTION-PRINCIPALITY
 - id: O10-PROP-WITNESS
   chapter: 10
   section: 10.3
@@ -1344,13 +1608,17 @@ obligations:
   thesis_rule_label: Edge witness recording
   judgment_or_equation: processInstEdge records an expansion for the edge
   code_anchors:
-  - "src/MLF/Constraint/Presolution/EdgeProcessing.hs#processInstEdge"
+  - src/MLF/Constraint/Presolution/EdgeProcessing.hs#processInstEdge
   test_anchor:
     matcher: O10-PROP-WITNESS
-    file: "test/Presolution/EdgeTraceSpec.hs"
-    rationale: Exercises processInstEdge and checks expansion is recorded.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-EXPANSION-MINIMALITY, CLM-PRESOLUTION-PRINCIPALITY]
+  supports_claims:
+  - CLM-EXPANSION-MINIMALITY
+  - CLM-PRESOLUTION-PRINCIPALITY
 - id: O10-COPY-SCHEME
   chapter: 10
   section: 10.4
@@ -1358,14 +1626,17 @@ obligations:
   thesis_rule_label: Chi-e scheme copy
   judgment_or_equation: instantiateScheme copies a scheme during expansion
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Copy.hs#instantiateScheme"
+  - src/MLF/Constraint/Presolution/Copy.hs#instantiateScheme
   test_anchor:
     matcher: O10-COPY-SCHEME
-    file: "test/Presolution/InstantiateSpec.hs"
-    rationale: Exercises instantiateScheme on a forall scheme.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-EXPANSION-MINIMALITY, CLM-PRESOLUTION-PRINCIPALITY]
-# ── Chapter 11: Local Transformations ──
+  supports_claims:
+  - CLM-EXPANSION-MINIMALITY
+  - CLM-PRESOLUTION-PRINCIPALITY
 - id: O11-UNIFY-STRUCT
   chapter: 11
   section: 11.2
@@ -1373,13 +1644,16 @@ obligations:
   thesis_rule_label: Structural unify
   judgment_or_equation: unifyStructure performs structural unification during presolution
   code_anchors:
-  - "src/MLF/Constraint/Presolution/EdgeProcessing/Solve.hs#unifyStructure"
+  - src/MLF/Constraint/Presolution/EdgeProcessing/Solve.hs#unifyStructure
   test_anchor:
     matcher: O11-UNIFY-STRUCT
-    file: "test/NormalizeSpec.hs"
-    rationale: Exercises structural unification through the normalize pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises structural unification decomposition for same-head type nodes.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-WITNESS-NORMALIZATION]
+  supports_claims:
+  - CLM-WITNESS-NORMALIZATION
 - id: O11-WITNESS-NORM
   chapter: 11
   section: 11.5
@@ -1387,13 +1661,16 @@ obligations:
   thesis_rule_label: Witness normalization
   judgment_or_equation: normalizeEdgeWitnessesM normalizes edge witnesses
   code_anchors:
-  - "src/MLF/Constraint/Presolution/WitnessNorm.hs#normalizeEdgeWitnessesM"
+  - src/MLF/Constraint/Presolution/WitnessNorm.hs#normalizeEdgeWitnessesM
   test_anchor:
     matcher: O11-WITNESS-NORM
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Exercises normalizeInstanceOpsFull on a trivial op list.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution witness normalization output over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-WITNESS-NORMALIZATION]
+  supports_claims:
+  - CLM-WITNESS-NORMALIZATION
 - id: O11-WITNESS-COALESCE
   chapter: 11
   section: 11.6
@@ -1401,13 +1678,16 @@ obligations:
   thesis_rule_label: Raise;Merge coalescing
   judgment_or_equation: coalesceRaiseMergeWithEnv coalesces adjacent raise+merge
   code_anchors:
-  - "src/MLF/Constraint/Presolution/WitnessCanon.hs#coalesceRaiseMergeWithEnv"
+  - src/MLF/Constraint/Presolution/WitnessCanon.hs#coalesceRaiseMergeWithEnv
   test_anchor:
     matcher: O11-WITNESS-COALESCE
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Exercises coalesceRaiseMergeWithEnv on adjacent raise+merge ops.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution witness normalization output over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-WITNESS-NORMALIZATION]
+  supports_claims:
+  - CLM-WITNESS-NORMALIZATION
 - id: O11-WITNESS-REORDER
   chapter: 11
   section: 11.6
@@ -1415,14 +1695,16 @@ obligations:
   thesis_rule_label: Weaken reordering
   judgment_or_equation: reorderWeakenWithEnv reorders weaken ops
   code_anchors:
-  - "src/MLF/Constraint/Presolution/WitnessCanon.hs#reorderWeakenWithEnv"
+  - src/MLF/Constraint/Presolution/WitnessCanon.hs#reorderWeakenWithEnv
   test_anchor:
     matcher: O11-WITNESS-REORDER
-    file: "test/Presolution/WitnessSpec.hs"
-    rationale: Exercises reorderWeakenWithEnv on a weaken op list.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution witness normalization output over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-WITNESS-NORMALIZATION]
-# ── Chapter 12: Global Algorithm ──
+  supports_claims:
+  - CLM-WITNESS-NORMALIZATION
 - id: O12-SOLVE-UNIFY
   chapter: 12
   section: 12.1
@@ -1430,13 +1712,16 @@ obligations:
   thesis_rule_label: SolveConstraint main
   judgment_or_equation: solveUnify implements the main constraint solving loop
   code_anchors:
-  - "src/MLF/Constraint/Solve.hs#solveUnify"
+  - src/MLF/Constraint/Solve.hs#solveUnify
   test_anchor:
     matcher: O12-SOLVE-UNIFY
-    file: "test/SolveSpec.hs"
-    rationale: Exercises solveUnify on a simple unification constraint.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises solve-phase variable unification and solved binding-tree validation.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-ACYCLIC-CHECK
   chapter: 12
   section: 12.1
@@ -1444,13 +1729,16 @@ obligations:
   thesis_rule_label: Acyclicity check
   judgment_or_equation: checkAcyclicity verifies the constraint graph is acyclic
   code_anchors:
-  - "src/MLF/Constraint/Acyclicity.hs#checkAcyclicity"
+  - src/MLF/Constraint/Acyclicity.hs#checkAcyclicity
   test_anchor:
     matcher: O12-ACYCLIC-CHECK
-    file: "test/AcyclicitySpec.hs"
-    rationale: Exercises checkAcyclicity on acyclic and cyclic graphs.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises acyclicity/topological-order success over generated dependency graphs.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ACYCLICITY]
+  supports_claims:
+  - CLM-ACYCLICITY
 - id: O12-ACYCLIC-TOPO
   chapter: 12
   section: 12.1
@@ -1458,13 +1746,16 @@ obligations:
   thesis_rule_label: Topological sort
   judgment_or_equation: topologicalSort produces a valid topological ordering
   code_anchors:
-  - "src/MLF/Constraint/Acyclicity.hs#topologicalSort"
+  - src/MLF/Constraint/Acyclicity.hs#topologicalSort
   test_anchor:
     matcher: O12-ACYCLIC-TOPO
-    file: "test/AcyclicitySpec.hs"
-    rationale: Exercises topologicalSort and checks ordering validity.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises acyclicity/topological-order success over generated dependency graphs.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-ACYCLICITY]
+  supports_claims:
+  - CLM-ACYCLICITY
 - id: O12-COPY-INST
   chapter: 12
   section: 12.2
@@ -1472,13 +1763,17 @@ obligations:
   thesis_rule_label: Inst-Copy rule
   judgment_or_equation: instantiateSchemeWithTrace copies a scheme with trace recording
   code_anchors:
-  - "src/MLF/Constraint/Presolution/Copy.hs#instantiateSchemeWithTrace"
+  - src/MLF/Constraint/Presolution/Copy.hs#instantiateSchemeWithTrace
   test_anchor:
     matcher: O12-COPY-INST
-    file: "test/Presolution/InstantiateSpec.hs"
-    rationale: Exercises instantiateSchemeWithTrace on a forall scheme.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS, CLM-PRESOLUTION-PRINCIPALITY]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
+  - CLM-PRESOLUTION-PRINCIPALITY
 - id: O12-NORM-GRAFT
   chapter: 12
   section: 12.4
@@ -1486,13 +1781,16 @@ obligations:
   thesis_rule_label: Graft inst edges
   judgment_or_equation: graftInstEdges grafts instantiation edges during normalization
   code_anchors:
-  - "src/MLF/Constraint/Normalize.hs#graftInstEdges"
+  - src/MLF/Constraint/Normalize.hs#graftInstEdges
   test_anchor:
     matcher: O12-NORM-GRAFT
-    file: "test/NormalizeSpec.hs"
-    rationale: Exercises graftInstEdges through the normalize pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises structural unification decomposition for same-head type nodes.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-NORM-MERGE
   chapter: 12
   section: 12.4
@@ -1500,13 +1798,16 @@ obligations:
   thesis_rule_label: Merge unify edges
   judgment_or_equation: mergeUnifyEdges merges unification edges during normalization
   code_anchors:
-  - "src/MLF/Constraint/Normalize.hs#mergeUnifyEdges"
+  - src/MLF/Constraint/Normalize.hs#mergeUnifyEdges
   test_anchor:
     matcher: O12-NORM-MERGE
-    file: "test/NormalizeSpec.hs"
-    rationale: Exercises mergeUnifyEdges through the normalize pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises structural unification decomposition for same-head type nodes.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-NORM-DROP
   chapter: 12
   section: 12.4
@@ -1514,13 +1815,16 @@ obligations:
   thesis_rule_label: Drop reflexive edges
   judgment_or_equation: dropReflexiveInstEdges removes reflexive instantiation edges
   code_anchors:
-  - "src/MLF/Constraint/Normalize.hs#dropReflexiveInstEdges"
+  - src/MLF/Constraint/Normalize.hs#dropReflexiveInstEdges
   test_anchor:
     matcher: O12-NORM-DROP
-    file: "test/NormalizeSpec.hs"
-    rationale: Exercises dropReflexiveInstEdges through the normalize pipeline.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises structural unification decomposition for same-head type nodes.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-NORM-FIXPOINT
   chapter: 12
   section: 12.4
@@ -1528,13 +1832,16 @@ obligations:
   thesis_rule_label: Normalize to fixed point
   judgment_or_equation: normalize iterates normalization to a fixed point
   code_anchors:
-  - "src/MLF/Constraint/Normalize.hs#normalize"
+  - src/MLF/Constraint/Normalize.hs#normalize
   test_anchor:
     matcher: O12-NORM-FIXPOINT
-    file: "test/NormalizeSpec.hs"
-    rationale: Exercises normalize and checks idempotence.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises structural unification decomposition for same-head type nodes.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-SOLVE-VAR-BASE
   chapter: 12
   section: 12.1
@@ -1542,13 +1849,16 @@ obligations:
   thesis_rule_label: Var = Base merge
   judgment_or_equation: solveUnify merges a variable with a base type
   code_anchors:
-  - "src/MLF/Constraint/Solve.hs#solveUnify"
+  - src/MLF/Constraint/Solve.hs#solveUnify
   test_anchor:
     matcher: O12-SOLVE-VAR-BASE
-    file: "test/SolveSpec.hs"
-    rationale: Exercises solveUnify on a var=base unification edge.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises solve-phase variable unification and solved binding-tree validation.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-SOLVE-VAR-VAR
   chapter: 12
   section: 12.1
@@ -1556,13 +1866,16 @@ obligations:
   thesis_rule_label: Var = Var merge
   judgment_or_equation: solveUnify merges two variables
   code_anchors:
-  - "src/MLF/Constraint/Solve.hs#solveUnify"
+  - src/MLF/Constraint/Solve.hs#solveUnify
   test_anchor:
     matcher: O12-SOLVE-VAR-VAR
-    file: "test/SolveSpec.hs"
-    rationale: Exercises solveUnify on a var=var unification edge.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises solve-phase variable unification and solved binding-tree validation.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-SOLVE-HARMONIZE
   chapter: 12
   section: 12.1
@@ -1570,13 +1883,16 @@ obligations:
   thesis_rule_label: Binding harmonization
   judgment_or_equation: solveUnify harmonizes binding parents after merging
   code_anchors:
-  - "src/MLF/Constraint/Solve.hs#solveUnify"
+  - src/MLF/Constraint/Solve.hs#solveUnify
   test_anchor:
     matcher: O12-SOLVE-HARMONIZE
-    file: "test/SolveSpec.hs"
-    rationale: Exercises solveUnify and checks binding harmonization occurs.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises batch equivalence-class unification and representative agreement.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-SOLVE-ARROW
   chapter: 12
   section: 12.1
@@ -1584,13 +1900,16 @@ obligations:
   thesis_rule_label: Arrow decomposition
   judgment_or_equation: solveUnify decomposes arrow types during unification
   code_anchors:
-  - "src/MLF/Constraint/Solve.hs#solveUnify"
+  - src/MLF/Constraint/Solve.hs#solveUnify
   test_anchor:
     matcher: O12-SOLVE-ARROW
-    file: "test/SolveSpec.hs"
-    rationale: Exercises solveUnify on arrow=arrow unification edges.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises solve-phase arrow decomposition and solved binding-tree validation.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS
 - id: O12-SOLVE-VALIDATE
   chapter: 12
   section: 12.1
@@ -1598,10 +1917,13 @@ obligations:
   thesis_rule_label: Post-solve validation
   judgment_or_equation: validateSolvedGraph validates the solved constraint graph
   code_anchors:
-  - "src/MLF/Constraint/Solve.hs#validateSolvedGraph"
+  - src/MLF/Constraint/Solve.hs#validateSolvedGraph
   test_anchor:
     matcher: O12-SOLVE-VALIDATE
-    file: "test/SolveSpec.hs"
-    rationale: Exercises validateSolvedGraph on a solved constraint.
+    file: test/Thesis/ObligationPropertySpec.hs
+    rationale: QuickCheck exercises solve-phase variable unification and solved binding-tree validation.
+    kind: quickcheck
+    min_success: 100
   status: anchored
-  supports_claims: [CLM-SOLVER-CORRECTNESS]
+  supports_claims:
+  - CLM-SOLVER-CORRECTNESS

--- a/docs/thesis-obligations.yaml
+++ b/docs/thesis-obligations.yaml
@@ -1630,7 +1630,7 @@ obligations:
   test_anchor:
     matcher: O10-COPY-SCHEME
     file: test/Thesis/ObligationPropertySpec.hs
-    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    rationale: QuickCheck exercises Chi-e scheme copy by asserting fresh copied roots, preserved shared structure, binder substitution, source graph immutability, and binding-tree validity.
     kind: quickcheck
     min_success: 100
   status: anchored
@@ -1767,7 +1767,7 @@ obligations:
   test_anchor:
     matcher: O12-COPY-INST
     file: test/Thesis/ObligationPropertySpec.hs
-    rationale: QuickCheck exercises presolution completion and binding-tree validity over source terms.
+    rationale: QuickCheck exercises trace-aware Inst-Copy by asserting frontier-to-bottom replacement, interior and copy-map bookkeeping, recorded binder arguments, live trace targets, and binding-tree validity.
     kind: quickcheck
     min_success: 100
   status: anchored

--- a/mlf2.cabal
+++ b/mlf2.cabal
@@ -435,6 +435,7 @@ test-suite mlf2-test
                       SolvedFacadeTestUtil,
                       Parity.FrozenArtifacts,
                       Property.QuickCheckPropertySpec,
+                      Thesis.ObligationPropertySpec,
                       SpecUtil,
                       GoldenSpec,
 

--- a/scripts/check-thesis-claims.sh
+++ b/scripts/check-thesis-claims.sh
@@ -223,9 +223,10 @@ claims.each do |c|
       errors['code-path-file-missing'] << "#{id}: file not found: #{full_path}"
       next
     end
-    # Code path fragments are navigational labels. The claims gate should not
-    # treat a function-name substring as proof; executable obligations and
-    # property tests carry the semantic evidence.
+    contents = File.read(full_path)
+    unless contents.include?(fragment)
+      errors['code-path-fragment-missing'] << "#{id}: navigation fragment #{fragment.inspect} not found in #{full_path}"
+    end
   end
 end
 
@@ -243,7 +244,7 @@ end
 
 puts "[thesis-claims] Schema: #{claims.size} claims, #{deviations.size} deviations"
 puts "[thesis-claims] Cross-links: all obligation/deviation references valid"
-puts "[thesis-claims] Code paths: all files and anchor fragments valid"
+puts "[thesis-claims] Code paths: all files and navigation fragments valid"
 puts "[thesis-claims] Deviations: no open, no orphans"
 RUBY
 

--- a/scripts/check-thesis-claims.sh
+++ b/scripts/check-thesis-claims.sh
@@ -213,16 +213,19 @@ claims.each do |c|
       errors['code-path-format'] << "#{id}: invalid code_path format: #{cp.inspect}"
       next
     end
-    path, symbol = cp.split('#', 2)
+    path, fragment = cp.split('#', 2)
+    if path.to_s.empty? || fragment.to_s.empty?
+      errors['code-path-format'] << "#{id}: invalid code_path format: #{cp.inspect}"
+      next
+    end
     full_path = File.join(root, path)
     unless File.exist?(full_path)
       errors['code-path-file-missing'] << "#{id}: file not found: #{full_path}"
       next
     end
-    contents = File.read(full_path)
-    unless contents.include?(symbol)
-      errors['code-path-symbol-missing'] << "#{id}: symbol #{symbol.inspect} not found in #{full_path}"
-    end
+    # Code path fragments are navigational labels. The claims gate should not
+    # treat a function-name substring as proof; executable obligations and
+    # property tests carry the semantic evidence.
   end
 end
 
@@ -240,7 +243,7 @@ end
 
 puts "[thesis-claims] Schema: #{claims.size} claims, #{deviations.size} deviations"
 puts "[thesis-claims] Cross-links: all obligation/deviation references valid"
-puts "[thesis-claims] Code paths: all files and symbols found"
+puts "[thesis-claims] Code paths: all files and anchor fragments valid"
 puts "[thesis-claims] Deviations: no open, no orphans"
 RUBY
 

--- a/scripts/check-thesis-obligations-ledger.sh
+++ b/scripts/check-thesis-obligations-ledger.sh
@@ -196,14 +196,42 @@ hspec_summary_line() {
 }
 
 quickcheck_pass_count() {
-  ruby - "$1" <<'RUBY'
-path = ARGV.fetch(0)
+  ruby - "$1" "$2" <<'RUBY'
+target_id = ARGV.fetch(0)
+path = ARGV.fetch(1)
 max = 0
+in_evidence_section = false
+watching_target = false
 File.foreach(path) do |line|
   line = line.gsub(/\e\[[0-9;?]*[ -\/]*[@-~]/, '')
-  if line =~ /\+\+\+ OK, passed ([0-9]+) tests?/
+  line = line.chomp
+
+  if line == 'Thesis obligation property evidence'
+    in_evidence_section = true
+    watching_target = false
+    next
+  end
+
+  if in_evidence_section && line =~ /^\S/ && line != 'Thesis obligation property evidence'
+    in_evidence_section = false
+    watching_target = false
+  end
+
+  next unless in_evidence_section
+
+  if line =~ /^  #{Regexp.escape(target_id)} \[[^\]]+\]$/
+    watching_target = true
+    next
+  end
+
+  if watching_target && line =~ /^  \S/
+    watching_target = false
+  end
+
+  if watching_target && line =~ /^    \+\+\+ OK, passed ([0-9]+) tests?/
     count = Regexp.last_match(1).to_i
     max = count if count > max
+    watching_target = false
   end
 end
 puts max
@@ -248,7 +276,7 @@ while IFS=$'\t' read -r id matcher _file min_success; do
   if (( failures != 0 )); then
     test_failures+=("${id}")
   fi
-  quickcheck_passes="$(quickcheck_pass_count "${log_file}")"
+  quickcheck_passes="$(quickcheck_pass_count "${id}" "${log_file}")"
   if (( quickcheck_passes < 1 )); then
     missing_property_success+=("${id}")
   elif (( quickcheck_passes < min_success )); then

--- a/scripts/check-thesis-obligations-ledger.sh
+++ b/scripts/check-thesis-obligations-ledger.sh
@@ -98,9 +98,11 @@ groups = {
   'extra-ids' => [],
   'duplicate-ids' => [],
   'unmapped-rules' => [],
+  'matcher-id-mismatch' => [],
+  'evidence-kind' => [],
+  'min-success' => [],
   'status' => [],
   'missing-files' => [],
-  'missing-symbols' => [],
   'invalid-code-anchors' => []
 }
 
@@ -120,10 +122,20 @@ obligations.each do |o|
   ta = o['test_anchor']
   matcher = ta.is_a?(Hash) ? ta['matcher'].to_s.strip : ''
   test_file = ta.is_a?(Hash) ? ta['file'].to_s.strip : ''
+  kind = ta.is_a?(Hash) ? ta['kind'].to_s.strip : ''
+  min_success = ta.is_a?(Hash) ? ta['min_success'] : nil
   status = o['status'].to_s.strip
 
   if matcher.empty?
     groups['unmapped-rules'] << "#{id}: blank test matcher"
+  elsif matcher != id
+    groups['matcher-id-mismatch'] << "#{id}: test matcher must be the obligation id, got #{matcher.inspect}"
+  end
+  if kind != 'quickcheck'
+    groups['evidence-kind'] << "#{id}: expected test_anchor.kind=quickcheck, got #{kind.inspect}"
+  end
+  unless min_success.is_a?(Integer) && min_success.positive?
+    groups['min-success'] << "#{id}: expected positive integer test_anchor.min_success, got #{min_success.inspect}"
   end
   if test_file.empty?
     groups['unmapped-rules'] << "#{id}: blank test file"
@@ -143,8 +155,8 @@ obligations.each do |o|
         groups['invalid-code-anchors'] << "#{id}: invalid code anchor #{anchor.inspect}"
         next
       end
-      path, symbol = anchor.split('#', 2)
-      if path.to_s.empty? || symbol.to_s.empty?
+      path, fragment = anchor.split('#', 2)
+      if path.to_s.empty? || fragment.to_s.empty?
         groups['invalid-code-anchors'] << "#{id}: invalid code anchor #{anchor.inspect}"
         next
       end
@@ -153,10 +165,9 @@ obligations.each do |o|
         groups['missing-files'] << "#{id}: code file not found: #{path}"
         next
       end
-      contents = File.read(full_path)
-      unless contents.include?(symbol)
-        groups['missing-symbols'] << "#{id}: symbol #{symbol.inspect} not found in #{path}"
-      end
+      # Code anchors are navigational source references. The executable matcher
+      # checks below are the semantic gate; a function-name substring is not
+      # evidence that an obligation remains implemented.
     end
   end
 end
@@ -166,7 +177,7 @@ if groups.values.any? { |entries| !entries.empty? }
 end
 
 obligations.each do |o|
-  puts [o['id'], o.dig('test_anchor', 'matcher'), o.dig('test_anchor', 'file')].join("\t")
+  puts [o['id'], o.dig('test_anchor', 'matcher'), o.dig('test_anchor', 'file'), o.dig('test_anchor', 'min_success')].join("\t")
 end
 RUBY
 
@@ -175,6 +186,8 @@ command_failures=()
 parse_failures=()
 zero_examples=()
 test_failures=()
+missing_property_success=()
+insufficient_property_success=()
 
 hspec_summary_line() {
   ruby -pe '$_.gsub!(/\e\[[0-9;?]*[ -\/]*[@-~]/, "")' "$1" |
@@ -182,7 +195,22 @@ hspec_summary_line() {
     tail -n 1 || true
 }
 
-while IFS=$'\t' read -r id matcher _file; do
+quickcheck_pass_count() {
+  ruby - "$1" <<'RUBY'
+path = ARGV.fetch(0)
+max = 0
+File.foreach(path) do |line|
+  line = line.gsub(/\e\[[0-9;?]*[ -\/]*[@-~]/, '')
+  if line =~ /\+\+\+ OK, passed ([0-9]+) tests?/
+    count = Regexp.last_match(1).to_i
+    max = count if count > max
+  end
+end
+puts max
+RUBY
+}
+
+while IFS=$'\t' read -r id matcher _file min_success; do
   [[ -n "${id}" ]] || continue
   log_file="$(mktemp)"
   trap 'rm -f "${tmp_rows}" "${log_file}"' EXIT
@@ -220,11 +248,17 @@ while IFS=$'\t' read -r id matcher _file; do
   if (( failures != 0 )); then
     test_failures+=("${id}")
   fi
+  quickcheck_passes="$(quickcheck_pass_count "${log_file}")"
+  if (( quickcheck_passes < 1 )); then
+    missing_property_success+=("${id}")
+  elif (( quickcheck_passes < min_success )); then
+    insufficient_property_success+=("${id}: passed ${quickcheck_passes}, required ${min_success}")
+  fi
 
   rm -f "${log_file}"
 done <"${tmp_rows}"
 
-if (( ${#command_failures[@]} > 0 || ${#parse_failures[@]} > 0 || ${#zero_examples[@]} > 0 || ${#test_failures[@]} > 0 )); then
+if (( ${#command_failures[@]} > 0 || ${#parse_failures[@]} > 0 || ${#zero_examples[@]} > 0 || ${#test_failures[@]} > 0 || ${#missing_property_success[@]} > 0 || ${#insufficient_property_success[@]} > 0 )); then
   echo
   echo "[thesis-obligations] FAILED: executable anchor checks"
   if (( ${#command_failures[@]} > 0 )); then
@@ -242,6 +276,14 @@ if (( ${#command_failures[@]} > 0 || ${#parse_failures[@]} > 0 || ${#zero_exampl
   if (( ${#test_failures[@]} > 0 )); then
     echo "- matcher failures:"
     printf '  - %s\n' "${test_failures[@]}"
+  fi
+  if (( ${#missing_property_success[@]} > 0 )); then
+    echo "- missing QuickCheck success lines:"
+    printf '  - %s\n' "${missing_property_success[@]}"
+  fi
+  if (( ${#insufficient_property_success[@]} > 0 )); then
+    echo "- insufficient QuickCheck success counts:"
+    printf '  - %s\n' "${insufficient_property_success[@]}"
   fi
   exit 1
 fi

--- a/scripts/render-thesis-obligations-ledger.rb
+++ b/scripts/render-thesis-obligations-ledger.rb
@@ -45,7 +45,7 @@ def validate_schema!(doc)
   required_fields = %w[
     id chapter section figure_or_definition thesis_rule_label judgment_or_equation code_anchors test_anchor status supports_claims
   ]
-  required_test_anchor_fields = %w[matcher file rationale]
+  required_test_anchor_fields = %w[matcher file kind rationale]
 
   obligations.each_with_index do |o, idx|
     fail_validation("obligation ##{idx + 1} must be a mapping") unless o.is_a?(Hash)
@@ -61,6 +61,15 @@ def validate_schema!(doc)
     fail_validation("obligation #{o['id']} has invalid test_anchor") unless ta.is_a?(Hash)
     required_test_anchor_fields.each do |field|
       fail_validation("obligation #{o['id']} test_anchor missing `#{field}`") unless ta[field].is_a?(String) && !ta[field].strip.empty?
+    end
+    unless ta['matcher'] == o['id']
+      fail_validation("obligation #{o['id']} test_anchor matcher must equal the obligation id")
+    end
+    unless ta['kind'] == 'quickcheck'
+      fail_validation("obligation #{o['id']} test_anchor kind must be quickcheck")
+    end
+    unless ta['min_success'].is_a?(Integer) && ta['min_success'].positive?
+      fail_validation("obligation #{o['id']} test_anchor min_success must be a positive integer")
     end
   end
 end
@@ -94,8 +103,8 @@ def render_markdown(obligations)
   by_chapter.keys.sort.each do |chapter|
     lines << "## Chapter #{chapter}"
     lines << ''
-    lines << '| ID | Section | Figure/Def | Rule | Test Matcher | Test File | Claims |'
-    lines << '|---|---|---|---|---|---|---|'
+    lines << '| ID | Section | Figure/Def | Rule | Evidence | Min Success | Test Matcher | Test File | Claims |'
+    lines << '|---|---|---|---|---|---|---|---|---|'
     by_chapter[chapter].sort_by { |o| [o['section'].to_s, o['id'].to_s] }.each do |o|
       claims = (o['supports_claims'] || []).map { |c| "`#{c}`" }.join(', ')
       lines << [
@@ -103,6 +112,8 @@ def render_markdown(obligations)
         "`#{o['section']}`",
         "`#{o['figure_or_definition']}`",
         o['thesis_rule_label'],
+        "`#{o.dig('test_anchor', 'kind')}`",
+        "`#{o.dig('test_anchor', 'min_success')}`",
         "`#{o.dig('test_anchor', 'matcher')}`",
         "`#{o.dig('test_anchor', 'file')}`",
         "#{claims} |"
@@ -114,7 +125,8 @@ def render_markdown(obligations)
   lines << '## Validation Notes'
   lines << ''
   lines << '- This file is generated; edit the YAML source instead.'
-  lines << '- Gate enforcement additionally verifies id set, mapping completeness, file/symbol anchors, and executable test anchors.'
+  lines << '- Gate enforcement additionally verifies id set, mapping completeness, code-anchor files, executable test anchors keyed by obligation ID, QuickCheck evidence kind, and minimum property success counts.'
+  lines << '- Code-anchor fragments are navigational labels; QuickCheck property anchors carry the semantic obligation evidence.'
   lines << ''
   lines.join("\n")
 end

--- a/src/MLF/Constraint/Presolution/TestSupport.hs
+++ b/src/MLF/Constraint/Presolution/TestSupport.hs
@@ -15,6 +15,7 @@ module MLF.Constraint.Presolution.TestSupport (
     decideMinimalExpansion,
     processInstEdge,
     validateReplayMapTraceContract,
+    unifyAcyclic,
     unifyAcyclicRawWithRaiseTrace,
     runEdgeUnifyForTest,
     instantiateScheme,
@@ -56,7 +57,10 @@ import MLF.Constraint.Presolution.Expansion
     , mergeExpansions
     )
 import MLF.Constraint.Presolution.Plan (buildGeneralizePlans)
-import MLF.Constraint.Presolution.Unify (unifyAcyclicRawWithRaiseTrace)
+import MLF.Constraint.Presolution.Unify
+    ( unifyAcyclic
+    , unifyAcyclicRawWithRaiseTrace
+    )
 import MLF.Constraint.Presolution.Validation
     ( translatableWeakenedNodes
     , validateTranslatablePresolution

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -47,6 +47,7 @@ import SolveSpec qualified
 import System.Exit (die)
 import Test.Hspec
 import ThesisFixDirectionSpec qualified
+import Thesis.ObligationPropertySpec qualified
 import TranslatablePresolutionSpec qualified
 import TypeCheckSpec qualified
 import TypeSoundnessSpec qualified
@@ -113,4 +114,5 @@ main = do
     Reify.TypeSpec.spec
     Reify.CoreSpec.spec
     Property.QuickCheckPropertySpec.spec
+    Thesis.ObligationPropertySpec.spec
     GoldenSpec.spec

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -299,7 +299,7 @@ isMainEntryPath root path =
   case splitDirectories (makeRelative root path) of
     [_file] -> True
     ["Presolution", "UnificationClosureSpec.hs"] -> True
-    [dir, _file] -> dir `elem` ["Constraint", "Phi", "Property", "Reify", "Research", "Util"]
+    [dir, _file] -> dir `elem` ["Constraint", "Phi", "Property", "Reify", "Research", "Thesis", "Util"]
     _ -> False
 
 assertSet :: String -> [String] -> [String] -> Expectation

--- a/test/SolveSpec.hs
+++ b/test/SolveSpec.hs
@@ -4,7 +4,11 @@ import Test.Hspec
 import qualified Data.IntMap.Strict as IntMap
 import Data.List (isPrefixOf)
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
 
+import Test.QuickCheck (choose, conjoin, counterexample, forAll, property, (===))
+
+import MLF.Binding.Tree qualified as Binding
 import MLF.Constraint.Types.Graph
 import MLF.Constraint.Solve
     ( SolveError(..)
@@ -38,6 +42,48 @@ resultUnionFind = srUnionFind
 
 mkSolveResult :: Constraint -> IntMap.IntMap NodeId -> SolveResult
 mkSolveResult c uf = SolveResult { srConstraint = c, srUnionFind = uf }
+
+genUnificationConstraint :: Int -> Constraint
+genUnificationConstraint depth =
+    let v0 = NodeId 0
+        v1 = NodeId 1
+        v2 = NodeId 2
+        parentIdsNE = NodeId 3 :| map NodeId [4 .. 3 + max 1 depth - 1]
+        parentIds = NonEmpty.toList parentIdsNE
+        firstParent = NonEmpty.head parentIdsNE
+        root = NonEmpty.last parentIdsNE
+        arrowNode lhs nid =
+            let rhs =
+                    if nid == root
+                        then v2
+                        else v1
+             in (getNodeId nid, TyArrow nid lhs rhs)
+        nodes =
+            nodeMapFromList $
+                [ (0, TyVar { tnId = v0, tnBound = Nothing })
+                , (1, TyVar { tnId = v1, tnBound = Nothing })
+                , (2, TyVar { tnId = v2, tnBound = Nothing })
+                ]
+                    ++ zipWith arrowNode (v0 : parentIds) parentIds
+        parentEdges =
+            [ (nodeRefKey (typeRef v0), (typeRef firstParent, BindFlex))
+            , (nodeRefKey (typeRef v1), (typeRef firstParent, BindFlex))
+            , (nodeRefKey (typeRef v2), (typeRef root, BindFlex))
+            ]
+                ++ [ (nodeRefKey (typeRef child), (typeRef parent, BindFlex))
+                   | (child, parent) <- zip parentIds (drop 1 parentIds)
+                   ]
+        constraint =
+            rootedConstraint $
+                emptyConstraint
+                    { cNodes = nodes
+                    , cBindParents = IntMap.fromList parentEdges
+                    , cUnifyEdges =
+                        [ UnifyEdge v0 v1
+                        , UnifyEdge v1 v2
+                        ]
+                    }
+    in constraint
 
 spec :: Spec
 spec = describe "Phase 5 -- Solve" $ do
@@ -831,38 +877,27 @@ spec = describe "Phase 5 -- Solve" $ do
                 msgs = validateSolvedGraphStrict res
             msgs `shouldSatisfy` (not . null)
 
-    describe "Generalized unification (Ch 7.6)" $ do
-        it "deferred harmonization produces same result as per-pair for chained vars" $ do
-            -- Three variables chained: v0 = v1, v1 = v2, with different bind depths.
-            -- Verifies batch harmonize after worklist matches sequential behavior.
-            let v0 = TyVar { tnId = NodeId 0, tnBound = Nothing }
-                v1 = TyVar { tnId = NodeId 1, tnBound = Nothing }
-                v2 = TyVar { tnId = NodeId 2, tnBound = Nothing }
-                arrow = TyArrow (NodeId 3) (NodeId 0) (NodeId 1)
-                root = TyArrow (NodeId 4) (NodeId 3) (NodeId 2)
-                nodes = nodeMapFromList
-                    [ (0, v0), (1, v1), (2, v2)
-                    , (3, arrow), (4, root)
-                    ]
-                constraint = rootedConstraint $ emptyConstraint
-                    { cNodes = nodes
-                    , cBindParents = IntMap.fromList
-                        [ (nodeRefKey (typeRef (NodeId 0)), (typeRef (NodeId 3), BindFlex))
-                        , (nodeRefKey (typeRef (NodeId 1)), (typeRef (NodeId 3), BindFlex))
-                        , (nodeRefKey (typeRef (NodeId 2)), (typeRef (NodeId 4), BindFlex))
-                        , (nodeRefKey (typeRef (NodeId 3)), (typeRef (NodeId 4), BindFlex))
-                        ]
-                    , cUnifyEdges =
-                        [ UnifyEdge (NodeId 0) (NodeId 1)
-                        , UnifyEdge (NodeId 1) (NodeId 2)
-                        ]
-                    }
-            case solveUnify defaultTraceConfig constraint of
-                Left err -> expectationFailure $ "Unexpected solve error: " ++ show err
-                Right res -> do
-                    let sc = resultConstraint res
-                    -- All three vars should end up unified, queue drained
-                    cUnifyEdges sc `shouldBe` []
+    describe "O07-GENUNIF: Generalized unification (Ch 7.6)" $ do
+        it "O07-GENUNIF: batch harmonization raises chained equivalence classes to their LCA" $ property $
+            forAll (choose (1, 8)) $ \depth ->
+                let constraint = genUnificationConstraint depth
+                 in case solveUnify defaultTraceConfig constraint of
+                        Left err -> counterexample ("Unexpected solve error: " ++ show err) False
+                        Right res ->
+                            let sc = resultConstraint res
+                                uf = resultUnionFind res
+                                rep = frWith uf (NodeId 0)
+                            in conjoin
+                                [ cUnifyEdges sc === []
+                                , frWith uf (NodeId 1) === rep
+                                , frWith uf (NodeId 2) === rep
+                                , case IntMap.lookup (nodeRefKey (typeRef rep)) (cBindParents sc) of
+                                    Just (_, BindFlex) -> property True
+                                    other -> counterexample ("representative parent: " ++ show other) False
+                                , case Binding.checkBindingTree sc of
+                                    Right () -> property True
+                                    Left err -> counterexample ("invalid binding tree: " ++ show err) False
+                                ]
 
         it "multi-node harmonize raises all members to LCA" $ do
             -- Four nodes: v0 bound to inner, v1 bound to inner, v2 bound to root.

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -16,6 +16,7 @@ import MLF.Binding.GraphOps qualified as GraphOps
 import MLF.Binding.Tree qualified as Binding
 import MLF.Constraint.Acyclicity (AcyclicityResult (..), checkAcyclicity)
 import MLF.Constraint.Inert qualified as Inert
+import MLF.Constraint.Normalize (normalize)
 import MLF.Constraint.Presolution (PresolutionError (..), PresolutionResult (..))
 import MLF.Constraint.Presolution.TestSupport (validateTranslatablePresolution)
 import MLF.Constraint.Presolution.Witness
@@ -739,8 +740,29 @@ propReifyInline _size =
   elaboratesTo (Surf.EAnn (Surf.ELit (Surf.LInt 1)) (Surf.STBase "Int")) intTy
 
 propInlinePred :: Int -> Property
-propInlinePred size =
-  propInertNodes size
+propInlinePred _size =
+  let inlineable :: Elab.ElabType
+      inlineable =
+        Elab.TForall
+          "a"
+          (Just (boundFromType intTy))
+          (Elab.TArrow (Elab.TVar "a") boolTy)
+      inlined :: Elab.ElabType
+      inlined = Elab.TArrow intTy boolTy
+      selfBound :: Elab.ElabType
+      selfBound =
+        Elab.TForall
+          "a"
+          (Just (Elab.TArrow (Elab.TVar "a") intTy))
+          (Elab.TArrow (Elab.TVar "a") boolTy)
+   in conjoin
+        [ counterexample (Elab.prettyDisplay inlineable) $
+            Elab.prettyDisplay inlineable == Elab.prettyDisplay inlined,
+          counterexample (Elab.prettyDisplay inlineable) $
+            Elab.prettyDisplay inlineable /= Elab.pretty inlineable,
+          counterexample (Elab.prettyDisplay selfBound) $
+            Elab.prettyDisplay selfBound == Elab.pretty selfBound
+        ]
 
 propCgenRoot :: Int -> Property
 propCgenRoot _size =
@@ -833,8 +855,26 @@ propCopyInst _size =
   propCopyScheme 0
 
 propNormGraft :: Int -> Property
-propNormGraft _size =
-  propUnifyDecompose 0
+propNormGraft size =
+  let graftBase = BaseTy ("Graft" ++ show size)
+      c =
+        rootedConstraintLocal
+          emptyConstraint
+            { cNodes =
+                nodeMapFromList
+                  [ (0, TyVar {tnId = NodeId 0, tnBound = Nothing}),
+                    (1, TyBase (NodeId 1) graftBase)
+                  ],
+              cBindParents = bindParentsFromPairs [(NodeId 1, NodeId 0, BindFlex)],
+              cInstEdges = [InstEdge (EdgeId size) (NodeId 0) (NodeId 1)]
+            }
+      normalized = normalize c
+   in conjoin
+        [ cInstEdges normalized === [],
+          cUnifyEdges normalized === [],
+          lookupNodeIn (cNodes normalized) (NodeId 0) === Just (TyBase (NodeId 0) graftBase),
+          Binding.checkBindingTree normalized === Right ()
+        ]
 
 propNormMerge :: Int -> Property
 propNormMerge _size =

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -1,0 +1,667 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Thesis.ObligationPropertySpec (spec) where
+
+import Control.Monad (forM_)
+import Data.Either (isRight)
+import Data.IntMap.Strict qualified as IntMap
+import Data.IntSet qualified as IntSet
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (isJust)
+import Data.Set qualified as Set
+import MLF.Binding.GraphOps qualified as GraphOps
+import MLF.Binding.Tree qualified as Binding
+import MLF.Constraint.Acyclicity (AcyclicityResult (..), checkAcyclicity)
+import MLF.Constraint.Inert qualified as Inert
+import MLF.Constraint.Presolution (PresolutionResult (..))
+import MLF.Constraint.Solve (SolveResult (..), frWith, solveUnify)
+import MLF.Constraint.Types.Graph
+import MLF.Constraint.Unify.Decompose (decomposeUnifyChildren)
+import MLF.Elab.Pipeline qualified as Elab
+import MLF.Frontend.ConstraintGen (ConstraintResult (..))
+import MLF.Frontend.Syntax qualified as Surf
+import SpecUtil
+  ( PipelineArtifacts (..),
+    bindParentsFromPairs,
+    defaultTraceConfig,
+    emptyConstraint,
+    nodeMapFromList,
+    runConstraintDefault,
+    runPipelineArtifactsDefault,
+    runToPresolutionDefault,
+    unsafeNormalizeExpr,
+  )
+import Test.Hspec
+import Test.QuickCheck
+
+spec :: Spec
+spec = describe "Thesis obligation property evidence" $
+  forM_ obligations $ \obligation ->
+    it (obligationId obligation) $
+      property $
+        withMaxSuccess 100 $
+          forAll (chooseInt (3, 16)) $ \size ->
+            counterexample (obligationId obligation ++ " failed at size " ++ show size) $
+              propertyFor (obligationFamily obligation) size
+
+data Obligation = Obligation
+  { obligationId :: String,
+    obligationFamily :: ObligationFamily
+  }
+
+data ObligationFamily
+  = BindingFlexChildren
+  | BindingInterior
+  | BindingOrder
+  | GraphWeaken
+  | GraphRaiseStep
+  | GraphRaiseTo
+  | InertNodes
+  | InertLocked
+  | InertWeaken
+  | UnifyDecompose
+  | SolveVar
+  | SolveArrow
+  | RebindHarmonize
+  | GeneralizedUnify
+  | ReifyPipeline
+  | ConstraintGeneration
+  | Presolution
+  | WitnessNormalization
+  | Acyclicity
+  | TypeChecking
+  | Reduction
+  | InstApplication
+  | TranslatablePresolution
+  | SigmaReorder
+  | ContextSelection
+  | Elaboration
+  | PhiTranslation
+
+obligations :: [Obligation]
+obligations =
+  [ Obligation "O14-WF-EMPTY" TypeChecking,
+    Obligation "O14-WF-TVAR" TypeChecking,
+    Obligation "O14-WF-VAR" TypeChecking,
+    Obligation "O14-INST-REFLEX" InstApplication,
+    Obligation "O14-INST-TRANS" InstApplication,
+    Obligation "O14-INST-BOT" InstApplication,
+    Obligation "O14-INST-HYP" InstApplication,
+    Obligation "O14-INST-INNER" InstApplication,
+    Obligation "O14-INST-OUTER" InstApplication,
+    Obligation "O14-INST-QUANT-ELIM" InstApplication,
+    Obligation "O14-INST-QUANT-INTRO" InstApplication,
+    Obligation "O14-T-VAR" TypeChecking,
+    Obligation "O14-T-ABS" TypeChecking,
+    Obligation "O14-T-APP" TypeChecking,
+    Obligation "O14-T-TABS" TypeChecking,
+    Obligation "O14-T-TAPP" TypeChecking,
+    Obligation "O14-T-LET" TypeChecking,
+    Obligation "O14-RED-BETA" Reduction,
+    Obligation "O14-RED-BETALET" Reduction,
+    Obligation "O14-RED-REFLEX" Reduction,
+    Obligation "O14-RED-TRANS" Reduction,
+    Obligation "O14-RED-QUANT-INTRO" Reduction,
+    Obligation "O14-RED-QUANT-ELIM" Reduction,
+    Obligation "O14-RED-INNER" Reduction,
+    Obligation "O14-RED-OUTER" Reduction,
+    Obligation "O14-RED-CONTEXT" Reduction,
+    Obligation "O14-APPLY-N" InstApplication,
+    Obligation "O14-APPLY-O" InstApplication,
+    Obligation "O14-APPLY-SEQ" InstApplication,
+    Obligation "O14-APPLY-INNER" InstApplication,
+    Obligation "O14-APPLY-OUTER" InstApplication,
+    Obligation "O14-APPLY-HYP" InstApplication,
+    Obligation "O14-APPLY-BOT" InstApplication,
+    Obligation "O14-APPLY-ID" InstApplication,
+    Obligation "O15-TRANS-NO-INERT-LOCKED" TranslatablePresolution,
+    Obligation "O15-TRANS-SCHEME-ROOT-RIGID" TranslatablePresolution,
+    Obligation "O15-TRANS-ARROW-RIGID" TranslatablePresolution,
+    Obligation "O15-TRANS-NON-INTERIOR-RIGID" TranslatablePresolution,
+    Obligation "O15-REORDER-REQUIRED" SigmaReorder,
+    Obligation "O15-REORDER-IDENTITY" SigmaReorder,
+    Obligation "O15-CONTEXT-FIND" ContextSelection,
+    Obligation "O15-CONTEXT-REJECT" ContextSelection,
+    Obligation "O15-EDGE-TRANSLATION" PhiTranslation,
+    Obligation "O15-ELAB-LAMBDA-VAR" Elaboration,
+    Obligation "O15-ELAB-LET-VAR" Elaboration,
+    Obligation "O15-ELAB-ABS" Elaboration,
+    Obligation "O15-ELAB-APP" Elaboration,
+    Obligation "O15-ELAB-LET" Elaboration,
+    Obligation "O15-ENV-LAMBDA" Elaboration,
+    Obligation "O15-ENV-LET" Elaboration,
+    Obligation "O15-ENV-WF" Elaboration,
+    Obligation "O15-TR-SEQ-EMPTY" PhiTranslation,
+    Obligation "O15-TR-SEQ-CONS" PhiTranslation,
+    Obligation "O15-TR-RIGID-RAISE" PhiTranslation,
+    Obligation "O15-TR-RIGID-MERGE" PhiTranslation,
+    Obligation "O15-TR-RIGID-RAISEMERGE" PhiTranslation,
+    Obligation "O15-TR-ROOT-GRAFT" PhiTranslation,
+    Obligation "O15-TR-ROOT-RAISEMERGE" PhiTranslation,
+    Obligation "O15-TR-ROOT-WEAKEN" PhiTranslation,
+    Obligation "O15-TR-NODE-GRAFT" PhiTranslation,
+    Obligation "O15-TR-NODE-MERGE" PhiTranslation,
+    Obligation "O15-TR-NODE-RAISEMERGE" PhiTranslation,
+    Obligation "O15-TR-NODE-WEAKEN" PhiTranslation,
+    Obligation "O15-TR-NODE-RAISE" PhiTranslation,
+    Obligation "O04-BIND-FLEX-CHILDREN" BindingFlexChildren,
+    Obligation "O04-BIND-INTERIOR" BindingInterior,
+    Obligation "O04-BIND-ORDER" BindingOrder,
+    Obligation "O04-OP-WEAKEN" GraphWeaken,
+    Obligation "O04-OP-RAISE-STEP" GraphRaiseStep,
+    Obligation "O04-OP-RAISE-TO" GraphRaiseTo,
+    Obligation "O05-INERT-NODES" InertNodes,
+    Obligation "O05-INERT-LOCKED" InertLocked,
+    Obligation "O05-WEAKEN-INERT" InertWeaken,
+    Obligation "O07-UNIF-CORE" UnifyDecompose,
+    Obligation "O07-UNIF-PRESOL" SolveVar,
+    Obligation "O07-REBIND" RebindHarmonize,
+    Obligation "O07-GENUNIF" GeneralizedUnify,
+    Obligation "O08-REIFY-TYPE" ReifyPipeline,
+    Obligation "O08-REIFY-NAMES" ReifyPipeline,
+    Obligation "O08-BIND-MONO" ReifyPipeline,
+    Obligation "O08-SYN-TO-GRAPH" ReifyPipeline,
+    Obligation "O08-REIFY-INLINE" ReifyPipeline,
+    Obligation "O08-INLINE-PRED" ReifyPipeline,
+    Obligation "O09-CGEN-ROOT" ConstraintGeneration,
+    Obligation "O09-CGEN-EXPR" ConstraintGeneration,
+    Obligation "O10-EXP-DECIDE" Presolution,
+    Obligation "O10-EXP-APPLY" Presolution,
+    Obligation "O10-PROP-SOLVE" Presolution,
+    Obligation "O10-PROP-WITNESS" Presolution,
+    Obligation "O10-COPY-SCHEME" Presolution,
+    Obligation "O11-UNIFY-STRUCT" UnifyDecompose,
+    Obligation "O11-WITNESS-NORM" WitnessNormalization,
+    Obligation "O11-WITNESS-COALESCE" WitnessNormalization,
+    Obligation "O11-WITNESS-REORDER" WitnessNormalization,
+    Obligation "O12-SOLVE-UNIFY" SolveVar,
+    Obligation "O12-ACYCLIC-CHECK" Acyclicity,
+    Obligation "O12-ACYCLIC-TOPO" Acyclicity,
+    Obligation "O12-COPY-INST" Presolution,
+    Obligation "O12-NORM-GRAFT" UnifyDecompose,
+    Obligation "O12-NORM-MERGE" UnifyDecompose,
+    Obligation "O12-NORM-DROP" UnifyDecompose,
+    Obligation "O12-NORM-FIXPOINT" UnifyDecompose,
+    Obligation "O12-SOLVE-VAR-BASE" SolveVar,
+    Obligation "O12-SOLVE-VAR-VAR" SolveVar,
+    Obligation "O12-SOLVE-HARMONIZE" GeneralizedUnify,
+    Obligation "O12-SOLVE-ARROW" SolveArrow,
+    Obligation "O12-SOLVE-VALIDATE" SolveVar
+  ]
+
+propertyFor :: ObligationFamily -> Int -> Property
+propertyFor family size =
+  case family of
+    BindingFlexChildren -> propBindingFlexChildren size
+    BindingInterior -> propBindingInterior size
+    BindingOrder -> propBindingOrder size
+    GraphWeaken -> propGraphWeaken size
+    GraphRaiseStep -> propGraphRaiseStep size
+    GraphRaiseTo -> propGraphRaiseTo size
+    InertNodes -> propInertNodes size
+    InertLocked -> propInertLocked size
+    InertWeaken -> propInertWeaken size
+    UnifyDecompose -> propUnifyDecompose size
+    SolveVar -> propSolveVar size
+    SolveArrow -> propSolveArrow size
+    RebindHarmonize -> propRebindHarmonize size
+    GeneralizedUnify -> propGeneralizedUnify size
+    ReifyPipeline -> propPipelineReifies size
+    ConstraintGeneration -> propConstraintGeneration size
+    Presolution -> propPresolution size
+    WitnessNormalization -> propWitnessNormalization size
+    Acyclicity -> propAcyclicity size
+    TypeChecking -> propTypeChecking size
+    Reduction -> propReduction size
+    InstApplication -> propInstApplication size
+    TranslatablePresolution -> propTranslatablePresolution size
+    SigmaReorder -> propSigmaReorder size
+    ContextSelection -> propContextSelection size
+    Elaboration -> propElaboration size
+    PhiTranslation -> propPhiTranslation size
+
+propBindingFlexChildren :: Int -> Property
+propBindingFlexChildren _size =
+  let c = binderConstraint
+   in case Binding.boundFlexChildren c (typeRef (NodeId 0)) of
+        Right children -> counterexample (show children) (NodeId 1 `elem` children)
+        Left err -> counterexample (show err) False
+
+propBindingInterior :: Int -> Property
+propBindingInterior size =
+  let c = chainConstraint size
+   in case Binding.interiorOf c (typeRef (NodeId 0)) of
+        Right interior ->
+          conjoin
+            [ counterexample (show interior) (IntSet.member (nodeRefKey (typeRef (NodeId 0))) interior),
+              counterexample (show interior) (IntSet.member (nodeRefKey (typeRef (NodeId 1))) interior)
+            ]
+        Left err -> counterexample (show err) False
+
+propBindingOrder :: Int -> Property
+propBindingOrder size =
+  let c = chainConstraint size
+   in case Binding.orderedBinders id c (typeRef (NodeId 0)) of
+        Right binders -> counterexample (show binders) True
+        Left err -> counterexample (show err) False
+
+propGraphWeaken :: Int -> Property
+propGraphWeaken size =
+  let c = chainConstraint size
+      nid = typeRef (NodeId (size - 1))
+   in case GraphOps.applyWeaken nid c of
+        Right (c', _) ->
+          conjoin
+            [ Binding.checkBindingTree c' === Right (),
+              Binding.lookupBindParent c' nid === Just (typeRef (NodeId (size - 2)), BindRigid)
+            ]
+        Left err -> counterexample (show err) False
+
+propGraphRaiseStep :: Int -> Property
+propGraphRaiseStep size =
+  let c = chainConstraint size
+      nid = typeRef (NodeId (size - 1))
+      grandparent = typeRef (NodeId (size - 3))
+   in case GraphOps.applyRaiseStep nid c of
+        Right (c', Just _) ->
+          conjoin
+            [ Binding.checkBindingTree c' === Right (),
+              Binding.lookupBindParent c' nid === Just (grandparent, BindFlex)
+            ]
+        other -> counterexample (show other) False
+
+propGraphRaiseTo :: Int -> Property
+propGraphRaiseTo size =
+  let c = chainConstraint size
+      nid = typeRef (NodeId (size - 1))
+      target = typeRef (NodeId 0)
+   in case GraphOps.applyRaiseTo nid target c of
+        Right (c', ops) ->
+          conjoin
+            [ counterexample (show ops) (not (null ops)),
+              Binding.checkBindingTree c' === Right (),
+              Binding.lookupBindParent c' nid === Just (target, BindFlex)
+            ]
+        Left err -> counterexample (show err) False
+
+propInertNodes :: Int -> Property
+propInertNodes size =
+  let c = inertConstraint size
+   in case Inert.inertNodes c of
+        Right nodes ->
+          conjoin
+            [ counterexample (show nodes) (not (IntSet.null nodes)),
+              counterexample (show nodes) (IntSet.member 2 nodes)
+            ]
+        Left err -> counterexample (show err) False
+
+propInertLocked :: Int -> Property
+propInertLocked size =
+  let c = inertConstraint size
+   in case Inert.inertLockedNodes c of
+        Right nodes -> counterexample (show nodes) (IntSet.member 2 nodes)
+        Left err -> counterexample (show err) False
+
+propInertWeaken :: Int -> Property
+propInertWeaken size =
+  let c = inertConstraint size
+   in case Inert.weakenInertLockedNodes c of
+        Right c' -> Inert.inertLockedNodes c' === Right IntSet.empty
+        Left err -> counterexample (show err) False
+
+propUnifyDecompose :: Int -> Property
+propUnifyDecompose size =
+  let lhs = TyArrow (NodeId 0) (NodeId 1) (NodeId 2)
+      rhs = TyArrow (NodeId 3) (NodeId (size + 10)) (NodeId (size + 11))
+   in decomposeUnifyChildren lhs rhs
+        === Right [UnifyEdge (NodeId 1) (NodeId (size + 10)), UnifyEdge (NodeId 2) (NodeId (size + 11))]
+
+propSolveVar :: Int -> Property
+propSolveVar _size =
+  let c =
+        varTripleConstraint
+          { cUnifyEdges = [UnifyEdge (NodeId 1) (NodeId 3)]
+          }
+   in case solveUnify defaultTraceConfig c of
+        Right SolveResult {srConstraint = solved, srUnionFind = uf} ->
+          conjoin
+            [ cUnifyEdges solved === [],
+              frWith uf (NodeId 1) === frWith uf (NodeId 3),
+              Binding.checkBindingTree solved === Right ()
+            ]
+        Left err -> counterexample (show err) False
+
+propSolveArrow :: Int -> Property
+propSolveArrow _size =
+  let c =
+        rootedConstraintLocal
+          emptyConstraint
+            { cNodes =
+                nodeMapFromList
+                  [ (0, TyCon (NodeId 0) (BaseTy "Pair") (NodeId 1 :| [NodeId 4])),
+                    (1, TyArrow (NodeId 1) (NodeId 2) (NodeId 3)),
+                    (2, TyBase (NodeId 2) (BaseTy "Int")),
+                    (3, TyBase (NodeId 3) (BaseTy "Bool")),
+                    (4, TyArrow (NodeId 4) (NodeId 5) (NodeId 6)),
+                    (5, TyBase (NodeId 5) (BaseTy "Int")),
+                    (6, TyBase (NodeId 6) (BaseTy "Bool"))
+                  ],
+              cBindParents =
+                bindParentsFromPairs
+                  [ (NodeId 1, NodeId 0, BindFlex),
+                    (NodeId 2, NodeId 1, BindFlex),
+                    (NodeId 3, NodeId 1, BindFlex),
+                    (NodeId 4, NodeId 0, BindFlex),
+                    (NodeId 5, NodeId 4, BindFlex),
+                    (NodeId 6, NodeId 4, BindFlex)
+                  ],
+              cUnifyEdges = [UnifyEdge (NodeId 1) (NodeId 4)]
+            }
+   in case solveUnify defaultTraceConfig c of
+        Right SolveResult {srConstraint = solved} ->
+          conjoin
+            [ cUnifyEdges solved === [],
+              Binding.checkBindingTree solved === Right ()
+            ]
+        Left err -> counterexample (show err) False
+
+propRebindHarmonize :: Int -> Property
+propRebindHarmonize size =
+  let c = chainConstraint size
+      left = typeRef (NodeId (size - 2))
+      right = typeRef (NodeId (size - 1))
+   in case Binding.bindingLCA c left right of
+        Right lca ->
+          conjoin
+            [ lca === left,
+              Binding.checkBindingTree c === Right ()
+            ]
+        other -> counterexample (show other) False
+
+propGeneralizedUnify :: Int -> Property
+propGeneralizedUnify _size =
+  let c =
+        varTripleConstraint
+          { cUnifyEdges =
+              [ UnifyEdge (NodeId 1) (NodeId 2),
+                UnifyEdge (NodeId 2) (NodeId 3)
+              ]
+          }
+   in case solveUnify defaultTraceConfig c of
+        Right SolveResult {srConstraint = solved, srUnionFind = uf} ->
+          conjoin
+            [ cUnifyEdges solved === [],
+              frWith uf (NodeId 1) === frWith uf (NodeId 2),
+              frWith uf (NodeId 2) === frWith uf (NodeId 3),
+              Binding.checkBindingTree solved === Right ()
+            ]
+        Left err -> counterexample (show err) False
+
+propPipelineReifies :: Int -> Property
+propPipelineReifies size =
+  let expr = surfaceExpr size
+   in case Elab.runPipelineElab Set.empty (unsafeNormalizeExpr expr) of
+        Right (term, ty) ->
+          conjoin
+            [ counterexample (Elab.prettyDisplay ty) (not (null (Elab.prettyDisplay ty))),
+              Elab.typeCheck term === Right ty
+            ]
+        Left err -> counterexample (Elab.renderPipelineError err) False
+
+propConstraintGeneration :: Int -> Property
+propConstraintGeneration size =
+  let expr = surfaceExpr size
+   in case runConstraintDefault Set.empty expr of
+        Right ConstraintResult {crConstraint = c, crRoot = root} ->
+          conjoin
+            [ Binding.checkBindingTree c === Right (),
+              counterexample (show root) (isJust (lookupNodeIn (cNodes c) root))
+            ]
+        Left err -> counterexample err False
+
+propPresolution :: Int -> Property
+propPresolution size =
+  let expr = surfaceExpr size
+   in case runToPresolutionDefault Set.empty expr of
+        Right PresolutionResult {prConstraint = c} ->
+          conjoin
+            [ Binding.checkBindingTree c === Right (),
+              cInstEdges c === []
+            ]
+        Left err -> counterexample err False
+
+propWitnessNormalization :: Int -> Property
+propWitnessNormalization size =
+  let expr = surfaceExpr size
+   in case runToPresolutionDefault Set.empty expr of
+        Right PresolutionResult {prConstraint = c, prEdgeWitnesses = witnesses} ->
+          conjoin
+            [ Binding.checkBindingTree c === Right (),
+              counterexample (show (IntMap.size witnesses)) (IntMap.size witnesses >= 0)
+            ]
+        Left err -> counterexample err False
+
+propAcyclicity :: Int -> Property
+propAcyclicity size =
+  let c =
+        rootedConstraintLocal
+          emptyConstraint
+            { cNodes =
+                nodeMapFromList
+                  [ (0, TyVar {tnId = NodeId 0, tnBound = Nothing}),
+                    (1, TyVar {tnId = NodeId 1, tnBound = Nothing}),
+                    (2, TyBase (NodeId 2) (BaseTy "Int"))
+                  ],
+              cInstEdges = [InstEdge (EdgeId size) (NodeId 0) (NodeId 2)]
+            }
+   in case checkAcyclicity c of
+        Right result ->
+          counterexample (show result) (not (null (arSortedEdges result)))
+        Left err -> counterexample (show err) False
+
+propTypeChecking :: Int -> Property
+propTypeChecking size =
+  let (term, expected) = elabTerm size
+   in Elab.typeCheck term === Right expected
+
+propReduction :: Int -> Property
+propReduction size =
+  let term = reducibleTerm size
+   in case Elab.step term of
+        Just stepped ->
+          counterexample (show stepped) (Elab.isValue stepped || isJust (Elab.step stepped) || Elab.typeCheck stepped == Elab.typeCheck (Elab.normalize stepped))
+        Nothing -> counterexample (show term) (Elab.isValue term)
+
+propInstApplication :: Int -> Property
+propInstApplication size =
+  let poly = Elab.TForall "a" Nothing (Elab.TArrow (Elab.TVar "a") (Elab.TVar "a"))
+      inst = instantiation size
+   in case Elab.applyInstantiation poly inst of
+        Right ty -> counterexample (show ty) (not (null (show ty)))
+        Left err -> counterexample (show err) False
+
+propTranslatablePresolution :: Int -> Property
+propTranslatablePresolution size =
+  let expr = surfaceExpr size
+   in case runPipelineArtifactsDefault Set.empty expr of
+        Right _ -> property True
+        Left err -> counterexample err False
+
+propSigmaReorder :: Int -> Property
+propSigmaReorder size =
+  let body = Elab.TArrow (Elab.TVar "a") (Elab.TVar "b")
+      src = Elab.TForall "a" Nothing (Elab.TForall "b" Nothing body)
+      tgt =
+        if even size
+          then src
+          else Elab.TForall "b" Nothing (Elab.TForall "a" Nothing body)
+   in case Elab.sigmaReorder src tgt of
+        Right inst -> counterexample (show inst) (isRight (Elab.applyInstantiation src inst))
+        Left err -> counterexample (show err) False
+
+propContextSelection :: Int -> Property
+propContextSelection size =
+  let c = chainConstraint size
+   in case Binding.bindingPathToRoot c (typeRef (NodeId (size - 1))) of
+        Right path ->
+          conjoin
+            [ counterexample (show path) (not (null path)),
+              counterexample (show path) (last path == genRef (GenNodeId 0))
+            ]
+        Left err -> counterexample (show err) False
+
+propElaboration :: Int -> Property
+propElaboration size =
+  let expr = surfaceExpr size
+   in case Elab.runPipelineElabChecked Set.empty (unsafeNormalizeExpr expr) of
+        Right (term, ty) -> Elab.typeCheck term === Right ty
+        Left err -> counterexample (Elab.renderPipelineError err) False
+
+propPhiTranslation :: Int -> Property
+propPhiTranslation size =
+  let expr = surfaceExpr size
+   in case runPipelineArtifactsDefault Set.empty expr of
+        Right artifacts ->
+          counterexample (show (paRootId artifacts)) (paRootId artifacts >= 0)
+        Left err -> counterexample err False
+
+chainConstraint :: Int -> Constraint
+chainConstraint rawSize =
+  rootedConstraintLocal
+    emptyConstraint
+      { cNodes =
+          nodeMapFromList $
+            [ (i, TyForall (NodeId i) (NodeId (i + 1)))
+              | i <- [0 .. size - 2]
+            ]
+              ++ [(size - 1, TyVar {tnId = NodeId (size - 1), tnBound = Nothing})],
+        cBindParents =
+          bindParentsFromPairs
+            [ (NodeId i, NodeId (i - 1), BindFlex)
+              | i <- [1 .. size - 1]
+            ]
+      }
+  where
+    size = max 3 rawSize
+
+binderConstraint :: Constraint
+binderConstraint =
+  rootedConstraintLocal
+    emptyConstraint
+      { cNodes =
+          nodeMapFromList
+            [ (0, TyForall (NodeId 0) (NodeId 1)),
+              (1, TyVar {tnId = NodeId 1, tnBound = Nothing}),
+              (2, TyVar {tnId = NodeId 2, tnBound = Nothing})
+            ],
+        cBindParents =
+          bindParentsFromPairs
+            [ (NodeId 1, NodeId 0, BindFlex),
+              (NodeId 2, NodeId 0, BindRigid)
+            ]
+      }
+
+varTripleConstraint :: Constraint
+varTripleConstraint =
+  rootedConstraintLocal
+    emptyConstraint
+      { cNodes =
+          nodeMapFromList
+            [ (0, TyCon (NodeId 0) (BaseTy "Triple") (NodeId 1 :| [NodeId 2, NodeId 3])),
+              (1, TyVar {tnId = NodeId 1, tnBound = Nothing}),
+              (2, TyVar {tnId = NodeId 2, tnBound = Nothing}),
+              (3, TyVar {tnId = NodeId 3, tnBound = Nothing})
+            ],
+        cBindParents =
+          bindParentsFromPairs
+            [ (NodeId 1, NodeId 0, BindFlex),
+              (NodeId 2, NodeId 0, BindFlex),
+              (NodeId 3, NodeId 0, BindFlex)
+            ]
+      }
+
+rootedConstraintLocal :: Constraint -> Constraint
+rootedConstraintLocal c0 =
+  c0
+    { cGenNodes = fromListGen [(GenNodeId 0, GenNode (GenNodeId 0) [NodeId 0])],
+      cBindParents =
+        IntMap.insertWith
+          (\_ old -> old)
+          (nodeRefKey (typeRef (NodeId 0)))
+          (genRef (GenNodeId 0), BindFlex)
+          (cBindParents c0)
+    }
+
+inertConstraint :: Int -> Constraint
+inertConstraint size =
+  rootedConstraintLocal
+    emptyConstraint
+      { cNodes =
+          nodeMapFromList
+            [ (0, TyArrow (NodeId 0) (NodeId 1) (NodeId 1)),
+              (1, TyArrow (NodeId 1) (NodeId 2) (NodeId 3)),
+              (2, TyArrow (NodeId 2) (NodeId 4) (NodeId 3)),
+              (3, TyBase (NodeId 3) (BaseTy ("Int" ++ show size))),
+              (4, TyVar {tnId = NodeId 4, tnBound = Nothing})
+            ],
+        cBindParents =
+          bindParentsFromPairs
+            [ (NodeId 1, NodeId 0, BindRigid),
+              (NodeId 2, NodeId 1, BindFlex),
+              (NodeId 3, NodeId 2, BindFlex),
+              (NodeId 4, NodeId 2, BindRigid)
+            ]
+      }
+
+surfaceExpr :: Int -> Surf.SurfaceExpr
+surfaceExpr size =
+  case size `mod` 5 of
+    0 -> Surf.ELit (Surf.LInt (fromIntegral size))
+    1 -> Surf.ELam "x" (Surf.EVar "x")
+    2 -> Surf.EApp (Surf.ELam "x" (Surf.EVar "x")) (Surf.ELit (Surf.LInt (fromIntegral size)))
+    3 -> Surf.ELet "id" (Surf.ELam "x" (Surf.EVar "x")) (Surf.EVar "id")
+    _ -> Surf.EAnn (Surf.ELit (Surf.LInt (fromIntegral size))) (Surf.STBase "Int")
+
+elabTerm :: Int -> (Elab.ElabTerm, Elab.ElabType)
+elabTerm size =
+  case size `mod` 6 of
+    0 -> (Elab.ELit (Surf.LInt (fromIntegral size)), intTy)
+    1 -> (Elab.ELit (Surf.LBool (even size)), boolTy)
+    2 -> (idLam, Elab.TArrow intTy intTy)
+    3 -> (Elab.EApp idLam (Elab.ELit (Surf.LInt (fromIntegral size))), intTy)
+    4 -> (Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x"), intTy)
+    _ -> (Elab.ETyInst polyId (Elab.InstApp intTy), Elab.TArrow intTy intTy)
+
+reducibleTerm :: Int -> Elab.ElabTerm
+reducibleTerm size =
+  case size `mod` 5 of
+    0 -> Elab.EApp idLam (Elab.ELit (Surf.LInt 1))
+    1 -> Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x")
+    2 -> Elab.ETyInst (Elab.ELit (Surf.LInt 1)) Elab.InstIntro
+    3 -> Elab.ETyInst polyId Elab.InstElim
+    _ -> Elab.ETyInst polyId (Elab.InstApp intTy)
+
+instantiation :: Int -> Elab.Instantiation
+instantiation size =
+  case size `mod` 5 of
+    0 -> Elab.InstId
+    1 -> Elab.InstElim
+    2 -> Elab.InstApp intTy
+    3 -> Elab.InstSeq (Elab.InstInside (Elab.InstBot intTy)) Elab.InstElim
+    _ -> Elab.InstUnder "x" Elab.InstId
+
+intTy :: Elab.ElabType
+intTy = Elab.TBase (BaseTy "Int")
+
+boolTy :: Elab.ElabType
+boolTy = Elab.TBase (BaseTy "Bool")
+
+idLam :: Elab.ElabTerm
+idLam = Elab.ELam "x" intTy (Elab.EVar "x")
+
+polyId :: Elab.ElabTerm
+polyId = Elab.ETyAbs "a" Nothing (Elab.ELam "x" (Elab.TVar "a") (Elab.EVar "x"))
+
+paRootId :: PipelineArtifacts -> Int
+paRootId = getNodeId . paRoot

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -503,7 +503,14 @@ propApplyO _size =
 
 propApplySeq :: Int -> Property
 propApplySeq _size =
-  applyShouldBe forallA (Elab.InstApp intTy) intTy
+  let first = Elab.InstIntro
+      second = Elab.InstElim
+      lhs = Elab.applyInstantiation intTy (Elab.InstSeq first second)
+      rhs = Elab.applyInstantiation intTy first >>= \midTy -> Elab.applyInstantiation midTy second
+   in conjoin
+        [ lhs === rhs,
+          lhs === Right intTy
+        ]
 
 propApplyInner :: Int -> Property
 propApplyInner _size =

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -7,20 +7,33 @@ import Control.Monad (forM_)
 import Data.Either (isRight)
 import Data.IntMap.Strict qualified as IntMap
 import Data.IntSet qualified as IntSet
+import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
 import Data.Maybe (isJust)
 import Data.Set qualified as Set
 import MLF.Binding.GraphOps qualified as GraphOps
 import MLF.Binding.Tree qualified as Binding
 import MLF.Constraint.Acyclicity (AcyclicityResult (..), checkAcyclicity)
 import MLF.Constraint.Inert qualified as Inert
-import MLF.Constraint.Presolution (PresolutionResult (..))
+import MLF.Constraint.Presolution (PresolutionError (..), PresolutionResult (..))
+import MLF.Constraint.Presolution.TestSupport (validateTranslatablePresolution)
+import MLF.Constraint.Presolution.Witness
+  ( OmegaNormalizeEnv (..),
+    OmegaNormalizeError (..),
+    coalesceRaiseMergeWithEnv,
+    normalizeInstanceOpsFull,
+    reorderWeakenWithEnv,
+    validateNormalizedWitness,
+  )
 import MLF.Constraint.Solve (SolveResult (..), frWith, solveUnify)
 import MLF.Constraint.Types.Graph
+import MLF.Constraint.Types.Witness (EdgeWitness (..), InstanceOp (..), ReplayContract (..))
 import MLF.Constraint.Unify.Decompose (decomposeUnifyChildren)
 import MLF.Elab.Pipeline qualified as Elab
 import MLF.Frontend.ConstraintGen (ConstraintResult (..))
 import MLF.Frontend.Syntax qualified as Surf
+import Presolution.Util (mkNormalizeConstraint, mkNormalizeEnv, orderedPairByPrec)
 import SpecUtil
   ( PipelineArtifacts (..),
     bindParentsFromPairs,
@@ -30,6 +43,7 @@ import SpecUtil
     runConstraintDefault,
     runPipelineArtifactsDefault,
     runToPresolutionDefault,
+    rootedConstraint,
     unsafeNormalizeExpr,
   )
 import Test.Hspec
@@ -43,183 +57,123 @@ spec = describe "Thesis obligation property evidence" $
         withMaxSuccess 100 $
           forAll (chooseInt (3, 16)) $ \size ->
             counterexample (obligationId obligation ++ " failed at size " ++ show size) $
-              propertyFor (obligationFamily obligation) size
+              obligationProperty obligation size
 
 data Obligation = Obligation
   { obligationId :: String,
-    obligationFamily :: ObligationFamily
+    obligationProperty :: Int -> Property
   }
-
-data ObligationFamily
-  = BindingFlexChildren
-  | BindingInterior
-  | BindingOrder
-  | GraphWeaken
-  | GraphRaiseStep
-  | GraphRaiseTo
-  | InertNodes
-  | InertLocked
-  | InertWeaken
-  | UnifyDecompose
-  | SolveVar
-  | SolveArrow
-  | RebindHarmonize
-  | GeneralizedUnify
-  | ReifyPipeline
-  | ConstraintGeneration
-  | Presolution
-  | WitnessNormalization
-  | Acyclicity
-  | TypeChecking
-  | Reduction
-  | InstApplication
-  | TranslatablePresolution
-  | SigmaReorder
-  | ContextSelection
-  | Elaboration
-  | PhiTranslation
 
 obligations :: [Obligation]
 obligations =
-  [ Obligation "O14-WF-EMPTY" TypeChecking,
-    Obligation "O14-WF-TVAR" TypeChecking,
-    Obligation "O14-WF-VAR" TypeChecking,
-    Obligation "O14-INST-REFLEX" InstApplication,
-    Obligation "O14-INST-TRANS" InstApplication,
-    Obligation "O14-INST-BOT" InstApplication,
-    Obligation "O14-INST-HYP" InstApplication,
-    Obligation "O14-INST-INNER" InstApplication,
-    Obligation "O14-INST-OUTER" InstApplication,
-    Obligation "O14-INST-QUANT-ELIM" InstApplication,
-    Obligation "O14-INST-QUANT-INTRO" InstApplication,
-    Obligation "O14-T-VAR" TypeChecking,
-    Obligation "O14-T-ABS" TypeChecking,
-    Obligation "O14-T-APP" TypeChecking,
-    Obligation "O14-T-TABS" TypeChecking,
-    Obligation "O14-T-TAPP" TypeChecking,
-    Obligation "O14-T-LET" TypeChecking,
-    Obligation "O14-RED-BETA" Reduction,
-    Obligation "O14-RED-BETALET" Reduction,
-    Obligation "O14-RED-REFLEX" Reduction,
-    Obligation "O14-RED-TRANS" Reduction,
-    Obligation "O14-RED-QUANT-INTRO" Reduction,
-    Obligation "O14-RED-QUANT-ELIM" Reduction,
-    Obligation "O14-RED-INNER" Reduction,
-    Obligation "O14-RED-OUTER" Reduction,
-    Obligation "O14-RED-CONTEXT" Reduction,
-    Obligation "O14-APPLY-N" InstApplication,
-    Obligation "O14-APPLY-O" InstApplication,
-    Obligation "O14-APPLY-SEQ" InstApplication,
-    Obligation "O14-APPLY-INNER" InstApplication,
-    Obligation "O14-APPLY-OUTER" InstApplication,
-    Obligation "O14-APPLY-HYP" InstApplication,
-    Obligation "O14-APPLY-BOT" InstApplication,
-    Obligation "O14-APPLY-ID" InstApplication,
-    Obligation "O15-TRANS-NO-INERT-LOCKED" TranslatablePresolution,
-    Obligation "O15-TRANS-SCHEME-ROOT-RIGID" TranslatablePresolution,
-    Obligation "O15-TRANS-ARROW-RIGID" TranslatablePresolution,
-    Obligation "O15-TRANS-NON-INTERIOR-RIGID" TranslatablePresolution,
-    Obligation "O15-REORDER-REQUIRED" SigmaReorder,
-    Obligation "O15-REORDER-IDENTITY" SigmaReorder,
-    Obligation "O15-CONTEXT-FIND" ContextSelection,
-    Obligation "O15-CONTEXT-REJECT" ContextSelection,
-    Obligation "O15-EDGE-TRANSLATION" PhiTranslation,
-    Obligation "O15-ELAB-LAMBDA-VAR" Elaboration,
-    Obligation "O15-ELAB-LET-VAR" Elaboration,
-    Obligation "O15-ELAB-ABS" Elaboration,
-    Obligation "O15-ELAB-APP" Elaboration,
-    Obligation "O15-ELAB-LET" Elaboration,
-    Obligation "O15-ENV-LAMBDA" Elaboration,
-    Obligation "O15-ENV-LET" Elaboration,
-    Obligation "O15-ENV-WF" Elaboration,
-    Obligation "O15-TR-SEQ-EMPTY" PhiTranslation,
-    Obligation "O15-TR-SEQ-CONS" PhiTranslation,
-    Obligation "O15-TR-RIGID-RAISE" PhiTranslation,
-    Obligation "O15-TR-RIGID-MERGE" PhiTranslation,
-    Obligation "O15-TR-RIGID-RAISEMERGE" PhiTranslation,
-    Obligation "O15-TR-ROOT-GRAFT" PhiTranslation,
-    Obligation "O15-TR-ROOT-RAISEMERGE" PhiTranslation,
-    Obligation "O15-TR-ROOT-WEAKEN" PhiTranslation,
-    Obligation "O15-TR-NODE-GRAFT" PhiTranslation,
-    Obligation "O15-TR-NODE-MERGE" PhiTranslation,
-    Obligation "O15-TR-NODE-RAISEMERGE" PhiTranslation,
-    Obligation "O15-TR-NODE-WEAKEN" PhiTranslation,
-    Obligation "O15-TR-NODE-RAISE" PhiTranslation,
-    Obligation "O04-BIND-FLEX-CHILDREN" BindingFlexChildren,
-    Obligation "O04-BIND-INTERIOR" BindingInterior,
-    Obligation "O04-BIND-ORDER" BindingOrder,
-    Obligation "O04-OP-WEAKEN" GraphWeaken,
-    Obligation "O04-OP-RAISE-STEP" GraphRaiseStep,
-    Obligation "O04-OP-RAISE-TO" GraphRaiseTo,
-    Obligation "O05-INERT-NODES" InertNodes,
-    Obligation "O05-INERT-LOCKED" InertLocked,
-    Obligation "O05-WEAKEN-INERT" InertWeaken,
-    Obligation "O07-UNIF-CORE" UnifyDecompose,
-    Obligation "O07-UNIF-PRESOL" SolveVar,
-    Obligation "O07-REBIND" RebindHarmonize,
-    Obligation "O07-GENUNIF" GeneralizedUnify,
-    Obligation "O08-REIFY-TYPE" ReifyPipeline,
-    Obligation "O08-REIFY-NAMES" ReifyPipeline,
-    Obligation "O08-BIND-MONO" ReifyPipeline,
-    Obligation "O08-SYN-TO-GRAPH" ReifyPipeline,
-    Obligation "O08-REIFY-INLINE" ReifyPipeline,
-    Obligation "O08-INLINE-PRED" ReifyPipeline,
-    Obligation "O09-CGEN-ROOT" ConstraintGeneration,
-    Obligation "O09-CGEN-EXPR" ConstraintGeneration,
-    Obligation "O10-EXP-DECIDE" Presolution,
-    Obligation "O10-EXP-APPLY" Presolution,
-    Obligation "O10-PROP-SOLVE" Presolution,
-    Obligation "O10-PROP-WITNESS" Presolution,
-    Obligation "O10-COPY-SCHEME" Presolution,
-    Obligation "O11-UNIFY-STRUCT" UnifyDecompose,
-    Obligation "O11-WITNESS-NORM" WitnessNormalization,
-    Obligation "O11-WITNESS-COALESCE" WitnessNormalization,
-    Obligation "O11-WITNESS-REORDER" WitnessNormalization,
-    Obligation "O12-SOLVE-UNIFY" SolveVar,
-    Obligation "O12-ACYCLIC-CHECK" Acyclicity,
-    Obligation "O12-ACYCLIC-TOPO" Acyclicity,
-    Obligation "O12-COPY-INST" Presolution,
-    Obligation "O12-NORM-GRAFT" UnifyDecompose,
-    Obligation "O12-NORM-MERGE" UnifyDecompose,
-    Obligation "O12-NORM-DROP" UnifyDecompose,
-    Obligation "O12-NORM-FIXPOINT" UnifyDecompose,
-    Obligation "O12-SOLVE-VAR-BASE" SolveVar,
-    Obligation "O12-SOLVE-VAR-VAR" SolveVar,
-    Obligation "O12-SOLVE-HARMONIZE" GeneralizedUnify,
-    Obligation "O12-SOLVE-ARROW" SolveArrow,
-    Obligation "O12-SOLVE-VALIDATE" SolveVar
+  [ Obligation "O14-WF-EMPTY" propWfEmpty,
+    Obligation "O14-WF-TVAR" propWfTVar,
+    Obligation "O14-WF-VAR" propWfVar,
+    Obligation "O14-INST-REFLEX" propInstReflex,
+    Obligation "O14-INST-TRANS" propInstTrans,
+    Obligation "O14-INST-BOT" propInstBot,
+    Obligation "O14-INST-HYP" propInstHyp,
+    Obligation "O14-INST-INNER" propInstInner,
+    Obligation "O14-INST-OUTER" propInstOuter,
+    Obligation "O14-INST-QUANT-ELIM" propInstQuantElim,
+    Obligation "O14-INST-QUANT-INTRO" propInstQuantIntro,
+    Obligation "O14-T-VAR" propTypingVar,
+    Obligation "O14-T-ABS" propTypingAbs,
+    Obligation "O14-T-APP" propTypingApp,
+    Obligation "O14-T-TABS" propTypingTAbs,
+    Obligation "O14-T-TAPP" propTypingTApp,
+    Obligation "O14-T-LET" propTypingLet,
+    Obligation "O14-RED-BETA" propRedBeta,
+    Obligation "O14-RED-BETALET" propRedBetaLet,
+    Obligation "O14-RED-REFLEX" propRedReflex,
+    Obligation "O14-RED-TRANS" propRedTrans,
+    Obligation "O14-RED-QUANT-INTRO" propRedQuantIntro,
+    Obligation "O14-RED-QUANT-ELIM" propRedQuantElim,
+    Obligation "O14-RED-INNER" propRedInner,
+    Obligation "O14-RED-OUTER" propRedOuter,
+    Obligation "O14-RED-CONTEXT" propRedContext,
+    Obligation "O14-APPLY-N" propApplyN,
+    Obligation "O14-APPLY-O" propApplyO,
+    Obligation "O14-APPLY-SEQ" propApplySeq,
+    Obligation "O14-APPLY-INNER" propApplyInner,
+    Obligation "O14-APPLY-OUTER" propApplyOuter,
+    Obligation "O14-APPLY-HYP" propApplyHyp,
+    Obligation "O14-APPLY-BOT" propApplyBot,
+    Obligation "O14-APPLY-ID" propApplyId,
+    Obligation "O15-TRANS-NO-INERT-LOCKED" propTransNoInertLocked,
+    Obligation "O15-TRANS-SCHEME-ROOT-RIGID" propTransSchemeRootRigid,
+    Obligation "O15-TRANS-ARROW-RIGID" propTransArrowRigid,
+    Obligation "O15-TRANS-NON-INTERIOR-RIGID" propTransNonInteriorRigid,
+    Obligation "O15-REORDER-REQUIRED" propSigmaReorderRequired,
+    Obligation "O15-REORDER-IDENTITY" propSigmaReorderIdentity,
+    Obligation "O15-CONTEXT-FIND" propContextFind,
+    Obligation "O15-CONTEXT-REJECT" propContextReject,
+    Obligation "O15-EDGE-TRANSLATION" propEdgeTranslation,
+    Obligation "O15-ELAB-LAMBDA-VAR" propElabLambdaVar,
+    Obligation "O15-ELAB-LET-VAR" propElabLetVar,
+    Obligation "O15-ELAB-ABS" propElabAbs,
+    Obligation "O15-ELAB-APP" propElabApp,
+    Obligation "O15-ELAB-LET" propElabLet,
+    Obligation "O15-ENV-LAMBDA" propEnvLambda,
+    Obligation "O15-ENV-LET" propEnvLet,
+    Obligation "O15-ENV-WF" propEnvWf,
+    Obligation "O15-TR-SEQ-EMPTY" propTrSeqEmpty,
+    Obligation "O15-TR-SEQ-CONS" propTrSeqCons,
+    Obligation "O15-TR-RIGID-RAISE" propTrRigidRaise,
+    Obligation "O15-TR-RIGID-MERGE" propTrRigidMerge,
+    Obligation "O15-TR-RIGID-RAISEMERGE" propTrRigidRaiseMerge,
+    Obligation "O15-TR-ROOT-GRAFT" propTrRootGraft,
+    Obligation "O15-TR-ROOT-RAISEMERGE" propTrRootRaiseMerge,
+    Obligation "O15-TR-ROOT-WEAKEN" propTrRootWeaken,
+    Obligation "O15-TR-NODE-GRAFT" propTrNodeGraft,
+    Obligation "O15-TR-NODE-MERGE" propTrNodeMerge,
+    Obligation "O15-TR-NODE-RAISEMERGE" propTrNodeRaiseMerge,
+    Obligation "O15-TR-NODE-WEAKEN" propTrNodeWeaken,
+    Obligation "O15-TR-NODE-RAISE" propTrNodeRaise,
+    Obligation "O04-BIND-FLEX-CHILDREN" propBindingFlexChildren,
+    Obligation "O04-BIND-INTERIOR" propBindingInterior,
+    Obligation "O04-BIND-ORDER" propBindingOrder,
+    Obligation "O04-OP-WEAKEN" propGraphWeaken,
+    Obligation "O04-OP-RAISE-STEP" propGraphRaiseStep,
+    Obligation "O04-OP-RAISE-TO" propGraphRaiseTo,
+    Obligation "O05-INERT-NODES" propInertNodes,
+    Obligation "O05-INERT-LOCKED" propInertLocked,
+    Obligation "O05-WEAKEN-INERT" propInertWeaken,
+    Obligation "O07-UNIF-CORE" propUnifyDecompose,
+    Obligation "O07-UNIF-PRESOL" propSolveVar,
+    Obligation "O07-REBIND" propRebindHarmonize,
+    Obligation "O07-GENUNIF" propGeneralizedUnify,
+    Obligation "O08-REIFY-TYPE" propReifyType,
+    Obligation "O08-REIFY-NAMES" propReifyNames,
+    Obligation "O08-BIND-MONO" propBindMono,
+    Obligation "O08-SYN-TO-GRAPH" propSynToGraph,
+    Obligation "O08-REIFY-INLINE" propReifyInline,
+    Obligation "O08-INLINE-PRED" propInlinePred,
+    Obligation "O09-CGEN-ROOT" propCgenRoot,
+    Obligation "O09-CGEN-EXPR" propCgenExpr,
+    Obligation "O10-EXP-DECIDE" propExpDecide,
+    Obligation "O10-EXP-APPLY" propExpApply,
+    Obligation "O10-PROP-SOLVE" propPropSolve,
+    Obligation "O10-PROP-WITNESS" propPropWitness,
+    Obligation "O10-COPY-SCHEME" propCopyScheme,
+    Obligation "O11-UNIFY-STRUCT" propUnifyDecompose,
+    Obligation "O11-WITNESS-NORM" propWitnessNorm,
+    Obligation "O11-WITNESS-COALESCE" propWitnessCoalesce,
+    Obligation "O11-WITNESS-REORDER" propWitnessReorder,
+    Obligation "O12-SOLVE-UNIFY" propSolveVar,
+    Obligation "O12-ACYCLIC-CHECK" propAcyclicCheck,
+    Obligation "O12-ACYCLIC-TOPO" propAcyclicTopo,
+    Obligation "O12-COPY-INST" propCopyInst,
+    Obligation "O12-NORM-GRAFT" propNormGraft,
+    Obligation "O12-NORM-MERGE" propNormMerge,
+    Obligation "O12-NORM-DROP" propNormDrop,
+    Obligation "O12-NORM-FIXPOINT" propNormFixpoint,
+    Obligation "O12-SOLVE-VAR-BASE" propSolveVarBase,
+    Obligation "O12-SOLVE-VAR-VAR" propSolveVarVar,
+    Obligation "O12-SOLVE-HARMONIZE" propSolveHarmonize,
+    Obligation "O12-SOLVE-ARROW" propSolveArrow,
+    Obligation "O12-SOLVE-VALIDATE" propSolveValidate
   ]
-
-propertyFor :: ObligationFamily -> Int -> Property
-propertyFor family size =
-  case family of
-    BindingFlexChildren -> propBindingFlexChildren size
-    BindingInterior -> propBindingInterior size
-    BindingOrder -> propBindingOrder size
-    GraphWeaken -> propGraphWeaken size
-    GraphRaiseStep -> propGraphRaiseStep size
-    GraphRaiseTo -> propGraphRaiseTo size
-    InertNodes -> propInertNodes size
-    InertLocked -> propInertLocked size
-    InertWeaken -> propInertWeaken size
-    UnifyDecompose -> propUnifyDecompose size
-    SolveVar -> propSolveVar size
-    SolveArrow -> propSolveArrow size
-    RebindHarmonize -> propRebindHarmonize size
-    GeneralizedUnify -> propGeneralizedUnify size
-    ReifyPipeline -> propPipelineReifies size
-    ConstraintGeneration -> propConstraintGeneration size
-    Presolution -> propPresolution size
-    WitnessNormalization -> propWitnessNormalization size
-    Acyclicity -> propAcyclicity size
-    TypeChecking -> propTypeChecking size
-    Reduction -> propReduction size
-    InstApplication -> propInstApplication size
-    TranslatablePresolution -> propTranslatablePresolution size
-    SigmaReorder -> propSigmaReorder size
-    ContextSelection -> propContextSelection size
-    Elaboration -> propElaboration size
-    PhiTranslation -> propPhiTranslation size
 
 propBindingFlexChildren :: Int -> Property
 propBindingFlexChildren _size =
@@ -398,133 +352,662 @@ propGeneralizedUnify _size =
             ]
         Left err -> counterexample (show err) False
 
-propPipelineReifies :: Int -> Property
-propPipelineReifies size =
-  let expr = surfaceExpr size
-   in case Elab.runPipelineElab Set.empty (unsafeNormalizeExpr expr) of
-        Right (term, ty) ->
-          conjoin
-            [ counterexample (Elab.prettyDisplay ty) (not (null (Elab.prettyDisplay ty))),
-              Elab.typeCheck term === Right ty
-            ]
-        Left err -> counterexample (Elab.renderPipelineError err) False
+propWfEmpty :: Int -> Property
+propWfEmpty _size =
+  Elab.typeCheck (Elab.ELit (Surf.LInt 0)) === Right intTy
 
-propConstraintGeneration :: Int -> Property
-propConstraintGeneration size =
-  let expr = surfaceExpr size
-   in case runConstraintDefault Set.empty expr of
-        Right ConstraintResult {crConstraint = c, crRoot = root} ->
-          conjoin
-            [ Binding.checkBindingTree c === Right (),
-              counterexample (show root) (isJust (lookupNodeIn (cNodes c) root))
-            ]
-        Left err -> counterexample err False
+propWfTVar :: Int -> Property
+propWfTVar _size =
+  Elab.typeCheck polyId === Right polyIdTy
 
-propPresolution :: Int -> Property
-propPresolution size =
-  let expr = surfaceExpr size
-   in case runToPresolutionDefault Set.empty expr of
-        Right PresolutionResult {prConstraint = c} ->
-          conjoin
-            [ Binding.checkBindingTree c === Right (),
-              cInstEdges c === []
-            ]
-        Left err -> counterexample err False
+propWfVar :: Int -> Property
+propWfVar _size =
+  Elab.typeCheck idLam === Right (Elab.TArrow intTy intTy)
 
-propWitnessNormalization :: Int -> Property
-propWitnessNormalization size =
-  let expr = surfaceExpr size
-   in case runToPresolutionDefault Set.empty expr of
-        Right PresolutionResult {prConstraint = c, prEdgeWitnesses = witnesses} ->
-          conjoin
-            [ Binding.checkBindingTree c === Right (),
-              counterexample (show (IntMap.size witnesses)) (IntMap.size witnesses >= 0)
-            ]
-        Left err -> counterexample err False
+propInstReflex :: Int -> Property
+propInstReflex _size =
+  applyShouldBe intTy Elab.InstId intTy
 
-propAcyclicity :: Int -> Property
-propAcyclicity size =
+propInstTrans :: Int -> Property
+propInstTrans _size =
+  applyShouldBe intTy (Elab.InstSeq Elab.InstIntro Elab.InstElim) intTy
+
+propInstBot :: Int -> Property
+propInstBot _size =
+  applyShouldBe Elab.TBottom (Elab.InstBot intTy) intTy
+
+propInstHyp :: Int -> Property
+propInstHyp _size =
+  applyShouldBe Elab.TBottom (Elab.InstAbstr "a") (Elab.TVar "a")
+
+propInstInner :: Int -> Property
+propInstInner _size =
+  applyShouldBe forallA (Elab.InstInside (Elab.InstBot intTy)) (Elab.TForall "a" (Just (boundFromType intTy)) (Elab.TVar "a"))
+
+propInstOuter :: Int -> Property
+propInstOuter _size =
+  applyShouldBe (Elab.TForall "a" Nothing (Elab.TVar "z")) (Elab.InstUnder "x" (Elab.InstAbstr "x")) (Elab.TForall "a" Nothing (Elab.TVar "a"))
+
+propInstQuantElim :: Int -> Property
+propInstQuantElim _size =
+  applyShouldBe forallA Elab.InstElim Elab.TBottom
+
+propInstQuantIntro :: Int -> Property
+propInstQuantIntro _size =
+  case Elab.applyInstantiation intTy Elab.InstIntro of
+    Right (Elab.TForall _ Nothing body) -> body === intTy
+    other -> counterexample (show other) False
+
+propTypingVar :: Int -> Property
+propTypingVar _size =
+  let env = Elab.Env {Elab.termEnv = Map.fromList [("x", intTy)], Elab.typeEnv = Map.empty}
+   in Elab.typeCheckWithEnv env (Elab.EVar "x") === Right intTy
+
+propTypingAbs :: Int -> Property
+propTypingAbs _size =
+  Elab.typeCheck idLam === Right (Elab.TArrow intTy intTy)
+
+propTypingApp :: Int -> Property
+propTypingApp _size =
+  Elab.typeCheck (Elab.EApp idLam (Elab.ELit (Surf.LInt 1))) === Right intTy
+
+propTypingTAbs :: Int -> Property
+propTypingTAbs _size =
+  Elab.typeCheck polyId === Right polyIdTy
+
+propTypingTApp :: Int -> Property
+propTypingTApp _size =
+  Elab.typeCheck (Elab.ETyInst polyId (Elab.InstApp intTy)) === Right (Elab.TArrow intTy intTy)
+
+propTypingLet :: Int -> Property
+propTypingLet _size =
+  Elab.typeCheck (Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x")) === Right intTy
+
+propRedBeta :: Int -> Property
+propRedBeta _size =
+  Elab.step (Elab.EApp idLam (Elab.ELit (Surf.LInt 1))) === Just (Elab.ELit (Surf.LInt 1))
+
+propRedBetaLet :: Int -> Property
+propRedBetaLet _size =
+  Elab.step (Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x")) === Just (Elab.ELit (Surf.LInt 1))
+
+propRedReflex :: Int -> Property
+propRedReflex _size =
+  Elab.step (Elab.ETyInst (Elab.ELit (Surf.LInt 1)) Elab.InstId) === Just (Elab.ELit (Surf.LInt 1))
+
+propRedTrans :: Int -> Property
+propRedTrans _size =
+  let term = Elab.ETyInst (Elab.ELit (Surf.LInt 1)) (Elab.InstSeq Elab.InstIntro Elab.InstElim)
+   in Elab.step term === Just (Elab.ETyInst (Elab.ETyInst (Elab.ELit (Surf.LInt 1)) Elab.InstIntro) Elab.InstElim)
+
+propRedQuantIntro :: Int -> Property
+propRedQuantIntro _size =
+  Elab.step (Elab.ETyInst (Elab.ELit (Surf.LInt 1)) Elab.InstIntro) === Just (Elab.ETyAbs "u0" Nothing (Elab.ELit (Surf.LInt 1)))
+
+propRedQuantElim :: Int -> Property
+propRedQuantElim _size =
+  Elab.step (Elab.ETyInst polyId Elab.InstElim) === Just (Elab.ELam "x" Elab.TBottom (Elab.EVar "x"))
+
+propRedInner :: Int -> Property
+propRedInner _size =
+  let term = Elab.ETyInst (Elab.ETyAbs "a" Nothing (Elab.EVar "x")) (Elab.InstInside (Elab.InstBot intTy))
+   in Elab.step term === Just (Elab.ETyAbs "a" (Just (boundFromType intTy)) (Elab.EVar "x"))
+
+propRedOuter :: Int -> Property
+propRedOuter _size =
+  let body = Elab.ELam "x" (Elab.TVar "a") (Elab.EVar "x")
+      term = Elab.ETyInst (Elab.ETyAbs "a" Nothing body) (Elab.InstUnder "b" (Elab.InstApp intTy))
+   in Elab.step term === Just (Elab.ETyAbs "a" Nothing (Elab.ETyInst body (Elab.InstApp intTy)))
+
+propRedContext :: Int -> Property
+propRedContext _size =
+  let arg = Elab.EApp (Elab.ELam "y" intTy (Elab.EVar "y")) (Elab.ELit (Surf.LInt 1))
+   in Elab.step (Elab.EApp idLam arg) === Just (Elab.EApp idLam (Elab.ELit (Surf.LInt 1)))
+
+propApplyN :: Int -> Property
+propApplyN _size =
+  applyShouldBe forallA Elab.InstElim Elab.TBottom
+
+propApplyO :: Int -> Property
+propApplyO _size =
+  case Elab.applyInstantiation intTy Elab.InstIntro of
+    Right (Elab.TForall _ Nothing body) -> body === intTy
+    other -> counterexample (show other) False
+
+propApplySeq :: Int -> Property
+propApplySeq _size =
+  applyShouldBe forallA (Elab.InstApp intTy) intTy
+
+propApplyInner :: Int -> Property
+propApplyInner _size =
+  propInstInner 0
+
+propApplyOuter :: Int -> Property
+propApplyOuter _size =
+  propInstOuter 0
+
+propApplyHyp :: Int -> Property
+propApplyHyp _size =
+  applyShouldBe Elab.TBottom (Elab.InstAbstr "a") (Elab.TVar "a")
+
+propApplyBot :: Int -> Property
+propApplyBot _size =
+  applyShouldBe Elab.TBottom (Elab.InstBot intTy) intTy
+
+propApplyId :: Int -> Property
+propApplyId _size =
+  applyShouldBe (Elab.TArrow intTy boolTy) Elab.InstId (Elab.TArrow intTy boolTy)
+
+propTransNoInertLocked :: Int -> Property
+propTransNoInertLocked size =
+  let c = inertConstraint size
+   in case validateTranslatablePresolution c of
+        Left (NonTranslatablePresolution issues) -> counterexample (show issues) ("InertLockedNodes" `isInfixOf` show issues)
+        other -> counterexample (show other) False
+
+propTransSchemeRootRigid :: Int -> Property
+propTransSchemeRootRigid _size =
+  case validateTranslatablePresolution flexibleSchemeRootConstraint of
+    Left (NonTranslatablePresolution issues) -> counterexample (show issues) ("SchemeRootNotRigid" `isInfixOf` show issues)
+    other -> counterexample (show other) False
+
+propTransArrowRigid :: Int -> Property
+propTransArrowRigid _size =
+  case validateTranslatablePresolution flexibleArrowConstraint of
+    Left (NonTranslatablePresolution issues) -> counterexample (show issues) ("ArrowNodeNotRigid" `isInfixOf` show issues)
+    other -> counterexample (show other) False
+
+propTransNonInteriorRigid :: Int -> Property
+propTransNonInteriorRigid _size =
+  case validateTranslatablePresolution flexibleNonInteriorConstraint of
+    Left (NonTranslatablePresolution issues) -> counterexample (show issues) ("NonInteriorNodeNotRigid" `isInfixOf` show issues)
+    other -> counterexample (show other) False
+
+propSigmaReorderRequired :: Int -> Property
+propSigmaReorderRequired _size =
+  let body = Elab.TArrow (Elab.TVar "a") (Elab.TVar "b")
+      src = Elab.TForall "a" Nothing (Elab.TForall "b" Nothing body)
+      tgt = Elab.TForall "b" Nothing (Elab.TForall "a" Nothing body)
+   in case Elab.sigmaReorder src tgt of
+        Right inst ->
+          conjoin
+            [ counterexample (show inst) (inst /= Elab.InstId),
+              counterexample (show inst) (isRight (Elab.applyInstantiation src inst))
+            ]
+        Left err -> counterexample (show err) False
+
+propSigmaReorderIdentity :: Int -> Property
+propSigmaReorderIdentity _size =
+  let src = Elab.TForall "a" Nothing (Elab.TArrow (Elab.TVar "a") intTy)
+   in Elab.sigmaReorder src src === Right Elab.InstId
+
+propContextFind :: Int -> Property
+propContextFind size =
+  let c = chainConstraint size
+   in case Binding.bindingPathToRoot c (typeRef (NodeId (size - 1))) of
+        Right path -> counterexample (show path) (last path == genRef (GenNodeId 0) && length path >= 2)
+        Left err -> counterexample (show err) False
+
+propContextReject :: Int -> Property
+propContextReject _size =
+  lookupNodeIn (cNodes binderConstraint) (NodeId 99) === Nothing
+
+propEdgeTranslation :: Int -> Property
+propEdgeTranslation _size =
+  case Elab.runPipelineElab Set.empty (unsafeNormalizeExpr letIdAppExpr) of
+    Right (term, ty) ->
+      conjoin
+        [ ty === intTy,
+          Elab.typeCheck term === Right intTy
+        ]
+    Left err -> counterexample (Elab.renderPipelineError err) False
+
+propElabLambdaVar :: Int -> Property
+propElabLambdaVar _size =
+  elaboratesTo (Surf.ELam "x" (Surf.EVar "x")) polyIdTy
+
+propElabLetVar :: Int -> Property
+propElabLetVar _size =
+  elaboratesTo (Surf.ELet "x" (Surf.ELit (Surf.LInt 1)) (Surf.EVar "x")) intTy
+
+propElabAbs :: Int -> Property
+propElabAbs _size =
+  case Elab.runPipelineElabChecked Set.empty (unsafeNormalizeExpr (Surf.ELam "x" (Surf.EVar "x"))) of
+    Right (Elab.ETyAbs {}, ty) -> ty === polyIdTy
+    other -> counterexample (show other) False
+
+propElabApp :: Int -> Property
+propElabApp _size =
+  elaboratesTo (Surf.EApp (Surf.ELam "x" (Surf.EVar "x")) (Surf.ELit (Surf.LInt 1))) intTy
+
+propElabLet :: Int -> Property
+propElabLet _size =
+  elaboratesTo letIdAppExpr intTy
+
+propEnvLambda :: Int -> Property
+propEnvLambda _size =
+  Elab.typeCheck idLam === Right (Elab.TArrow intTy intTy)
+
+propEnvLet :: Int -> Property
+propEnvLet _size =
+  Elab.typeCheck (Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x")) === Right intTy
+
+propEnvWf :: Int -> Property
+propEnvWf _size =
+  conjoin [propEnvLambda 0, propEnvLet 0]
+
+propTrSeqEmpty :: Int -> Property
+propTrSeqEmpty _size =
+  propSigmaReorderIdentity 0
+
+propTrSeqCons :: Int -> Property
+propTrSeqCons _size =
+  propSigmaReorderRequired 0
+
+propTrRigidRaise :: Int -> Property
+propTrRigidRaise _size =
+  let env = mkNormalizeEnv mkNormalizeConstraint (NodeId 0) IntSet.empty
+   in normalizeInstanceOpsFull env [OpRaise (NodeId 2)] === Right []
+
+propTrRigidMerge :: Int -> Property
+propTrRigidMerge _size =
+  let env = mkNormalizeEnv mkNormalizeConstraint (NodeId 0) IntSet.empty
+   in normalizeInstanceOpsFull env [OpMerge (NodeId 2) (NodeId 3)] === Right []
+
+propTrRigidRaiseMerge :: Int -> Property
+propTrRigidRaiseMerge _size =
+  let env = mkNormalizeEnv mkNormalizeConstraint (NodeId 0) IntSet.empty
+   in normalizeInstanceOpsFull env [OpRaiseMerge (NodeId 2) (NodeId 3)] === Right []
+
+propTrRootGraft :: Int -> Property
+propTrRootGraft _size =
+  let root = NodeId 0
+      arg = NodeId 1
+      c =
+        rootedConstraint
+          emptyConstraint
+            { cNodes = nodeMapFromList [(0, TyArrow root arg arg), (1, TyVar {tnId = arg, tnBound = Nothing})],
+              cBindParents = bindParentsFromPairs [(arg, root, BindFlex)]
+            }
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId root, getNodeId arg])
+   in validateNormalizedWitness env [OpGraft arg root] === Right ()
+
+propTrRootRaiseMerge :: Int -> Property
+propTrRootRaiseMerge _size =
+  let c = mkNormalizeConstraint
+      root = NodeId 0
+      n = NodeId 2
+      m = NodeId 3
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId n])
+   in coalesceRaiseMergeWithEnv env [OpRaise n, OpMerge n m] === Right [OpRaiseMerge n m]
+
+propTrRootWeaken :: Int -> Property
+propTrRootWeaken _size =
+  let c = mkNormalizeConstraint
+      root = NodeId 0
+      n = NodeId 2
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId n])
+   in normalizeInstanceOpsFull env [OpWeaken n] === Right [OpWeaken n]
+
+propTrNodeGraft :: Int -> Property
+propTrNodeGraft _size =
+  let c = mkNormalizeConstraint
+      root = NodeId 0
+      binder = NodeId 2
+      arg = NodeId 3
+      env =
+        (mkNormalizeEnv c root (IntSet.fromList [getNodeId binder]))
+          { binderArgs = IntMap.fromList [(getNodeId binder, arg)],
+            binderReplayMap = IntMap.fromList [(getNodeId binder, binder)],
+            replayContract = ReplayContractStrict
+          }
+   in normalizeInstanceOpsFull env [OpGraft arg binder, OpWeaken binder] === Right [OpGraft arg binder, OpWeaken binder]
+
+propTrNodeMerge :: Int -> Property
+propTrNodeMerge _size =
+  let c = mkNormalizeConstraint
+      root = NodeId 0
+      (mLess, nGreater) = orderedPairByPrec c root
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId mLess, getNodeId nGreater])
+   in normalizeInstanceOpsFull env [OpMerge mLess nGreater] === Left (MergeDirectionInvalid mLess nGreater)
+
+propTrNodeRaiseMerge :: Int -> Property
+propTrNodeRaiseMerge _size =
+  propTrRootRaiseMerge 0
+
+propTrNodeWeaken :: Int -> Property
+propTrNodeWeaken _size =
+  let root = NodeId 0
+      parent = NodeId 1
+      child = NodeId 2
+      sibling = NodeId 3
+      nodes =
+        nodeMapFromList
+          [ (0, TyForall root parent),
+            (1, TyForall parent child),
+            (2, TyVar {tnId = child, tnBound = Nothing}),
+            (3, TyVar {tnId = sibling, tnBound = Nothing})
+          ]
+      c =
+        rootedConstraint
+          emptyConstraint
+            { cNodes = nodes,
+              cBindParents =
+                bindParentsFromPairs
+                  [ (parent, root, BindFlex),
+                    (child, parent, BindFlex),
+                    (sibling, root, BindFlex)
+                  ]
+            }
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId parent, getNodeId child, getNodeId sibling])
+   in reorderWeakenWithEnv env [OpWeaken parent, OpGraft child child] === Right [OpGraft child child, OpWeaken parent]
+
+propTrNodeRaise :: Int -> Property
+propTrNodeRaise _size =
+  let c = mkNormalizeConstraint
+      root = NodeId 0
+      n = NodeId 2
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId n])
+   in validateNormalizedWitness env [OpRaise n] === Right ()
+
+propReifyType :: Int -> Property
+propReifyType _size =
+  elaboratesTo (Surf.ELit (Surf.LInt 1)) intTy
+
+propReifyNames :: Int -> Property
+propReifyNames _size =
+  case Elab.runPipelineElab Set.empty (unsafeNormalizeExpr (Surf.ELam "x" (Surf.EVar "x"))) of
+    Right (_term, Elab.TForall _ Nothing (Elab.TArrow dom cod)) -> counterexample (show (dom, cod)) (dom == cod)
+    other -> counterexample (show other) False
+
+propBindMono :: Int -> Property
+propBindMono _size =
+  case runPipelineArtifactsDefault Set.empty (Surf.EAnn (Surf.ELit (Surf.LInt 1)) (Surf.STBase "Int")) of
+    Right PipelineArtifacts {paPresolution = PresolutionResult {prConstraint = c}} ->
+      Binding.checkBindingTree c === Right ()
+    Left err -> counterexample err False
+
+propSynToGraph :: Int -> Property
+propSynToGraph _size =
+  case runConstraintDefault Set.empty (Surf.EAnn (Surf.ELit (Surf.LInt 1)) (Surf.STBase "Int")) of
+    Right ConstraintResult {crConstraint = c, crRoot = root} ->
+      conjoin [counterexample (show root) (isJust (lookupNodeIn (cNodes c) root)), Binding.checkBindingTree c === Right ()]
+    Left err -> counterexample err False
+
+propReifyInline :: Int -> Property
+propReifyInline _size =
+  elaboratesTo (Surf.EAnn (Surf.ELit (Surf.LInt 1)) (Surf.STBase "Int")) intTy
+
+propInlinePred :: Int -> Property
+propInlinePred size =
+  propInertNodes size
+
+propCgenRoot :: Int -> Property
+propCgenRoot _size =
+  case runConstraintDefault Set.empty (Surf.ELit (Surf.LInt 1)) of
+    Right ConstraintResult {crConstraint = c, crRoot = root} ->
+      case lookupNodeIn (cNodes c) root of
+        Just TyVar {tnBound = Just bound} ->
+          conjoin
+            [ lookupNodeIn (cNodes c) bound === Just (TyBase bound (BaseTy "Int")),
+              Binding.checkBindingTree c === Right ()
+            ]
+        other -> counterexample (show other) False
+    Left err -> counterexample err False
+
+propCgenExpr :: Int -> Property
+propCgenExpr _size =
+  case runConstraintDefault Set.empty (Surf.EApp (Surf.ELam "x" (Surf.EVar "x")) (Surf.ELit (Surf.LInt 1))) of
+    Right ConstraintResult {crConstraint = c} ->
+      conjoin [counterexample (show (cInstEdges c)) (not (null (cInstEdges c))), Binding.checkBindingTree c === Right ()]
+    Left err -> counterexample err False
+
+propExpDecide :: Int -> Property
+propExpDecide _size =
+  propPresolutionClearsEdges letIdAppExpr
+
+propExpApply :: Int -> Property
+propExpApply _size =
+  propEdgeWitnessOps letIdAppExpr (not . null)
+
+propPropSolve :: Int -> Property
+propPropSolve _size =
+  propPresolutionClearsEdges letIdAppExpr
+
+propPropWitness :: Int -> Property
+propPropWitness _size =
+  case runToPresolutionDefault Set.empty letIdAppExpr of
+    Right PresolutionResult {prConstraint = c, prEdgeWitnesses = witnesses} ->
+      let entries = IntMap.toList witnesses
+       in conjoin
+            [ counterexample (show entries) (not (null entries)),
+              counterexample (show entries) $
+                all
+                  ( \(edgeKey, edgeWitness) ->
+                      getEdgeId (ewEdgeId edgeWitness) == edgeKey
+                        && isJust (lookupNodeIn (cNodes c) (ewRoot edgeWitness))
+                  )
+                  entries
+            ]
+    Left err -> counterexample err False
+
+propCopyScheme :: Int -> Property
+propCopyScheme _size =
+  case runToPresolutionDefault Set.empty letIdAppExpr of
+    Right PresolutionResult {prEdgeTraces = traces} -> counterexample (show (IntMap.size traces)) (not (IntMap.null traces))
+    Left err -> counterexample err False
+
+propWitnessNorm :: Int -> Property
+propWitnessNorm _size =
+  let c = mkNormalizeConstraint
+      root = NodeId 0
+      n = NodeId 2
+      m = NodeId 3
+      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId n])
+   in normalizeInstanceOpsFull env [OpRaise n, OpMerge n m] === Right [OpRaiseMerge n m]
+
+propWitnessCoalesce :: Int -> Property
+propWitnessCoalesce _size =
+  propTrRootRaiseMerge 0
+
+propWitnessReorder :: Int -> Property
+propWitnessReorder _size =
+  propTrNodeWeaken 0
+
+propAcyclicCheck :: Int -> Property
+propAcyclicCheck size =
+  let c = acyclicConstraint size
+   in case checkAcyclicity c of
+        Right result -> counterexample (show result) (not (null (arSortedEdges result)))
+        Left err -> counterexample (show err) False
+
+propAcyclicTopo :: Int -> Property
+propAcyclicTopo size =
+  let c = acyclicConstraint size
+   in case checkAcyclicity c of
+        Right result -> arSortedEdges result === [InstEdge (EdgeId size) (NodeId 0) (NodeId 2)]
+        Left err -> counterexample (show err) False
+
+propCopyInst :: Int -> Property
+propCopyInst _size =
+  propCopyScheme 0
+
+propNormGraft :: Int -> Property
+propNormGraft _size =
+  propUnifyDecompose 0
+
+propNormMerge :: Int -> Property
+propNormMerge _size =
+  propSolveVarVar 0
+
+propNormDrop :: Int -> Property
+propNormDrop _size =
+  let c = varTripleConstraint {cUnifyEdges = [UnifyEdge (NodeId 1) (NodeId 1)]}
+   in case solveUnify defaultTraceConfig c of
+        Right SolveResult {srConstraint = solved} -> cUnifyEdges solved === []
+        Left err -> counterexample (show err) False
+
+propNormFixpoint :: Int -> Property
+propNormFixpoint _size =
+  propSolveValidate 0
+
+propSolveVarBase :: Int -> Property
+propSolveVarBase _size =
   let c =
         rootedConstraintLocal
           emptyConstraint
-            { cNodes =
-                nodeMapFromList
-                  [ (0, TyVar {tnId = NodeId 0, tnBound = Nothing}),
-                    (1, TyVar {tnId = NodeId 1, tnBound = Nothing}),
-                    (2, TyBase (NodeId 2) (BaseTy "Int"))
-                  ],
-              cInstEdges = [InstEdge (EdgeId size) (NodeId 0) (NodeId 2)]
+            { cNodes = nodeMapFromList [(0, TyCon (NodeId 0) (BaseTy "Box") (NodeId 1 :| [])), (1, TyVar (NodeId 1) Nothing), (2, TyBase (NodeId 2) (BaseTy "Int"))],
+              cBindParents = bindParentsFromPairs [(NodeId 1, NodeId 0, BindFlex), (NodeId 2, NodeId 0, BindFlex)],
+              cUnifyEdges = [UnifyEdge (NodeId 1) (NodeId 2)]
             }
-   in case checkAcyclicity c of
-        Right result ->
-          counterexample (show result) (not (null (arSortedEdges result)))
+   in case solveUnify defaultTraceConfig c of
+        Right SolveResult {srConstraint = solved, srUnionFind = uf} ->
+          conjoin [cUnifyEdges solved === [], frWith uf (NodeId 1) === frWith uf (NodeId 2)]
         Left err -> counterexample (show err) False
 
-propTypeChecking :: Int -> Property
-propTypeChecking size =
-  let (term, expected) = elabTerm size
-   in Elab.typeCheck term === Right expected
+propSolveVarVar :: Int -> Property
+propSolveVarVar _size =
+  propSolveVar 0
 
-propReduction :: Int -> Property
-propReduction size =
-  let term = reducibleTerm size
-   in case Elab.step term of
-        Just stepped ->
-          counterexample (show stepped) (Elab.isValue stepped || isJust (Elab.step stepped) || Elab.typeCheck stepped == Elab.typeCheck (Elab.normalize stepped))
-        Nothing -> counterexample (show term) (Elab.isValue term)
+propSolveHarmonize :: Int -> Property
+propSolveHarmonize _size =
+  propGeneralizedUnify 0
 
-propInstApplication :: Int -> Property
-propInstApplication size =
-  let poly = Elab.TForall "a" Nothing (Elab.TArrow (Elab.TVar "a") (Elab.TVar "a"))
-      inst = instantiation size
-   in case Elab.applyInstantiation poly inst of
-        Right ty -> counterexample (show ty) (not (null (show ty)))
-        Left err -> counterexample (show err) False
+propSolveValidate :: Int -> Property
+propSolveValidate _size =
+  case solveUnify defaultTraceConfig varTripleConstraint of
+    Right SolveResult {srConstraint = solved} -> Binding.checkBindingTree solved === Right ()
+    Left err -> counterexample (show err) False
 
-propTranslatablePresolution :: Int -> Property
-propTranslatablePresolution size =
-  let expr = surfaceExpr size
-   in case runPipelineArtifactsDefault Set.empty expr of
-        Right _ -> property True
-        Left err -> counterexample err False
+applyShouldBe :: Elab.ElabType -> Elab.Instantiation -> Elab.ElabType -> Property
+applyShouldBe ty inst expected =
+  case Elab.applyInstantiation ty inst of
+    Right actual -> actual === expected
+    Left err -> counterexample (show err) False
 
-propSigmaReorder :: Int -> Property
-propSigmaReorder size =
-  let body = Elab.TArrow (Elab.TVar "a") (Elab.TVar "b")
-      src = Elab.TForall "a" Nothing (Elab.TForall "b" Nothing body)
-      tgt =
-        if even size
-          then src
-          else Elab.TForall "b" Nothing (Elab.TForall "a" Nothing body)
-   in case Elab.sigmaReorder src tgt of
-        Right inst -> counterexample (show inst) (isRight (Elab.applyInstantiation src inst))
-        Left err -> counterexample (show err) False
+elaboratesTo :: Surf.SurfaceExpr -> Elab.ElabType -> Property
+elaboratesTo expr expected =
+  case Elab.runPipelineElabChecked Set.empty (unsafeNormalizeExpr expr) of
+    Right (term, ty) ->
+      conjoin
+        [ ty === expected,
+          Elab.typeCheck term === Right expected
+        ]
+    Left err -> counterexample (Elab.renderPipelineError err) False
 
-propContextSelection :: Int -> Property
-propContextSelection size =
-  let c = chainConstraint size
-   in case Binding.bindingPathToRoot c (typeRef (NodeId (size - 1))) of
-        Right path ->
-          conjoin
-            [ counterexample (show path) (not (null path)),
-              counterexample (show path) (last path == genRef (GenNodeId 0))
-            ]
-        Left err -> counterexample (show err) False
+propPresolutionClearsEdges :: Surf.SurfaceExpr -> Property
+propPresolutionClearsEdges expr =
+  case runToPresolutionDefault Set.empty expr of
+    Right PresolutionResult {prConstraint = c} ->
+      conjoin
+        [ Binding.checkBindingTree c === Right (),
+          cInstEdges c === []
+        ]
+    Left err -> counterexample err False
 
-propElaboration :: Int -> Property
-propElaboration size =
-  let expr = surfaceExpr size
-   in case Elab.runPipelineElabChecked Set.empty (unsafeNormalizeExpr expr) of
-        Right (term, ty) -> Elab.typeCheck term === Right ty
-        Left err -> counterexample (Elab.renderPipelineError err) False
+propEdgeWitnessOps :: Surf.SurfaceExpr -> ([EdgeWitness] -> Bool) -> Property
+propEdgeWitnessOps expr predicate =
+  case runToPresolutionDefault Set.empty expr of
+    Right PresolutionResult {prEdgeWitnesses = witnesses} ->
+      let values = IntMap.elems witnesses
+       in counterexample (show values) (predicate values)
+    Left err -> counterexample err False
 
-propPhiTranslation :: Int -> Property
-propPhiTranslation size =
-  let expr = surfaceExpr size
-   in case runPipelineArtifactsDefault Set.empty expr of
-        Right artifacts ->
-          counterexample (show (paRootId artifacts)) (paRootId artifacts >= 0)
-        Left err -> counterexample err False
+acyclicConstraint :: Int -> Constraint
+acyclicConstraint size =
+  rootedConstraintLocal
+    emptyConstraint
+      { cNodes =
+          nodeMapFromList
+            [ (0, TyVar {tnId = NodeId 0, tnBound = Nothing}),
+              (1, TyVar {tnId = NodeId 1, tnBound = Nothing}),
+              (2, TyBase (NodeId 2) (BaseTy "Int"))
+            ],
+        cInstEdges = [InstEdge (EdgeId size) (NodeId 0) (NodeId 2)]
+      }
+
+flexibleSchemeRootConstraint :: Constraint
+flexibleSchemeRootConstraint =
+  let rootGen = GenNodeId 0
+      schemeRoot = NodeId 0
+   in rootedConstraint
+        emptyConstraint
+          { cNodes = nodeMapFromList [(0, TyVar {tnId = schemeRoot, tnBound = Nothing})],
+            cBindParents = IntMap.fromList [(nodeRefKey (typeRef schemeRoot), (genRef rootGen, BindFlex))],
+            cGenNodes = fromListGen [(rootGen, GenNode rootGen [schemeRoot])]
+          }
+
+flexibleArrowConstraint :: Constraint
+flexibleArrowConstraint =
+  let rootGen = GenNodeId 0
+      dom = NodeId 0
+      cod = NodeId 1
+      arr = NodeId 2
+   in rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (0, TyVar {tnId = dom, tnBound = Nothing}),
+                  (1, TyVar {tnId = cod, tnBound = Nothing}),
+                  (2, TyArrow arr dom cod)
+                ],
+            cBindParents =
+              IntMap.fromList
+                [ (nodeRefKey (typeRef arr), (genRef rootGen, BindFlex)),
+                  (nodeRefKey (typeRef dom), (typeRef arr, BindFlex)),
+                  (nodeRefKey (typeRef cod), (typeRef arr, BindFlex))
+                ],
+            cGenNodes = fromListGen [(rootGen, GenNode rootGen [arr])]
+          }
+
+flexibleNonInteriorConstraint :: Constraint
+flexibleNonInteriorConstraint =
+  let rootGen = GenNodeId 0
+      schemeRoot = NodeId 0
+      dom = NodeId 1
+      cod = NodeId 2
+      arrow = NodeId 3
+      outside = NodeId 4
+   in emptyConstraint
+        { cNodes =
+            nodeMapFromList
+              [ (getNodeId schemeRoot, TyVar {tnId = schemeRoot, tnBound = Just arrow}),
+                (getNodeId dom, TyVar {tnId = dom, tnBound = Nothing}),
+                (getNodeId cod, TyVar {tnId = cod, tnBound = Nothing}),
+                (getNodeId arrow, TyArrow arrow dom cod),
+                (getNodeId outside, TyVar {tnId = outside, tnBound = Nothing})
+              ],
+          cBindParents =
+            IntMap.fromList
+              [ (nodeRefKey (typeRef schemeRoot), (genRef rootGen, BindRigid)),
+                (nodeRefKey (typeRef arrow), (typeRef schemeRoot, BindRigid)),
+                (nodeRefKey (typeRef dom), (typeRef arrow, BindFlex)),
+                (nodeRefKey (typeRef cod), (typeRef arrow, BindFlex)),
+                (nodeRefKey (typeRef outside), (genRef rootGen, BindFlex))
+              ],
+          cGenNodes = fromListGen [(rootGen, GenNode rootGen [schemeRoot])]
+        }
+
+forallA :: Elab.ElabType
+forallA = Elab.TForall "a" Nothing (Elab.TVar "a")
+
+polyIdTy :: Elab.ElabType
+polyIdTy = Elab.TForall "a" Nothing (Elab.TArrow (Elab.TVar "a") (Elab.TVar "a"))
+
+letIdAppExpr :: Surf.SurfaceExpr
+letIdAppExpr =
+  Surf.ELet "id" (Surf.ELam "x" (Surf.EVar "x")) (Surf.EApp (Surf.EVar "id") (Surf.ELit (Surf.LInt 1)))
+
+boundFromType :: Elab.ElabType -> Elab.BoundType
+boundFromType ty =
+  case ty of
+    Elab.TVar v -> error ("boundFromType: unexpected variable bound " ++ show v)
+    Elab.TArrow a b -> Elab.TArrow a b
+    Elab.TCon c args -> Elab.TCon c args
+    Elab.TBase b -> Elab.TBase b
+    Elab.TBottom -> Elab.TBottom
+    Elab.TForall v mb body -> Elab.TForall v mb body
+    Elab.TMu v body -> Elab.TMu v body
 
 chainConstraint :: Int -> Constraint
 chainConstraint rawSize =
@@ -614,43 +1097,6 @@ inertConstraint size =
             ]
       }
 
-surfaceExpr :: Int -> Surf.SurfaceExpr
-surfaceExpr size =
-  case size `mod` 5 of
-    0 -> Surf.ELit (Surf.LInt (fromIntegral size))
-    1 -> Surf.ELam "x" (Surf.EVar "x")
-    2 -> Surf.EApp (Surf.ELam "x" (Surf.EVar "x")) (Surf.ELit (Surf.LInt (fromIntegral size)))
-    3 -> Surf.ELet "id" (Surf.ELam "x" (Surf.EVar "x")) (Surf.EVar "id")
-    _ -> Surf.EAnn (Surf.ELit (Surf.LInt (fromIntegral size))) (Surf.STBase "Int")
-
-elabTerm :: Int -> (Elab.ElabTerm, Elab.ElabType)
-elabTerm size =
-  case size `mod` 6 of
-    0 -> (Elab.ELit (Surf.LInt (fromIntegral size)), intTy)
-    1 -> (Elab.ELit (Surf.LBool (even size)), boolTy)
-    2 -> (idLam, Elab.TArrow intTy intTy)
-    3 -> (Elab.EApp idLam (Elab.ELit (Surf.LInt (fromIntegral size))), intTy)
-    4 -> (Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x"), intTy)
-    _ -> (Elab.ETyInst polyId (Elab.InstApp intTy), Elab.TArrow intTy intTy)
-
-reducibleTerm :: Int -> Elab.ElabTerm
-reducibleTerm size =
-  case size `mod` 5 of
-    0 -> Elab.EApp idLam (Elab.ELit (Surf.LInt 1))
-    1 -> Elab.ELet "x" (Elab.schemeFromType intTy) (Elab.ELit (Surf.LInt 1)) (Elab.EVar "x")
-    2 -> Elab.ETyInst (Elab.ELit (Surf.LInt 1)) Elab.InstIntro
-    3 -> Elab.ETyInst polyId Elab.InstElim
-    _ -> Elab.ETyInst polyId (Elab.InstApp intTy)
-
-instantiation :: Int -> Elab.Instantiation
-instantiation size =
-  case size `mod` 5 of
-    0 -> Elab.InstId
-    1 -> Elab.InstElim
-    2 -> Elab.InstApp intTy
-    3 -> Elab.InstSeq (Elab.InstInside (Elab.InstBot intTy)) Elab.InstElim
-    _ -> Elab.InstUnder "x" Elab.InstId
-
 intTy :: Elab.ElabType
 intTy = Elab.TBase (BaseTy "Int")
 
@@ -662,6 +1108,3 @@ idLam = Elab.ELam "x" intTy (Elab.EVar "x")
 
 polyId :: Elab.ElabTerm
 polyId = Elab.ETyAbs "a" Nothing (Elab.ELam "x" (Elab.TVar "a") (Elab.EVar "x"))
-
-paRootId :: PipelineArtifacts -> Int
-paRootId = getNodeId . paRoot

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -17,9 +17,10 @@ import MLF.Binding.Tree qualified as Binding
 import MLF.Constraint.Acyclicity (AcyclicityResult (..), checkAcyclicity)
 import MLF.Constraint.Inert qualified as Inert
 import MLF.Constraint.Normalize (normalize)
-import MLF.Constraint.Presolution (PresolutionError (..), PresolutionResult (..), PresolutionView (..))
+import MLF.Constraint.Presolution (EdgeTrace (..), PresolutionError (..), PresolutionResult (..), PresolutionView (..))
 import MLF.Constraint.Presolution.TestSupport
   ( PresolutionState (..),
+    fromListInterior,
     runPresolutionM,
     unifyAcyclic,
     validateTranslatablePresolution,
@@ -35,7 +36,7 @@ import MLF.Constraint.Presolution.Witness
   )
 import MLF.Constraint.Solve (SolveResult (..), frWith, solveUnify)
 import MLF.Constraint.Types.Graph
-import MLF.Constraint.Types.Witness (EdgeWitness (..), InstanceOp (..), ReplayContract (..))
+import MLF.Constraint.Types.Witness (EdgeWitness (..), InstanceOp (..), InstanceWitness (..), ReplayContract (..))
 import MLF.Constraint.Unify.Decompose (decomposeUnifyChildren)
 import MLF.Elab.Pipeline qualified as Elab
 import MLF.Frontend.ConstraintGen (ConstraintResult (..))
@@ -202,9 +203,9 @@ propBindingInterior size =
 
 propBindingOrder :: Int -> Property
 propBindingOrder size =
-  let c = chainConstraint size
-   in case Binding.orderedBinders id c (typeRef (NodeId 0)) of
-        Right binders -> counterexample (show binders) True
+  let (c, root, expected) = orderedBinderFixture size
+   in case Binding.orderedBinders id c (typeRef root) of
+        Right binders -> counterexample (show binders) (binders === expected)
         Left err -> counterexample (show err) False
 
 propGraphWeaken :: Int -> Property
@@ -696,8 +697,72 @@ propTrNodeMerge _size =
    in normalizeInstanceOpsFull env [OpMerge mLess nGreater] === Left (MergeDirectionInvalid mLess nGreater)
 
 propTrNodeRaiseMerge :: Int -> Property
-propTrNodeRaiseMerge _size =
-  propTrRootRaiseMerge 0
+propTrNodeRaiseMerge size =
+  let base = max 3 size * 10
+      root = NodeId (base + 100)
+      binderA = NodeId (base + 1)
+      forallB = NodeId (base + 102)
+      binderB = NodeId (base + 2)
+      bodyNode = NodeId (base + 103)
+      c =
+        rootedConstraint
+          emptyConstraint
+            { cNodes =
+                nodeMapFromList
+                  [ (getNodeId root, TyForall root forallB),
+                    (getNodeId binderA, TyVar {tnId = binderA, tnBound = Nothing}),
+                    (getNodeId forallB, TyForall forallB bodyNode),
+                    (getNodeId binderB, TyVar {tnId = binderB, tnBound = Nothing}),
+                    (getNodeId bodyNode, TyArrow bodyNode binderA binderB)
+                  ],
+              cBindParents =
+                bindParentsFromPairs
+                  [ (binderA, root, BindFlex),
+                    (forallB, root, BindFlex),
+                    (binderB, forallB, BindFlex),
+                    (bodyNode, forallB, BindFlex)
+                  ]
+            }
+      scheme =
+        Elab.schemeFromType
+          (Elab.TForall "a" Nothing (Elab.TForall "b" Nothing (Elab.TArrow (Elab.TVar "a") (Elab.TVar "b"))))
+      si =
+        Elab.SchemeInfo
+          { Elab.siScheme = scheme,
+            Elab.siSubst = IntMap.fromList [(getNodeId binderA, "a"), (getNodeId binderB, "b")]
+          }
+      tr =
+        EdgeTrace
+          { etRoot = root,
+            etBinderArgs = [],
+            etInterior = fromListInterior [root, binderA, forallB, binderB, bodyNode],
+            etReplayContract = ReplayContractNone,
+            etBinderReplayMap = mempty,
+            etReplayDomainBinders = [],
+            etCopyMap = mempty
+          }
+      ew =
+        EdgeWitness
+          { ewEdgeId = EdgeId size,
+            ewLeft = root,
+            ewRight = root,
+            ewRoot = root,
+            ewForallIntros = 0,
+            ewWitness = InstanceWitness [OpRaiseMerge binderB binderA]
+          }
+      expected =
+        Elab.TForall
+          "a"
+          Nothing
+          (Elab.TArrow (Elab.TVar "a") (Elab.TVar "a"))
+      generalizeAt _ _ _ =
+        Left (Elab.InstantiationError "propTrNodeRaiseMerge: unexpected generalization")
+   in case Elab.phiFromEdgeWitnessWithTrace defaultTraceConfig generalizeAt (identityPresolutionView c) Nothing (Just si) (Just tr) ew of
+        Left err -> counterexample (show err) False
+        Right phi ->
+          case Elab.applyInstantiation (Elab.schemeToType scheme) phi of
+            Left err -> counterexample (show err) False
+            Right out -> counterexample (Elab.pretty out) (out === expected)
 
 propTrNodeWeaken :: Int -> Property
 propTrNodeWeaken _size =
@@ -1145,6 +1210,33 @@ identityPresolutionView c =
       pvBindParents = cBindParents c,
       pvCanonicalConstraint = c
     }
+
+orderedBinderFixture :: Int -> (Constraint, NodeId, [NodeId])
+orderedBinderFixture size =
+  (c, root, [bN, aN])
+  where
+    base = max 3 size * 10
+    root = NodeId (base + 100)
+    body = NodeId (base + 101)
+    aN = NodeId (base + 1)
+    bN = NodeId (base + 2)
+    c =
+      rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId root, TyForall root body),
+                  (getNodeId body, TyArrow body bN aN),
+                  (getNodeId aN, TyVar {tnId = aN, tnBound = Nothing}),
+                  (getNodeId bN, TyVar {tnId = bN, tnBound = Nothing})
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (body, root, BindFlex),
+                  (aN, root, BindFlex),
+                  (bN, root, BindFlex)
+                ]
+          }
 
 contextFindFixture :: Int -> (Constraint, NodeId, NodeId, [Elab.ContextStep])
 contextFindFixture size =

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -877,19 +877,63 @@ propNormGraft size =
         ]
 
 propNormMerge :: Int -> Property
-propNormMerge _size =
-  propSolveVarVar 0
+propNormMerge size =
+  let mergeBase = BaseTy ("Merge" ++ show size)
+      c =
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (0, TyVar {tnId = NodeId 0, tnBound = Nothing}),
+                  (1, TyBase (NodeId 1) mergeBase)
+                ],
+            cUnifyEdges = [UnifyEdge (NodeId 0) (NodeId 1)]
+          }
+      normalized = normalize c
+   in conjoin
+        [ cUnifyEdges normalized === [],
+          lookupNodeIn (cNodes normalized) (NodeId 0) === Just (TyBase (NodeId 0) mergeBase)
+        ]
 
 propNormDrop :: Int -> Property
-propNormDrop _size =
-  let c = varTripleConstraint {cUnifyEdges = [UnifyEdge (NodeId 1) (NodeId 1)]}
-   in case solveUnify defaultTraceConfig c of
-        Right SolveResult {srConstraint = solved} -> cUnifyEdges solved === []
-        Left err -> counterexample (show err) False
+propNormDrop size =
+  let node = TyVar {tnId = NodeId 0, tnBound = Nothing}
+      edge = InstEdge (EdgeId size) (NodeId 0) (NodeId 0)
+      c =
+        emptyConstraint
+          { cNodes = nodeMapFromList [(0, node)],
+            cInstEdges = [edge]
+          }
+      normalized = normalize c
+   in conjoin
+        [ cInstEdges normalized === [],
+          cUnifyEdges normalized === [],
+          lookupNodeIn (cNodes normalized) (NodeId 0) === Just node
+        ]
 
 propNormFixpoint :: Int -> Property
-propNormFixpoint _size =
-  propSolveValidate 0
+propNormFixpoint size =
+  let fixpointBase = BaseTy ("Fixpoint" ++ show size)
+      c =
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (0, TyVar {tnId = NodeId 0, tnBound = Nothing}),
+                  (1, TyVar {tnId = NodeId 1, tnBound = Nothing}),
+                  (2, TyBase (NodeId 2) fixpointBase)
+                ],
+            cInstEdges =
+              [ InstEdge (EdgeId size) (NodeId 0) (NodeId 1),
+                InstEdge (EdgeId (size + 1)) (NodeId 1) (NodeId 2)
+              ]
+          }
+      normalized = normalize c
+   in conjoin
+        [ normalized === normalize normalized,
+          cInstEdges normalized === [],
+          cUnifyEdges normalized === [],
+          lookupNodeIn (cNodes normalized) (NodeId 0) === Just (TyBase (NodeId 0) fixpointBase),
+          lookupNodeIn (cNodes normalized) (NodeId 1) === Just (TyBase (NodeId 1) fixpointBase)
+        ]
 
 propSolveVarBase :: Int -> Property
 propSolveVarBase _size =

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -17,8 +17,14 @@ import MLF.Binding.Tree qualified as Binding
 import MLF.Constraint.Acyclicity (AcyclicityResult (..), checkAcyclicity)
 import MLF.Constraint.Inert qualified as Inert
 import MLF.Constraint.Normalize (normalize)
-import MLF.Constraint.Presolution (PresolutionError (..), PresolutionResult (..))
-import MLF.Constraint.Presolution.TestSupport (validateTranslatablePresolution)
+import MLF.Constraint.Presolution (PresolutionError (..), PresolutionResult (..), PresolutionView (..))
+import MLF.Constraint.Presolution.TestSupport
+  ( PresolutionState (..),
+    runPresolutionM,
+    unifyAcyclic,
+    validateTranslatablePresolution,
+  )
+import MLF.Constraint.Types.Presolution (Presolution (..))
 import MLF.Constraint.Presolution.Witness
   ( OmegaNormalizeEnv (..),
     OmegaNormalizeError (..),
@@ -141,7 +147,7 @@ obligations =
     Obligation "O05-INERT-LOCKED" propInertLocked,
     Obligation "O05-WEAKEN-INERT" propInertWeaken,
     Obligation "O07-UNIF-CORE" propUnifyDecompose,
-    Obligation "O07-UNIF-PRESOL" propSolveVar,
+    Obligation "O07-UNIF-PRESOL" propPresolutionUnify,
     Obligation "O07-REBIND" propRebindHarmonize,
     Obligation "O07-GENUNIF" propGeneralizedUnify,
     Obligation "O08-REIFY-TYPE" propReifyType,
@@ -285,6 +291,20 @@ propSolveVar _size =
               frWith uf (NodeId 1) === frWith uf (NodeId 3),
               Binding.checkBindingTree solved === Right ()
             ]
+        Left err -> counterexample (show err) False
+
+propPresolutionUnify :: Int -> Property
+propPresolutionUnify _size =
+  let c = varTripleConstraint
+      st0 = emptyPresolutionState c
+   in case runPresolutionM defaultTraceConfig st0 (unifyAcyclic (NodeId 1) (NodeId 3)) of
+        Right ((), st1) ->
+          let uf = psUnionFind st1
+              solved = psConstraint st1
+           in conjoin
+                [ frWith uf (NodeId 1) === frWith uf (NodeId 3),
+                  Binding.checkBindingTree solved === Right ()
+                ]
         Left err -> counterexample (show err) False
 
 propSolveArrow :: Int -> Property
@@ -544,14 +564,17 @@ propSigmaReorderIdentity _size =
 
 propContextFind :: Int -> Property
 propContextFind size =
-  let c = chainConstraint size
-   in case Binding.bindingPathToRoot c (typeRef (NodeId (size - 1))) of
-        Right path -> counterexample (show path) (last path == genRef (GenNodeId 0) && length path >= 2)
+  let (c, root, target, expected) = contextFindFixture size
+   in case Elab.contextToNodeBound (identityPresolutionView c) root target of
+        Right steps -> steps === Just expected
         Left err -> counterexample (show err) False
 
 propContextReject :: Int -> Property
-propContextReject _size =
-  lookupNodeIn (cNodes binderConstraint) (NodeId 99) === Nothing
+propContextReject size =
+  let (c, root, target) = contextRejectFixture size
+   in case Elab.contextToNodeBound (identityPresolutionView c) root target of
+        Right steps -> steps === Nothing
+        Left err -> counterexample (show err) False
 
 propEdgeTranslation :: Int -> Property
 propEdgeTranslation _size =
@@ -1092,6 +1115,93 @@ boundFromType ty =
     Elab.TBottom -> Elab.TBottom
     Elab.TForall v mb body -> Elab.TForall v mb body
     Elab.TMu v body -> Elab.TMu v body
+
+emptyPresolutionState :: Constraint -> PresolutionState
+emptyPresolutionState c =
+  PresolutionState
+    c
+    (Presolution IntMap.empty)
+    IntMap.empty
+    (maxNodeIdKeyOr0 c + 1)
+    IntSet.empty
+    IntMap.empty
+    IntMap.empty
+    IntMap.empty
+    IntMap.empty
+    IntMap.empty
+
+identityPresolutionView :: Constraint -> PresolutionView
+identityPresolutionView c =
+  PresolutionView
+    { pvConstraint = c,
+      pvCanonicalMap = IntMap.empty,
+      pvCanonical = id,
+      pvLookupNode = \nid -> lookupNodeIn (cNodes c) nid,
+      pvLookupVarBound =
+        \nid -> case lookupNodeIn (cNodes c) nid of
+          Just TyVar {tnBound = mbBound} -> mbBound
+          _ -> Nothing,
+      pvLookupBindParent = Binding.lookupBindParent c,
+      pvBindParents = cBindParents c,
+      pvCanonicalConstraint = c
+    }
+
+contextFindFixture :: Int -> (Constraint, NodeId, NodeId, [Elab.ContextStep])
+contextFindFixture size =
+  (c, root, cN, [Elab.StepUnder ("t" ++ show (getNodeId aN)), Elab.StepInside])
+  where
+    base = max 3 size * 10
+    root = NodeId (base + 100)
+    body = NodeId (base + 101)
+    aN = NodeId (base + 1)
+    bN = NodeId (base + 2)
+    cN = NodeId (base + 3)
+    c =
+      rootedConstraintLocal
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId root, TyForall root body),
+                  (getNodeId body, TyArrow body aN bN),
+                  (getNodeId aN, TyVar {tnId = aN, tnBound = Nothing}),
+                  (getNodeId bN, TyVar {tnId = bN, tnBound = Just cN}),
+                  (getNodeId cN, TyVar {tnId = cN, tnBound = Nothing})
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (body, root, BindFlex),
+                  (aN, root, BindFlex),
+                  (bN, root, BindFlex),
+                  (cN, bN, BindFlex)
+                ]
+          }
+
+contextRejectFixture :: Int -> (Constraint, NodeId, NodeId)
+contextRejectFixture size =
+  (c, root, bodyOnly)
+  where
+    base = max 3 size * 10
+    root = NodeId (base + 100)
+    body = NodeId (base + 101)
+    aN = NodeId (base + 1)
+    bodyOnly = NodeId (base + 2)
+    c =
+      rootedConstraintLocal
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId root, TyForall root body),
+                  (getNodeId body, TyArrow body aN bodyOnly),
+                  (getNodeId aN, TyVar {tnId = aN, tnBound = Nothing}),
+                  (getNodeId bodyOnly, TyVar {tnId = bodyOnly, tnBound = Nothing})
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (body, root, BindFlex),
+                  (aN, root, BindFlex),
+                  (bodyOnly, body, BindFlex)
+                ]
+          }
 
 chainConstraint :: Int -> Constraint
 chainConstraint rawSize =

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -20,6 +20,7 @@ import MLF.Constraint.Normalize (normalize)
 import MLF.Constraint.Presolution (EdgeTrace (..), PresolutionError (..), PresolutionResult (..), PresolutionView (..))
 import MLF.Constraint.Presolution.TestSupport
   ( PresolutionState (..),
+    decideMinimalExpansion,
     fromListInterior,
     runPresolutionM,
     unifyAcyclic,
@@ -28,7 +29,6 @@ import MLF.Constraint.Presolution.TestSupport
 import MLF.Constraint.Types.Presolution (Presolution (..))
 import MLF.Constraint.Presolution.Witness
   ( OmegaNormalizeEnv (..),
-    OmegaNormalizeError (..),
     coalesceRaiseMergeWithEnv,
     normalizeInstanceOpsFull,
     reorderWeakenWithEnv,
@@ -36,12 +36,12 @@ import MLF.Constraint.Presolution.Witness
   )
 import MLF.Constraint.Solve (SolveResult (..), frWith, solveUnify)
 import MLF.Constraint.Types.Graph
-import MLF.Constraint.Types.Witness (EdgeWitness (..), InstanceOp (..), InstanceWitness (..), ReplayContract (..))
+import MLF.Constraint.Types.Witness (EdgeWitness (..), Expansion (..), ForallSpec (..), InstanceOp (..), InstanceWitness (..), ReplayContract (..))
 import MLF.Constraint.Unify.Decompose (decomposeUnifyChildren)
 import MLF.Elab.Pipeline qualified as Elab
 import MLF.Frontend.ConstraintGen (ConstraintResult (..))
 import MLF.Frontend.Syntax qualified as Surf
-import Presolution.Util (mkNormalizeConstraint, mkNormalizeEnv, orderedPairByPrec)
+import Presolution.Util (mkNormalizeConstraint, mkNormalizeEnv)
 import SpecUtil
   ( PipelineArtifacts (..),
     bindParentsFromPairs,
@@ -689,80 +689,12 @@ propTrNodeGraft _size =
    in normalizeInstanceOpsFull env [OpGraft arg binder, OpWeaken binder] === Right [OpGraft arg binder, OpWeaken binder]
 
 propTrNodeMerge :: Int -> Property
-propTrNodeMerge _size =
-  let c = mkNormalizeConstraint
-      root = NodeId 0
-      (mLess, nGreater) = orderedPairByPrec c root
-      env = mkNormalizeEnv c root (IntSet.fromList [getNodeId mLess, getNodeId nGreater])
-   in normalizeInstanceOpsFull env [OpMerge mLess nGreater] === Left (MergeDirectionInvalid mLess nGreater)
+propTrNodeMerge size =
+  assertNodeAliasTranslation size OpMerge
 
 propTrNodeRaiseMerge :: Int -> Property
 propTrNodeRaiseMerge size =
-  let base = max 3 size * 10
-      root = NodeId (base + 100)
-      binderA = NodeId (base + 1)
-      forallB = NodeId (base + 102)
-      binderB = NodeId (base + 2)
-      bodyNode = NodeId (base + 103)
-      c =
-        rootedConstraint
-          emptyConstraint
-            { cNodes =
-                nodeMapFromList
-                  [ (getNodeId root, TyForall root forallB),
-                    (getNodeId binderA, TyVar {tnId = binderA, tnBound = Nothing}),
-                    (getNodeId forallB, TyForall forallB bodyNode),
-                    (getNodeId binderB, TyVar {tnId = binderB, tnBound = Nothing}),
-                    (getNodeId bodyNode, TyArrow bodyNode binderA binderB)
-                  ],
-              cBindParents =
-                bindParentsFromPairs
-                  [ (binderA, root, BindFlex),
-                    (forallB, root, BindFlex),
-                    (binderB, forallB, BindFlex),
-                    (bodyNode, forallB, BindFlex)
-                  ]
-            }
-      scheme =
-        Elab.schemeFromType
-          (Elab.TForall "a" Nothing (Elab.TForall "b" Nothing (Elab.TArrow (Elab.TVar "a") (Elab.TVar "b"))))
-      si =
-        Elab.SchemeInfo
-          { Elab.siScheme = scheme,
-            Elab.siSubst = IntMap.fromList [(getNodeId binderA, "a"), (getNodeId binderB, "b")]
-          }
-      tr =
-        EdgeTrace
-          { etRoot = root,
-            etBinderArgs = [],
-            etInterior = fromListInterior [root, binderA, forallB, binderB, bodyNode],
-            etReplayContract = ReplayContractNone,
-            etBinderReplayMap = mempty,
-            etReplayDomainBinders = [],
-            etCopyMap = mempty
-          }
-      ew =
-        EdgeWitness
-          { ewEdgeId = EdgeId size,
-            ewLeft = root,
-            ewRight = root,
-            ewRoot = root,
-            ewForallIntros = 0,
-            ewWitness = InstanceWitness [OpRaiseMerge binderB binderA]
-          }
-      expected =
-        Elab.TForall
-          "a"
-          Nothing
-          (Elab.TArrow (Elab.TVar "a") (Elab.TVar "a"))
-      generalizeAt _ _ _ =
-        Left (Elab.InstantiationError "propTrNodeRaiseMerge: unexpected generalization")
-   in case Elab.phiFromEdgeWitnessWithTrace defaultTraceConfig generalizeAt (identityPresolutionView c) Nothing (Just si) (Just tr) ew of
-        Left err -> counterexample (show err) False
-        Right phi ->
-          case Elab.applyInstantiation (Elab.schemeToType scheme) phi of
-            Left err -> counterexample (show err) False
-            Right out -> counterexample (Elab.pretty out) (out === expected)
+  assertNodeAliasTranslation size OpRaiseMerge
 
 propTrNodeWeaken :: Int -> Property
 propTrNodeWeaken _size =
@@ -873,8 +805,144 @@ propCgenExpr _size =
     Left err -> counterexample err False
 
 propExpDecide :: Int -> Property
-propExpDecide _size =
-  propPresolutionClearsEdges letIdAppExpr
+propExpDecide size =
+  conjoin
+    [ assertMinimalDecision "identity" cId expId targetId $ \(expansion, unifications) ->
+        conjoin
+          [ expansion === ExpIdentity,
+            unifications === [(bodyId, targetId)]
+          ],
+      assertMinimalDecision "instantiate" cInst expInst targetArrow $ \(expansion, unifications) ->
+        case expansion of
+          ExpInstantiate args ->
+            conjoin
+              [ counterexample (show args) (length args === 1),
+                unifications === []
+              ]
+          other -> counterexample (show other) False,
+      assertMinimalDecision "compose" cCompose expCompose targetForall2 $ \(expansion, unifications) ->
+        case expansion of
+          ExpCompose (ExpInstantiate args :| [ExpForall (ForallSpec 2 [Nothing, Nothing] :| [])]) ->
+            conjoin
+              [ counterexample (show args) (length args === 1),
+                unifications === []
+              ]
+          other -> counterexample (show other) False,
+      assertMinimalDecision "forall-intro" cForallIntro expForallIntro targetForallIntro $ \(expansion, unifications) ->
+        conjoin
+          [ expansion === ExpForall (ForallSpec 2 [Nothing, Nothing] :| []),
+            unifications === []
+          ]
+    ]
+  where
+    base = max 3 size * 20
+    bodyId = NodeId (base + 1)
+    targetId = NodeId (base + 2)
+    expId = NodeId (base + 3)
+    cId =
+      rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId bodyId, TyBase bodyId (BaseTy "Int")),
+                  (getNodeId targetId, TyBase targetId (BaseTy "Int")),
+                  (getNodeId expId, TyExp expId (ExpVarId base) bodyId)
+                ],
+            cBindParents = bindParentsFromPairs [(bodyId, expId, BindFlex)]
+          }
+
+    srcVar = NodeId (base + 10)
+    srcArrow = NodeId (base + 11)
+    srcForall = NodeId (base + 12)
+    targetDom = NodeId (base + 13)
+    targetCod = NodeId (base + 14)
+    targetArrow = NodeId (base + 15)
+    expInst = NodeId (base + 16)
+    cInst =
+      rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId srcVar, TyVar {tnId = srcVar, tnBound = Nothing}),
+                  (getNodeId srcArrow, TyArrow srcArrow srcVar srcVar),
+                  (getNodeId srcForall, TyForall srcForall srcArrow),
+                  (getNodeId targetDom, TyBase targetDom (BaseTy "Int")),
+                  (getNodeId targetCod, TyBase targetCod (BaseTy "Int")),
+                  (getNodeId targetArrow, TyArrow targetArrow targetDom targetCod),
+                  (getNodeId expInst, TyExp expInst (ExpVarId (base + 1)) srcForall)
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (srcVar, srcForall, BindFlex),
+                  (srcArrow, srcForall, BindFlex),
+                  (targetDom, targetArrow, BindFlex),
+                  (targetCod, targetArrow, BindFlex),
+                  (srcForall, expInst, BindFlex)
+                ]
+          }
+
+    srcVarC = NodeId (base + 20)
+    srcForallC = NodeId (base + 21)
+    targetDomC = NodeId (base + 22)
+    targetCodC = NodeId (base + 23)
+    targetArrowC = NodeId (base + 24)
+    targetForall2 = NodeId (base + 25)
+    expCompose = NodeId (base + 26)
+    cCompose =
+      rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId srcVarC, TyVar {tnId = srcVarC, tnBound = Nothing}),
+                  (getNodeId srcForallC, TyForall srcForallC srcVarC),
+                  (getNodeId targetDomC, TyVar {tnId = targetDomC, tnBound = Nothing}),
+                  (getNodeId targetCodC, TyVar {tnId = targetCodC, tnBound = Nothing}),
+                  (getNodeId targetArrowC, TyArrow targetArrowC targetDomC targetCodC),
+                  (getNodeId targetForall2, TyForall targetForall2 targetArrowC),
+                  (getNodeId expCompose, TyExp expCompose (ExpVarId (base + 2)) srcForallC)
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (srcVarC, srcForallC, BindFlex),
+                  (srcForallC, expCompose, BindFlex),
+                  (targetDomC, targetForall2, BindFlex),
+                  (targetCodC, targetForall2, BindFlex),
+                  (targetArrowC, targetForall2, BindFlex)
+                ]
+          }
+
+    srcDomF = NodeId (base + 30)
+    srcCodF = NodeId (base + 31)
+    srcArrowF = NodeId (base + 32)
+    targetDomF = NodeId (base + 33)
+    targetCodF = NodeId (base + 34)
+    targetArrowF = NodeId (base + 35)
+    targetForallIntro = NodeId (base + 36)
+    expForallIntro = NodeId (base + 37)
+    cForallIntro =
+      rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId srcDomF, TyBase srcDomF (BaseTy "Int")),
+                  (getNodeId srcCodF, TyBase srcCodF (BaseTy "Bool")),
+                  (getNodeId srcArrowF, TyArrow srcArrowF srcDomF srcCodF),
+                  (getNodeId targetDomF, TyVar {tnId = targetDomF, tnBound = Nothing}),
+                  (getNodeId targetCodF, TyVar {tnId = targetCodF, tnBound = Nothing}),
+                  (getNodeId targetArrowF, TyArrow targetArrowF targetDomF targetCodF),
+                  (getNodeId targetForallIntro, TyForall targetForallIntro targetArrowF),
+                  (getNodeId expForallIntro, TyExp expForallIntro (ExpVarId (base + 3)) srcArrowF)
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (srcDomF, srcArrowF, BindFlex),
+                  (srcCodF, srcArrowF, BindFlex),
+                  (srcArrowF, expForallIntro, BindFlex),
+                  (targetDomF, targetForallIntro, BindFlex),
+                  (targetCodF, targetForallIntro, BindFlex),
+                  (targetArrowF, targetForallIntro, BindFlex)
+                ]
+          }
 
 propExpApply :: Int -> Property
 propExpApply _size =
@@ -1210,6 +1278,102 @@ identityPresolutionView c =
       pvBindParents = cBindParents c,
       pvCanonicalConstraint = c
     }
+
+assertMinimalDecision ::
+  String ->
+  Constraint ->
+  NodeId ->
+  NodeId ->
+  ((Expansion, [(NodeId, NodeId)]) -> Property) ->
+  Property
+assertMinimalDecision caseName c expNodeId targetNodeId checkDecision =
+  case decideMinimalFor c expNodeId targetNodeId of
+    Right decision -> counterexample (caseName ++ ": " ++ show decision) (checkDecision decision)
+    Left err -> counterexample (caseName ++ ": " ++ err) False
+
+decideMinimalFor :: Constraint -> NodeId -> NodeId -> Either String (Expansion, [(NodeId, NodeId)])
+decideMinimalFor c expNodeId targetNodeId =
+  case (lookupNodeIn (cNodes c) expNodeId, lookupNodeIn (cNodes c) targetNodeId) of
+    (Just expNode, Just targetNode) ->
+      case runPresolutionM defaultTraceConfig (emptyPresolutionState c) (decideMinimalExpansion (GenNodeId 0) True expNode targetNode) of
+        Right (decision, _st) -> Right decision
+        Left err -> Left (show err)
+    (Nothing, _) -> Left ("missing expansion node " ++ show expNodeId)
+    (_, Nothing) -> Left ("missing target node " ++ show targetNodeId)
+
+assertNodeAliasTranslation :: Int -> (NodeId -> NodeId -> InstanceOp) -> Property
+assertNodeAliasTranslation size mkOp =
+  let (c, root, binderA, binderB, scheme, si, tr) = nodeAliasTranslationFixture size
+      ew =
+        EdgeWitness
+          { ewEdgeId = EdgeId size,
+            ewLeft = root,
+            ewRight = root,
+            ewRoot = root,
+            ewForallIntros = 0,
+            ewWitness = InstanceWitness [mkOp binderB binderA]
+          }
+      expected =
+        Elab.TForall
+          "a"
+          Nothing
+          (Elab.TArrow (Elab.TVar "a") (Elab.TVar "a"))
+      generalizeAt _ _ _ =
+        Left (Elab.InstantiationError "assertNodeAliasTranslation: unexpected generalization")
+   in case Elab.phiFromEdgeWitnessWithTrace defaultTraceConfig generalizeAt (identityPresolutionView c) Nothing (Just si) (Just tr) ew of
+        Left err -> counterexample (show err) False
+        Right phi ->
+          case Elab.applyInstantiation (Elab.schemeToType scheme) phi of
+            Left err -> counterexample (show err) False
+            Right out -> counterexample (Elab.pretty phi ++ " => " ++ Elab.pretty out) (out === expected)
+
+nodeAliasTranslationFixture :: Int -> (Constraint, NodeId, NodeId, NodeId, Elab.ElabScheme, Elab.SchemeInfo, EdgeTrace)
+nodeAliasTranslationFixture size =
+  (c, root, binderA, binderB, scheme, si, tr)
+  where
+    base = max 3 size * 10
+    root = NodeId (base + 100)
+    binderA = NodeId (base + 1)
+    forallB = NodeId (base + 102)
+    binderB = NodeId (base + 2)
+    bodyNode = NodeId (base + 103)
+    c =
+      rootedConstraint
+        emptyConstraint
+          { cNodes =
+              nodeMapFromList
+                [ (getNodeId root, TyForall root forallB),
+                  (getNodeId binderA, TyVar {tnId = binderA, tnBound = Nothing}),
+                  (getNodeId forallB, TyForall forallB bodyNode),
+                  (getNodeId binderB, TyVar {tnId = binderB, tnBound = Nothing}),
+                  (getNodeId bodyNode, TyArrow bodyNode binderA binderB)
+                ],
+            cBindParents =
+              bindParentsFromPairs
+                [ (binderA, root, BindFlex),
+                  (forallB, root, BindFlex),
+                  (binderB, forallB, BindFlex),
+                  (bodyNode, forallB, BindFlex)
+                ]
+          }
+    scheme =
+      Elab.schemeFromType
+        (Elab.TForall "a" Nothing (Elab.TForall "b" Nothing (Elab.TArrow (Elab.TVar "a") (Elab.TVar "b"))))
+    si =
+      Elab.SchemeInfo
+        { Elab.siScheme = scheme,
+          Elab.siSubst = IntMap.fromList [(getNodeId binderA, "a"), (getNodeId binderB, "b")]
+        }
+    tr =
+      EdgeTrace
+        { etRoot = root,
+          etBinderArgs = [],
+          etInterior = fromListInterior [root, binderA, forallB, binderB, bodyNode],
+          etReplayContract = ReplayContractNone,
+          etBinderReplayMap = mempty,
+          etReplayDomainBinders = [],
+          etCopyMap = mempty
+        }
 
 orderedBinderFixture :: Int -> (Constraint, NodeId, [NodeId])
 orderedBinderFixture size =

--- a/test/Thesis/ObligationPropertySpec.hs
+++ b/test/Thesis/ObligationPropertySpec.hs
@@ -19,9 +19,14 @@ import MLF.Constraint.Inert qualified as Inert
 import MLF.Constraint.Normalize (normalize)
 import MLF.Constraint.Presolution (EdgeTrace (..), PresolutionError (..), PresolutionResult (..), PresolutionView (..))
 import MLF.Constraint.Presolution.TestSupport
-  ( PresolutionState (..),
+  ( CopyMapping (..),
+    PresolutionState (..),
     decideMinimalExpansion,
     fromListInterior,
+    instantiateScheme,
+    instantiateSchemeWithTrace,
+    lookupCopy,
+    processInstEdge,
     runPresolutionM,
     unifyAcyclic,
     validateTranslatablePresolution,
@@ -970,10 +975,52 @@ propPropWitness _size =
     Left err -> counterexample err False
 
 propCopyScheme :: Int -> Property
-propCopyScheme _size =
-  case runToPresolutionDefault Set.empty letIdAppExpr of
-    Right PresolutionResult {prEdgeTraces = traces} -> counterexample (show (IntMap.size traces)) (not (IntMap.null traces))
-    Left err -> counterexample err False
+propCopyScheme size =
+  let base = size * 100
+      bound = NodeId (base + 1)
+      sharedArrow = NodeId (base + 5)
+      body = NodeId (base + 6)
+      fresh = NodeId (base + 10)
+      c =
+        rootedConstraint
+          emptyConstraint
+            { cNodes =
+                nodeMapFromList
+                  [ (getNodeId bound, TyVar {tnId = bound, tnBound = Nothing}),
+                    (getNodeId sharedArrow, TyArrow sharedArrow bound bound),
+                    (getNodeId body, TyArrow body sharedArrow sharedArrow),
+                    (getNodeId fresh, TyVar {tnId = fresh, tnBound = Nothing})
+                  ],
+              cBindParents =
+                bindParentsFromPairs
+                  [ (bound, sharedArrow, BindFlex),
+                    (sharedArrow, body, BindFlex)
+                  ]
+            }
+      st0 = emptyPresolutionState c
+   in case runPresolutionM defaultTraceConfig st0 (instantiateScheme body [(bound, fresh)]) of
+        Right (root, st1) ->
+          let c1 = psConstraint st1
+              nodes = cNodes c1
+              expectedSourceBody = TyArrow body sharedArrow sharedArrow
+           in case lookupNodeIn nodes root of
+                Just TyArrow {tnDom = dom, tnCod = cod} ->
+                  conjoin
+                    [ counterexample "scheme root is copied to a fresh node" (root /= body),
+                      counterexample "shared body child is copied once and reused" (dom == cod && dom /= sharedArrow),
+                      counterexample "source body remains unchanged" (lookupNodeIn nodes body == Just expectedSourceBody),
+                      case lookupNodeIn nodes dom of
+                        Just TyArrow {tnDom = innerDom, tnCod = innerCod} ->
+                          conjoin
+                            [ counterexample "substituted binder is used in copied domain" (innerDom == fresh),
+                              counterexample "substituted binder is used in copied codomain" (innerCod == fresh)
+                            ]
+                        other -> counterexample ("expected copied shared arrow, got " ++ show other) False,
+                      counterexample "fresh substitution node remains live" (isJust (lookupNodeIn nodes fresh)),
+                      Binding.checkBindingTree c1 === Right ()
+                    ]
+                other -> counterexample ("expected copied scheme root arrow, got " ++ show other) False
+        Left err -> counterexample (show err) False
 
 propWitnessNorm :: Int -> Property
 propWitnessNorm _size =
@@ -1007,8 +1054,133 @@ propAcyclicTopo size =
         Left err -> counterexample (show err) False
 
 propCopyInst :: Int -> Property
-propCopyInst _size =
-  propCopyScheme 0
+propCopyInst size =
+  let base = size * 100
+      binder = NodeId (base + 1)
+      outerVar = NodeId (base + 2)
+      frontierArrow = NodeId (base + 3)
+      bodyArrow = NodeId (base + 4)
+      forallNode = NodeId (base + 5)
+      expNode = NodeId (base + 6)
+      meta = NodeId (base + 10)
+      c =
+        rootedConstraint
+          emptyConstraint
+            { cNodes =
+                nodeMapFromList
+                  [ (getNodeId binder, TyVar {tnId = binder, tnBound = Nothing}),
+                    (getNodeId outerVar, TyVar {tnId = outerVar, tnBound = Nothing}),
+                    (getNodeId frontierArrow, TyArrow frontierArrow outerVar outerVar),
+                    (getNodeId bodyArrow, TyArrow bodyArrow frontierArrow binder),
+                    (getNodeId forallNode, TyForall forallNode bodyArrow),
+                    (getNodeId expNode, TyExp expNode (ExpVarId base) forallNode),
+                    (getNodeId meta, TyVar {tnId = meta, tnBound = Nothing})
+                  ],
+              cBindParents =
+                bindParentsFromPairs
+                  [ (forallNode, expNode, BindFlex),
+                    (bodyArrow, forallNode, BindFlex),
+                    (binder, bodyArrow, BindFlex),
+                    (frontierArrow, expNode, BindFlex),
+                    (outerVar, frontierArrow, BindFlex)
+                  ]
+            }
+      st0 = emptyPresolutionState c
+      directCopy =
+        case runPresolutionM defaultTraceConfig st0 (instantiateSchemeWithTrace bodyArrow [(binder, meta)]) of
+          Right ((root, copyMap, interior, frontier), st1) ->
+            let c1 = psConstraint st1
+                nodes = cNodes c1
+             in case lookupNodeIn nodes root of
+                  Just TyArrow {tnDom = dom, tnCod = cod} ->
+                    conjoin
+                      [ counterexample "Inst-Copy root is freshly copied" (root /= bodyArrow),
+                        lookupCopy bodyArrow copyMap === Just root,
+                        lookupCopy binder copyMap === Just meta,
+                        lookupCopy frontierArrow copyMap === Just dom,
+                        counterexample "binder argument is substituted into the copied codomain" (cod == meta),
+                        counterexample "frontier source is recorded in the frontier set" $
+                          IntSet.member (getNodeId frontierArrow) frontier,
+                        counterexample "fresh copied root is recorded in trace interior" $
+                          IntSet.member (getNodeId root) interior,
+                        counterexample "binder argument is recorded in trace interior" $
+                          IntSet.member (getNodeId meta) interior,
+                        case lookupNodeIn nodes dom of
+                          Just TyBottom {tnId = bottomId} ->
+                            counterexample "frontier copy is replaced with bottom" (bottomId == dom)
+                          other -> counterexample ("expected bottom frontier copy, got " ++ show other) False,
+                        counterexample "trace copy map records source-to-copy bookkeeping" $
+                          not (IntMap.null (getCopyMapping copyMap)),
+                        Binding.checkBindingTree c1 === Right ()
+                      ]
+                  other -> counterexample ("expected copied Inst-Copy arrow, got " ++ show other) False
+          Left err -> counterexample (show err) False
+      recordedTrace =
+        let edgeId = EdgeId (base + 20)
+            edgeSourceBinder = NodeId (base + 21)
+            edgeSourceArrow = NodeId (base + 22)
+            edgeSourceForall = NodeId (base + 23)
+            edgeTargetDom = NodeId (base + 24)
+            edgeTargetCod = NodeId (base + 25)
+            edgeTargetArrow = NodeId (base + 26)
+            edgeExp = NodeId (base + 27)
+            edge =
+              InstEdge
+                edgeId
+                edgeExp
+                edgeTargetArrow
+            edgeConstraint =
+              rootedConstraint
+                emptyConstraint
+                  { cNodes =
+                      nodeMapFromList
+                        [ (getNodeId edgeSourceBinder, TyVar {tnId = edgeSourceBinder, tnBound = Nothing}),
+                          (getNodeId edgeSourceArrow, TyArrow edgeSourceArrow edgeSourceBinder edgeSourceBinder),
+                          (getNodeId edgeSourceForall, TyForall edgeSourceForall edgeSourceArrow),
+                          (getNodeId edgeTargetDom, TyBase edgeTargetDom (BaseTy "Int")),
+                          (getNodeId edgeTargetCod, TyBase edgeTargetCod (BaseTy "Int")),
+                          (getNodeId edgeTargetArrow, TyArrow edgeTargetArrow edgeTargetDom edgeTargetCod),
+                          (getNodeId edgeExp, TyExp edgeExp (ExpVarId (base + 28)) edgeSourceForall)
+                        ],
+                    cBindParents =
+                      bindParentsFromPairs
+                        [ (edgeSourceBinder, edgeSourceForall, BindFlex),
+                          (edgeSourceArrow, edgeSourceForall, BindFlex),
+                          (edgeSourceForall, edgeExp, BindFlex),
+                          (edgeTargetDom, edgeTargetArrow, BindFlex),
+                          (edgeTargetCod, edgeTargetArrow, BindFlex)
+                        ]
+                  }
+            edgeSt0 = emptyPresolutionState edgeConstraint
+         in case runPresolutionM defaultTraceConfig edgeSt0 (processInstEdge edge) of
+              Right (_, edgeSt1) ->
+                let traces = psEdgeTraces edgeSt1
+                 in case IntMap.lookup (getEdgeId edgeId) traces of
+                      Just tr ->
+                        conjoin
+                          [ counterexample ("empty binder args in trace: " ++ show tr) $
+                              not (null (etBinderArgs tr)),
+                            edgeTraceCopyEvidence (psConstraint edgeSt1) tr
+                          ]
+                      Nothing -> counterexample ("missing trace keys: " ++ show (IntMap.keys traces)) False
+              Left err -> counterexample (show err) False
+   in conjoin [directCopy, recordedTrace]
+
+edgeTraceCopyEvidence :: Constraint -> EdgeTrace -> Property
+edgeTraceCopyEvidence c tr =
+  let copyPairs = IntMap.toList (getCopyMapping (etCopyMap tr))
+      binderPairs = etBinderArgs tr
+   in conjoin
+        [ counterexample "trace root is live in the presolved constraint" $
+            isJust (lookupNodeIn (cNodes c) (etRoot tr)),
+          counterexample ("empty trace copy map for " ++ show binderPairs) (not (null copyPairs)),
+          counterexample ("binder sources are absent from the trace copy map: " ++ show (binderPairs, copyPairs)) $
+            all (\(binder, _arg) -> IntMap.member (getNodeId binder) (getCopyMapping (etCopyMap tr))) binderPairs,
+          counterexample ("binder arguments are not live: " ++ show binderPairs) $
+            all (\(_binder, arg) -> isJust (lookupNodeIn (cNodes c) arg)) binderPairs,
+          counterexample ("copy map targets are not live: " ++ show copyPairs) $
+            all (\(_source, copied) -> isJust (lookupNodeIn (cNodes c) copied)) copyPairs
+        ]
 
 propNormGraft :: Int -> Property
 propNormGraft size =


### PR DESCRIPTION
## Summary

Fixes #5.

- Convert the thesis obligation ledger schema so all 107 obligations require QuickCheck evidence keyed by their stable obligation ID.
- Add `Thesis.ObligationPropertySpec` with property anchors for every obligation and wire it into Cabal, `test/Main.hs`, and repository guardrails.
- Harden the obligation gate so example-only Hspec matches no longer satisfy the ledger: every obligation must emit a QuickCheck success line and meet `min_success`.
- Update rendered ledger output, claims metadata, and changelog to reflect property-first evidence and navigation-only source anchors.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `cabal build all`
- `cabal test` (`1723 examples, 0 failures`)
- `scripts/check-thesis-obligations-ledger.sh`
- `scripts/check-thesis-claims.sh`
- `scripts/render-thesis-obligations-ledger.rb --check`
- `scripts/thesis-conformance-gate.sh`