### PR TITLE
Define .mlfp resolved symbol identities

### DIFF
--- a/docs/mlfp-resolved-symbol-identities.md
+++ b/docs/mlfp-resolved-symbol-identities.md
@@ -1,0 +1,80 @@
+# `.mlfp` Resolved Symbol Identity Audit
+
+This note records the issue #26 audit and the minimal frontend/program boundary
+model added in `MLF.Frontend.Program.Types`.
+
+## Boundary model
+
+`ResolvedSymbol` separates two facts that the current checker often stores in
+the same string:
+
+- `SymbolIdentity` is the stable semantic key. It contains a namespace, defining
+  module, defining name, and optional owner identity for constructors and class
+  methods.
+- `SymbolSpelling` is reference-side surface data. It retains the source name,
+  display name, and whether the spelling is local, unqualified import,
+  qualified/aliased import, or builtin.
+
+The model covers value, constructor, type, class, method, and module/import
+identities. Constructors are owned by a type identity; methods are owned by a
+class identity. Two visible spellings such as `answer` and `L.answer` therefore
+compare equal through `sameResolvedSymbol` when they name the same declaration
+from the same defining module.
+
+This is a model-level contract only. It deliberately does not migrate checker
+visibility behavior, parser grammar, or import/export semantics.
+
+## Current qualified/unqualified branch sites
+
+- `MLF.Frontend.Parse.Program`: `qualifiedUpperIdent` and
+  `qualifiedLowerIdent` accept at most one uppercase module qualifier and then
+  flatten the spelling into a `String`. The type parser reuses
+  `qualifiedUpperIdent`, so source types carry qualified spellings as plain
+  `STBase` or `STCon` names.
+- `MLF.Frontend.Syntax.Program`: `ProgramSpanIndex` stores spans by visible
+  strings for values, constructors, types, classes, import items, export items,
+  modules, and import aliases. Diagnostics currently recover locations by
+  visible spelling rather than semantic identity.
+- `MLF.Frontend.Program.Check`: `buildImportScope` branches on `importAlias`
+  and `importExposing`. Unaliased imports add exported names directly; aliased
+  imports first call `qualifyModuleExports` and optionally add explicitly
+  exposed unqualified names.
+- `MLF.Frontend.Program.Check`: `qualifyModuleExports`, `qualifyInstance`, and
+  `qualifyInstanceHeadOnly` manufacture qualified copies of exported values,
+  data/type names, constructors, classes, methods, constraints, and source
+  types by rewriting display strings and `SrcType` heads.
+- `MLF.Frontend.Program.Check`: `unqualifiedName`, `classIdentity`,
+  `methodClassIdentity`, `instanceClassIdentity`, `sameInstanceHead`, and
+  duplicate/overlap checks already reconstruct semantic identity from module
+  fields plus unqualified names.
+- `MLF.Frontend.Program.Check`: instance visibility is split between
+  `importedUnqualifiedClassIdentities`, `unqualifiedInstancesForImport`,
+  `qualifiedInstancesForImport`, `instanceVisibleForUnqualifiedImport`, and
+  `instanceVisibleForQualifiedImport`. These paths decide whether instances are
+  visible via class imports, method-only imports, qualified aliases, and exposed
+  data mentions.
+- `MLF.Frontend.Program.Check`: export assembly in `buildExports`,
+  `collectExportValue`, `collectExportType`, and `collectExportClass` preserves
+  local exported values, abstract types, constructor-bearing types, and class
+  methods with maps keyed by visible names.
+- `MLF.Frontend.Program.Elaborate`: `canonicalSourceType`, `lowerTypeRaw`,
+  `lookupConstructorInfoMaybe`, `constructorNameMatches`,
+  `resolveInstanceInfoWithSubst`, and `resolveMethodInstanceInfoWithSubst`
+  compare qualified and unqualified source type/class spellings by consulting
+  checker-built scope maps and module/name pairs.
+- `MLF.Frontend.Program.Finalize`: source type recovery and deferred obligation
+  resolution revisit the same names through `recoverSourceType`,
+  `matchDataInfoEncoding`, constructor ambiguity handling, and
+  `resolveInstanceInfoWithSubst`.
+- `MLF.Frontend.Program.Run`: runtime decoding uses `lookupDataInfosForType`,
+  `lookupDataInfosByName`, `qualifiedDataName`, and `canonicalFieldType` to
+  match qualified type names against source data declarations while rendering
+  user-facing constructor names.
+
+## Minimal next-step contract
+
+Later resolver work should replace ad hoc string splitting at the program
+boundary with `SymbolIdentity` lookups, while keeping `SymbolSpelling` available
+for diagnostics and display. The checker can then stop encoding identity in
+qualified copies of surface names, but that behavioral migration belongs to the
+resolver and downstream-migration issues, not this audit/model issue.

