### PR TITLE
Implement #28

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,20 @@ The code is organized by domain (not by phase) under `src/MLF/`:
 Tests and executables that need `MLF.Research.*` must add `mlf2:mlf2-research`
 to `build-depends`.
 
+### `.mlfp` resolved-symbol boundary
+
+`MLF.Frontend.Program.Resolve` owns semantic identity for `.mlfp` names. A
+`SymbolIdentity` records namespace, defining module/name, and constructor or
+method owner identity; `SymbolSpelling` records the source spelling that reached
+that identity.
+
+`MLF.Frontend.Program.Check`, `Elaborate`, `Finalize`, and `Run` may keep maps
+keyed by surface spelling for lookup, diagnostics, source rendering, and
+runtime-name construction. They must compare values, types, classes,
+constructors, methods, and instance heads through stored semantic identities or
+identity-aware type canonicalization, not by stripping or interpreting qualified
+strings.
+
 ## Key graph and witness types
 
 - `Expr` (`MLF.Frontend.Syntax`) — surface eMLF terms

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -51,13 +51,27 @@ import MLF.Frontend.Program.Types
     ModuleExports (..),
     ProgramDiagnostic (..),
     ProgramError (..),
+    ResolvedModule (..),
+    ResolvedProgram (..),
+    ResolvedScope (..),
+    ResolvedSymbol (..),
+    SymbolIdentity (..),
+    SymbolNamespace (..),
+    SymbolOwnerIdentity (..),
     ValueInfo (..),
+    classInfoSymbolIdentity,
     constrainedVisibleType,
+    constructorInfoSymbolIdentity,
+    dataInfoSymbolIdentity,
     diagnosticForProgramError,
+    instanceInfoClassSymbolIdentity,
+    methodInfoOwnerClassSymbolIdentity,
+    methodInfoSymbolIdentity,
     specializeMethodType,
     substituteTypeVar,
     splitArrows,
     splitForalls,
+    valueInfoSymbolIdentity,
   )
 import MLF.Frontend.Syntax (Lit (..), SrcBound (..), SrcTy (..), SrcType)
 import qualified MLF.Frontend.Syntax.Program as P
@@ -77,7 +91,7 @@ data Scope = Scope
   }
   deriving (Eq, Show)
 
-type ClassIdentity = (P.ModuleName, P.ClassName)
+type ClassIdentity = SymbolIdentity
 
 emptyScope :: Scope
 emptyScope = Scope builtinValues Map.empty Map.empty []
