### PR TITLE
Implement #13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Changed
+- Documented the `.mlfp` module compilation contract: modules are checked as
+  one parsed `Program` compilation unit, the CLI Prelude is added explicitly,
+  and separate compilation/interface files remain future work. Added regression
+  coverage for imports that name modules outside the current program.
 - Enforced the `.mlfp` resolved-symbol phase boundary. Program syntax is now
   phase-indexed, the resolver produces a resolved AST with semantic symbols at
   global reference sites and resolved type heads, `checkProgram` routes through

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The unified `.mlfp` surface includes:
 - single-parameter typeclasses, class constraints, and schema instances
 - `deriving Eq` for nullary, recursive, and parameterized ADTs whose fields have Eq evidence
 
+`.mlfp` modules are same-compilation-unit modules today: imports resolve among
+modules in the parsed program, with the CLI runner adding the built-in Prelude
+as an explicit module. Separate module compilation and interface files are not
+supported yet; see `docs/mlfp-language-reference.md` for the user-facing module
+contract.
+
 Internally, `.mlfp` now reuses the old MLF ownership boundary:
 
 - `MLF.Frontend.Program.Check` assembles module/import/class/data environments

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,17 @@ The code is organized by domain (not by phase) under `src/MLF/`:
 - `MLF.Types.*` — elaborated/runtime term and type representations
 - `MLF.Util.*` — shared utilities (order keys, union-find, etc.)
 
+The `.mlfp` module boundary is a same-compilation-unit boundary. `Resolve` and
+`Check` receive the full `Program`, topologically sort its module graph, and can
+therefore accept imports of modules declared later in that program. `Finalize`
+consumes the assembled program scope, and `Run` evaluates all checked module
+bindings together. There is no persisted interface artifact, import loader,
+stable `.mlfp` ABI, or linker today. Future separate compilation should be
+introduced only through an explicit compiler-owned interface artifact carrying
+exported principal schemes, visible type/class/instance summaries, and checked
+xMLF/runtime payloads rather than by peeking at source outside the current
+`Program`.
+
 Tests and executables that need `MLF.Research.*` must add `mlf2:mlf2-research`
 to `build-depends`.
 

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -25,9 +25,13 @@ module User export (main) {
 }
 ```
 
-Imports may refer to modules declared later in the same file. Hidden
-constructors remain hidden: importing `Nat(..)` from a module that exported only
-`Nat` is a visibility error.
+Imports may refer to modules declared later in the same file. A parsed `.mlfp`
+`Program` is one compilation unit: imports resolve only against modules in that
+same program. The CLI runner parses one source file and prepends the built-in
+`Prelude` as an explicit module before checking. There is no filesystem module
+discovery, persisted interface file, stable `.mlfp` ABI, linker, or separate
+module compilation mode yet. Hidden constructors remain hidden: importing
+`Nat(..)` from a module that exported only `Nat` is a visibility error.
 
 Imports can be qualified and aliased:
 

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2311,6 +2311,17 @@ spec = do
             program <- requireParsed programText
             (prettyValue <$> runProgram program) `shouldBe` Right "true"
 
+        it "rejects imports outside the same compilation unit" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import ExternalCore;"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramUnknownImportModule "ExternalCore")
+
         it "rejects non-exhaustive case analysis for semantic reasons" $ do
             let programText =
                     unlines


### PR DESCRIPTION
Closes #13.

## Implementation Plan

---
issue_number: 13
pr_number: 35
branch: codex/issue-13
---

## Decision

Implement issue #13 as an explicit documentation-and-regression slice: `.mlfp` modules are same-compilation-unit modules today. Separate compilation is not supported until a future compiler-owned interface artifact is designed around exported principal schemes, visible type/class/instance summaries, and checked xMLF/runtime payloads.

## Plan

1. Before editing, synchronize `codex/issue-13` with `origin/HEAD`. The branch currently has an empty starter commit and is behind current `origin/master`; rebase onto `origin/HEAD` or otherwise update the branch so the PR does not accidentally revert newer base changes. Verify `git status --short` is clean and PR #35 still uses head `codex/issue-13`.
2. Update `docs/mlfp-language-reference.md` under `Modules` to state the supported contract clearly: a `.mlfp` `Program` is one compilation unit; imports resolve only against modules in that same parsed program; modules may be declared later in that program; the CLI runner adds the built-in Prelude explicitly; there is no filesystem module discovery, persisted interface file, stable `.mlfp` ABI, linker, or separate compilation mode yet.
3. Mirror the short user-facing version in `README.md` near the unified `.mlfp` surface summary, pointing readers to the language reference for details.
4. Update `docs/architecture.md` in the `.mlfp` frontend/program ownership area to record the implementation boundary: `Resolve`/`Check` topologically sort the full `Program`, `Finalize` consumes the assembled program scope, and `Run` evaluates all checked module bindings together. Note that future separate compilation would need an explicit interface artifact rather than source peeking.
5. Add a concise `CHANGELOG.md` Unreleased entry because this settles a user-visible module-compilation contract.
6. Add focused regression coverage in `test/ProgramSpec.hs`, preferably under `MLF.Program diagnostics`, with a test named around same-compilation-unit imports. Parse a program that imports a module absent from that program and assert `checkProgram program == Left (ProgramUnknownImportModule "ExternalCore")`. Keep it in-memory unless a CLI filesystem search regression appears necessary; current behavior is already enforced by `topoSortModules`/`buildImportScope` and `runProgramFile` parsing one file plus explicit Prelude.
7. Avoid production code changes unless the new test exposes behavior contrary to the intended contract. If production code is touched, keep it narrowly within `MLF.Frontend.Program.*` and preserve the existing fail-closed unknown-import diagnostic.
8. Validate with a focused ProgramSpec run, for example `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Program diagnostics"'`, then run `cabal build all && cabal test` before handoff because the final diff includes regression coverage.
9. Before publishing, inspect `git status --short` and relevant diffs, stage only issue-related docs/tests, commit with an imperative message as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, then push the existing `codex/issue-13` branch for PR #35. Do not create a new PR or resolve PR review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.