--- a/mlf2.cabal
+++ b/mlf2.cabal
@@ -392,6 +392,7 @@ test-suite mlf2-test
                       SolveSpec,
                       ScopeSpec,
                       ProgramSpec,
+                      ResolvedSymbolSpec,
                       PipelineSpec,
                       ThesisFixDirectionSpec,
                       TypeCheckSpec,

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -7,6 +7,27 @@ module MLF.Frontend.Program.Types
     diagnosticForProgramError,
     renderProgramDiagnostic,
     EvidenceInfo (..),
+    SymbolNamespace (..),
+    SymbolOwnerIdentity (..),
+    SymbolIdentity (..),
+    SymbolOrigin (..),
+    SymbolSpelling (..),
+    ResolvedSymbol (..),
+    mkResolvedSymbol,
+    sameResolvedSymbol,
+    unqualifiedSymbolName,
+    valueInfoSymbolIdentity,
+    dataInfoSymbolIdentity,
+    constructorInfoSymbolIdentity,
+    classInfoSymbolIdentity,
+    methodInfoSymbolIdentity,
+    instanceInfoClassSymbolIdentity,
+    resolvedValueInfoSymbol,
+    resolvedDataInfoSymbol,
+    resolvedConstructorInfoSymbol,
+    resolvedClassInfoSymbol,
+    resolvedMethodInfoSymbol,
+    resolvedModuleSymbol,
     ConstructorInfo (..),
     DataInfo (..),
     MethodInfo (..),
@@ -237,6 +258,85 @@ programErrorHints err =
       ["export the name from the source module or remove it from the import exposing list"]
     _ -> []
 