@@ -88,6 +102,13 @@ builtinValues =
     "__mlfp_and"
     OrdinaryValue
       { valueDisplayName = "__mlfp_and",
+        valueInfoSymbol =
+          SymbolIdentity
+            { symbolNamespace = SymbolValue,
+              symbolDefiningModule = "<builtin>",
+              symbolDefiningName = "__mlfp_and",
+              symbolOwnerIdentity = Nothing
+            },
         valueRuntimeName = "__mlfp_and",
         valueType = STArrow (STBase "Bool") (STArrow (STBase "Bool") (STBase "Bool")),
         valueConstraints = [],
@@ -98,9 +119,11 @@ addValues :: Map String ValueInfo -> Map String ValueInfo -> Either ProgramError
 addValues base incoming =
   foldM
     ( \acc (name, info) ->
-        if Map.member name acc
-          then Left (ProgramDuplicateVisibleName name)
-          else Right (Map.insert name info acc)
+        case Map.lookup name acc of
+          Just existing
+            | valueInfoSymbolIdentity existing == valueInfoSymbolIdentity info -> Right acc
+            | otherwise -> Left (ProgramDuplicateVisibleName name)
+          Nothing -> Right (Map.insert name info acc)
     )
     base
     (Map.toList incoming)
@@ -109,9 +132,11 @@ addTypes :: Map String DataInfo -> Map String DataInfo -> Either ProgramError (M
 addTypes base incoming =
   foldM
     ( \acc (name, info) ->
-        if Map.member name acc
-          then Left (ProgramDuplicateVisibleName name)
-          else Right (Map.insert name info acc)
+        case Map.lookup name acc of
+          Just existing
+            | dataInfoSymbolIdentity existing == dataInfoSymbolIdentity info -> Right acc
+            | otherwise -> Left (ProgramDuplicateVisibleName name)
+          Nothing -> Right (Map.insert name info acc)
     )
     base
     (Map.toList incoming)
@@ -120,9 +145,11 @@ addClasses :: Map String ClassInfo -> Map String ClassInfo -> Either ProgramErro
 addClasses base incoming =
   foldM
     ( \acc (name, info) ->
-        if Map.member name acc
-          then Left (ProgramDuplicateVisibleName name)
-          else Right (Map.insert name info acc)
+        case Map.lookup name acc of
+          Just existing
+            | classInfoSymbolIdentity existing == classInfoSymbolIdentity info -> Right acc
+            | otherwise -> Left (ProgramDuplicateVisibleName name)
+          Nothing -> Right (Map.insert name info acc)
     )
     base
     (Map.toList incoming)
@@ -144,7 +171,7 @@ lookupClassInfo scope name =
 checkProgram :: P.Program -> Either ProgramError CheckedProgram
 checkProgram program = runTcM $ do
   resolved <- resolveProgram program
-  modulesChecked <- checkModules program
+  modulesChecked <- checkModules resolved program
   let mainNames =
         [ checkedBindingName binding
           | checked <- modulesChecked,
@@ -169,15 +196,41 @@ checkLocatedProgram located =
     Right checked -> Right checked
     Left err -> Left (diagnosticForProgramError (Just located) err)
 
-checkModules :: P.Program -> TcM [CheckedModule]
-checkModules (P.Program modules0) = do
+resolvedIdentityOr ::
+  (ResolvedScope -> Map String ResolvedSymbol) ->
+  ResolvedModule ->
+  String ->
+  SymbolIdentity ->
+  SymbolIdentity
+resolvedIdentityOr select resolvedModule name fallback =
+  case Map.lookup name (select (resolvedModuleScope resolvedModule)) of
+    Just symbol -> resolvedSymbolIdentity symbol
+    Nothing -> fallback
+
+resolvedValueIdentityOr :: ResolvedModule -> String -> SymbolIdentity -> SymbolIdentity
+resolvedValueIdentityOr = resolvedIdentityOr resolvedScopeValues
+
+resolvedTypeIdentityOr :: ResolvedModule -> String -> SymbolIdentity -> SymbolIdentity
+resolvedTypeIdentityOr = resolvedIdentityOr resolvedScopeTypes
+
+resolvedClassIdentityOr :: ResolvedModule -> String -> SymbolIdentity -> SymbolIdentity
+resolvedClassIdentityOr = resolvedIdentityOr resolvedScopeClasses
+
+checkModules :: ResolvedProgram -> P.Program -> TcM [CheckedModule]
+checkModules (ResolvedProgram resolvedModules) (P.Program modules0) = do
   ensureDistinctBy ProgramDuplicateModule P.moduleName modules0
   orderedModules <- topoSortModules modules0
   go [] orderedModules
   where
+    resolvedByModule = Map.fromList [(resolvedModuleName resolvedModule, resolvedModule) | resolvedModule <- resolvedModules]
+
     go acc [] = pure (reverse acc)
     go acc (mod0 : rest) = do
-      checked <- checkModule acc mod0
+      resolvedModule <-
+        case Map.lookup (P.moduleName mod0) resolvedByModule of
+          Just found -> pure found
+          Nothing -> throwError (ProgramUnknownImportModule (P.moduleName mod0))
+      checked <- checkModule resolvedModule acc mod0
       go (checked : acc) rest
 
 topoSortModules :: [P.Module] -> TcM [P.Module]
@@ -207,8 +260,8 @@ topoSortModules modules0 = do
               mod0 : ordered'
             )
 
-checkModule :: [CheckedModule] -> P.Module -> TcM CheckedModule
-checkModule priorModules mod0 = do
+checkModule :: ResolvedModule -> [CheckedModule] -> P.Module -> TcM CheckedModule
+checkModule resolvedModule priorModules mod0 = do
   let priorExports = Map.fromList [(checkedModuleName checked, checkedModuleExports checked) | checked <- priorModules]
       priorData = Map.fromList [(checkedModuleName checked, checkedModuleData checked) | checked <- priorModules]
       priorInstances = concatMap checkedModuleInstances priorModules
@@ -217,14 +270,21 @@ checkModule priorModules mod0 = do
         visibleInstancesForImports priorExports priorData priorInstances unqualifiedClassIdentities (P.moduleImports mod0)
   ensureDistinctImportAliases (P.moduleImports mod0)
   importScope <- buildImportScope priorExports (P.moduleImports mod0)
-  localData <- buildLocalDataInfo mod0
-  localClasses <- buildLocalClassInfo mod0
-  localDefs <- buildLocalDefInfo mod0
+  localData <- buildLocalDataInfo resolvedModule mod0
+  localClasses <- buildLocalClassInfo resolvedModule mod0
+  localDefs <- buildLocalDefInfo resolvedModule mod0
   localValues0 <- addConstructorValues (P.moduleName mod0) localData
   localValues1 <- mergeMaps ProgramDuplicateValue localValues0 localDefs
   let localMethodValues =
         Map.fromList
-          [ (methodName method, OverloadedMethod (methodName method) method (P.moduleName mod0))
+          [ ( methodName method,
+              OverloadedMethod
+                { valueDisplayName = methodName method,
+                  valueInfoSymbol = methodInfoSymbolIdentity method,
+                  valueMethodInfo = method,
+                  valueOriginModule = P.moduleName mod0
+                }
+            )
             | classInfo <- Map.elems localClasses,
               method <- Map.elems (classMethods classInfo)
           ]
@@ -369,6 +429,7 @@ qualifyModuleExports alias exports =
         [ ( ctorName ctor,
             ConstructorValue
               { valueDisplayName = ctorName ctor,
+                valueInfoSymbol = constructorInfoSymbolIdentity dataInfo ctor,
                 valueRuntimeName = ctorRuntimeName ctor,
                 valueType = ctorType ctor,
                 valueCtorInfo = ctor,
@@ -429,6 +490,7 @@ qualifyModuleExports alias exports =
         OverloadedMethod {valueMethodInfo = methodInfo} ->
           OverloadedMethod
             { valueDisplayName = qualifiedName sourceName,
+              valueInfoSymbol = valueInfoSymbolIdentity valueInfo,
               valueMethodInfo = qualifyMethodFromExport methodInfo,
               valueOriginModule = valueOriginModule valueInfo
             }
@@ -436,6 +498,7 @@ qualifyModuleExports alias exports =
           let qualifiedCtorInfo = qualifyConstructorInfo ctorInfo
            in ConstructorValue
                 { valueDisplayName = qualifiedName sourceName,
+                  valueInfoSymbol = valueInfoSymbolIdentity valueInfo,
                   valueRuntimeName = valueRuntimeName valueInfo,
                   valueType = qualifySrcType (valueType valueInfo),
                   valueCtorInfo = qualifiedCtorInfo,
@@ -483,24 +546,18 @@ unqualifyQualifiedName alias name =
       | prefix == alias ++ "." -> rest
     _ -> name
 
-unqualifiedName :: String -> String
-unqualifiedName =
-  reverse . takeWhile (/= '.') . reverse
-
 classIdentity :: ClassInfo -> ClassIdentity
-classIdentity classInfo =
-  (classModule classInfo, unqualifiedName (className classInfo))
+classIdentity = classInfoSymbolIdentity
 
 methodClassIdentity :: ValueInfo -> Maybe ClassIdentity
 methodClassIdentity valueInfo =
   case valueInfo of
     OverloadedMethod {valueMethodInfo = methodInfo} ->
-      Just (methodClassModule methodInfo, unqualifiedName (methodClassName methodInfo))
+      Just (methodInfoOwnerClassSymbolIdentity methodInfo)
     _ -> Nothing
 
 instanceClassIdentity :: InstanceInfo -> ClassIdentity
-instanceClassIdentity instanceInfo =
-  (instanceClassModule instanceInfo, unqualifiedName (instanceClassName instanceInfo))
+instanceClassIdentity = instanceInfoClassSymbolIdentity
 
 visibleInstancesForImports ::
   Map P.ModuleName ModuleExports ->
@@ -701,6 +758,27 @@ sameInstanceSurfaceHead left right =
   instanceClassName left == instanceClassName right
     && instanceHeadType left == instanceHeadType right
 
+canonicalTypeInScope :: Scope -> SrcType -> SrcType
+canonicalTypeInScope scope = canonical
+  where
+    canonical ty =
+      case ty of
+        STVar {} -> ty
+        STArrow dom cod -> STArrow (canonical dom) (canonical cod)
+        STBase name -> STBase (canonicalTypeName name)
+        STCon name args -> STCon (canonicalTypeName name) (fmap canonical args)
+        STForall name mb body ->
+          STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)
+        STMu name body -> STMu name (canonical body)
+        STBottom -> STBottom
+
+    canonicalTypeName name =
+      case Map.lookup name (scopeTypes scope) of
+        Just info ->
+          let identity = dataInfoSymbolIdentity info
+           in symbolDefiningModule identity ++ "." ++ symbolDefiningName identity
+        Nothing -> name
+
 instanceExportedTypeMentions :: Set.Set String -> InstanceInfo -> Set.Set String
 instanceExportedTypeMentions exportedTypeNames instanceInfo =
   Set.unions (headMentions : constraintMentions ++ methodMentions)
@@ -860,7 +938,14 @@ applyImportItem moduleName0 exports scope item =
               ctorValues =
                 Map.fromList
                   [ ( ctorName ctor,
-                      ConstructorValue (ctorName ctor) (ctorRuntimeName ctor) (ctorType ctor) ctor (dataModule dataInfo)
+                      ConstructorValue
+                        { valueDisplayName = ctorName ctor,
+                          valueInfoSymbol = constructorInfoSymbolIdentity dataInfo ctor,
+                          valueRuntimeName = ctorRuntimeName ctor,
+                          valueType = ctorType ctor,
+                          valueCtorInfo = ctor,
+                          valueOriginModule = dataModule dataInfo
+                        }
                     )
                     | ctor <- Map.elems (exportedTypeConstructors typeInfo)
                   ]
@@ -873,8 +958,8 @@ applyImportItem moduleName0 exports scope item =
               }
         Nothing -> throwError (ProgramImportNotExported moduleName0 typeName)
 
-buildLocalDataInfo :: P.Module -> TcM (Map String DataInfo)
-buildLocalDataInfo mod0 = do
+buildLocalDataInfo :: ResolvedModule -> P.Module -> TcM (Map String DataInfo)
+buildLocalDataInfo resolvedModule mod0 = do
   let dataDecls = moduleDataDecls mod0
   ensureDistinctBy ProgramDuplicateType P.dataDeclName dataDecls
   ctorNames <- pure (concatMap (map P.constructorDeclName . P.dataDeclConstructors) dataDecls)
@@ -883,10 +968,18 @@ buildLocalDataInfo mod0 = do
   where
     toDataInfo dataDecl = do
       constructors <- zipWithM (toCtorInfo dataDecl) [0 ..] (P.dataDeclConstructors dataDecl)
+      let fallbackIdentity =
+            SymbolIdentity
+              { symbolNamespace = SymbolType,
+                symbolDefiningModule = P.moduleName mod0,
+                symbolDefiningName = P.dataDeclName dataDecl,
+                symbolOwnerIdentity = Nothing
+              }
       pure
         ( P.dataDeclName dataDecl,
           DataInfo
             { dataName = P.dataDeclName dataDecl,
+              dataInfoSymbol = resolvedTypeIdentityOr resolvedModule (P.dataDeclName dataDecl) fallbackIdentity,
               dataModule = P.moduleName mod0,
               dataParams = P.dataDeclParams dataDecl,
               dataConstructors = constructors
@@ -896,11 +989,19 @@ buildLocalDataInfo mod0 = do
     toCtorInfo dataDecl index ctorDecl =
       let (foralls, ctorBody) = splitForalls (P.constructorDeclType ctorDecl)
           (args0, result0) = splitArrows ctorBody
+          fallbackIdentity =
+            SymbolIdentity
+              { symbolNamespace = SymbolConstructor,
+                symbolDefiningModule = P.moduleName mod0,
+                symbolDefiningName = P.constructorDeclName ctorDecl,
+                symbolOwnerIdentity = Just (SymbolOwnerType (P.moduleName mod0) (P.dataDeclName dataDecl))
+              }
        in do
             validateConstructorResult dataDecl ctorDecl result0
             pure
               ConstructorInfo
                 { ctorName = P.constructorDeclName ctorDecl,
+                  ctorInfoSymbol = resolvedValueIdentityOr resolvedModule (P.constructorDeclName ctorDecl) fallbackIdentity,
                   ctorRuntimeName = qualify (P.moduleName mod0) (P.constructorDeclName ctorDecl),
                   ctorType = P.constructorDeclType ctorDecl,
                   ctorForalls = foralls,
@@ -922,19 +1023,37 @@ buildLocalDataInfo mod0 = do
               | name == owner && NE.length args == length params -> pure ()
             _ -> invalid
 
-buildLocalClassInfo :: P.Module -> TcM (Map String ClassInfo)
-buildLocalClassInfo mod0 = do
+buildLocalClassInfo :: ResolvedModule -> P.Module -> TcM (Map String ClassInfo)
+buildLocalClassInfo resolvedModule mod0 = do
   let classDecls = moduleClassDecls mod0
   ensureDistinctBy ProgramDuplicateClass P.classDeclName classDecls
   pure . Map.fromList =<< mapM toClassInfo classDecls
   where
     toClassInfo classDecl = do
       ensureDistinctBy ProgramDuplicateMethod P.methodSigName (P.classDeclMethods classDecl)
+      let classIdentityFallback =
+            SymbolIdentity
+              { symbolNamespace = SymbolClass,
+                symbolDefiningModule = P.moduleName mod0,
+                symbolDefiningName = P.classDeclName classDecl,
+                symbolOwnerIdentity = Nothing
+              }
+          resolvedClassIdentity =
+            resolvedClassIdentityOr resolvedModule (P.classDeclName classDecl) classIdentityFallback
       let methods =
             Map.fromList
               [ ( P.methodSigName sig,
+                  let methodIdentityFallback =
+                        SymbolIdentity
+                          { symbolNamespace = SymbolMethod,
+                            symbolDefiningModule = P.moduleName mod0,
+                            symbolDefiningName = P.methodSigName sig,
+                            symbolOwnerIdentity = Just (SymbolOwnerClass (P.moduleName mod0) (P.classDeclName classDecl))
+                          }
+                   in
                   MethodInfo
                     { methodClassName = P.classDeclName classDecl,
+                      methodInfoSymbol = resolvedValueIdentityOr resolvedModule (P.methodSigName sig) methodIdentityFallback,
                       methodClassModule = P.moduleName mod0,
                       methodName = P.methodSigName sig,
                       methodRuntimeBase = qualify (P.moduleName mod0) (P.classDeclName classDecl ++ "__" ++ P.methodSigName sig),
@@ -949,6 +1068,7 @@ buildLocalClassInfo mod0 = do
         ( P.classDeclName classDecl,
           ClassInfo
             { className = P.classDeclName classDecl,
+              classInfoSymbol = resolvedClassIdentity,
               classModule = P.moduleName mod0,
               classParamName = P.classDeclParam classDecl,
               classMethods = methods
@@ -973,8 +1093,8 @@ validateClassConstraintClasses scope =
     _ <- lookupClassInfo scope (P.constraintClassName constraint)
     pure ()
 
-buildLocalDefInfo :: P.Module -> TcM (Map String ValueInfo)
-buildLocalDefInfo mod0 = do
+buildLocalDefInfo :: ResolvedModule -> P.Module -> TcM (Map String ValueInfo)
+buildLocalDefInfo resolvedModule mod0 = do
   let defs = moduleDefDecls mod0
   ensureDistinctBy ProgramDuplicateValue P.defDeclName defs
   pure $
@@ -982,6 +1102,17 @@ buildLocalDefInfo mod0 = do
       [ ( P.defDeclName defDecl,
           OrdinaryValue
             { valueDisplayName = P.defDeclName defDecl,
+              valueInfoSymbol =
+                resolvedValueIdentityOr
+                  resolvedModule
+                  (P.defDeclName defDecl)
+                  ( SymbolIdentity
+                      { symbolNamespace = SymbolValue,
+                        symbolDefiningModule = P.moduleName mod0,
+                        symbolDefiningName = P.defDeclName defDecl,
+                        symbolOwnerIdentity = Nothing
+                      }
+                  ),
               valueRuntimeName = qualify (P.moduleName mod0) (P.defDeclName defDecl),
               valueType = constrainedVisibleType (P.defDeclType defDecl),
               valueConstraints = P.constrainedConstraints (P.defDeclType defDecl),
@@ -998,6 +1129,7 @@ addConstructorValues moduleName0 dataInfos =
       [ ( ctorName ctor,
           ConstructorValue
             { valueDisplayName = ctorName ctor,
+              valueInfoSymbol = constructorInfoSymbolIdentity dataInfo ctor,
               valueRuntimeName = ctorRuntimeName ctor,
               valueType = ctorType ctor,
               valueCtorInfo = ctor,
@@ -1037,9 +1169,9 @@ synthesizeDerivedInstances scope mod0 = do
   where
     deriveForData dataDecl = do
       forM (P.dataDeclDeriving dataDecl) $ \className0 -> do
-        if unqualifiedName className0 == "Eq"
-          then do
-            classInfo <- lookupClassInfo scope className0
+        classInfo <- lookupClassInfo scope className0
+        if symbolDefiningName (classInfoSymbolIdentity classInfo) == "Eq"
+          then
             case eqMethodReference classInfo of
               Just eqMethodName -> pure (dataDecl, classInfo, mkEqInstance classInfo eqMethodName dataDecl)
               Nothing -> throwError (ProgramUnsupportedDeriving className0)
@@ -1049,12 +1181,14 @@ synthesizeDerivedInstances scope mod0 = do
       fst <$> find matchesEqMethod (Map.toList (scopeValues scope))
       where
         matchesEqMethod (_, OverloadedMethod {valueMethodInfo = methodInfo}) =
-          methodClassName methodInfo == className classInfo && methodName methodInfo == "eq"
+          methodInfoOwnerClassSymbolIdentity methodInfo == classInfoSymbolIdentity classInfo
+            && methodName methodInfo == "eq"
         matchesEqMethod _ = False
 
     pendingDerivedInstance classInfo instDecl =
       InstanceInfo
         { instanceClassName = P.instanceDeclClass instDecl,
+          instanceClassSymbol = classInfoSymbolIdentity classInfo,
           instanceClassModule = classModule classInfo,
           instanceOriginModule = P.moduleName mod0,
           instanceConstraints = P.instanceDeclConstraints instDecl,
@@ -1255,6 +1389,13 @@ buildInstanceSkeletons scope mod0 derived = do
                  in ( P.methodDefName methodDef,
                       OrdinaryValue
                         { valueDisplayName = P.methodDefName methodDef,
+                          valueInfoSymbol =
+                            SymbolIdentity
+                              { symbolNamespace = SymbolValue,
+                                symbolDefiningModule = P.moduleName mod0,
+                                symbolDefiningName = renderInstanceName (P.instanceDeclClass instDecl) (P.instanceDeclType instDecl) (P.methodDefName methodDef),
+                                symbolOwnerIdentity = Nothing
+                              },
                           valueRuntimeName = qualify (P.moduleName mod0) (renderInstanceName (P.instanceDeclClass instDecl) (P.instanceDeclType instDecl) (P.methodDefName methodDef)),
                           valueType = constrainedVisibleType (P.ConstrainedType methodValueConstraints rawMethodType),
                           valueConstraints = methodValueConstraints,
@@ -1266,6 +1407,7 @@ buildInstanceSkeletons scope mod0 derived = do
       pure
         InstanceInfo
           { instanceClassName = P.instanceDeclClass instDecl,
+            instanceClassSymbol = classInfoSymbolIdentity classInfo,
             instanceClassModule = classModule classInfo,
             instanceOriginModule = P.moduleName mod0,
             instanceConstraints = P.instanceDeclConstraints instDecl,
@@ -1278,7 +1420,7 @@ buildInstanceSkeletons scope mod0 derived = do
         | (ix, left) <- zip [(0 :: Int) ..] infos,
           right <- drop (ix + 1) infos,
           sameInstanceClass left right,
-          instanceHeadType left /= instanceHeadType right,
+          canonicalInstanceHead (instanceHeadType left) /= canonicalInstanceHead (instanceHeadType right),
           instanceHeadsOverlap (instanceHeadType left) (instanceHeadType right)
       ]
 
@@ -1286,14 +1428,14 @@ buildInstanceSkeletons scope mod0 derived = do
       [ left
         | (ix, left) <- zip [(0 :: Int) ..] infos,
           right <- drop (ix + 1) infos,
-          sameInstanceHead left right
+          sameCanonicalInstanceHead left right
       ]
 
     duplicateExistingInstances infos =
       [ local
         | local <- infos,
           existing <- scopeInstances scope,
-          sameInstanceHead local existing
+          sameCanonicalInstanceHead local existing
       ]
 
     overlappingWithExistingInstances infos =
@@ -1301,12 +1443,16 @@ buildInstanceSkeletons scope mod0 derived = do
         | local <- infos,
           existing <- scopeInstances scope,
           sameInstanceClass local existing,
-          instanceHeadType local /= instanceHeadType existing,
+          canonicalInstanceHead (instanceHeadType local) /= canonicalInstanceHead (instanceHeadType existing),
           instanceHeadsOverlap (instanceHeadType local) (instanceHeadType existing)
       ]
 
     sameInstanceClass left right =
       instanceClassIdentity left == instanceClassIdentity right
+
+    sameCanonicalInstanceHead left right =
+      sameInstanceClass left right
+        && canonicalInstanceHead (instanceHeadType left) == canonicalInstanceHead (instanceHeadType right)
 
     instanceHeadsOverlap left right =
       case
@@ -1319,23 +1465,7 @@ buildInstanceSkeletons scope mod0 derived = do
         Nothing -> False
 
     canonicalInstanceHead :: SrcType -> SrcType
-    canonicalInstanceHead = canonical
-      where
-        canonical ty =
-          case ty of
-            STVar {} -> ty
-            STArrow dom cod -> STArrow (canonical dom) (canonical cod)
-            STBase name -> STBase (canonicalTypeName name)
-            STCon name args -> STCon (canonicalTypeName name) (fmap canonical args)
-            STForall name mb body ->
-              STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)
-            STMu name body -> STMu name (canonical body)
-            STBottom -> STBottom
-
-        canonicalTypeName name =
-          case Map.lookup name (scopeTypes scope) of
-            Just info -> dataModule info ++ "." ++ dataName info
-            Nothing -> name
+    canonicalInstanceHead = canonicalTypeInScope scope
 
     unifyOverlap subst left right =
       case (applyOverlapSubst subst left, applyOverlapSubst subst right) of
@@ -1451,7 +1581,10 @@ checkInstance elaborateScope scope instDecl = do
   where
     findInstance scope0 classInfo headTy =
       find
-        (\info -> instanceClassIdentity info == classIdentity classInfo && instanceHeadType info == headTy)
+        ( \info ->
+            instanceClassIdentity info == classIdentity classInfo
+              && canonicalTypeInScope scope0 (instanceHeadType info) == canonicalTypeInScope scope0 headTy
+        )
         (scopeInstances scope0)
 
 checkDef :: ElaborateScope -> Scope -> P.DefDecl -> TcM CheckedBinding
@@ -1502,7 +1635,14 @@ collectExportValue localValues localClasses localData acc = \case
         let ctorValues =
               Map.fromList
                 [ ( ctorName ctor,
-                    ConstructorValue (ctorName ctor) (ctorRuntimeName ctor) (ctorType ctor) ctor (dataModule dataInfo)
+                    ConstructorValue
+                      { valueDisplayName = ctorName ctor,
+                        valueInfoSymbol = constructorInfoSymbolIdentity dataInfo ctor,
+                        valueRuntimeName = ctorRuntimeName ctor,
+                        valueType = ctorType ctor,
+                        valueCtorInfo = ctor,
+                        valueOriginModule = dataModule dataInfo
+                      }
                   )
                   | ctor <- dataConstructors dataInfo
                 ]
@@ -1511,7 +1651,18 @@ collectExportValue localValues localClasses localData acc = \case
   P.ExportType typeName ->
     case Map.lookup typeName localClasses of
       Just classInfo ->
-        let methodValues = Map.fromList [(methodName method, OverloadedMethod (methodName method) method (classModule classInfo)) | method <- Map.elems (classMethods classInfo)]
+        let methodValues =
+              Map.fromList
+                [ ( methodName method,
+                    OverloadedMethod
+                      { valueDisplayName = methodName method,
+                        valueInfoSymbol = methodInfoSymbolIdentity method,
+                        valueMethodInfo = method,
+                        valueOriginModule = classModule classInfo
+                      }
+                  )
+                  | method <- Map.elems (classMethods classInfo)
+                ]
          in liftEither (addValues acc methodValues)
       Nothing -> pure acc
 

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -496,7 +496,7 @@ explicitExprAnnotation expr =
 
 compileValueApp :: ElaborateScope -> Maybe SrcType -> ValueInfo -> [P.Expr] -> ElaborateM SurfaceExpr
 compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} args = do
-  let expectedArgTys = constructorExpectedArgTypes scope ctorInfo args
+  let expectedArgTys = constructorExpectedArgTypes scope ctorInfo mbExpected args
   argSurfaces <-
     zipWithM compileConstructorArg expectedArgTys args
   placeholder <- deferConstructorCall scope ctorInfo (length args) mbExpected
@@ -569,10 +569,15 @@ isPartialOverloadedMethodApp scope expr =
           not (null args) && length args < methodFullArity methodInfo
     _ -> False
 
-constructorExpectedArgTypes :: ElaborateScope -> ConstructorInfo -> [P.Expr] -> [SrcType]
-constructorExpectedArgTypes scope ctorInfo args =
-  reverse (snd (foldl step (Map.empty, []) (zip (ctorArgs ctorInfo) args)))
+constructorExpectedArgTypes :: ElaborateScope -> ConstructorInfo -> Maybe SrcType -> [P.Expr] -> [SrcType]
+constructorExpectedArgTypes scope ctorInfo mbExpected args =
+  reverse (snd (foldl step (initialSubst, []) (zip (ctorArgs ctorInfo) args)))
   where
+    initialSubst =
+      case mbExpected >>= matchTypesInScope scope Map.empty (constructorOccurrenceType ctorInfo (length args)) of
+        Just subst -> subst
+        Nothing -> Map.empty
+
     step (subst, acc) (templateTy, arg) =
       let expectedTy = specializeSrcType subst templateTy
           subst' =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -506,6 +506,7 @@ compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} arg
       case inferKnownExprType scope arg of
         Just knownTy
           | Set.null (freeTypeVarsSrcType knownTy) ->
+              ensureSourceTypeCompatible scope expectedTy knownTy >>
               compileExpr scope (Just knownTy) arg
           | otherwise ->
               compileExpr scope (Just expectedTy) arg
@@ -535,9 +536,17 @@ compileValueApp scope mbExpected valueInfo args = do
   where
     compileValueArg (Just expectedTy) arg
       | isPartialOverloadedMethodApp scope arg =
-          compileExpr scope (Just expectedTy) arg
+          compileKnownExpectedArg expectedTy arg
+    compileValueArg (Just expectedTy) arg =
+      compileKnownExpectedArg expectedTy arg
     compileValueArg _ arg =
       compileExpr scope Nothing arg
+
+    compileKnownExpectedArg expectedTy arg = do
+      case inferKnownExprType scope arg of
+        Just actualTy -> ensureSourceTypeCompatible scope expectedTy actualTy
+        Nothing -> pure ()
+      compileExpr scope (Just expectedTy) arg
 
 valueExpectedArgTypes :: ValueInfo -> [P.Expr] -> [Maybe SrcType]
 valueExpectedArgTypes valueInfo args =
@@ -721,7 +730,10 @@ compileMethodApp scope mbExpected methodInfo args
       | otherwise = expanded
 
 compileExpectedMethodArg :: ElaborateScope -> SrcType -> P.Expr -> ElaborateM SurfaceExpr
-compileExpectedMethodArg scope expectedTy expr =
+compileExpectedMethodArg scope expectedTy expr = do
+  case inferKnownExprType scope expr of
+    Just actualTy -> ensureSourceTypeCompatible scope expectedTy actualTy
+    Nothing -> pure ()
   case expr of
     EAnn {} ->
       compileExpr scope (Just expectedTy) expr
@@ -746,6 +758,36 @@ compileExpectedMethodArg scope expectedTy expr =
     _ -> do
       argExpr <- compileExpr scope Nothing expr
       pure (surfaceAnn argExpr (lowerType scope expectedTy))
+
+ensureSourceTypeCompatible :: ElaborateScope -> SrcType -> SrcType -> ElaborateM ()
+ensureSourceTypeCompatible scope expectedTy actualTy =
+  when (sourceTypesNeedNominalRejection scope expectedTy actualTy) $
+    throwError (ProgramTypeMismatch actualTy expectedTy)
+
+sourceTypesNeedNominalRejection :: ElaborateScope -> SrcType -> SrcType -> Bool
+sourceTypesNeedNominalRejection scope expectedTy actualTy =
+  sourceTypeMentionsVisibleData scope expectedTy
+    && sourceTypeMentionsVisibleData scope actualTy
+    && lowerType scope expectedTy == lowerType scope actualTy
+    && matchTypesInScope scope Map.empty expectedTy actualTy == Nothing
+    && matchTypesInScope scope Map.empty actualTy expectedTy == Nothing
+
+sourceTypeMentionsVisibleData :: ElaborateScope -> SrcType -> Bool
+sourceTypeMentionsVisibleData scope ty =
+  case ty of
+    STVar {} -> False
+    STBase name -> Map.member name (esTypes scope)
+    STCon name args ->
+      Map.member name (esTypes scope)
+        || any (sourceTypeMentionsVisibleData scope) args
+    STArrow dom cod ->
+      sourceTypeMentionsVisibleData scope dom
+        || sourceTypeMentionsVisibleData scope cod
+    STForall _ mb body ->
+      maybe False (sourceTypeMentionsVisibleData scope . unSrcBound) mb
+        || sourceTypeMentionsVisibleData scope body
+    STMu _ body -> sourceTypeMentionsVisibleData scope body
+    STBottom -> False
 
 resolveMethodHeadExpr :: ElaborateScope -> Set (P.ClassName, String) -> MethodInfo -> SrcType -> ElaborateM SurfaceExpr
 resolveMethodHeadExpr scope seen methodInfo classArgTy =
@@ -1594,10 +1636,7 @@ resolveInstanceInfoWithIdentity scope className0 expectedClassIdentity headTy =
     matchInstanceHead info =
       case matchTypesInScope scope Map.empty (instanceHeadType info) headTy of
         Just subst -> Just (subst, True)
-        Nothing ->
-          if lowerType scope (instanceHeadType info) == lowerType scope headTy
-            then Just (Map.empty, False)
-            else Nothing
+        Nothing -> Nothing
 
     deduplicateEquivalentMatches [] = []
     deduplicateEquivalentMatches (match : rest) =
@@ -1607,12 +1646,19 @@ resolveInstanceInfoWithIdentity scope className0 expectedClassIdentity headTy =
     equivalentInstanceMatch (left, _, _) (right, _, _) =
       instanceOriginModule left == instanceOriginModule right
         && instanceInfoClassIdentity left == instanceInfoClassIdentity right
-        && lowerType scope (instanceHeadType left) == lowerType scope (instanceHeadType right)
-        && map lowerConstraint (instanceConstraints left) == map lowerConstraint (instanceConstraints right)
+        && canonicalSourceType scope (instanceHeadType left) == canonicalSourceType scope (instanceHeadType right)
+        && map canonicalConstraint (instanceConstraints left) == map canonicalConstraint (instanceConstraints right)
         && fmap methodRuntimeIdentity (instanceMethods left) == fmap methodRuntimeIdentity (instanceMethods right)
 
-    lowerConstraint constraint =
-      constraint {P.constraintType = lowerType scope (P.constraintType constraint)}
+    canonicalConstraint constraint =
+      ( canonicalConstraintClassKey (P.constraintClassName constraint),
+        canonicalSourceType scope (P.constraintType constraint)
+      )
+
+    canonicalConstraintClassKey classKeyName =
+      case constraintClassIdentity scope classKeyName of
+        Just identity -> Right identity
+        Nothing -> Left classKeyName
 
     methodRuntimeIdentity valueInfo =
       case valueInfo of
@@ -1691,7 +1737,6 @@ matchTypesWith sameType sameTypeHead subst template actual = case template of
 semanticTypeEqual :: ElaborateScope -> SrcType -> SrcType -> Bool
 semanticTypeEqual scope left right =
   canonicalSourceType scope left == canonicalSourceType scope right
-    || lowerType scope left == lowerType scope right
 
 sameTypeHeadInScope :: ElaborateScope -> String -> String -> Bool
 sameTypeHeadInScope scope left right =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -75,7 +75,7 @@ data ElaborateResult a = ElaborateResult
     elaborateResultExternalTypes :: Map String SrcType
   }
 
-type ClassIdentity = (P.ModuleName, P.ClassName)
+type ClassIdentity = SymbolIdentity
 
 runElaborateM :: ElaborateM a -> Either ProgramError (ElaborateResult a)
 runElaborateM action =
@@ -170,7 +170,9 @@ canonicalSourceType scope = canonical
         STMu name body -> STMu name (canonical body)
         STBottom -> STBottom
 
-    qualifiedDataName info = dataModule info ++ "." ++ dataName info
+    qualifiedDataName info =
+      let identity = dataInfoSymbolIdentity info
+       in symbolDefiningModule identity ++ "." ++ symbolDefiningName identity
 
 constrainedRuntimeType :: ElaborateScope -> [P.ClassConstraint] -> SrcType -> SrcType
 constrainedRuntimeType scope =
@@ -302,7 +304,9 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
             Just info -> dataIdentity info == ownerIdentity
             Nothing -> name == ownerIdentity
 
-    dataIdentity info = dataModule info ++ "." ++ dataName info
+    dataIdentity info =
+      let identity = dataInfoSymbolIdentity info
+       in symbolDefiningModule identity ++ "." ++ symbolDefiningName identity
 
 toListNE :: NonEmpty a -> [a]
 toListNE (x :| xs) = x : xs
@@ -563,7 +567,7 @@ constructorExpectedArgTypes scope ctorInfo args =
     step (subst, acc) (templateTy, arg) =
       let expectedTy = specializeSrcType subst templateTy
           subst' =
-            case inferKnownExprType scope arg >>= matchTypes subst templateTy of
+            case inferKnownExprType scope arg >>= matchTypesInScope scope subst templateTy of
               Just matched -> matched
               Nothing -> subst
        in (subst', expectedTy : acc)
@@ -646,7 +650,7 @@ inferCallSubst scope visibleTy args = do
           | (templateTy, arg) <- zip argTys args,
             Just actualTy <- [inferKnownExprType scope arg]
         ]
-  foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty knownPairs
+  foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty knownPairs
 
 inlineImmediateLetUse :: String -> P.Expr -> P.Expr -> Maybe P.Expr
 inlineImmediateLetUse bindingName rhs body =
@@ -674,7 +678,7 @@ isLocalOrdinaryValue _ = False
 knownConstructorResultType :: ElaborateScope -> ConstructorInfo -> [P.Expr] -> Maybe SrcType
 knownConstructorResultType scope ctorInfo args = do
   argTypes <- traverse (inferKnownExprType scope) args
-  subst <- foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty (zip (ctorArgs ctorInfo) argTypes)
+  subst <- foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty (zip (ctorArgs ctorInfo) argTypes)
   pure (Map.foldrWithKey substituteTypeVar (ctorResult ctorInfo) subst)
 
 compileMethodApp :: ElaborateScope -> Maybe SrcType -> MethodInfo -> [P.Expr] -> ElaborateM SurfaceExpr
@@ -796,7 +800,7 @@ inferMethodCallSubst scope methodInfo classArgTy args = do
           | (templateTy, arg) <- zip paramTys args,
             Just actualTy <- [inferKnownExprType scope arg]
         ]
-  foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty knownPairs
+  foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty knownPairs
 
 shouldResolveMethodBeforeInference :: ElaborateScope -> MethodInfo -> SrcType -> Bool
 shouldResolveMethodBeforeInference scope methodInfo classArgTy =
@@ -843,25 +847,35 @@ resolveZeroMethodEvidenceExpr scope seen constraint
 
 zeroMethodConstraintCoveredByEvidence :: ElaborateScope -> P.ClassConstraint -> Bool
 zeroMethodConstraintCoveredByEvidence scope constraint =
-  any
-    ( \evidence ->
-        evidenceClassName evidence == P.constraintClassName constraint
-          && lowerType scope (evidenceType evidence) == lowerType scope (P.constraintType constraint)
-    )
-    (esEvidence scope)
+  case constraintClassIdentity scope (P.constraintClassName constraint) of
+    Nothing -> False
+    Just classIdentity0 ->
+      any
+        ( \evidence ->
+            evidenceClassSymbol evidence == classIdentity0
+              && lowerType scope (evidenceType evidence) == lowerType scope (P.constraintType constraint)
+        )
+        (esEvidence scope)
 
 lookupEvidenceMethod :: ElaborateScope -> P.ClassName -> SrcType -> P.MethodName -> Maybe (String, SrcType)
 lookupEvidenceMethod scope className0 headTy methodName0 =
-  case
-    [ methodEvidence
-      | evidence <- esEvidence scope,
-        evidenceClassName evidence == className0,
-        lowerType scope (evidenceType evidence) == lowerType scope headTy,
-        Just methodEvidence <- [Map.lookup methodName0 (evidenceMethods evidence)]
-    ]
-  of
-    methodEvidence : _ -> Just methodEvidence
-    [] -> Nothing
+  case constraintClassIdentity scope className0 of
+    Nothing -> Nothing
+    Just classIdentity0 ->
+      case
+        [ methodEvidence
+          | evidence <- esEvidence scope,
+            evidenceClassSymbol evidence == classIdentity0,
+            lowerType scope (evidenceType evidence) == lowerType scope headTy,
+            Just methodEvidence <- [Map.lookup methodName0 (evidenceMethods evidence)]
+        ]
+      of
+        methodEvidence : _ -> Just methodEvidence
+        [] -> Nothing
+
+constraintClassIdentity :: ElaborateScope -> P.ClassName -> Maybe SymbolIdentity
+constraintClassIdentity scope className0 =
+  classInfoSymbolIdentity <$> Map.lookup className0 (esClasses scope)
 
 applyConstraintSubst :: Map String SrcType -> P.ClassConstraint -> P.ClassConstraint
 applyConstraintSubst subst constraint =
@@ -935,7 +949,7 @@ deferConstructorCall scope ctorInfo argCount mbExpected = do
       occurrenceTy = constructorOccurrenceType ctorInfo argCount
       instBinders = map fst (fst (splitForalls quantifiedTy))
       initialSubst =
-        case mbExpected >>= matchTypes Map.empty occurrenceTy of
+        case mbExpected >>= matchTypesInScope scope Map.empty occurrenceTy of
           Just subst -> subst
           Nothing -> Map.empty
       placeholderSourceTy = specializeQuantifiedType initialSubst quantifiedTy
@@ -1033,7 +1047,7 @@ knownMethodClassArg scope methodInfo args = do
           | (templateTy, arg) <- zip paramTys args,
             Just actualTy <- [inferKnownExprType scope arg]
         ]
-  subst <- foldM (\acc (templateTy, actualTy) -> matchTypes acc templateTy actualTy) Map.empty knownPairs
+  subst <- foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty knownPairs
   Map.lookup (methodParamName methodInfo) subst
 
 quantifiedMethodType :: MethodInfo -> SrcType
@@ -1128,7 +1142,7 @@ compileCase scope mbExpected scrutinee alts = do
             case inferKnownExprType scope scrutinee of
               Just knownTy -> knownTy
               Nothing -> headTy
-      validateOrderedPatterns alts
+      validateOrderedPatterns scope alts
       mapM_ (validatePatternType scope scrutineeTy . P.altPattern) alts
       (resultTy, _quantifyResult) <-
         case mbExpected of
@@ -1292,7 +1306,7 @@ compileHandler scope scrutineeExpr scrutineeTy resultTy dataInfo alts forceAnnot
               pure (surfaceAnn handlerBody handlerTy)
 
     specializeConstructorArgsForScrutinee actualScrutineeTy ctor =
-      case matchTypes Map.empty (ctorResult ctor) actualScrutineeTy of
+      case matchTypesInScope scope Map.empty (ctorResult ctor) actualScrutineeTy of
         Just subst -> map (specializeSrcType subst) (ctorArgs ctor)
         Nothing -> ctorArgs ctor
 
@@ -1343,10 +1357,10 @@ validatePatternType scope expectedTy pattern0 =
             (zip patterns (ctorArgs ctorInfo))
   where
     matchPatternTypes template actual =
-      case matchTypes Map.empty template actual of
+      case matchTypesInScope scope Map.empty template actual of
         Just subst -> Just subst
         Nothing ->
-          case matchTypes Map.empty actual template of
+          case matchTypesInScope scope Map.empty actual template of
             Just subst -> Just subst
             Nothing
               | lowerType scope template == lowerType scope actual -> Just Map.empty
@@ -1359,11 +1373,11 @@ validatePatternAnnotation scope expectedTy annTy =
   where
     patternAnnotationCompatible left right =
       lowerType scope left == lowerType scope right
-        || matchTypes Map.empty left right /= Nothing
-        || matchTypes Map.empty right left /= Nothing
+        || matchTypesInScope scope Map.empty left right /= Nothing
+        || matchTypesInScope scope Map.empty right left /= Nothing
 
-validateOrderedPatterns :: [P.Alt] -> ElaborateM ()
-validateOrderedPatterns = go Set.empty False
+validateOrderedPatterns :: ElaborateScope -> [P.Alt] -> ElaborateM ()
+validateOrderedPatterns scope = go Set.empty False
   where
     go _ _ [] = pure ()
     go seen catchAllSeen (P.Alt pattern0 _ : rest)
@@ -1371,12 +1385,19 @@ validateOrderedPatterns = go Set.empty False
           throwError (ProgramDuplicateCaseBranch (maybe "_" id (topConstructorName pattern0)))
       | isCatchAllPattern pattern0 =
           go seen True rest
-      | Just ctorName0 <- topConstructorName pattern0,
-        ctorName0 `Set.member` seen =
+      | Just (ctorName0, ctorIdentity) <- topConstructorIdentity pattern0,
+        ctorIdentity `Set.member` seen =
           throwError (ProgramDuplicateCaseBranch ctorName0)
-      | Just ctorName0 <- flatCatchAllConstructor pattern0 =
-          go (Set.insert ctorName0 seen) False rest
+      | Just (_, ctorIdentity) <- flatCatchAllConstructor scope pattern0 =
+          go (Set.insert ctorIdentity seen) False rest
       | otherwise = go seen False rest
+
+    topConstructorIdentity pattern0 =
+      case topConstructorName pattern0 of
+        Just ctorName0
+          | Just ctorInfo <- lookupConstructorInfoMaybe scope ctorName0 ->
+              Just (ctorName0, ctorInfoSymbol ctorInfo)
+        _ -> Nothing
 
 topConstructorName :: P.Pattern -> Maybe String
 topConstructorName pattern0 =
@@ -1384,11 +1405,13 @@ topConstructorName pattern0 =
     P.PatCtor ctorName0 _ -> Just ctorName0
     _ -> Nothing
 
-flatCatchAllConstructor :: P.Pattern -> Maybe String
-flatCatchAllConstructor pattern0 =
+flatCatchAllConstructor :: ElaborateScope -> P.Pattern -> Maybe (String, SymbolIdentity)
+flatCatchAllConstructor scope pattern0 =
   case stripPatternAnn pattern0 of
     P.PatCtor ctorName0 patterns
-      | all isCatchAllPattern patterns -> Just ctorName0
+      | all isCatchAllPattern patterns,
+        Just ctorInfo <- lookupConstructorInfoMaybe scope ctorName0 ->
+          Just (ctorName0, ctorInfoSymbol ctorInfo)
     _ -> Nothing
 
 isCatchAllPattern :: P.Pattern -> Bool
@@ -1461,7 +1484,7 @@ visibleDataInfo (visibleName, info) =
 
 sameDataInfo :: (String, DataInfo) -> (String, DataInfo) -> Bool
 sameDataInfo (_, left) (_, right) =
-  dataModule left == dataModule right && dataName left == dataName right
+  dataInfoSymbolIdentity left == dataInfoSymbolIdentity right
 
 constructorBelongsToDataInfo :: ConstructorInfo -> DataInfo -> Bool
 constructorBelongsToDataInfo ctorInfo =
@@ -1475,7 +1498,7 @@ constructorNameMatches scope ctorName0 ctorInfo =
 
 sameConstructorInfo :: ConstructorInfo -> ConstructorInfo -> Bool
 sameConstructorInfo left right =
-  ctorRuntimeName left == ctorRuntimeName right
+  ctorInfoSymbol left == ctorInfoSymbol right
 
 handlerSurfaceType :: ElaborateScope -> ConstructorInfo -> SrcType -> SrcType
 handlerSurfaceType scope ctorInfo resultTy =
@@ -1534,16 +1557,10 @@ resolveMethodInstanceInfoWithSubst scope methodInfo =
   resolveInstanceInfoWithIdentity scope (methodClassName methodInfo) (Just (methodInfoClassIdentity methodInfo))
 
 classInfoIdentity :: ClassInfo -> ClassIdentity
-classInfoIdentity classInfo =
-  (classModule classInfo, unqualifiedName (className classInfo))
+classInfoIdentity = classInfoSymbolIdentity
 
 methodInfoClassIdentity :: MethodInfo -> ClassIdentity
-methodInfoClassIdentity methodInfo =
-  (methodClassModule methodInfo, unqualifiedName (methodClassName methodInfo))
-
-unqualifiedName :: String -> String
-unqualifiedName =
-  reverse . takeWhile (/= '.') . reverse
+methodInfoClassIdentity = methodInfoOwnerClassSymbolIdentity
 
 resolveInstanceInfoWithIdentity ::
   ElaborateScope ->
@@ -1572,10 +1589,10 @@ resolveInstanceInfoWithIdentity scope className0 expectedClassIdentity headTy =
         Nothing -> False
 
     instanceInfoClassIdentity info =
-      (instanceClassModule info, unqualifiedName (instanceClassName info))
+      instanceInfoClassSymbolIdentity info
 
     matchInstanceHead info =
-      case matchTypes Map.empty (instanceHeadType info) headTy of
+      case matchTypesInScope scope Map.empty (instanceHeadType info) headTy of
         Just subst -> Just (subst, True)
         Nothing ->
           if lowerType scope (instanceHeadType info) == lowerType scope headTy
@@ -1616,44 +1633,77 @@ inferClassArgument methodTy classParam args =
         =<< foldM (\subst (templateTy, actualTy) -> matchTypes subst templateTy actualTy) Map.empty (zip paramTys args)
 
 matchTypes :: Map String SrcType -> SrcType -> SrcType -> Maybe (Map String SrcType)
-matchTypes subst template actual = case template of
+matchTypes = matchTypesWith (==) (==)
+
+matchTypesInScope :: ElaborateScope -> Map String SrcType -> SrcType -> SrcType -> Maybe (Map String SrcType)
+matchTypesInScope scope =
+  matchTypesWith (semanticTypeEqual scope) (sameTypeHeadInScope scope)
+
+matchTypesWith ::
+  (SrcType -> SrcType -> Bool) ->
+  (String -> String -> Bool) ->
+  Map String SrcType ->
+  SrcType ->
+  SrcType ->
+  Maybe (Map String SrcType)
+matchTypesWith sameType sameTypeHead subst template actual = case template of
   STVar name ->
     case Map.lookup name subst of
       Nothing -> Just (Map.insert name actual subst)
       Just existing
-        | existing == actual -> Just subst
+        | sameType existing actual -> Just subst
         | otherwise -> Nothing
   STArrow dom cod ->
     case actual of
       STArrow dom' cod' -> do
-        subst' <- matchTypes subst dom dom'
-        matchTypes subst' cod cod'
+        subst' <- matchTypesWith sameType sameTypeHead subst dom dom'
+        matchTypesWith sameType sameTypeHead subst' cod cod'
       _ -> Nothing
-  STBase name ->
+  STBase {} ->
     case actual of
-      STBase name' | name == name' -> Just subst
+      STBase {} | sameType template actual -> Just subst
       _ -> Nothing
   STCon name args ->
     case actual of
       STCon name' args'
-        | name == name' && length (toListNE args) == length (toListNE args') ->
-            foldM (\acc (leftTy, rightTy) -> matchTypes acc leftTy rightTy) subst (zip (toListNE args) (toListNE args'))
+        | sameTypeHead name name' && length (toListNE args) == length (toListNE args') ->
+            foldM
+              (\acc (leftTy, rightTy) -> matchTypesWith sameType sameTypeHead acc leftTy rightTy)
+              subst
+              (zip (toListNE args) (toListNE args'))
       _ -> Nothing
   STForall name mb body ->
     case actual of
       STForall name' mb' body'
-        | maybe True (\bound -> fmap unSrcBound mb' == Just (unSrcBound bound)) mb && name == name' ->
-            matchTypes subst body body'
+        | maybe True (\bound -> maybe False (sameType (unSrcBound bound) . unSrcBound) mb') mb && name == name' ->
+            matchTypesWith sameType sameTypeHead subst body body'
       _ -> Nothing
   STMu name body ->
     case actual of
       STMu name' body'
-        | name == name' -> matchTypes subst body body'
+        | name == name' -> matchTypesWith sameType sameTypeHead subst body body'
       _ -> Nothing
   STBottom ->
     case actual of
       STBottom -> Just subst
       _ -> Nothing
+
+semanticTypeEqual :: ElaborateScope -> SrcType -> SrcType -> Bool
+semanticTypeEqual scope left right =
+  canonicalSourceType scope left == canonicalSourceType scope right
+    || lowerType scope left == lowerType scope right
+
+sameTypeHeadInScope :: ElaborateScope -> String -> String -> Bool
+sameTypeHeadInScope scope left right =
+  canonicalTypeHeadName scope left == canonicalTypeHeadName scope right
+
+canonicalTypeHeadName :: ElaborateScope -> String -> String
+canonicalTypeHeadName scope name =
+  case Map.lookup name (esTypes scope) of
+    Just info ->
+      let identity = dataInfoSymbolIdentity info
+       in symbolDefiningModule identity ++ "." ++ symbolDefiningName identity
+    Nothing -> name
 
 -- | Strip leading STForall binders that do not appear in the body.
 stripVacuousSrcForalls :: SrcType -> SrcType
@@ -1712,6 +1762,7 @@ extendConstraintEvidence scope constraints = do
       let evidenceInfo =
             EvidenceInfo
               { evidenceClassName = P.constraintClassName constraint,
+                evidenceClassSymbol = classInfoSymbolIdentity classInfo,
                 evidenceType = P.constraintType constraint,
                 evidenceMethods = Map.fromList methodEntries
               }
@@ -1738,6 +1789,7 @@ extendLocalLoweredPure scope sourceName runtimeName loweredTy =
           sourceName
           OrdinaryValue
             { valueDisplayName = sourceName,
+              valueInfoSymbol = localValueSymbol runtimeName,
               valueRuntimeName = runtimeName,
               valueType = loweredTy,
               valueConstraints = [],
@@ -1755,6 +1807,7 @@ extendLocalSourceTypePure scope sourceName runtimeName sourceTy =
           sourceName
           OrdinaryValue
             { valueDisplayName = sourceName,
+              valueInfoSymbol = localValueSymbol runtimeName,
               valueRuntimeName = runtimeName,
               valueType = sourceTy,
               valueConstraints = [],
@@ -1762,6 +1815,15 @@ extendLocalSourceTypePure scope sourceName runtimeName sourceTy =
             }
           (esValues scope),
       esRuntimeTypes = Map.insert runtimeName (lowerType scope sourceTy) (esRuntimeTypes scope)
+    }
+
+localValueSymbol :: String -> SymbolIdentity
+localValueSymbol runtimeName =
+  SymbolIdentity
+    { symbolNamespace = SymbolValue,
+      symbolDefiningModule = "<local>",
+      symbolDefiningName = runtimeName,
+      symbolOwnerIdentity = Nothing
     }
 
 expectedCodomain :: Maybe SrcType -> Maybe SrcType

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -504,12 +504,12 @@ compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} arg
   where
     compileConstructorArg expectedTy arg = do
       case inferKnownExprType scope arg of
-        Just knownTy
-          | Set.null (freeTypeVarsSrcType knownTy) ->
-              ensureSourceTypeCompatible scope expectedTy knownTy >>
-              compileExpr scope (Just knownTy) arg
-          | otherwise ->
-              compileExpr scope (Just expectedTy) arg
+        Just knownTy -> do
+          let specializedKnownTy = specializeKnownTypeForExpected scope expectedTy knownTy
+          ensureSourceTypeCompatible scope expectedTy specializedKnownTy
+          if Set.null (freeTypeVarsSrcType knownTy)
+            then compileExpr scope (Just knownTy) arg
+            else compileExpr scope (Just expectedTy) arg
         Nothing -> do
           argSurface <- compileExpr scope Nothing arg
           pure $
@@ -568,6 +568,63 @@ isPartialOverloadedMethodApp scope expr =
       | Just OverloadedMethod {valueMethodInfo = methodInfo} <- Map.lookup name (esValues scope) ->
           not (null args) && length args < methodFullArity methodInfo
     _ -> False
+
+specializeKnownTypeForExpected :: ElaborateScope -> SrcType -> SrcType -> SrcType
+specializeKnownTypeForExpected scope expectedTy knownTy =
+  case matchTypesInScope scope Map.empty knownTy expectedTy of
+    Just subst -> specializeSrcType subst knownTy
+    Nothing ->
+      case matchTypesByShape Map.empty knownTy expectedTy of
+        Just subst -> specializeSrcType subst knownTy
+        Nothing -> knownTy
+
+matchTypesByShape :: Map String SrcType -> SrcType -> SrcType -> Maybe (Map String SrcType)
+matchTypesByShape subst template actual = case template of
+  STVar name ->
+    case Map.lookup name subst of
+      Nothing -> Just (Map.insert name actual subst)
+      Just existing
+        | existing == actual -> Just subst
+        | otherwise -> Nothing
+  STArrow dom cod ->
+    case actual of
+      STArrow dom' cod' -> do
+        subst' <- matchTypesByShape subst dom dom'
+        matchTypesByShape subst' cod cod'
+      _ -> Nothing
+  STBase {} ->
+    case actual of
+      STBase {} -> Just subst
+      _ -> Nothing
+  STCon _ args ->
+    case actual of
+      STCon _ args'
+        | length (toListNE args) == length (toListNE args') ->
+            foldM
+              (\acc (templateTy, actualTy) -> matchTypesByShape acc templateTy actualTy)
+              subst
+              (zip (toListNE args) (toListNE args'))
+      _ -> Nothing
+  STForall name mb body ->
+    case actual of
+      STForall name' mb' body'
+        | name == name' -> do
+            subst' <-
+              case (mb, mb') of
+                (Nothing, _) -> Just subst
+                (Just bound, Just bound') -> matchTypesByShape subst (unSrcBound bound) (unSrcBound bound')
+                (Just {}, Nothing) -> Nothing
+            matchTypesByShape subst' body body'
+      _ -> Nothing
+  STMu name body ->
+    case actual of
+      STMu name' body'
+        | name == name' -> matchTypesByShape subst body body'
+      _ -> Nothing
+  STBottom ->
+    case actual of
+      STBottom -> Just subst
+      _ -> Nothing
 
 constructorExpectedArgTypes :: ElaborateScope -> ConstructorInfo -> Maybe SrcType -> [P.Expr] -> [SrcType]
 constructorExpectedArgTypes scope ctorInfo mbExpected args =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -875,8 +875,7 @@ dataInfoHeadNames scope info =
       ]
   where
     sameDataIdentity left right =
-      dataModule left == dataModule right
-        && dataName left == dataName right
+      dataInfoSymbol left == dataInfoSymbol right
 
 {- Note [recoverSourceType]
 

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -22,6 +22,7 @@ import MLF.Frontend.Program.Types
     DataInfo (..),
     ProgramDiagnostic,
     ProgramError (..),
+    SymbolIdentity (..),
   )
 import MLF.Frontend.Syntax (Lit (..), SrcBound (..), SrcTy (..), SrcType)
 import qualified MLF.Frontend.Syntax.Program as ProgramSyntax
@@ -197,13 +198,14 @@ dataTypeHeadMatches :: DataInfo -> String -> Bool
 dataTypeHeadMatches dataInfo name =
   if isQualifiedSourceHead name
     then qualifiedDataName dataInfo == name
-    else dataName dataInfo == name
+    else symbolDefiningName (dataInfoSymbol dataInfo) == name
 
 isQualifiedSourceHead :: String -> Bool
 isQualifiedSourceHead = elem '.'
 
 qualifiedDataName :: DataInfo -> String
-qualifiedDataName dataInfo = dataModule dataInfo ++ "." ++ dataName dataInfo
+qualifiedDataName dataInfo =
+  symbolDefiningModule (dataInfoSymbol dataInfo) ++ "." ++ symbolDefiningName (dataInfoSymbol dataInfo)
 
 allDataInfos :: CheckedProgram -> [DataInfo]
 allDataInfos checked =
@@ -288,8 +290,8 @@ lookupDataInfoInModule checked moduleName0 name =
   case
     [ dataInfo
       | dataInfo <- allDataInfos checked,
-        dataModule dataInfo == moduleName0,
-        dataName dataInfo == name
+        symbolDefiningModule (dataInfoSymbol dataInfo) == moduleName0,
+        symbolDefiningName (dataInfoSymbol dataInfo) == name
     ]
   of
     dataInfo : _ -> Just dataInfo

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -26,6 +26,7 @@ module MLF.Frontend.Program.Types
     constructorInfoSymbolIdentity,
     classInfoSymbolIdentity,
     methodInfoSymbolIdentity,
+    methodInfoOwnerClassSymbolIdentity,
     instanceInfoClassSymbolIdentity,
     resolvedValueInfoSymbol,
     resolvedDataInfoSymbol,
@@ -346,20 +347,17 @@ newtype ResolvedProgram = ResolvedProgram
   deriving (Eq, Show)
 
 {- Note [Resolved .mlfp symbol identities]
-The current checker still accepts qualified spellings by materializing qualified
-copies of imported `ValueInfo`, `DataInfo`, and `ClassInfo` records. That keeps
-surface lookup working, but later phases need a stable model that does not
-confuse the spelling used at a reference site with the semantic declaration it
-resolved to.
-
 `SymbolIdentity` is the semantic key. It uses the defining module plus the
 unqualified declaration name, and method/constructor identities carry their
 owning class/type identity. `SymbolSpelling` is the reference-side surface data:
 the source name, display name, and whether it came from a local declaration,
 unqualified import, qualified/aliased import, or builtin.
 
-This is intentionally only a model/boundary contract for now. It should be used
-by the resolver migration before changing checker visibility semantics.
+The checker and elaborator keep visible maps keyed by surface spelling because
+source lookup and diagnostics need those names. Downstream metadata stores
+`SymbolIdentity` separately, and semantic checks compare that identity instead
+of inferring declaration equality from qualified/unqualified strings. Runtime
+names remain explicit generated names, not semantic identities.
 -}
 
 mkResolvedSymbol :: SymbolIdentity -> String -> String -> SymbolOrigin -> ResolvedSymbol
@@ -384,6 +382,7 @@ unqualifiedSymbolName =
 
 data EvidenceInfo = EvidenceInfo
   { evidenceClassName :: P.ClassName,
+    evidenceClassSymbol :: SymbolIdentity,
     evidenceType :: SrcType,
     evidenceMethods :: Map P.MethodName (String, SrcType)
   }
@@ -391,6 +390,7 @@ data EvidenceInfo = EvidenceInfo
 
 data ConstructorInfo = ConstructorInfo
   { ctorName :: P.ConstructorName,
+    ctorInfoSymbol :: SymbolIdentity,
     ctorRuntimeName :: String,
     ctorType :: SrcType,
     ctorForalls :: [(String, Maybe SrcType)],
@@ -403,6 +403,7 @@ data ConstructorInfo = ConstructorInfo
 
 data DataInfo = DataInfo
   { dataName :: P.TypeName,
+    dataInfoSymbol :: SymbolIdentity,
     dataModule :: P.ModuleName,
     dataParams :: [String],
     dataConstructors :: [ConstructorInfo]
@@ -411,6 +412,7 @@ data DataInfo = DataInfo
 
 data MethodInfo = MethodInfo
   { methodClassName :: P.ClassName,
+    methodInfoSymbol :: SymbolIdentity,
     methodClassModule :: P.ModuleName,
     methodName :: P.MethodName,
     methodRuntimeBase :: String,
@@ -422,6 +424,7 @@ data MethodInfo = MethodInfo
 
 data ClassInfo = ClassInfo
   { className :: P.ClassName,
+    classInfoSymbol :: SymbolIdentity,
     classModule :: P.ModuleName,
     classParamName :: String,
     classMethods :: Map P.MethodName MethodInfo
@@ -431,6 +434,7 @@ data ClassInfo = ClassInfo
 data ValueInfo
   = OrdinaryValue
       { valueDisplayName :: String,
+        valueInfoSymbol :: SymbolIdentity,
         valueRuntimeName :: String,
         valueType :: SrcType,
         valueConstraints :: [P.ClassConstraint],
@@ -438,6 +442,7 @@ data ValueInfo
       }
   | ConstructorValue
       { valueDisplayName :: String,
+        valueInfoSymbol :: SymbolIdentity,
         valueRuntimeName :: String,
         valueType :: SrcType,
         valueCtorInfo :: ConstructorInfo,
@@ -445,6 +450,7 @@ data ValueInfo
       }
   | OverloadedMethod
       { valueDisplayName :: String,
+        valueInfoSymbol :: SymbolIdentity,
         valueMethodInfo :: MethodInfo,
         valueOriginModule :: P.ModuleName
       }
@@ -452,6 +458,7 @@ data ValueInfo
 
 data InstanceInfo = InstanceInfo
   { instanceClassName :: P.ClassName,
+    instanceClassSymbol :: SymbolIdentity,
     instanceClassModule :: P.ModuleName,
     instanceOriginModule :: P.ModuleName,
     instanceConstraints :: [P.ClassConstraint],
@@ -553,74 +560,40 @@ data CheckedProgram = CheckedProgram
   deriving (Eq, Show)
 
 valueInfoSymbolIdentity :: ValueInfo -> SymbolIdentity
-valueInfoSymbolIdentity valueInfo =
-  case valueInfo of
-    OrdinaryValue {} ->
-      SymbolIdentity
-        { symbolNamespace = SymbolValue,
-          symbolDefiningModule = valueOriginModule valueInfo,
-          symbolDefiningName = unqualifiedSymbolName (valueDisplayName valueInfo),
-          symbolOwnerIdentity = Nothing
-        }
-    ConstructorValue {valueCtorInfo = ctorInfo} ->
-      SymbolIdentity
-        { symbolNamespace = SymbolConstructor,
-          symbolDefiningModule = valueOriginModule valueInfo,
-          symbolDefiningName = unqualifiedSymbolName (ctorName ctorInfo),
-          symbolOwnerIdentity = Just (SymbolOwnerType (valueOriginModule valueInfo) (ctorOwningType ctorInfo))
-        }
-    OverloadedMethod {valueMethodInfo = methodInfo} ->
-      methodInfoSymbolIdentity methodInfo
+valueInfoSymbolIdentity = valueInfoSymbol
 
 dataInfoSymbolIdentity :: DataInfo -> SymbolIdentity
-dataInfoSymbolIdentity dataInfo =
-  SymbolIdentity
-    { symbolNamespace = SymbolType,
-      symbolDefiningModule = dataModule dataInfo,
-      symbolDefiningName = dataName dataInfo,
-      symbolOwnerIdentity = Nothing
-    }
+dataInfoSymbolIdentity = dataInfoSymbol
 
 constructorInfoSymbolIdentity :: DataInfo -> ConstructorInfo -> SymbolIdentity
-constructorInfoSymbolIdentity dataInfo ctorInfo =
-  SymbolIdentity
-    { symbolNamespace = SymbolConstructor,
-      symbolDefiningModule = dataModule dataInfo,
-      symbolDefiningName = unqualifiedSymbolName (ctorName ctorInfo),
-      symbolOwnerIdentity = Just (SymbolOwnerType (dataModule dataInfo) (ctorOwningType ctorInfo))
-    }
+constructorInfoSymbolIdentity _ = ctorInfoSymbol
 
 classInfoSymbolIdentity :: ClassInfo -> SymbolIdentity
-classInfoSymbolIdentity classInfo =
-  SymbolIdentity
-    { symbolNamespace = SymbolClass,
-      symbolDefiningModule = classModule classInfo,
-      symbolDefiningName = unqualifiedSymbolName (className classInfo),
-      symbolOwnerIdentity = Nothing
-    }
+classInfoSymbolIdentity = classInfoSymbol
 
 methodInfoSymbolIdentity :: MethodInfo -> SymbolIdentity
-methodInfoSymbolIdentity methodInfo =
-  SymbolIdentity
-    { symbolNamespace = SymbolMethod,
-      symbolDefiningModule = methodClassModule methodInfo,
-      symbolDefiningName = methodName methodInfo,
-      symbolOwnerIdentity =
-        Just
-          ( SymbolOwnerClass
-              (methodClassModule methodInfo)
-              (unqualifiedSymbolName (methodClassName methodInfo))
-          )
-    }
+methodInfoSymbolIdentity = methodInfoSymbol
+
+methodInfoOwnerClassSymbolIdentity :: MethodInfo -> SymbolIdentity
+methodInfoOwnerClassSymbolIdentity methodInfo =
+  case symbolOwnerIdentity (methodInfoSymbolIdentity methodInfo) of
+    Just (SymbolOwnerClass moduleName className0) ->
+      SymbolIdentity
+        { symbolNamespace = SymbolClass,
+          symbolDefiningModule = moduleName,
+          symbolDefiningName = className0,
+          symbolOwnerIdentity = Nothing
+        }
+    _ ->
+      SymbolIdentity
+        { symbolNamespace = SymbolClass,
+          symbolDefiningModule = methodClassModule methodInfo,
+          symbolDefiningName = unqualifiedSymbolName (methodClassName methodInfo),
+          symbolOwnerIdentity = Nothing
+        }
 
 instanceInfoClassSymbolIdentity :: InstanceInfo -> SymbolIdentity
-instanceInfoClassSymbolIdentity instanceInfo =
-  SymbolIdentity
-    { symbolNamespace = SymbolClass,
-      symbolDefiningModule = instanceClassModule instanceInfo,
-      symbolDefiningName = unqualifiedSymbolName (instanceClassName instanceInfo),
-      symbolOwnerIdentity = Nothing
-    }
+instanceInfoClassSymbolIdentity = instanceClassSymbol
 
 resolvedValueInfoSymbol :: SymbolOrigin -> ValueInfo -> ResolvedSymbol
 resolvedValueInfoSymbol origin valueInfo =

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1681,6 +1681,33 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramTypeMismatch")
     , ProgramMatrixCase
+        "rejects same-shape qualified constructor arguments after result specialization"
+        ( InlineProgram $
+            unlines
+                [ "module A export (Box(..)) {"
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , "}"
+                , ""
+                , "module B export (Box(..)) {"
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , "}"
+                , ""
+                , "module Main export (Use(..), main) {"
+                , "  import A as A;"
+                , "  import B as B;"
+                , ""
+                , "  data Use a ="
+                , "      Use : A.Box a -> Use a;"
+                , ""
+                , "  def bad : Use Bool = Use (B.Box true);"
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramTypeMismatch")
+    , ProgramMatrixCase
         "runs local class instance for alias-only imported type"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1628,6 +1628,59 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "true")
     , ProgramMatrixCase
+        "deduplicates constrained imported instances from mixed unqualified and aliased imports"
+        ( InlineProgram $
+            unlines
+                [ "module Core export (Eq, Box(..), eq) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  instance Eq Bool {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  instance Eq a => Eq (Box a) {"
+                , "    eq = \\left \\right true;"
+                , "  }"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import Core exposing (Eq, Box(..), eq);"
+                , "  import Core as C;"
+                , "  def main : Bool = eq (C.Box true) (C.Box false);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "true")
+    , ProgramMatrixCase
+        "rejects same-shape qualified ADTs with distinct source identities"
+        ( InlineProgram $
+            unlines
+                [ "module A export (Token(..), accept) {"
+                , "  data Token ="
+                , "      Token : Token;"
+                , ""
+                , "  def accept : Token -> Bool = \\x true;"
+                , "}"
+                , ""
+                , "module B export (Token(..)) {"
+                , "  data Token ="
+                , "      Token : Token;"
+                , "}"
+                , ""
+                , "module Main export (main) {"
+                , "  import A as A;"
+                , "  import B as B;"
+                , "  def main : Bool = A.accept B.Token;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramTypeMismatch")
+    , ProgramMatrixCase
         "runs local class instance for alias-only imported type"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1708,6 +1708,33 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramTypeMismatch")
     , ProgramMatrixCase
+        "rejects same-shape polymorphic constructor values after result specialization"
+        ( InlineProgram $
+            unlines
+                [ "module A export (Box(..)) {"
+                , "  data Box a ="
+                , "      Empty : Box a;"
+                , "}"
+                , ""
+                , "module B export (Box(..)) {"
+                , "  data Box a ="
+                , "      Empty : Box a;"
+                , "}"
+                , ""
+                , "module Main export (Use(..), main) {"
+                , "  import A as A;"
+                , "  import B as B;"
+                , ""
+                , "  data Use a ="
+                , "      Use : A.Box a -> Use a;"
+                , ""
+                , "  def bad : Use Bool = Use B.Empty;"
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramTypeMismatch")
+    , ProgramMatrixCase
         "runs local class instance for alias-only imported type"
         ( InlineProgram $
             unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1266,7 +1266,7 @@ emlfBoundaryMatrix =
         )
         (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
     , ProgramMatrixCase
-        "rejects alias-equivalent overlapping instance heads"
+        "rejects alias-equivalent duplicate type instance heads"
         ( InlineProgram $
             unlines
                 [ "module Core export (Nat(..)) {"
@@ -1293,7 +1293,7 @@ emlfBoundaryMatrix =
                 , "}"
                 ]
         )
-        (ExpectCheckFailureContaining "ProgramOverlappingInstance \"Eq\"")
+        (ExpectCheckFailureContaining "ProgramDuplicateInstance \"Eq\"")
     , ProgramMatrixCase
         "rejects alias-equivalent duplicate class instance heads"
         ( InlineProgram $
@@ -2390,6 +2390,76 @@ spec = do
                     symbolDisplayName (resolvedSymbolSpelling qualified) `shouldBe` "C.answer"
                 Left err -> expectationFailure ("expected check success, got " ++ show err)
 
+        it "records one resolved identity for mixed spellings across values, types, constructors, classes, and methods" $ do
+            let programText =
+                    unlines
+                        [ "module Core export (Eq, Token(..), answer, eq) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , "  data Token ="
+                        , "      Token : Token;"
+                        , "  instance Eq Token {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , "  def answer : Token = Token;"
+                        , "}"
+                        , ""
+                        , "module Main export (main) {"
+                        , "  import Core as C exposing (Eq, Token(..), answer, eq);"
+                        , "  def left : Token = answer;"
+                        , "  def right : C.Token = C.answer;"
+                        , "  def sameCtor : C.Token = C.Token;"
+                        , "  def usesClass : Eq Token => Bool = true;"
+                        , "  def usesQualifiedClass : C.Eq C.Token => Bool = true;"
+                        , "  def also : Bool = eq Token Token;"
+                        , "  def main : Bool = C.eq Token C.Token;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            case checkProgram program of
+                Right checked -> do
+                    let references =
+                            [ ref
+                            | resolvedModule <- resolvedProgramModules (checkedProgramResolved checked)
+                            , resolvedModuleName resolvedModule == "Main"
+                            , ref <- resolvedModuleReferences resolvedModule
+                            ]
+                        symbolFor kind name =
+                            case [resolvedReferenceSymbol ref | ref <- references, resolvedReferenceKind ref == kind, resolvedReferenceName ref == name] of
+                                symbol : _ -> symbol
+                                [] -> error ("missing resolved reference " ++ show (kind, name))
+                    sameResolvedSymbol (symbolFor ResolvedValueReference "answer") (symbolFor ResolvedValueReference "C.answer") `shouldBe` True
+                    sameResolvedSymbol (symbolFor ResolvedTypeReference "Token") (symbolFor ResolvedTypeReference "C.Token") `shouldBe` True
+                    sameResolvedSymbol (symbolFor ResolvedConstructorReference "Token") (symbolFor ResolvedConstructorReference "C.Token") `shouldBe` True
+                    sameResolvedSymbol (symbolFor ResolvedClassReference "Eq") (symbolFor ResolvedClassReference "C.Eq") `shouldBe` True
+                    sameResolvedSymbol (symbolFor ResolvedMethodReference "eq") (symbolFor ResolvedMethodReference "C.eq") `shouldBe` True
+                Left err -> expectationFailure ("expected check success, got " ++ show err)
+
+        it "deduplicates mixed unqualified and aliased imports by semantic identity" $ do
+            let programText =
+                    unlines
+                        [ "module Core export (Eq, Token(..), answer, eq) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , "  data Token ="
+                        , "      Token : Token;"
+                        , "  instance Eq Token {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , "  def answer : Token = Token;"
+                        , "}"
+                        , ""
+                        , "module Main export (main) {"
+                        , "  import Core;"
+                        , "  import Core as C exposing (Eq, Token(..), answer, eq);"
+                        , "  def main : Bool = eq answer C.answer;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            (prettyValue <$> runProgram program) `shouldBe` Right "true"
+
         it "rejects unknown value references at the resolver boundary" $ do
             let programText =
                     unlines
@@ -2457,6 +2527,49 @@ spec = do
                         ]
             program <- requireParsed programText
             checkProgram program `shouldBe` Left (ProgramAmbiguousUnqualifiedReference "value")
+
+        it "rejects duplicate case branches across mixed constructor spellings" $ do
+            let programText =
+                    unlines
+                        [ "module Core export (Nat(..)) {"
+                        , "  data Nat ="
+                        , "      Zero : Nat"
+                        , "    | Succ : Nat -> Nat;"
+                        , "}"
+                        , "module Main export (main) {"
+                        , "  import Core as C exposing (Nat(..));"
+                        , "  def main : Bool = case Zero of {"
+                        , "    Zero -> true;"
+                        , "    C.Zero -> false"
+                        , "  };"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramDuplicateCaseBranch "C.Zero")
+
+        it "rejects duplicate instance heads across mixed class and type spellings" $ do
+            let programText =
+                    unlines
+                        [ "module Core export (Eq, Token(..), eq) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , "  data Token ="
+                        , "      Token : Token;"
+                        , "}"
+                        , "module Main export (main) {"
+                        , "  import Core as C exposing (Eq, Token(..), eq);"
+                        , "  instance Eq Token {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , "  instance C.Eq C.Token {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramDuplicateInstance "Eq" (STBase "Token"))
 
         it "keeps alias-only access valid through the resolver pass" $ do
             let programText =

--- a/test/ResolvedSymbolSpec.hs
+++ b/test/ResolvedSymbolSpec.hs
@@ -63,6 +63,7 @@ valueInfo :: ValueInfo
 valueInfo =
   OrdinaryValue
     { valueDisplayName = "answer",
+      valueInfoSymbol = SymbolIdentity SymbolValue "Lib" "answer" Nothing,
       valueRuntimeName = "Lib__answer",
       valueType = STBase "Int",
       valueConstraints = [],
@@ -73,6 +74,7 @@ mainValueInfo :: ValueInfo
 mainValueInfo =
   OrdinaryValue
     { valueDisplayName = "main",
+      valueInfoSymbol = SymbolIdentity SymbolValue "Main" "main" Nothing,
       valueRuntimeName = "Main__main",
       valueType = STBase "Int",
       valueConstraints = [],
@@ -83,6 +85,12 @@ someCtor :: ConstructorInfo
 someCtor =
   ConstructorInfo
     { ctorName = "Some",
+      ctorInfoSymbol =
+        SymbolIdentity
+          SymbolConstructor
+          "Lib"
+          "Some"
+          (Just (SymbolOwnerType "Lib" "Token")),
       ctorRuntimeName = "Lib__Some",
       ctorType = STBase "Token",
       ctorForalls = [],
@@ -96,6 +104,7 @@ tokenDataInfo :: DataInfo
 tokenDataInfo =
   DataInfo
     { dataName = "Token",
+      dataInfoSymbol = SymbolIdentity SymbolType "Lib" "Token" Nothing,
       dataModule = "Lib",
       dataParams = [],
       dataConstructors = [someCtor]
@@ -105,6 +114,12 @@ eqMethodInfo :: MethodInfo
 eqMethodInfo =
   MethodInfo
     { methodClassName = "Eq",
+      methodInfoSymbol =
+        SymbolIdentity
+          SymbolMethod
+          "Lib"
+          "eq"
+          (Just (SymbolOwnerClass "Lib" "Eq")),
       methodClassModule = "Lib",
       methodName = "eq",
       methodRuntimeBase = "Lib__Eq__eq",
@@ -121,6 +136,7 @@ eqClassInfo :: ClassInfo
 eqClassInfo =
   ClassInfo
     { className = "Eq",
+      classInfoSymbol = SymbolIdentity SymbolClass "Lib" "Eq" Nothing,
       classModule = "Lib",
       classParamName = "a",
       classMethods = Map.singleton "eq" eqMethodInfo
@@ -130,6 +146,7 @@ qualifiedEqClassInfo :: ClassInfo
 qualifiedEqClassInfo =
   ClassInfo
     { className = "L.Eq",
+      classInfoSymbol = SymbolIdentity SymbolClass "Lib" "Eq" Nothing,
       classModule = "Lib",
       classParamName = "a",
       classMethods = Map.singleton "eq" qualifiedEqMethodInfo
@@ -139,6 +156,7 @@ eqMethodValue :: ValueInfo
 eqMethodValue =
   OverloadedMethod
     { valueDisplayName = "eq",
+      valueInfoSymbol = methodInfoSymbolIdentity eqMethodInfo,
       valueMethodInfo = eqMethodInfo,
       valueOriginModule = "Lib"
     }
@@ -147,6 +165,7 @@ qualifiedEqMethodValue :: ValueInfo
 qualifiedEqMethodValue =
   OverloadedMethod
     { valueDisplayName = "L.eq",
+      valueInfoSymbol = methodInfoSymbolIdentity qualifiedEqMethodInfo,
       valueMethodInfo = qualifiedEqMethodInfo,
       valueOriginModule = "Lib"
     }


### PR DESCRIPTION
Implements #28.

# Implementation Plan for soulomoon/mlf2#28

1. Establish a resolver-backed checked-module context.
   - Change `checkProgram`/`checkModules` so the `ResolvedProgram` produced by `resolveProgram` is threaded into module checking instead of being stored only after the old checker completes.
   - For each module, build lookup maps from `ResolvedModule` scopes/references keyed by surface spelling and by `SymbolIdentity`.
   - Keep parser syntax, resolver semantics, runtime name generation, and source display names unchanged.

2. Attach semantic identities to downstream metadata.
   - Extend `ValueInfo`, `DataInfo`, `ConstructorInfo`, `ClassInfo`, `MethodInfo`, and `InstanceInfo` with stable identity fields or small accessor helpers backed by `SymbolIdentity`/`SymbolOwnerIdentity`.
   - Populate local metadata from existing constructors and imported metadata from resolver symbols rather than deriving semantic ownership from qualified strings.
   - Keep visible map keys as surface spellings only for lookup and diagnostics; all semantic comparisons should use identities.

3. Replace qualified-copy import semantics in `MLF.Frontend.Program.Check`.
   - Rework `buildImportScope`, `applyImportItem`, `qualifyModuleExports`, and instance-visibility helpers so alias imports create visible spellings pointing at the same semantic metadata, not cloned declarations with qualified semantic names.
   - Preserve explicit source display names for diagnostics/rendering and preserve `valueRuntimeName`, `ctorRuntimeName`, and method runtime names.
   - Deduplicate visible/imported values, constructors, types, classes, methods, and instances by semantic identity where mixed qualified/unqualified spellings refer to the same declaration, while still rejecting truly conflicting visible names.

4. Move type/class/constructor comparisons to identity-aware canonicalization.
   - Update constructor-result validation, deriving validation, instance duplicate/overlap checks, and `canonicalInstanceHead` so type heads compare by `DataInfo` identity rather than `STBase`/`STCon` spelling.
   - Update class and method checks to compare `classInfoSymbolIdentity`, `methodInfoSymbolIdentity`, and `instanceInfoClassSymbolIdentity` instead of `unqualifiedName` string stripping.
   - Keep overlap unification behavior otherwise unchanged.

5. Update elaboration and finalization consumers.
   - In `MLF.Frontend.Program.Elaborate`, make `canonicalSourceType`, `lowerTypeRaw` callers, constructor owner lookup, pattern/case matching, overloaded method resolution, and evidence lookup use metadata identities.
   - Ensure `constructorNameMatches`, `sameConstructorInfo`, `sameDataInfo`, and `resolveConstructorDataInfo` compare semantic identities so `Zero` and `C.Zero` can coexist as spellings for one constructor in the same case.
   - In `Finalize`, audit deferred constructor/case/method resolution for remaining spelling-derived semantic checks and convert those to identity-backed metadata where needed.

6. Add regression coverage in `ProgramSpec` and focused symbol tests.
   - Keep existing qualified/aliased import matrix cases passing.
   - Add mixed spelling regressions proving no duplicate semantic identities are created for values, constructors, classes, types, methods, and instances when imported both unqualified and through an alias.
   - Add behavior tests for constructor-result validation, deriving, case checking, and instance duplicate/overlap checks across mixed qualified/unqualified spellings.
   - Add one resolved-program assertion that mixed spellings produce distinct `SymbolSpelling` values but one `SymbolIdentity`.

7. Document the boundary.
   - Update `docs/architecture.md` with the resolved-symbol boundary: resolver owns semantic identity; checker/elaborator use surface spelling only for lookup, diagnostics, source rendering, and runtime-name construction.
   - Update the note in `MLF.Frontend.Program.Types` so it no longer says the model is unused/pending after the migration lands.

8. Validate and publish in implementation mode.
   - Run a narrow targeted test first, e.g. `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program"'`.
   - Then run the required behavior-changing gate: `cabal build all && cabal test`.
   - Before committing, inspect `git status --short` and relevant diffs; stage only implementation, tests, and docs for this issue.