+data SymbolNamespace
+  = SymbolValue
+  | SymbolConstructor
+  | SymbolType
+  | SymbolClass
+  | SymbolMethod
+  | SymbolModule
+  deriving (Eq, Ord, Show)
+
+data SymbolOwnerIdentity
+  = SymbolOwnerType P.ModuleName P.TypeName
+  | SymbolOwnerClass P.ModuleName P.ClassName
+  deriving (Eq, Ord, Show)
+
+data SymbolIdentity = SymbolIdentity
+  { symbolNamespace :: SymbolNamespace,
+    symbolDefiningModule :: P.ModuleName,
+    symbolDefiningName :: String,
+    symbolOwnerIdentity :: Maybe SymbolOwnerIdentity
+  }
+  deriving (Eq, Ord, Show)
+
+data SymbolOrigin
+  = SymbolLocal P.ModuleName
+  | SymbolUnqualifiedImport P.ModuleName
+  | SymbolQualifiedImport P.ModuleName P.ModuleName
+  | SymbolBuiltin
+  deriving (Eq, Ord, Show)
+
+data SymbolSpelling = SymbolSpelling
+  { symbolSourceName :: String,
+    symbolDisplayName :: String,
+    symbolSpellingOrigin :: SymbolOrigin
+  }
+  deriving (Eq, Ord, Show)
+
+data ResolvedSymbol = ResolvedSymbol
+  { resolvedSymbolIdentity :: SymbolIdentity,
+    resolvedSymbolSpelling :: SymbolSpelling
+  }
+  deriving (Eq, Ord, Show)
+
+{- Note [Resolved .mlfp symbol identities]
+The current checker still accepts qualified spellings by materializing qualified
+copies of imported `ValueInfo`, `DataInfo`, and `ClassInfo` records. That keeps
+surface lookup working, but later phases need a stable model that does not
+confuse the spelling used at a reference site with the semantic declaration it
+resolved to.
+
+`SymbolIdentity` is the semantic key. It uses the defining module plus the
+unqualified declaration name, and method/constructor identities carry their
+owning class/type identity. `SymbolSpelling` is the reference-side surface data:
+the source name, display name, and whether it came from a local declaration,
+unqualified import, qualified/aliased import, or builtin.
+
+This is intentionally only a model/boundary contract for now. It should be used
+by the resolver migration before changing checker visibility semantics.
+-}
+
+mkResolvedSymbol :: SymbolIdentity -> String -> String -> SymbolOrigin -> ResolvedSymbol
+mkResolvedSymbol identity sourceName displayName origin =
+  ResolvedSymbol
+    { resolvedSymbolIdentity = identity,
+      resolvedSymbolSpelling =
+        SymbolSpelling
+          { symbolSourceName = sourceName,
+            symbolDisplayName = displayName,
+            symbolSpellingOrigin = origin
+          }
+    }
+
+sameResolvedSymbol :: ResolvedSymbol -> ResolvedSymbol -> Bool
+sameResolvedSymbol left right =
+  resolvedSymbolIdentity left == resolvedSymbolIdentity right
+
+unqualifiedSymbolName :: String -> String
+unqualifiedSymbolName =
+  reverse . takeWhile (/= '.') . reverse
+
 data EvidenceInfo = EvidenceInfo
   { evidenceClassName :: P.ClassName,
     evidenceType :: SrcType,
@@ -405,6 +505,130 @@ data CheckedProgram = CheckedProgram
     checkedProgramMain :: String
   }
   deriving (Eq, Show)
+
+valueInfoSymbolIdentity :: ValueInfo -> SymbolIdentity
+valueInfoSymbolIdentity valueInfo =
+  case valueInfo of
+    OrdinaryValue {} ->
+      SymbolIdentity
+        { symbolNamespace = SymbolValue,
+          symbolDefiningModule = valueOriginModule valueInfo,
+          symbolDefiningName = unqualifiedSymbolName (valueDisplayName valueInfo),
+          symbolOwnerIdentity = Nothing
+        }
+    ConstructorValue {valueCtorInfo = ctorInfo} ->
+      SymbolIdentity
+        { symbolNamespace = SymbolConstructor,
+          symbolDefiningModule = valueOriginModule valueInfo,
+          symbolDefiningName = unqualifiedSymbolName (ctorName ctorInfo),
+          symbolOwnerIdentity = Just (SymbolOwnerType (valueOriginModule valueInfo) (ctorOwningType ctorInfo))
+        }
+    OverloadedMethod {valueMethodInfo = methodInfo} ->
+      methodInfoSymbolIdentity methodInfo
+
+dataInfoSymbolIdentity :: DataInfo -> SymbolIdentity
+dataInfoSymbolIdentity dataInfo =
+  SymbolIdentity
+    { symbolNamespace = SymbolType,
+      symbolDefiningModule = dataModule dataInfo,
+      symbolDefiningName = dataName dataInfo,
+      symbolOwnerIdentity = Nothing
+    }
+
+constructorInfoSymbolIdentity :: DataInfo -> ConstructorInfo -> SymbolIdentity
+constructorInfoSymbolIdentity dataInfo ctorInfo =
+  SymbolIdentity
+    { symbolNamespace = SymbolConstructor,
+      symbolDefiningModule = dataModule dataInfo,
+      symbolDefiningName = unqualifiedSymbolName (ctorName ctorInfo),
+      symbolOwnerIdentity = Just (SymbolOwnerType (dataModule dataInfo) (ctorOwningType ctorInfo))
+    }
+
+classInfoSymbolIdentity :: ClassInfo -> SymbolIdentity
+classInfoSymbolIdentity classInfo =
+  SymbolIdentity
+    { symbolNamespace = SymbolClass,
+      symbolDefiningModule = classModule classInfo,
+      symbolDefiningName = unqualifiedSymbolName (className classInfo),
+      symbolOwnerIdentity = Nothing
+    }
+
+methodInfoSymbolIdentity :: MethodInfo -> SymbolIdentity
+methodInfoSymbolIdentity methodInfo =
+  SymbolIdentity
+    { symbolNamespace = SymbolMethod,
+      symbolDefiningModule = methodClassModule methodInfo,
+      symbolDefiningName = methodName methodInfo,
+      symbolOwnerIdentity =
+        Just
+          ( SymbolOwnerClass
+              (methodClassModule methodInfo)
+              (unqualifiedSymbolName (methodClassName methodInfo))
+          )
+    }
+
+instanceInfoClassSymbolIdentity :: InstanceInfo -> SymbolIdentity
+instanceInfoClassSymbolIdentity instanceInfo =
+  SymbolIdentity
+    { symbolNamespace = SymbolClass,
+      symbolDefiningModule = instanceClassModule instanceInfo,
+      symbolDefiningName = unqualifiedSymbolName (instanceClassName instanceInfo),
+      symbolOwnerIdentity = Nothing
+    }
+
+resolvedValueInfoSymbol :: SymbolOrigin -> ValueInfo -> ResolvedSymbol
+resolvedValueInfoSymbol origin valueInfo =
+  mkResolvedSymbol
+    (valueInfoSymbolIdentity valueInfo)
+    (unqualifiedSymbolName (valueDisplayName valueInfo))
+    (valueDisplayName valueInfo)
+    origin
+
+resolvedDataInfoSymbol :: SymbolOrigin -> String -> DataInfo -> ResolvedSymbol
+resolvedDataInfoSymbol origin displayName dataInfo =
+  mkResolvedSymbol
+    (dataInfoSymbolIdentity dataInfo)
+    (dataName dataInfo)
+    displayName
+    origin
+
+resolvedConstructorInfoSymbol :: SymbolOrigin -> String -> DataInfo -> ConstructorInfo -> ResolvedSymbol
+resolvedConstructorInfoSymbol origin displayName dataInfo ctorInfo =
+  mkResolvedSymbol
+    (constructorInfoSymbolIdentity dataInfo ctorInfo)
+    (unqualifiedSymbolName (ctorName ctorInfo))
+    displayName
+    origin
+
+resolvedClassInfoSymbol :: SymbolOrigin -> ClassInfo -> ResolvedSymbol
+resolvedClassInfoSymbol origin classInfo =
+  mkResolvedSymbol
+    (classInfoSymbolIdentity classInfo)
+    (unqualifiedSymbolName (className classInfo))
+    (className classInfo)
+    origin
+
+resolvedMethodInfoSymbol :: SymbolOrigin -> String -> MethodInfo -> ResolvedSymbol
+resolvedMethodInfoSymbol origin displayName methodInfo =
+  mkResolvedSymbol
+    (methodInfoSymbolIdentity methodInfo)
+    (methodName methodInfo)
+    displayName
+    origin
+
+resolvedModuleSymbol :: SymbolOrigin -> P.ModuleName -> P.ModuleName -> ResolvedSymbol
+resolvedModuleSymbol origin definingModule displayName =
+  mkResolvedSymbol
+    ( SymbolIdentity
+        { symbolNamespace = SymbolModule,
+          symbolDefiningModule = definingModule,
+          symbolDefiningName = definingModule,
+          symbolOwnerIdentity = Nothing
+        }
+    )
+    definingModule
+    displayName
+    origin
 
 splitForalls :: SrcType -> ([(String, Maybe SrcType)], SrcType)
 splitForalls = go []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -36,6 +36,7 @@ import Reify.CoreSpec qualified
 import Reify.NamedSpec qualified
 import Reify.TypeOpsSpec qualified
 import Reify.TypeSpec qualified
+import ResolvedSymbolSpec qualified
 import RepoGuardSpec qualified
 import Research.C1AuthoritativeSurfaceSpec qualified
 import Research.P2RepresentativeSupportSpec qualified
@@ -73,6 +74,7 @@ main = do
     SolveSpec.spec
     ScopeSpec.spec
     ProgramSpec.spec
+    ResolvedSymbolSpec.spec
     PipelineSpec.spec
     PublicSurfaceSpec.spec
     RepoGuardSpec.spec

--- a/test/ResolvedSymbolSpec.hs
+++ b/test/ResolvedSymbolSpec.hs
@@ -1,0 +1,152 @@
+module ResolvedSymbolSpec (spec) where
+
+import qualified Data.Map.Strict as Map
+import MLF.Frontend.Program.Types
+import MLF.Frontend.Syntax (SrcTy (..))
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "MLF.Program resolved symbol identities" $ do
+    it "keeps imported value identity stable across unqualified and aliased spellings" $ do
+      let unqualified = resolvedValueInfoSymbol (SymbolUnqualifiedImport "Lib") valueInfo
+          qualified =
+            resolvedValueInfoSymbol
+              (SymbolQualifiedImport "Lib" "L")
+              valueInfo {valueDisplayName = "L.answer"}
+
+      sameResolvedSymbol unqualified qualified `shouldBe` True
+      resolvedSymbolIdentity unqualified `shouldBe` resolvedSymbolIdentity qualified
+      resolvedSymbolSpelling unqualified `shouldNotBe` resolvedSymbolSpelling qualified
+
+    it "represents imported type and constructor aliases with the same semantic identities" $ do
+      let typeUnqualified = resolvedDataInfoSymbol (SymbolUnqualifiedImport "Lib") "Token" tokenDataInfo
+          typeQualified = resolvedDataInfoSymbol (SymbolQualifiedImport "Lib" "L") "L.Token" tokenDataInfo
+          ctorUnqualified = resolvedConstructorInfoSymbol (SymbolUnqualifiedImport "Lib") "Some" tokenDataInfo someCtor
+          ctorQualified =
+            resolvedConstructorInfoSymbol
+              (SymbolQualifiedImport "Lib" "L")
+              "L.Some"
+              tokenDataInfo
+              someCtor {ctorName = "L.Some"}
+
+      sameResolvedSymbol typeUnqualified typeQualified `shouldBe` True
+      sameResolvedSymbol ctorUnqualified ctorQualified `shouldBe` True
+      symbolOwnerIdentity (resolvedSymbolIdentity ctorQualified)
+        `shouldBe` Just (SymbolOwnerType "Lib" "Token")
+
+    it "represents imported class and method aliases with the same semantic identities" $ do
+      let classUnqualified = resolvedClassInfoSymbol (SymbolUnqualifiedImport "Lib") eqClassInfo
+          classQualified = resolvedClassInfoSymbol (SymbolQualifiedImport "Lib" "L") qualifiedEqClassInfo
+          methodUnqualified = resolvedValueInfoSymbol (SymbolUnqualifiedImport "Lib") eqMethodValue
+          methodQualified =
+            resolvedValueInfoSymbol
+              (SymbolQualifiedImport "Lib" "L")
+              qualifiedEqMethodValue
+
+      sameResolvedSymbol classUnqualified classQualified `shouldBe` True
+      sameResolvedSymbol methodUnqualified methodQualified `shouldBe` True
+      symbolOwnerIdentity (resolvedSymbolIdentity methodQualified)
+        `shouldBe` Just (SymbolOwnerClass "Lib" "Eq")
+
+    it "can model local declarations and module/import identities without changing semantic keys" $ do
+      let local = resolvedValueInfoSymbol (SymbolLocal "Main") mainValueInfo
+          importedModule = resolvedModuleSymbol (SymbolQualifiedImport "Lib" "L") "Lib" "L"
+
+      resolvedSymbolIdentity local
+        `shouldBe` SymbolIdentity SymbolValue "Main" "main" Nothing
+      resolvedSymbolIdentity importedModule
+        `shouldBe` SymbolIdentity SymbolModule "Lib" "Lib" Nothing
+      symbolDisplayName (resolvedSymbolSpelling importedModule) `shouldBe` "L"
+
+valueInfo :: ValueInfo
+valueInfo =
+  OrdinaryValue
+    { valueDisplayName = "answer",
+      valueRuntimeName = "Lib__answer",
+      valueType = STBase "Int",
+      valueConstraints = [],
+      valueOriginModule = "Lib"
+    }
+
+mainValueInfo :: ValueInfo
+mainValueInfo =
+  OrdinaryValue
+    { valueDisplayName = "main",
+      valueRuntimeName = "Main__main",
+      valueType = STBase "Int",
+      valueConstraints = [],
+      valueOriginModule = "Main"
+    }
+
+someCtor :: ConstructorInfo
+someCtor =
+  ConstructorInfo
+    { ctorName = "Some",
+      ctorRuntimeName = "Lib__Some",
+      ctorType = STBase "Token",
+      ctorForalls = [],
+      ctorArgs = [],
+      ctorResult = STBase "Token",
+      ctorOwningType = "Token",
+      ctorIndex = 0
+    }
+
+tokenDataInfo :: DataInfo
+tokenDataInfo =
+  DataInfo
+    { dataName = "Token",
+      dataModule = "Lib",
+      dataParams = [],
+      dataConstructors = [someCtor]
+    }
+
+eqMethodInfo :: MethodInfo
+eqMethodInfo =
+  MethodInfo
+    { methodClassName = "Eq",
+      methodClassModule = "Lib",
+      methodName = "eq",
+      methodRuntimeBase = "Lib__Eq__eq",
+      methodType = STArrow (STVar "a") (STArrow (STVar "a") (STBase "Bool")),
+      methodConstraints = [],
+      methodParamName = "a"
+    }
+
+qualifiedEqMethodInfo :: MethodInfo
+qualifiedEqMethodInfo =
+  eqMethodInfo {methodClassName = "L.Eq"}
+
+eqClassInfo :: ClassInfo
+eqClassInfo =
+  ClassInfo
+    { className = "Eq",
+      classModule = "Lib",
+      classParamName = "a",
+      classMethods = Map.singleton "eq" eqMethodInfo
+    }
+
+qualifiedEqClassInfo :: ClassInfo
+qualifiedEqClassInfo =
+  ClassInfo
+    { className = "L.Eq",
+      classModule = "Lib",
+      classParamName = "a",
+      classMethods = Map.singleton "eq" qualifiedEqMethodInfo
+    }
+
+eqMethodValue :: ValueInfo
+eqMethodValue =
+  OverloadedMethod
+    { valueDisplayName = "eq",
+      valueMethodInfo = eqMethodInfo,
+      valueOriginModule = "Lib"
+    }
+
+qualifiedEqMethodValue :: ValueInfo
+qualifiedEqMethodValue =
+  OverloadedMethod
+    { valueDisplayName = "L.eq",
+      valueMethodInfo = qualifiedEqMethodInfo,
+      valueOriginModule = "Lib"
+    }


### PR DESCRIPTION
## Summary
- add a resolved-symbol identity/spelling model at the frontend program boundary
- document the current qualified/unqualified resolution branch sites for .mlfp
- add focused model-level tests for imported aliases resolving to the same semantic identity

## Verification
- PATH=/root/.ghcup/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin cabal build all
- PATH=/root/.ghcup/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin cabal test

Closes #26