### PR TITLE
Implement #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Changed
+- Added `.mlfp` declaration parameter kind metadata. Data and class parameters
+  now carry default `*` or parenthesized higher-kinded annotations, the program
+  pretty-printer preserves non-first-order declarations, variable-headed source
+  type applications have an explicit AST representation for follow-up kinding
+  work, and duplicate data type parameters are rejected during program checks.
 - Documented the `.mlfp` module compilation contract: modules are checked as
   one parsed `Program` compilation unit, the CLI Prelude is added explicitly,
   and separate compilation/interface files remain future work. Added regression

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -80,6 +80,37 @@ as real runtime bindings, but source constructor uses lower to deferred
 obligations so eMLF inference can choose the necessary type evidence before the
 constructor is rewritten to the concrete Church binding.
 
+## Type Parameter Kinds
+
+Data and class type parameters default to kind `*`:
+
+```mlf
+class Eq a {
+  eq : a -> a -> Bool;
+}
+
+data Option a =
+    None : Option a
+  | Some : a -> Option a;
+```
+
+Higher-kinded parameters can be declared with a parenthesized kind annotation.
+Kind arrows associate to the right, so `* -> * -> *` means `* -> (* -> *)`.
+
+```mlf
+class Functor (f :: * -> *) {
+  identity : forall a. a -> a;
+}
+
+data Higher (f :: * -> *) a =
+    Higher : a -> Higher f a;
+```
+
+This slice records and pretty-prints declaration parameter kinds while keeping
+existing first-order declarations unchanged. Full variable-headed type
+application parsing such as `f a`, source kind checking, and higher-kinded
+elaboration remain follow-up work for #16, #17, and #18.
+
 ## Case Expressions And Patterns
 
 Cases are ordered:

--- a/src/MLF/Elab/Elaborate/Algebra.hs
+++ b/src/MLF/Elab/Elaborate/Algebra.hs
@@ -2568,6 +2568,8 @@ srcTypeToElabType ty = case ty of
   STArrow dom cod -> TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
   STBase name -> TBase (BaseTy name)
   STCon name args -> TCon (BaseTy name) (fmap srcTypeToElabType args)
+  STVarApp name _ ->
+    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
   STForall name mb body ->
     TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
   STMu name body -> TMu name (srcTypeToElabType body)
@@ -2581,6 +2583,8 @@ srcTypeToElabType ty = case ty of
       STArrow dom cod -> Just (TArrow (srcTypeToElabType dom) (srcTypeToElabType cod))
       STBase name -> Just (TBase (BaseTy name))
       STCon name args -> Just (TCon (BaseTy name) (fmap srcTypeToElabType args))
+      STVarApp name _ ->
+        error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
       STForall name mb body ->
         Just (TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body))
       STMu name body -> Just (TMu name (srcTypeToElabType body))

--- a/src/MLF/Elab/Elaborate/Algebra.hs
+++ b/src/MLF/Elab/Elaborate/Algebra.hs
@@ -37,7 +37,8 @@ import MLF.Elab.Elaborate.Annotation
     stripUnusedTopTyAbs,
   )
 import MLF.Elab.Elaborate.Scope
-  ( generalizeAtNode,
+  ( ScopeContext,
+    generalizeAtNode,
     normalizeSchemeSubstPair,
     normalizeSubstForScheme,
     reifyNodeTypeDirect,
@@ -57,6 +58,7 @@ import MLF.Elab.TermClosure (closeTermWithSchemeSubstIfNeeded)
 import qualified MLF.Elab.TypeCheck as TypeCheck (Env (..), typeCheckWithEnv)
 import MLF.Elab.Types
   ( BoundType,
+    ElabScheme,
     ElabError (..),
     ElabTerm (..),
     ElabType,
@@ -180,6 +182,67 @@ envSchemeInfos = Map.map ebSchemeInfo
 
 lookupSchemeInfo :: VarName -> Env -> Maybe SchemeInfo
 lookupSchemeInfo name env = ebSchemeInfo <$> Map.lookup name env
+
+sourceAnnotatedTypeFrom :: AlgebraContext -> Env -> AnnExpr -> Either ElabError (Maybe ElabType)
+sourceAnnotatedTypeFrom algebraContext env ann =
+  case ann of
+    AVar name _ -> pure (schemeToType . siScheme <$> lookupSchemeInfo name env)
+    AAnn inner annNodeId _ ->
+      case IntMap.lookup (getNodeId annNodeId) (algAnnSourceTypes algebraContext) of
+        Just srcTy -> Just <$> srcTypeToElabType srcTy
+        Nothing -> sourceAnnotatedTypeFrom algebraContext env inner
+    AUnfold inner _ _ -> sourceAnnotatedTypeFrom algebraContext env inner
+    _ -> pure Nothing
+
+sourceSchemePairFromType :: NormSrcType -> Either ElabError (ElabScheme, IntMap.IntMap String)
+sourceSchemePairFromType srcTy = do
+  ty <- srcTypeToElabType srcTy
+  pure (schemeFromType ty, IntMap.empty)
+
+sourceSchemePairForNode :: AlgebraContext -> ScopeContext -> NodeId -> Either ElabError (Maybe (ElabScheme, IntMap.IntMap String))
+sourceSchemePairForNode algebraContext scopeContext nodeId =
+  case IntMap.lookup (getNodeId nodeId) (algAnnSourceTypes algebraContext) of
+    Just srcTy -> do
+      fallback <- sourceSchemePairFromType srcTy
+      pure $
+        case reifyNodeTypePreferringBound scopeContext nodeId of
+          Right ty@TMu {} -> Just (schemeFromType ty, IntMap.empty)
+          _ -> Just fallback
+    Nothing -> pure Nothing
+
+sourceSchemePairForOuterAnnotation :: AlgebraContext -> ScopeContext -> AnnExpr -> Either ElabError (Maybe (ElabScheme, IntMap.IntMap String))
+sourceSchemePairForOuterAnnotation algebraContext scopeContext annExpr =
+  case annExpr of
+    AAnn _ annNodeId _ -> sourceSchemePairForNode algebraContext scopeContext annNodeId
+    AUnfold (AAnn _ annNodeId _) _ _ -> sourceSchemePairForNode algebraContext scopeContext annNodeId
+    _ -> pure Nothing
+
+sourceSchemePairForAnnotation :: AlgebraContext -> ScopeContext -> AnnExpr -> Either ElabError (Maybe (ElabScheme, IntMap.IntMap String))
+sourceSchemePairForAnnotation algebraContext scopeContext annExpr =
+  case annExpr of
+    AAnn inner annNodeId _ -> do
+      current <- sourceSchemePairForNode algebraContext scopeContext annNodeId
+      case current of
+        Just _ -> pure current
+        Nothing -> sourceSchemePairForAnnotation algebraContext scopeContext inner
+    ALam _ _ _ body _ -> sourceSchemePairForAnnotation algebraContext scopeContext body
+    AApp fun arg _ _ _ ->
+      firstJustE
+        (sourceSchemePairForAnnotation algebraContext scopeContext fun)
+        (sourceSchemePairForAnnotation algebraContext scopeContext arg)
+    ALet _ _ _ _ _ rhs body _ ->
+      firstJustE
+        (sourceSchemePairForAnnotation algebraContext scopeContext rhs)
+        (sourceSchemePairForAnnotation algebraContext scopeContext body)
+    AUnfold inner _ _ -> sourceSchemePairForAnnotation algebraContext scopeContext inner
+    _ -> pure Nothing
+
+firstJustE :: Either ElabError (Maybe a) -> Either ElabError (Maybe a) -> Either ElabError (Maybe a)
+firstJustE left right = do
+  result <- left
+  case result of
+    Just _ -> pure result
+    Nothing -> right
 
 lookupAliasTarget :: VarName -> Env -> Maybe VarName
 lookupAliasTarget name env = Map.lookup name env >>= ebAliasTarget
@@ -492,15 +555,15 @@ elabAlg algebraContext layer =
                   -- the user wrote (after lowering), which presolution may have
                   -- corrupted (e.g. stripping TForall inside a μ body).
                   case IntMap.lookup (getNodeId annNodeId) (algAnnSourceTypes algebraContext) of
-                    Just srcTy ->
-                      let preservedTy = srcTypeToElabType srcTy
-                       in pure
-                            ( preservedTy,
-                              SchemeInfo
-                                { siScheme = schemeFromType preservedTy,
-                                  siSubst = IntMap.empty
-                                }
-                            )
+                    Just srcTy -> do
+                      preservedTy <- srcTypeToElabType srcTy
+                      pure
+                        ( preservedTy,
+                          SchemeInfo
+                            { siScheme = schemeFromType preservedTy,
+                              siSubst = IntMap.empty
+                            }
+                        )
                     Nothing ->
                       case generalizeAtNode scopeContext annNodeId of
                         Right (paramScheme, _subst) ->
@@ -573,6 +636,7 @@ elabAlg algebraContext layer =
       let f env = do
             f' <- elabTerm fOut env
             a' <- elabTerm aOut env
+            argSourceSchemeTy <- sourceAnnotatedTypeFrom algebraContext env aAnn
             let schemeEnv = envSchemeInfos env
                 tcEnv = TypeCheck.Env (Map.map (schemeToType . siScheme) schemeEnv) Map.empty
                 appTargetTy =
@@ -600,17 +664,6 @@ elabAlg algebraContext layer =
                   case sourceVarName ann >>= (`Map.lookup` env) of
                     Just binding -> ebExplicitRecursiveParam binding
                     Nothing -> False
-                sourceAnnotatedType ann =
-                  case ann of
-                    AVar name _ -> schemeToType . siScheme <$> lookupSchemeInfo name env
-                    AAnn inner annNodeId _ ->
-                      case IntMap.lookup (getNodeId annNodeId) (algAnnSourceTypes algebraContext) of
-                        Just srcTy -> Just (srcTypeToElabType srcTy)
-                        Nothing -> sourceAnnotatedType inner
-                    AUnfold inner _ _ -> sourceAnnotatedType inner
-                    _ -> Nothing
-                argSourceSchemeTy =
-                  sourceAnnotatedType aAnn
                 sourceMuMatchesActualType sourceTy actualTy =
                   alphaEqType sourceTy actualTy
                     || churchAwareEqType sourceTy actualTy
@@ -1131,59 +1184,6 @@ elabAlg algebraContext layer =
                     _ -> annExpr
                 aliasSourceName = transparentMediatorSourceName rhsAnn
                 aliasSourceSchemeInfo = aliasSourceName >>= (`lookupSchemeInfo` env)
-                letResultSourceScheme =
-                  case IntMap.lookup (getNodeId (canonical trivialRoot)) (algAnnSourceTypes algebraContext) of
-                    Just srcTy ->
-                      let fallback = (schemeFromType (srcTypeToElabType srcTy), IntMap.empty)
-                       in case reifyNodeTypePreferringBound scopeContext (canonical trivialRoot) of
-                            Right ty@TMu {} -> Just (schemeFromType ty, IntMap.empty)
-                            _ -> Just fallback
-                    Nothing -> Nothing
-                schemeRootSourceScheme =
-                  case IntMap.lookup (getNodeId schemeRootId) (algAnnSourceTypes algebraContext) of
-                    Just srcTy ->
-                      let fallback = (schemeFromType (srcTypeToElabType srcTy), IntMap.empty)
-                       in case reifyNodeTypePreferringBound scopeContext schemeRootId of
-                            Right ty@TMu {} -> Just (schemeFromType ty, IntMap.empty)
-                            _ -> Just fallback
-                    Nothing -> Nothing
-                rhsOuterSourceScheme =
-                  case rhsAnn of
-                    AAnn _ annNodeId _ ->
-                      case IntMap.lookup (getNodeId annNodeId) (algAnnSourceTypes algebraContext) of
-                        Just srcTy ->
-                          let fallback = (schemeFromType (srcTypeToElabType srcTy), IntMap.empty)
-                           in case reifyNodeTypePreferringBound scopeContext annNodeId of
-                                Right ty@TMu {} -> Just (schemeFromType ty, IntMap.empty)
-                                _ -> Just fallback
-                        Nothing -> Nothing
-                    AUnfold inner _ _ ->
-                      case inner of
-                        AAnn _ annNodeId _ ->
-                          case IntMap.lookup (getNodeId annNodeId) (algAnnSourceTypes algebraContext) of
-                            Just srcTy ->
-                              let fallback = (schemeFromType (srcTypeToElabType srcTy), IntMap.empty)
-                               in case reifyNodeTypePreferringBound scopeContext annNodeId of
-                                    Right ty@TMu {} -> Just (schemeFromType ty, IntMap.empty)
-                                    _ -> Just fallback
-                            Nothing -> Nothing
-                        _ -> Nothing
-                    _ -> Nothing
-                explicitSourceAnnotatedScheme annExpr =
-                  case annExpr of
-                    AAnn inner annNodeId _ ->
-                      case IntMap.lookup (getNodeId annNodeId) (algAnnSourceTypes algebraContext) of
-                        Just srcTy ->
-                          let fallback = (schemeFromType (srcTypeToElabType srcTy), IntMap.empty)
-                           in case reifyNodeTypePreferringBound scopeContext annNodeId of
-                                Right ty@TMu {} -> Just (schemeFromType ty, IntMap.empty)
-                                _ -> Just fallback
-                        Nothing -> explicitSourceAnnotatedScheme inner
-                    ALam _ _ _ body _ -> explicitSourceAnnotatedScheme body
-                    AApp fun arg _ _ _ -> explicitSourceAnnotatedScheme fun <|> explicitSourceAnnotatedScheme arg
-                    ALet _ _ _ _ _ rhs body _ -> explicitSourceAnnotatedScheme rhs <|> explicitSourceAnnotatedScheme body
-                    AUnfold inner _ _ -> explicitSourceAnnotatedScheme inner
-                    _ -> Nothing
                 containsRecursiveSelfAppToParam selfName paramName annExpr =
                   case annExpr of
                     AVar _ _ -> False
@@ -1259,7 +1259,11 @@ elabAlg algebraContext layer =
                     AAnn inner _ _ -> previewRecursiveCarrierTy selfName inner
                     AUnfold inner _ _ -> previewRecursiveCarrierTy selfName inner
                     _ -> Nothing
-                recoverGeneralizeAtNode err =
+            letResultSourceScheme <- sourceSchemePairForNode algebraContext scopeContext (canonical trivialRoot)
+            schemeRootSourceScheme <- sourceSchemePairForNode algebraContext scopeContext schemeRootId
+            rhsOuterSourceScheme <- sourceSchemePairForOuterAnnotation algebraContext scopeContext rhsAnn
+            explicitRhsSourceScheme <- sourceSchemePairForAnnotation algebraContext scopeContext rhsAnn
+            let recoverGeneralizeAtNode err =
                   case err of
                     SchemeFreeVars _ _
                       | Just schemePair <- rhsOuterSourceScheme ->
@@ -1268,7 +1272,7 @@ elabAlg algebraContext layer =
                           Right schemePair
                       | Just schemePair <- schemeRootSourceScheme ->
                           Right schemePair
-                      | Just schemePair <- explicitSourceAnnotatedScheme rhsAnn ->
+                      | Just schemePair <- explicitRhsSourceScheme ->
                           Right schemePair
                       | Just aliasInfo <- aliasSourceSchemeInfo ->
                           Right (siScheme aliasInfo, siSubst aliasInfo)
@@ -1288,7 +1292,7 @@ elabAlg algebraContext layer =
                   )
                   ()
             (scheme0Raw, subst0Raw) <-
-              case rhsOuterSourceScheme <|> explicitSourceAnnotatedScheme rhsAnn <|> letResultSourceScheme <|> schemeRootSourceScheme of
+              case rhsOuterSourceScheme <|> explicitRhsSourceScheme <|> letResultSourceScheme <|> schemeRootSourceScheme of
                 Just schemePair -> Right schemePair
                 Nothing ->
                   case generalizeAtNode scopeContext schemeRootId of
@@ -1605,7 +1609,7 @@ elabAlg algebraContext layer =
                     Nothing -> mkEnvBinding bindingSchemeInfo transparentMediator
                 tcEnvBase = TypeCheck.Env (Map.map (schemeToType . siScheme) (envSchemeInfos env)) Map.empty
                 authoritativeSourceSchemeInfo =
-                  case rhsOuterSourceScheme <|> explicitSourceAnnotatedScheme rhsAnn <|> letResultSourceScheme <|> schemeRootSourceScheme of
+                  case rhsOuterSourceScheme <|> explicitRhsSourceScheme <|> letResultSourceScheme <|> schemeRootSourceScheme of
                     Just (schemeSrc, substSrc) ->
                       Just
                         ( freshenSchemeInfoAgainstEnv
@@ -1834,7 +1838,7 @@ elabAlg algebraContext layer =
                 effectiveSubst = siSubst effectiveSchemeInfo
                 envSchemeInfoForBody =
                   if isJust rhsOuterSourceScheme
-                    || isJust (explicitSourceAnnotatedScheme rhsAnn)
+                    || isJust explicitRhsSourceScheme
                     || isJust letResultSourceScheme
                     || isJust schemeRootSourceScheme
                     then authoritativeEnvSchemeInfo
@@ -1986,7 +1990,7 @@ elabAlg algebraContext layer =
                       | sourceVarName bodyAnn == Just v,
                         lambdaAnn rhsAnn,
                         isNothing rhsOuterSourceScheme,
-                        isNothing (explicitSourceAnnotatedScheme rhsAnn),
+                        isNothing explicitRhsSourceScheme,
                         isNothing letResultSourceScheme,
                         isNothing schemeRootSourceScheme,
                         not (alphaEqType rhsTy (schemeToType effectiveScheme)) ->
@@ -2562,33 +2566,44 @@ internal consumer.
 -}
 
 -- | Convert a normalized source type to its elaboration-level equivalent.
-srcTypeToElabType :: NormSrcType -> ElabType
+srcTypeToElabType :: NormSrcType -> Either ElabError ElabType
 srcTypeToElabType ty = case ty of
-  STVar name -> TVar name
-  STArrow dom cod -> TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
-  STBase name -> TBase (BaseTy name)
-  STCon name args -> TCon (BaseTy name) (fmap srcTypeToElabType args)
+  STVar name -> Right (TVar name)
+  STArrow dom cod -> TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod
+  STBase name -> Right (TBase (BaseTy name))
+  STCon name args -> TCon (BaseTy name) <$> traverse srcTypeToElabType args
   STVarApp name _ ->
-    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
+    Left (unsupportedVariableHeadType name)
   STForall name mb body ->
-    TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
-  STMu name body -> TMu name (srcTypeToElabType body)
-  STBottom -> TBottom
+    TForall name
+      <$> maybe (Right Nothing) srcBoundToElabBound mb
+      <*> srcTypeToElabType body
+  STMu name body -> TMu name <$> srcTypeToElabType body
+  STBottom -> Right TBottom
   where
-    srcBoundToElabBound :: SrcBound 'NormN -> Maybe BoundType
+    srcBoundToElabBound :: SrcBound 'NormN -> Either ElabError (Maybe BoundType)
     srcBoundToElabBound (SrcBound boundTy) = structBoundToElabBound boundTy
 
-    structBoundToElabBound :: StructBound -> Maybe BoundType
+    structBoundToElabBound :: StructBound -> Either ElabError (Maybe BoundType)
     structBoundToElabBound bTy = case bTy of
-      STArrow dom cod -> Just (TArrow (srcTypeToElabType dom) (srcTypeToElabType cod))
-      STBase name -> Just (TBase (BaseTy name))
-      STCon name args -> Just (TCon (BaseTy name) (fmap srcTypeToElabType args))
+      STArrow dom cod -> Just <$> (TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod)
+      STBase name -> Right (Just (TBase (BaseTy name)))
+      STCon name args -> Just . TCon (BaseTy name) <$> traverse srcTypeToElabType args
       STVarApp name _ ->
-        error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
+        Left (unsupportedVariableHeadType name)
       STForall name mb body ->
-        Just (TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body))
-      STMu name body -> Just (TMu name (srcTypeToElabType body))
-      STBottom -> Nothing
+        Just
+          <$> ( TForall name
+                  <$> maybe (Right Nothing) srcBoundToElabBound mb
+                  <*> srcTypeToElabType body
+              )
+      STMu name body -> Just . TMu name <$> srcTypeToElabType body
+      STBottom -> Right Nothing
+
+unsupportedVariableHeadType :: String -> ElabError
+unsupportedVariableHeadType name =
+  InstantiationError
+    ("variable-headed source type application `" ++ name ++ "` is not supported before higher-kinded elaboration")
 
 annNode :: AnnExpr -> NodeId
 annNode ann =

--- a/src/MLF/Elab/Elaborate/Annotation.hs
+++ b/src/MLF/Elab/Elaborate/Annotation.hs
@@ -807,6 +807,8 @@ srcTypeToElabType ty = case ty of
   STVar name -> TVar name
   STArrow dom cod -> TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
   STCon name args -> TCon (BaseTy name) (fmap srcTypeToElabType args)
+  STVarApp name _ ->
+    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
   STForall name mb body -> TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
   STMu name body -> TMu name (srcTypeToElabType body)
   STBase name -> TBase (BaseTy name)
@@ -821,6 +823,8 @@ structBoundToElabBound bTy = case bTy of
   STArrow dom cod -> Just (TArrow (srcTypeToElabType dom) (srcTypeToElabType cod))
   STBase name -> Just (TBase (BaseTy name))
   STCon name args -> Just (TCon (BaseTy name) (fmap srcTypeToElabType args))
+  STVarApp name _ ->
+    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
   STForall name mb body -> Just (TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body))
   STMu name body -> Just (TMu name (srcTypeToElabType body))
   STBottom -> Nothing

--- a/src/MLF/Elab/Elaborate/Annotation.hs
+++ b/src/MLF/Elab/Elaborate/Annotation.hs
@@ -200,11 +200,11 @@ elaborateAnnotationTerm annotationContext namedSetReify env exprAnn annNodeId ei
           Left (PhiTranslatabilityError _)
             | canReuseSourceScheme -> pure InstId
           Left err -> Left err
-  let expectedSourceScheme =
-        case IntMap.lookup (getNodeId annNodeId) (acAnnSourceTypes annotationContext) of
-          Just srcTy -> Just (schemeFromType (srcTypeToElabType srcTy))
-          Nothing -> Nothing
-      expectedSchemeInfoForClose =
+  expectedSourceScheme <-
+    case IntMap.lookup (getNodeId annNodeId) (acAnnSourceTypes annotationContext) of
+      Just srcTy -> Just . schemeFromType <$> srcTypeToElabType srcTy
+      Nothing -> pure Nothing
+  let expectedSchemeInfoForClose =
         case expectedSourceScheme of
           Just schemeExpected -> Just (schemeExpected, IntMap.empty)
           Nothing -> expectedSchemeInfo
@@ -450,9 +450,9 @@ reifyInst annotationContext namedSetReify env funAnn (EdgeId eid) =
           () of
           () -> Right InstId
       Just edgeWitness -> do
+        mSchemeInfo <- schemeInfoForInst funAnn
         let mTrace = IntMap.lookup eid edgeTraces
             mExpansion = IntMap.lookup eid edgeExpansions
-            mSchemeInfo = schemeInfoForInst funAnn
         case debugGeneralize
           ( "reifyInst scheme edge="
               ++ show eid
@@ -604,38 +604,59 @@ reifyInst annotationContext namedSetReify env funAnn (EdgeId eid) =
     debugGeneralize = traceGeneralize traceCfg
 
     schemeInfoForInst annExpr =
-      case annExpr of
-        _ | Just schemeInfo <- syntheticLetSchemeInfo annExpr -> Just schemeInfo
-        AVar v _ -> Map.lookup v env
-        AAnn inner _ _ -> schemeInfoForInst inner
-        AUnfold inner _ _ -> schemeInfoForInst inner
-        _ -> Nothing
+      do
+        synthetic <- syntheticLetSchemeInfo annExpr
+        case synthetic of
+          Just schemeInfo -> pure (Just schemeInfo)
+          Nothing ->
+            case annExpr of
+              AVar v _ -> pure (Map.lookup v env)
+              AAnn inner _ _ -> schemeInfoForInst inner
+              AUnfold inner _ _ -> schemeInfoForInst inner
+              _ -> pure Nothing
 
     syntheticLetSchemeInfo annExpr =
       case annExpr of
         ALet letName _ schemeRootId _ _ rhsAnn bodyAnn _
           | annRefersToVar letName bodyAnn ->
-              explicitSourceAnnotatedScheme rhsAnn
-                <|> explicitSourceAnnotatedScheme annExpr
-                <|> ( case generalizeAtNode scopeContext schemeRootId of
-                        Right (scheme, subst) -> Just SchemeInfo {siScheme = scheme, siSubst = subst}
-                        Left _ -> Nothing
+              firstJustE
+                (explicitSourceAnnotatedScheme rhsAnn)
+                ( firstJustE
+                    (explicitSourceAnnotatedScheme annExpr)
+                    ( pure
+                        ( case generalizeAtNode scopeContext schemeRootId of
+                            Right (scheme, subst) -> Just SchemeInfo {siScheme = scheme, siSubst = subst}
+                            Left _ -> Nothing
+                        )
                     )
+                )
         AAnn inner _ _ -> syntheticLetSchemeInfo inner
         AUnfold inner _ _ -> syntheticLetSchemeInfo inner
-        _ -> Nothing
+        _ -> pure Nothing
 
     explicitSourceAnnotatedScheme annExpr =
       case annExpr of
         AAnn inner annNodeId _ ->
           case IntMap.lookup (getNodeId annNodeId) (acAnnSourceTypes annotationContext) of
-            Just srcTy -> Just SchemeInfo {siScheme = schemeFromType (srcTypeToElabType srcTy), siSubst = IntMap.empty}
+            Just srcTy -> Just <$> sourceSchemeInfoFromType srcTy
             Nothing -> explicitSourceAnnotatedScheme inner
         ALam _ _ _ body _ -> explicitSourceAnnotatedScheme body
-        AApp fun arg _ _ _ -> explicitSourceAnnotatedScheme fun <|> explicitSourceAnnotatedScheme arg
-        ALet _ _ _ _ _ rhs body _ -> explicitSourceAnnotatedScheme rhs <|> explicitSourceAnnotatedScheme body
+        AApp fun arg _ _ _ ->
+          firstJustE (explicitSourceAnnotatedScheme fun) (explicitSourceAnnotatedScheme arg)
+        ALet _ _ _ _ _ rhs body _ ->
+          firstJustE (explicitSourceAnnotatedScheme rhs) (explicitSourceAnnotatedScheme body)
         AUnfold inner _ _ -> explicitSourceAnnotatedScheme inner
-        _ -> Nothing
+        _ -> pure Nothing
+
+    sourceSchemeInfoFromType srcTy = do
+      ty <- srcTypeToElabType srcTy
+      pure SchemeInfo {siScheme = schemeFromType ty, siSubst = IntMap.empty}
+
+    firstJustE left right = do
+      result <- left
+      case result of
+        Just _ -> pure result
+        Nothing -> right
 
     inferAuthoritativeInstArgs namedSet schemeInfoWitness schemeInfo =
       case inferFromNode (ewRight schemeInfoWitness) of
@@ -802,29 +823,42 @@ renameTypeVarInTerm old new term =
         ERoll ty body -> ERoll (renameTy ty) (renameTypeVarInTerm old new body)
         EUnroll body -> EUnroll (renameTypeVarInTerm old new body)
 
-srcTypeToElabType :: NormSrcType -> ElabType
+srcTypeToElabType :: NormSrcType -> Either ElabError ElabType
 srcTypeToElabType ty = case ty of
-  STVar name -> TVar name
-  STArrow dom cod -> TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
-  STCon name args -> TCon (BaseTy name) (fmap srcTypeToElabType args)
+  STVar name -> Right (TVar name)
+  STArrow dom cod -> TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod
+  STCon name args -> TCon (BaseTy name) <$> traverse srcTypeToElabType args
   STVarApp name _ ->
-    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
-  STForall name mb body -> TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
-  STMu name body -> TMu name (srcTypeToElabType body)
-  STBase name -> TBase (BaseTy name)
-  STBottom -> TBottom
+    Left (unsupportedVariableHeadType name)
+  STForall name mb body ->
+    TForall name
+      <$> maybe (Right Nothing) srcBoundToElabBound mb
+      <*> srcTypeToElabType body
+  STMu name body -> TMu name <$> srcTypeToElabType body
+  STBase name -> Right (TBase (BaseTy name))
+  STBottom -> Right TBottom
 
-srcBoundToElabBound :: SrcBound 'NormN -> Maybe BoundType
+unsupportedVariableHeadType :: String -> ElabError
+unsupportedVariableHeadType name =
+  InstantiationError
+    ("variable-headed source type application `" ++ name ++ "` is not supported before higher-kinded elaboration")
+
+srcBoundToElabBound :: SrcBound 'NormN -> Either ElabError (Maybe BoundType)
 srcBoundToElabBound bound = case bound of
   SrcBound ty -> structBoundToElabBound ty
 
-structBoundToElabBound :: StructBound -> Maybe BoundType
+structBoundToElabBound :: StructBound -> Either ElabError (Maybe BoundType)
 structBoundToElabBound bTy = case bTy of
-  STArrow dom cod -> Just (TArrow (srcTypeToElabType dom) (srcTypeToElabType cod))
-  STBase name -> Just (TBase (BaseTy name))
-  STCon name args -> Just (TCon (BaseTy name) (fmap srcTypeToElabType args))
+  STArrow dom cod -> Just <$> (TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod)
+  STBase name -> Right (Just (TBase (BaseTy name)))
+  STCon name args -> Just . TCon (BaseTy name) <$> traverse srcTypeToElabType args
   STVarApp name _ ->
-    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
-  STForall name mb body -> Just (TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body))
-  STMu name body -> Just (TMu name (srcTypeToElabType body))
-  STBottom -> Nothing
+    Left (unsupportedVariableHeadType name)
+  STForall name mb body ->
+    Just
+      <$> ( TForall name
+              <$> maybe (Right Nothing) srcBoundToElabBound mb
+              <*> srcTypeToElabType body
+          )
+  STMu name body -> Just . TMu name <$> srcTypeToElabType body
+  STBottom -> Right Nothing

--- a/src/MLF/Elab/Run/Pipeline.hs
+++ b/src/MLF/Elab/Run/Pipeline.hs
@@ -142,6 +142,8 @@ validateDirectRecursiveAnnotations = goExpr
             Surface.STArrow dom cod -> bodyType True shadowed dom && bodyType True shadowed cod
             Surface.STBase _ -> True
             Surface.STCon _ args -> all (bodyType True shadowed) args
+            Surface.STVarApp v args ->
+              (shadowed || v /= needle || guarded) && all (bodyType True shadowed) args
             Surface.STForall v mb body ->
               let shadowed' = shadowed || v == needle
                   boundOk = maybe True (bodyBound guarded shadowed' . Surface.unNormBound) mb
@@ -156,6 +158,8 @@ validateDirectRecursiveAnnotations = goExpr
             Surface.STArrow dom cod -> bodyType True shadowed dom && bodyType True shadowed cod
             Surface.STBase _ -> True
             Surface.STCon _ args -> all (bodyType True shadowed) args
+            Surface.STVarApp v args ->
+              (shadowed || v /= needle || guarded) && all (bodyType True shadowed) args
             Surface.STForall v mb body ->
               let shadowed' = shadowed || v == needle
                   boundOk = maybe True (bodyBound guarded shadowed' . Surface.unNormBound) mb
@@ -639,6 +643,8 @@ srcTypeToElabType ty = case ty of
   Surface.STArrow dom cod -> TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
   Surface.STBase name -> TBase (BaseTy name)
   Surface.STCon name args -> TCon (BaseTy name) (fmap srcTypeToElabType args)
+  Surface.STVarApp name _ ->
+    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
   Surface.STForall name mb body ->
     TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
   Surface.STMu name body -> TMu name (srcTypeToElabType body)
@@ -652,6 +658,8 @@ srcTypeToElabType ty = case ty of
       Surface.STArrow dom cod -> Just (TArrow (srcTypeToElabType dom) (srcTypeToElabType cod))
       Surface.STBase name -> Just (TBase (BaseTy name))
       Surface.STCon name args -> Just (TCon (BaseTy name) (fmap srcTypeToElabType args))
+      Surface.STVarApp name _ ->
+        error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
       Surface.STForall name mb body ->
         Just (TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body))
       Surface.STMu name body -> Just (TMu name (srcTypeToElabType body))

--- a/src/MLF/Elab/Run/Pipeline.hs
+++ b/src/MLF/Elab/Run/Pipeline.hs
@@ -228,6 +228,7 @@ runPipelineElabWith ::
   Either PipelineError PipelineElabDetailedResult
 runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints expr = do
   () <- fromConstraintError (validateDirectRecursiveAnnotations expr)
+  initialSchemeInfos <- fromConstraintError (traverse externalBindingSchemeInfo extBindings)
   ConstraintResult {crConstraint = c0, crAnnotated = ann, crAnnSourceTypes = annSourceTypes, crInitialEnv = _initialBindings} <- fromConstraintError (genConstraints expr)
   let c1 = normalize c0
   (c1Broken, acyc) <- fromCycleError (breakCyclesAndCheckAcyclicity c1)
@@ -257,10 +258,6 @@ runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints ex
   -- NormSrcType values (which preserve lowerType naming) instead of
   -- re-generalizing through the constraint graph, which would produce
   -- graph-internal variable names that conflict with constructor types.
-  let initialSchemeInfos =
-        Map.map
-          (\ExternalBinding {externalBindingType = srcTy} -> SchemeInfo {siScheme = schemeFromType (srcTypeToElabType srcTy), siSubst = IntMap.empty})
-          extBindings
   let initialTcEnv =
         TypeCheck.Env
           { TypeCheck.termEnv = Map.map (schemeToType . siScheme) initialSchemeInfos,
@@ -637,30 +634,44 @@ stripLeadingTyAbs term =
    MLF.Frontend.Program.Elaborate (also internal, not exported).
    We keep this local to avoid widening production facades. -}
 
-srcTypeToElabType :: NormSrcType -> ElabType
+externalBindingSchemeInfo :: ExternalBinding -> Either ConstraintError SchemeInfo
+externalBindingSchemeInfo ExternalBinding {externalBindingType = srcTy} = do
+  ty <- srcTypeToElabType srcTy
+  pure SchemeInfo {siScheme = schemeFromType ty, siSubst = IntMap.empty}
+
+srcTypeToElabType :: NormSrcType -> Either ConstraintError ElabType
 srcTypeToElabType ty = case ty of
-  Surface.STVar name -> TVar name
-  Surface.STArrow dom cod -> TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
-  Surface.STBase name -> TBase (BaseTy name)
-  Surface.STCon name args -> TCon (BaseTy name) (fmap srcTypeToElabType args)
+  Surface.STVar name -> Right (TVar name)
+  Surface.STArrow dom cod -> TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod
+  Surface.STBase name -> Right (TBase (BaseTy name))
+  Surface.STCon name args -> TCon (BaseTy name) <$> traverse srcTypeToElabType args
   Surface.STVarApp name _ ->
-    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
+    unsupportedVariableHead name
   Surface.STForall name mb body ->
-    TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
-  Surface.STMu name body -> TMu name (srcTypeToElabType body)
-  Surface.STBottom -> TBottom
+    TForall name
+      <$> maybe (Right Nothing) srcBoundToElabBound mb
+      <*> srcTypeToElabType body
+  Surface.STMu name body -> TMu name <$> srcTypeToElabType body
+  Surface.STBottom -> Right TBottom
   where
-    srcBoundToElabBound :: Surface.SrcBound 'Surface.NormN -> Maybe BoundType
+    srcBoundToElabBound :: Surface.SrcBound 'Surface.NormN -> Either ConstraintError (Maybe BoundType)
     srcBoundToElabBound (Surface.SrcBound boundTy) = structBoundToElabBound boundTy
 
-    structBoundToElabBound :: StructBound -> Maybe BoundType
+    structBoundToElabBound :: StructBound -> Either ConstraintError (Maybe BoundType)
     structBoundToElabBound bTy = case bTy of
-      Surface.STArrow dom cod -> Just (TArrow (srcTypeToElabType dom) (srcTypeToElabType cod))
-      Surface.STBase name -> Just (TBase (BaseTy name))
-      Surface.STCon name args -> Just (TCon (BaseTy name) (fmap srcTypeToElabType args))
+      Surface.STArrow dom cod -> Just <$> (TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod)
+      Surface.STBase name -> Right (Just (TBase (BaseTy name)))
+      Surface.STCon name args -> Just . TCon (BaseTy name) <$> traverse srcTypeToElabType args
       Surface.STVarApp name _ ->
-        error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
+        unsupportedVariableHead name
       Surface.STForall name mb body ->
-        Just (TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body))
-      Surface.STMu name body -> Just (TMu name (srcTypeToElabType body))
-      Surface.STBottom -> Nothing
+        Just
+          <$> ( TForall name
+                  <$> maybe (Right Nothing) srcBoundToElabBound mb
+                  <*> srcTypeToElabType body
+              )
+      Surface.STMu name body -> Just . TMu name <$> srcTypeToElabType body
+      Surface.STBottom -> Right Nothing
+
+    unsupportedVariableHead name =
+      Left (InternalConstraintError ("variable-headed source type application `" ++ name ++ "` is not supported before higher-kinded elaboration"))

--- a/src/MLF/Frontend/ConstraintGen/Translate.hs
+++ b/src/MLF/Frontend/ConstraintGen/Translate.hs
@@ -679,6 +679,8 @@ internalizeCoercionCopy bindFlag wrap coerceGen currentGen tyEnv shared srcType 
       conNode <- allocCon (BaseTy name) argNodes
       rebindChildrenIfRigid bindFlag conNode (genRef currentGen) (NE.toList argNodes)
       withWrappedNode bindFlag wrap currentGen conNode sharedFinal
+    STVarApp name _ ->
+      throwError (InternalConstraintError ("variable-headed source type application `" ++ name ++ "` is not supported before higher-kinded elaboration"))
     STForall var mBound body -> do
       -- Note: Alias bounds (∀(b ⩾ a). body where the bound is a bare
       -- variable) are unreachable here — normalization inlines them via
@@ -774,6 +776,7 @@ structBoundToNormSrcType sb = case sb of
   STArrow dom cod -> STArrow dom cod
   STBase name -> STBase name
   STCon name args -> STCon name args
+  STVarApp name args -> STVarApp name args
   STForall v mb body -> STForall v mb body
   STMu v body -> STMu v body
   STBottom -> STBottom
@@ -786,6 +789,12 @@ structBoundFreeVars = go Set.empty
       STArrow dom cod -> normFreeVars bound dom <> normFreeVars bound cod
       STBase _ -> Set.empty
       STCon _ args -> foldMap (normFreeVars bound) args
+      STVarApp name args ->
+        let headVars =
+              if Set.member name bound
+                then Set.empty
+                else Set.singleton name
+         in headVars <> foldMap (normFreeVars bound) args
       STForall v mb body ->
         let bound' = Set.insert v bound
          in maybe Set.empty (go bound . unNormBound) mb <> normFreeVars bound' body
@@ -798,6 +807,12 @@ structBoundFreeVars = go Set.empty
       STArrow dom cod -> normFreeVars bound dom <> normFreeVars bound cod
       STBase _ -> Set.empty
       STCon _ args -> foldMap (normFreeVars bound) args
+      STVarApp name args ->
+        let headVars =
+              if Set.member name bound
+                then Set.empty
+                else Set.singleton name
+         in headVars <> foldMap (normFreeVars bound) args
       STForall v mb body ->
         let bound' = Set.insert v bound
          in maybe Set.empty (go bound . unNormBound) mb <> normFreeVars bound' body

--- a/src/MLF/Frontend/Normalize.hs
+++ b/src/MLF/Frontend/Normalize.hs
@@ -142,6 +142,8 @@ substSrcType x s = goSub
           case s of
             STVar replacementName -> Just (STVarApp replacementName args)
             STBase replacementName -> Just (STCon replacementName args)
+            STCon replacementName replacementArgs -> Just (STCon replacementName (replacementArgs <> args))
+            STVarApp replacementName replacementArgs -> Just (STVarApp replacementName (replacementArgs <> args))
             _ -> Nothing
 
 -- ---------------------------------------------------------------------------

--- a/src/MLF/Frontend/Normalize.hs
+++ b/src/MLF/Frontend/Normalize.hs
@@ -63,6 +63,12 @@ freeVarsSrcType = go Set.empty
       STArrow a b -> Set.union (go bound a) (go bound b)
       STBase _ -> Set.empty
       STCon _ args -> foldMap (go bound) args
+      STVarApp name args ->
+        let headVars =
+              if Set.member name bound
+                then Set.empty
+                else Set.singleton name
+         in headVars `Set.union` foldMap (go bound) args
       STForall v mb body ->
         let bound' = Set.insert v bound
             freeBound = maybe Set.empty (go bound . unSrcBound) mb
@@ -90,6 +96,11 @@ substSrcType x s = goSub
       STArrow a b -> STArrow (goSub a) (goSub b)
       STBase b -> STBase b
       STCon c args -> STCon c (fmap goSub args)
+      STVarApp name args ->
+        let args' = fmap goSub args
+         in case replacementHead name args' of
+              Just ty -> ty
+              Nothing -> STVarApp name args'
       STBottom -> STBottom
       STForall v mb body
         | v == x ->
@@ -125,6 +136,14 @@ substSrcType x s = goSub
         | otherwise ->
             STMu v (goSub body)
 
+    replacementHead name args
+      | name /= x = Nothing
+      | otherwise =
+          case s of
+            STVar replacementName -> Just (STVarApp replacementName args)
+            STBase replacementName -> Just (STCon replacementName args)
+            _ -> Nothing
+
 -- ---------------------------------------------------------------------------
 -- Fresh name generation
 -- ---------------------------------------------------------------------------
@@ -148,6 +167,7 @@ normalizeType = go
       STArrow a b -> STArrow <$> go a <*> go b
       STBase b -> Right (STBase b)
       STCon c args -> STCon c <$> traverse go args
+      STVarApp v args -> STVarApp v <$> traverse go args
       STBottom -> Right STBottom
       STForall v Nothing body ->
         STForall v Nothing <$> go body
@@ -173,6 +193,7 @@ normalizeType = go
       STArrow a b -> STArrow <$> go a <*> go b
       STBase b -> Right (STBase b)
       STCon c args -> STCon c <$> traverse go args
+      STVarApp v args -> STVarApp v <$> traverse go args
       STBottom -> Right STBottom
       STForall v Nothing body ->
         STForall v Nothing <$> go body

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -359,7 +359,7 @@ pLocatedClassDecl = do
     start <- getSourcePos
     void (symbol "class")
     className <- qualifiedUpperIdent
-    classParam <- lowerIdent reservedWords
+    classParam <- pTypeParam
     methods <- braces (many pLocatedMethodSig)
     end <- getSourcePos
     let classSpan = sourceSpanFromPositions start end
@@ -438,7 +438,7 @@ pLocatedDataDecl = do
     start <- getSourcePos
     void (symbol "data")
     dataName <- upperIdent reservedWords
-    params <- many (lowerIdent reservedWords)
+    params <- many pTypeParam
     void (symbol "=")
     ctors <- pLocatedConstructorDecl `sepBy1` symbol "|"
     derivingClause <- optional pLocatedDerivingClause
@@ -457,6 +457,28 @@ pLocatedDataDecl = do
                 `appendProgramSpanIndex` mergeSpanIndexes (map snd ctors)
                 `appendProgramSpanIndex` maybe emptyProgramSpanIndex snd derivingClause
     pure (decl, spans)
+
+pTypeParam :: Parser TypeParam
+pTypeParam =
+    try pKindedTypeParam
+        <|> (firstOrderTypeParam <$> lowerIdent reservedWords)
+  where
+    pKindedTypeParam =
+        parens $ do
+            name <- lowerIdent reservedWords
+            void (symbol "::")
+            TypeParam name <$> pKind
+
+pKind :: Parser SrcKind
+pKind = do
+    lhs <- pKindAtom
+    rhs <- optional (symbol "->" *> pKind)
+    pure $ maybe lhs (KArrow lhs) rhs
+
+pKindAtom :: Parser SrcKind
+pKindAtom =
+    (KType <$ symbol "*")
+        <|> parens pKind
 
 pConstructorDecl :: Parser ConstructorDecl
 pConstructorDecl = do

--- a/src/MLF/Frontend/Pretty.hs
+++ b/src/MLF/Frontend/Pretty.hs
@@ -27,6 +27,7 @@ prettyEmlfType = goType 0
       STBase b -> b
       STBottom -> "⊥"
       STCon c args -> c ++ " " ++ unwords (map (goArg 2) (toListNE args))
+      STVarApp v args -> v ++ " " ++ unwords (map (goArg 2) (toListNE args))
       STArrow a b ->
         paren (p > 1) (goType 2 a ++ " -> " ++ goType 1 b)
       STForall v mb body ->
@@ -42,6 +43,7 @@ prettyEmlfType = goType 0
       STVar {} -> goType p ty
       STBase {} -> goType p ty
       STBottom {} -> goType p ty
+      STVarApp {} -> "(" ++ goType 0 ty ++ ")"
       _ -> "(" ++ goType 0 ty ++ ")"
 
     prettyBind :: (String, Maybe (SrcTy n (BoundTopVar n))) -> String

--- a/src/MLF/Frontend/Pretty/Program.hs
+++ b/src/MLF/Frontend/Pretty/Program.hs
@@ -81,6 +81,7 @@ prettyTypeParam param
 prettyKind :: SrcKind -> String
 prettyKind = go 0
   where
+    go :: Int -> SrcKind -> String
     go prec kind0 =
         case kind0 of
             KType -> "*"

--- a/src/MLF/Frontend/Pretty/Program.hs
+++ b/src/MLF/Frontend/Pretty/Program.hs
@@ -45,7 +45,7 @@ prettyDecl decl = case decl of
 prettyClassDecl :: ClassDecl -> String
 prettyClassDecl classDecl =
     unlines
-        [ "class " ++ classDeclName classDecl ++ " " ++ classDeclParam classDecl ++ " {"
+        [ "class " ++ classDeclName classDecl ++ " " ++ prettyTypeParam (classDeclParam classDecl) ++ " {"
         , indent (concatMap prettyMethodSig (classDeclMethods classDecl))
         , "}"
         ]
@@ -67,11 +67,25 @@ prettyMethodDef methodDef = methodDefName methodDef ++ " = " ++ prettyExpr (meth
 prettyDataDecl :: DataDecl -> String
 prettyDataDecl dataDecl =
     unlines
-        [ "data " ++ unwords (dataDeclName dataDecl : dataDeclParams dataDecl) ++ " ="
+        [ "data " ++ unwords (dataDeclName dataDecl : map prettyTypeParam (dataDeclParams dataDecl)) ++ " ="
         , indent (intercalate "\n| " (map prettyConstructorDecl (dataDeclConstructors dataDecl)))
               ++ prettyDeriving (dataDeclDeriving dataDecl)
               ++ ";"
         ]
+
+prettyTypeParam :: TypeParam -> String
+prettyTypeParam param
+    | typeParamIsFirstOrder param = typeParamName param
+    | otherwise = "(" ++ typeParamName param ++ " :: " ++ prettyKind (typeParamKind param) ++ ")"
+
+prettyKind :: SrcKind -> String
+prettyKind = go 0
+  where
+    go prec kind0 =
+        case kind0 of
+            KType -> "*"
+            KArrow dom cod ->
+                paren (prec > 0) (go 1 dom ++ " -> " ++ go 0 cod)
 
 prettyConstructorDecl :: ConstructorDecl -> String
 prettyConstructorDecl ctor = constructorDeclName ctor ++ " : " ++ prettyEmlfType (constructorDeclType ctor)

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -1800,6 +1800,8 @@ buildInstanceSkeletons displayEnv scope mod0 derived = do
            in case Map.lookup name subst of
                 Just (STVar replacementName) -> STVarApp replacementName args'
                 Just (STBase replacementName) -> STCon replacementName args'
+                Just (STCon replacementName replacementArgs) -> STCon replacementName (replacementArgs <> args')
+                Just (STVarApp replacementName replacementArgs) -> STVarApp replacementName (replacementArgs <> args')
                 _ -> STVarApp name args'
         STForall name mb body ->
           STForall name (fmap (SrcBound . applyOverlapSubst subst . unSrcBound) mb) (applyOverlapSubst subst body)

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -719,6 +719,7 @@ qualifyModuleExports alias exports =
         STCon name args
           | name `Set.member` exportedTypeNames -> STCon (qualifiedName name) (fmap qualifySrcType args)
           | otherwise -> STCon name (fmap qualifySrcType args)
+        STVarApp name args -> STVarApp name (fmap qualifySrcType args)
         STArrow dom cod -> STArrow (qualifySrcType dom) (qualifySrcType cod)
         STForall name mb body -> STForall name (fmap (SrcBound . qualifySrcType . unSrcBound) mb) (qualifySrcType body)
         STMu name body -> STMu name (qualifySrcType body)
@@ -921,6 +922,7 @@ srcTypeMentionsAny names ty =
     STVar {} -> False
     STBase name -> name `Set.member` names
     STCon name args -> name `Set.member` names || any (srcTypeMentionsAny names) args
+    STVarApp _ args -> any (srcTypeMentionsAny names) args
     STArrow dom cod -> srcTypeMentionsAny names dom || srcTypeMentionsAny names cod
     STForall _ mb body ->
       maybe False (srcTypeMentionsAny names . unSrcBound) mb
@@ -976,6 +978,7 @@ srcTypeMentionedNames names ty =
             | name `Set.member` names = Set.singleton name
             | otherwise = Set.empty
        in Set.unions (headNames : map (srcTypeMentionedNames names) (NE.toList args))
+    STVarApp _ args -> Set.unions (map (srcTypeMentionedNames names) (NE.toList args))
     STArrow dom cod ->
       srcTypeMentionedNames names dom `Set.union` srcTypeMentionedNames names cod
     STForall _ mb body ->
@@ -1061,6 +1064,7 @@ displaySrcTypeForResolved env = \case
   RSTArrow dom cod -> STArrow <$> displaySrcTypeForResolved env dom <*> displaySrcTypeForResolved env cod
   RSTBase symbol -> STBase <$> displayTypeHeadName env symbol
   RSTCon symbol args -> STCon <$> displayTypeHeadName env symbol <*> traverse (displaySrcTypeForResolved env) args
+  RSTVarApp name args -> STVarApp name <$> traverse (displaySrcTypeForResolved env) args
   RSTForall name mb body ->
     STForall name
       <$> traverse (fmap SrcBound . displaySrcTypeForResolved env . unResolvedSrcBound) mb
@@ -1124,6 +1128,9 @@ buildLocalDataInfo displayEnv resolvedModule mod0 = do
   pure . Map.fromList =<< mapM toDataInfo dataDecls
   where
     toDataInfo dataDecl = do
+      let params = P.dataDeclParams dataDecl
+          paramNames = P.typeParamNames params
+      ensureDistinctPlain ProgramDuplicateTypeParameter paramNames
       dataIdentity <- lookupResolvedLocalTypeIdentity resolvedModule (P.dataDeclName dataDecl)
       constructors <- zipWithM (toCtorInfo dataDecl dataIdentity) [0 ..] (P.dataDeclConstructors dataDecl)
       pure
@@ -1132,7 +1139,8 @@ buildLocalDataInfo displayEnv resolvedModule mod0 = do
             { dataName = P.dataDeclName dataDecl,
               dataInfoSymbol = dataIdentity,
               dataModule = P.moduleName mod0,
-              dataParams = P.dataDeclParams dataDecl,
+              dataTypeParams = params,
+              dataParams = paramNames,
               dataConstructors = constructors
             }
         )
@@ -1165,7 +1173,7 @@ buildLocalDataInfo displayEnv resolvedModule mod0 = do
     validateConstructorResult :: SymbolIdentity -> P.ResolvedDataDecl -> P.ResolvedConstructorDecl -> ResolvedSrcType -> TcM ()
     validateConstructorResult dataIdentity dataDecl ctorDecl resultTy =
       let owner = P.dataDeclName dataDecl
-          params = P.dataDeclParams dataDecl
+          params = P.typeParamNames (P.dataDeclParams dataDecl)
           invalid = throwError (ProgramInvalidConstructorResult (P.constructorDeclName ctorDecl) (resolvedSrcTypeToSrcType resultTy) owner)
        in case constructorResultHead resultTy of
             Just (symbol, argCount)
@@ -1206,6 +1214,8 @@ buildLocalClassInfo displayEnv resolvedModule mod0 = do
     toClassInfo classDecl = do
       ensureDistinctBy ProgramDuplicateMethod P.methodSigName (P.classDeclMethods classDecl)
       resolvedClassIdentity <- lookupResolvedLocalClassIdentity resolvedModule (P.classDeclName classDecl)
+      let classParam = P.classDeclParam classDecl
+          classParamName0 = P.typeParamName classParam
       methods <-
         Map.fromList
           <$> forM
@@ -1231,7 +1241,8 @@ buildLocalClassInfo displayEnv resolvedModule mod0 = do
                         methodTypeIdentity = resolvedSrcTypeIdentityType (P.constrainedBody (P.methodSigType sig)),
                         methodConstraints = P.constrainedConstraints methodSigType0,
                         methodConstraintInfos = methodConstraintInfos0,
-                        methodParamName = P.classDeclParam classDecl
+                        methodTypeParam = classParam,
+                        methodParamName = classParamName0
                       }
                   )
             )
@@ -1241,7 +1252,8 @@ buildLocalClassInfo displayEnv resolvedModule mod0 = do
             { className = P.classDeclName classDecl,
               classInfoSymbol = resolvedClassIdentity,
               classModule = P.moduleName mod0,
-              classParamName = P.classDeclParam classDecl,
+              classTypeParam = classParam,
+              classParamName = classParamName0,
               classMethods = methods
             }
         )
@@ -1322,6 +1334,7 @@ constructorRuntimeBindingRecoverable ctor =
         STArrow dom cod -> freeTypeVars dom `Set.union` freeTypeVars cod
         STBase {} -> Set.empty
         STCon _ args -> foldMap freeTypeVars args
+        STVarApp name args -> Set.insert name (foldMap freeTypeVars args)
         STForall name mb body ->
           maybe Set.empty (freeTypeVars . unSrcBound) mb
             `Set.union` Set.delete name (freeTypeVars body)
@@ -1456,17 +1469,17 @@ synthesizeDerivedInstances displayEnv scope resolvedModule mod0 = do
 
     fieldCoveredByDerivedConstraints dataDecl fieldTy =
       case fieldTy of
-        STVar name -> name `elem` P.dataDeclParams dataDecl
+        STVar name -> name `elem` P.typeParamNames (P.dataDeclParams dataDecl)
         _ -> isRecursiveOwnerField dataDecl fieldTy
 
     derivedConstraintParams dataDecl =
-      let params = Set.fromList (P.dataDeclParams dataDecl)
+      let params = Set.fromList (P.typeParamNames (P.dataDeclParams dataDecl))
           fieldTypes =
             filter
               (not . isRecursiveOwnerField dataDecl)
               (concatMap constructorFieldTypes (P.dataDeclConstructors dataDecl))
           usedParams = Set.intersection params (foldMap freeTypeVars fieldTypes)
-       in [paramName | paramName <- P.dataDeclParams dataDecl, paramName `Set.member` usedParams]
+       in [paramName | paramName <- P.typeParamNames (P.dataDeclParams dataDecl), paramName `Set.member` usedParams]
 
     freeTypeVars ty =
       case ty of
@@ -1474,6 +1487,7 @@ synthesizeDerivedInstances displayEnv scope resolvedModule mod0 = do
         STArrow dom cod -> freeTypeVars dom `Set.union` freeTypeVars cod
         STBase {} -> Set.empty
         STCon _ args -> foldMap freeTypeVars args
+        STVarApp name args -> Set.insert name (foldMap freeTypeVars args)
         STForall name mb body ->
           maybe Set.empty (freeTypeVars . unSrcBound) mb
             `Set.union` Set.delete name (freeTypeVars body)
@@ -1571,12 +1585,12 @@ synthesizeDerivedInstances displayEnv scope resolvedModule mod0 = do
       argTy == dataDeclHeadType dataDecl
 
     dataDeclHeadType dataDecl =
-      case P.dataDeclParams dataDecl of
+      case P.typeParamNames (P.dataDeclParams dataDecl) of
         [] -> STBase (P.dataDeclName dataDecl)
         param0 : paramsRest -> STCon (P.dataDeclName dataDecl) (STVar param0 :| map STVar paramsRest)
 
     dataDeclHeadResolvedType dataSymbol dataDecl =
-      case P.dataDeclParams dataDecl of
+      case P.typeParamNames (P.dataDeclParams dataDecl) of
         [] -> RSTBase dataSymbol
         param0 : paramsRest -> RSTCon dataSymbol (RSTVar param0 :| map RSTVar paramsRest)
 
@@ -1754,6 +1768,12 @@ buildInstanceSkeletons displayEnv scope mod0 derived = do
                 (\acc (leftTy, rightTy) -> unifyOverlap acc leftTy rightTy)
                 subst
                 (zip (NE.toList leftArgs) (NE.toList rightArgs))
+        (STVarApp leftName leftArgs, STVarApp rightName rightArgs)
+          | leftName == rightName && NE.length leftArgs == NE.length rightArgs ->
+              foldM
+                (\acc (leftTy, rightTy) -> unifyOverlap acc leftTy rightTy)
+                subst
+                (zip (NE.toList leftArgs) (NE.toList rightArgs))
         (STArrow leftDom leftCod, STArrow rightDom rightCod) -> do
           subst' <- unifyOverlap subst leftDom rightDom
           unifyOverlap subst' leftCod rightCod
@@ -1775,6 +1795,12 @@ buildInstanceSkeletons displayEnv scope mod0 derived = do
             Nothing -> ty
         STArrow dom cod -> STArrow (applyOverlapSubst subst dom) (applyOverlapSubst subst cod)
         STCon name args -> STCon name (fmap (applyOverlapSubst subst) args)
+        STVarApp name args ->
+          let args' = fmap (applyOverlapSubst subst) args
+           in case Map.lookup name subst of
+                Just (STVar replacementName) -> STVarApp replacementName args'
+                Just (STBase replacementName) -> STCon replacementName args'
+                _ -> STVarApp name args'
         STForall name mb body ->
           STForall name (fmap (SrcBound . applyOverlapSubst subst . unSrcBound) mb) (applyOverlapSubst subst body)
         STMu name body -> STMu name (applyOverlapSubst subst body)
@@ -1788,6 +1814,7 @@ buildInstanceSkeletons displayEnv scope mod0 derived = do
             STVar name -> STVar (Map.findWithDefault (prefix ++ name) name env)
             STArrow dom cod -> STArrow (go env dom) (go env cod)
             STCon name args -> STCon name (fmap (go env) args)
+            STVarApp name args -> STVarApp (Map.findWithDefault (prefix ++ name) name env) (fmap (go env) args)
             STForall name mb body ->
               let tagged = prefix ++ name
                   env' = Map.insert name tagged env
@@ -1803,6 +1830,7 @@ buildInstanceSkeletons displayEnv scope mod0 derived = do
         STVar name -> Set.singleton name
         STArrow dom cod -> freeTypeVarsInType dom `Set.union` freeTypeVarsInType cod
         STCon _ args -> foldMap freeTypeVarsInType args
+        STVarApp name args -> Set.insert name (foldMap freeTypeVarsInType args)
         STForall name mb body ->
           maybe Set.empty (freeTypeVarsInType . unSrcBound) mb
             `Set.union` Set.delete name (freeTypeVarsInType body)
@@ -1833,6 +1861,7 @@ sanitizeType = \case
   STArrow dom cod -> "arr_" ++ sanitizeType dom ++ "_" ++ sanitizeType cod
   STBase base -> sanitizeName base
   STCon con args -> intercalate "_" (sanitizeName con : map sanitizeType (NE.toList args))
+  STVarApp name args -> intercalate "_" (sanitizeName name : map sanitizeType (NE.toList args))
   STForall v _ body -> "forall_" ++ sanitizeName v ++ "_" ++ sanitizeType body
   STMu v body -> "mu_" ++ sanitizeName v ++ "_" ++ sanitizeType body
   STBottom -> "bottom"

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -189,6 +189,9 @@ visibleTypeForIdentity dataTypes = go
           STCon
             (visibleHeadName identityName displayName)
             (zipWithNE go displayArgs identityArgs)
+        (STVarApp displayName displayArgs, STVarApp identityName identityArgs)
+          | displayName == identityName ->
+              STVarApp displayName (zipWithNE go displayArgs identityArgs)
         (STArrow displayDom displayCod, STArrow identityDom identityCod) ->
           STArrow (go displayDom identityDom) (go displayCod identityCod)
         (STForall name displayBound displayBody, STForall _ identityBound identityBody) ->
@@ -245,6 +248,7 @@ sourceTypeIdentityInScope scope = canonical
                 Nothing
                   | name `Set.member` builtinTypeNames -> STCon ("<builtin>." ++ name) args'
                   | otherwise -> STCon name args'
+        STVarApp name args -> STVarApp name (fmap canonical args)
         STArrow dom cod -> STArrow (canonical dom) (canonical cod)
         STForall name mb body ->
           STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)
@@ -343,6 +347,12 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
         case Map.lookup name dataTypes of
           Just info -> encodeDataType subst info (map (lower subst currentData) (toListNE args))
           Nothing -> STCon name (fmap (lower subst currentData) args)
+      STVarApp name args ->
+        let args' = fmap (lower subst currentData) args
+         in case Map.lookup name subst of
+              Just (STVar replacementName) -> STVarApp replacementName args'
+              Just (STBase replacementName) -> STCon replacementName args'
+              _ -> STVarApp name args'
       STForall name mb body ->
         let subst' = Map.delete name subst
          in STForall name (fmap (SrcBound . lower subst' currentData . unSrcBound) mb) (lower subst' currentData body)
@@ -388,6 +398,12 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
             case Map.lookup name dataTypes of
               Just info -> encodeDataType subst info (map (lowerCtorArg subst currentData selfTy) (toListNE args))
               Nothing -> STCon name (fmap (lowerCtorArg subst currentData selfTy) args)
+      STVarApp name args ->
+        let args' = fmap (lowerCtorArg subst currentData selfTy) args
+         in case Map.lookup name subst of
+              Just (STVar replacementName) -> STVarApp replacementName args'
+              Just (STBase replacementName) -> STCon replacementName args'
+              _ -> STVarApp name args'
       STForall name mb body ->
         let subst' = Map.delete name subst
          in STForall name (fmap (SrcBound . lowerCtorArg subst' currentData selfTy . unSrcBound) mb) (lowerCtorArg subst' currentData selfTy body)
@@ -545,6 +561,7 @@ displaySrcTypeForResolved scope = \case
   RSTArrow dom cod -> STArrow <$> displaySrcTypeForResolved scope dom <*> displaySrcTypeForResolved scope cod
   RSTBase symbol -> STBase <$> displayTypeHeadNameForResolved scope symbol
   RSTCon symbol args -> STCon <$> displayTypeHeadNameForResolved scope symbol <*> traverse (displaySrcTypeForResolved scope) args
+  RSTVarApp name args -> STVarApp name <$> traverse (displaySrcTypeForResolved scope) args
   RSTForall name mb body ->
     STForall name
       <$> traverse (fmap SrcBound . displaySrcTypeForResolved scope . unResolvedSrcBound) mb
@@ -1023,6 +1040,15 @@ matchTypesByShape subst template actual = case template of
               subst
               (zip (toListNE args) (toListNE args'))
       _ -> Nothing
+  STVarApp name args ->
+    case actual of
+      STVarApp name' args'
+        | name == name' && length (toListNE args) == length (toListNE args') ->
+            foldM
+              (\acc (templateTy, actualTy) -> matchTypesByShape acc templateTy actualTy)
+              subst
+              (zip (toListNE args) (toListNE args'))
+      _ -> Nothing
   STForall name mb body ->
     case actual of
       STForall name' mb' body'
@@ -1411,6 +1437,7 @@ sourceTypeMentionsVisibleData scope ty =
     STCon name args ->
       Map.member name (esTypes scope)
         || any (sourceTypeMentionsVisibleData scope) args
+    STVarApp _ args -> any (sourceTypeMentionsVisibleData scope) args
     STArrow dom cod ->
       sourceTypeMentionsVisibleData scope dom
         || sourceTypeMentionsVisibleData scope cod
@@ -1699,6 +1726,12 @@ specializeSrcType subst ty = case ty of
   STArrow dom cod -> STArrow (specializeSrcType subst dom) (specializeSrcType subst cod)
   STBase {} -> ty
   STCon name args -> STCon name (fmap (specializeSrcType subst) args)
+  STVarApp name args ->
+    let args' = fmap (specializeSrcType subst) args
+     in case Map.lookup name subst of
+          Just (STVar replacementName) -> STVarApp replacementName args'
+          Just (STBase replacementName) -> STCon replacementName args'
+          _ -> STVarApp name args'
   STForall name mb body
     | Map.member name subst -> STForall name mb body
     | otherwise ->
@@ -2782,6 +2815,16 @@ matchTypeViewAgainstIdentity scope subst template actual =
                 subst
                 (zip (map sameView (toListNE args)) (zipWithActual actualArgs))
         _ -> Nothing
+    STVarApp expectedName args ->
+      case typeViewIdentity actual of
+        STVarApp actualName actualArgs
+          | expectedName == actualName,
+            length (toListNE args) == length (toListNE actualArgs) ->
+              foldM
+                (\acc (templateTy, actualTy) -> matchTypeViewAgainstIdentity scope acc templateTy actualTy)
+                subst
+                (zip (map sameView (toListNE args)) (zipWithActual actualArgs))
+        _ -> Nothing
     STForall name mb body ->
       case typeViewIdentity actual of
         STForall name' mb' body'
@@ -2820,6 +2863,7 @@ matchTypeViewAgainstIdentity scope subst template actual =
     zipWithActual actualArgs =
       case typeViewDisplay actual of
         STCon _ displayArgs -> zipWith childView (toListNE displayArgs) (toListNE actualArgs)
+        STVarApp _ displayArgs -> zipWith childView (toListNE displayArgs) (toListNE actualArgs)
         _ -> map sameView (toListNE actualArgs)
 
 preferVisibleSourceType :: ElaborateScope -> SrcType -> SrcType
@@ -2830,6 +2874,7 @@ preferVisibleSourceType scope = go
         STVar {} -> ty
         STBase name -> STBase (preferVisibleTypeHeadName scope name)
         STCon name args -> STCon (preferVisibleTypeHeadName scope name) (fmap go args)
+        STVarApp name args -> STVarApp name (fmap go args)
         STArrow dom cod -> STArrow (go dom) (go cod)
         STForall name mb body -> STForall name (fmap (SrcBound . go . unSrcBound) mb) (go body)
         STMu name body -> STMu name (go body)
@@ -2858,6 +2903,7 @@ rewriteSrcTypeOccurrences needle replacement = go
             STVar {} -> ty
             STBase {} -> ty
             STCon name args -> STCon name (fmap go args)
+            STVarApp name args -> STVarApp name (fmap go args)
             STArrow dom cod -> STArrow (go dom) (go cod)
             STForall name mb body -> STForall name (fmap (SrcBound . go . unSrcBound) mb) (go body)
             STMu name body -> STMu name (go body)
@@ -2905,6 +2951,15 @@ matchTypesWith sameType sameTypeHead subst template actual = case template of
     case actual of
       STCon name' args'
         | sameTypeHead name name' && length (toListNE args) == length (toListNE args') ->
+            foldM
+              (\acc (leftTy, rightTy) -> matchTypesWith sameType sameTypeHead acc leftTy rightTy)
+              subst
+              (zip (toListNE args) (toListNE args'))
+      _ -> Nothing
+  STVarApp name args ->
+    case actual of
+      STVarApp name' args'
+        | name == name' && length (toListNE args) == length (toListNE args') ->
             foldM
               (\acc (leftTy, rightTy) -> matchTypesWith sameType sameTypeHead acc leftTy rightTy)
               subst
@@ -2967,6 +3022,12 @@ freeTypeVarsSrcType = go Set.empty
     go _ STBottom = Set.empty
     go bound (STArrow dom cod) = go bound dom `Set.union` go bound cod
     go bound (STCon _ args) = foldMap (go bound) args
+    go bound (STVarApp name args) =
+      let headVars =
+            if name `Set.member` bound
+              then Set.empty
+              else Set.singleton name
+       in headVars `Set.union` foldMap (go bound) args
     go bound (STForall name mb body) =
       let bound' = Set.insert name bound
           mbFvs = maybe Set.empty (go bound . unSrcBound) mb

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -352,6 +352,8 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
          in case Map.lookup name subst of
               Just (STVar replacementName) -> STVarApp replacementName args'
               Just (STBase replacementName) -> STCon replacementName args'
+              Just (STCon replacementName replacementArgs) -> STCon replacementName (replacementArgs <> args')
+              Just (STVarApp replacementName replacementArgs) -> STVarApp replacementName (replacementArgs <> args')
               _ -> STVarApp name args'
       STForall name mb body ->
         let subst' = Map.delete name subst
@@ -403,6 +405,8 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
          in case Map.lookup name subst of
               Just (STVar replacementName) -> STVarApp replacementName args'
               Just (STBase replacementName) -> STCon replacementName args'
+              Just (STCon replacementName replacementArgs) -> STCon replacementName (replacementArgs <> args')
+              Just (STVarApp replacementName replacementArgs) -> STVarApp replacementName (replacementArgs <> args')
               _ -> STVarApp name args'
       STForall name mb body ->
         let subst' = Map.delete name subst
@@ -1731,6 +1735,8 @@ specializeSrcType subst ty = case ty of
      in case Map.lookup name subst of
           Just (STVar replacementName) -> STVarApp replacementName args'
           Just (STBase replacementName) -> STCon replacementName args'
+          Just (STCon replacementName replacementArgs) -> STCon replacementName (replacementArgs <> args')
+          Just (STVarApp replacementName replacementArgs) -> STVarApp replacementName (replacementArgs <> args')
           _ -> STVarApp name args'
   STForall name mb body
     | Map.member name subst -> STForall name mb body

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -397,15 +397,7 @@ sourceForallMatches expected actual =
                     (zip (toListNE args) (toListNE actualArgs))
             _ -> Nothing
         STVarApp name args ->
-          case actualTy of
-            STVarApp actualName actualArgs
-              | length (toListNE args) == length (toListNE actualArgs) -> do
-                  subst' <- matchVarAppHead bound subst name actualName
-                  foldM
-                    (\acc (leftTy, rightTy) -> match bound acc leftTy rightTy)
-                    subst'
-                    (zip (toListNE args) (toListNE actualArgs))
-            _ -> Nothing
+          matchVarApp bound subst name args actualTy
         STMu _ body -> match bound subst body actualTy
         STBottom ->
           case actualTy of
@@ -434,10 +426,45 @@ sourceForallMatches expected actual =
             STMu name body -> go (Set.insert name boundVars) body
             STBottom -> Set.empty
 
-    matchVarAppHead bound subst expectedName actualName
-      | expectedName `Set.member` bound = matchBoundVar subst expectedName (STVar actualName)
-      | actualName == expectedName = Just subst
-      | otherwise = Nothing
+    matchVarApp bound subst expectedName args actualTy
+      | expectedName `Set.member` bound =
+          case actualTy of
+            STCon actualName actualArgs ->
+              matchAppliedHead actualName toConHead (toListNE actualArgs)
+            STVarApp actualName actualArgs ->
+              matchAppliedHead actualName toVarHead (toListNE actualArgs)
+            _ -> Nothing
+      | otherwise =
+          matchRigidVarAppHead expectedName
+      where
+        expectedArgs = toListNE args
+        expectedArgCount = length expectedArgs
+
+        matchAppliedHead actualName headFromPrefix actualArgs
+          | length actualArgs < expectedArgCount = Nothing
+          | otherwise = do
+              let (headArgs, appliedArgs) = splitAt (length actualArgs - expectedArgCount) actualArgs
+              subst' <- matchBoundVar subst expectedName (headFromPrefix actualName headArgs)
+              foldM
+                (\acc (leftTy, rightTy) -> match bound acc leftTy rightTy)
+                subst'
+                (zip expectedArgs appliedArgs)
+
+        matchRigidVarAppHead rigidName =
+          case actualTy of
+            STVarApp actualName actualArgs
+              | rigidName == actualName && expectedArgCount == length (toListNE actualArgs) ->
+                  foldM
+                    (\acc (leftTy, rightTy) -> match bound acc leftTy rightTy)
+                    subst
+                    (zip expectedArgs (toListNE actualArgs))
+            _ -> Nothing
+
+        toConHead actualName [] = STBase actualName
+        toConHead actualName (arg : rest) = STCon actualName (arg :| rest)
+
+        toVarHead actualName [] = STVar actualName
+        toVarHead actualName (arg : rest) = STVarApp actualName (arg :| rest)
 
     matchBoundVar subst name actualTy =
       case Map.lookup name subst of

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -251,6 +251,12 @@ runSurfacePipeline scope forceUnchecked deferredObligations externalTypes surfac
             STArrow dom cod -> go boundVars dom `Set.union` go boundVars cod
             STBase {} -> Set.empty
             STCon _ args -> foldMap (go boundVars) args
+            STVarApp name args ->
+              let headVars =
+                    if name `Set.member` boundVars
+                      then Set.empty
+                      else Set.singleton name
+               in headVars `Set.union` foldMap (go boundVars) args
             STForall name mb body ->
               maybe Set.empty (go boundVars . unSrcBound) mb
                 `Set.union` go (Set.insert name boundVars) body
@@ -385,6 +391,15 @@ sourceForallMatches expected actual =
                     subst
                     (zip (toListNE args) (toListNE actualArgs))
             _ -> Nothing
+        STVarApp name args ->
+          case actualTy of
+            STVarApp actualName actualArgs
+              | actualName == name && length (toListNE args) == length (toListNE actualArgs) ->
+                  foldM
+                    (\acc (leftTy, rightTy) -> match bound acc leftTy rightTy)
+                    subst
+                    (zip (toListNE args) (toListNE actualArgs))
+            _ -> Nothing
         STMu _ body -> match bound subst body actualTy
         STBottom ->
           case actualTy of
@@ -401,6 +416,12 @@ sourceForallMatches expected actual =
             STArrow dom cod -> go boundVars dom `Set.union` go boundVars cod
             STBase {} -> Set.empty
             STCon _ args -> foldMap (go boundVars) args
+            STVarApp name args ->
+              let headVars =
+                    if name `Set.member` boundVars
+                      then Set.empty
+                      else Set.singleton name
+               in headVars `Set.union` foldMap (go boundVars) args
             STForall name mb body ->
               maybe Set.empty (go boundVars . unSrcBound) mb
                 `Set.union` go (Set.insert name boundVars) body
@@ -921,6 +942,7 @@ recoverSourceType scope = recover
         STForall name (fmap (SrcBound . recover . unSrcBound) mb) (recover body)
       STMu name body -> STMu name (recover body)
       STCon name args -> STCon name (fmap recover args)
+      STVarApp name args -> STVarApp name (fmap recover args)
 
 matchDataInfoEncoding :: ElaborateScope -> DataInfo -> SrcType -> Maybe (SrcType, Map String SrcType)
 matchDataInfoEncoding = matchDataInfoEncodingWith id
@@ -995,6 +1017,15 @@ matchRecoverType params subst renames template actual =
     STCon name args ->
       case actual of
         STCon name' args'
+          | name == name' && length (toListNE args) == length (toListNE args') ->
+              foldM
+                (\acc (leftTy, rightTy) -> matchRecoverType params acc renames leftTy rightTy)
+                subst
+                (zip (toListNE args) (toListNE args'))
+        _ -> Nothing
+    STVarApp name args ->
+      case actual of
+        STVarApp name' args'
           | name == name' && length (toListNE args) == length (toListNE args') ->
               foldM
                 (\acc (leftTy, rightTy) -> matchRecoverType params acc renames leftTy rightTy)
@@ -1076,6 +1107,8 @@ srcTypeToElabType ty = case ty of
   STArrow dom cod -> X.TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
   STBase name -> X.TBase (Graph.BaseTy name)
   STCon name args -> X.TCon (Graph.BaseTy name) (fmap srcTypeToElabType args)
+  STVarApp name _ ->
+    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
   STForall name mb body -> X.TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
   STMu name body -> X.TMu name (srcTypeToElabType body)
   STBottom -> X.TBottom

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -361,12 +361,15 @@ sourceForallMatches expected actual =
   where
     match bound subst template actualTy =
       case template of
-        STForall name _ body ->
+        STForall name mb body ->
           case actualTy of
-            STForall actualName _ actualBody ->
+            STForall actualName actualMb actualBody -> do
+              let bound' = Set.insert name bound
+                  subst' = Map.insert name (STVar actualName) (Map.delete name subst)
+              subst'' <- matchForallBounds bound' subst' mb actualMb
               match
-                (Set.insert name bound)
-                (Map.insert name (STVar actualName) (Map.delete name subst))
+                bound'
+                subst''
                 body
                 actualBody
             _ -> match (Set.insert name bound) (Map.delete name subst) body actualTy
@@ -406,6 +409,13 @@ sourceForallMatches expected actual =
           case actualTy of
             STBottom -> Just subst
             _ -> Nothing
+
+    matchForallBounds bound subst expectedMb actualMb =
+      case (expectedMb, actualMb) of
+        (Nothing, Nothing) -> Just subst
+        (Just (SrcBound expectedBound), Just (SrcBound actualBound)) ->
+          match bound subst expectedBound actualBound
+        _ -> Nothing
 
     freeTypeVarsSrcTypeLocal = go Set.empty
       where

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -496,12 +496,10 @@ alphaEqSrcType = go Map.empty Map.empty
             && length (toListNE leftArgs) == length (toListNE rightArgs)
             && and (zipWith (go leftNames rightNames) (toListNE leftArgs) (toListNE rightArgs))
         (STForall leftName leftMb leftBody, STForall rightName rightMb rightBody) ->
-          sameBounds leftMb rightMb
-            && go
-              (Map.insert leftName rightName leftNames)
-              (Map.insert rightName leftName rightNames)
-              leftBody
-              rightBody
+          let leftNames' = Map.insert leftName rightName leftNames
+              rightNames' = Map.insert rightName leftName rightNames
+           in sameBounds leftNames' rightNames' leftMb rightMb
+                && go leftNames' rightNames' leftBody rightBody
         (STMu leftName leftBody, STMu rightName rightBody) ->
           go
             (Map.insert leftName rightName leftNames)
@@ -511,10 +509,10 @@ alphaEqSrcType = go Map.empty Map.empty
         (STBottom, STBottom) -> True
         _ -> False
       where
-        sameBounds Nothing Nothing = True
-        sameBounds (Just (SrcBound leftBound)) (Just (SrcBound rightBound)) =
-          go leftNames rightNames leftBound rightBound
-        sameBounds _ _ = False
+        sameBounds _ _ Nothing Nothing = True
+        sameBounds leftNames' rightNames' (Just (SrcBound leftBound)) (Just (SrcBound rightBound)) =
+          go leftNames' rightNames' leftBound rightBound
+        sameBounds _ _ _ _ = False
 
     sameTypeVar leftNames rightNames leftName rightName =
       case (Map.lookup leftName leftNames, Map.lookup rightName rightNames) of

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -443,8 +443,54 @@ sourceForallMatches expected actual =
       case Map.lookup name subst of
         Nothing -> Just (Map.insert name actualTy subst)
         Just existing
-          | alphaEqType (srcTypeToElabType existing) (srcTypeToElabType actualTy) -> Just subst
+          | alphaEqSrcType existing actualTy -> Just subst
           | otherwise -> Nothing
+
+alphaEqSrcType :: SrcType -> SrcType -> Bool
+alphaEqSrcType = go Map.empty Map.empty
+  where
+    go leftNames rightNames left right =
+      case (left, right) of
+        (STVar leftName, STVar rightName) ->
+          sameTypeVar leftNames rightNames leftName rightName
+        (STArrow leftDom leftCod, STArrow rightDom rightCod) ->
+          go leftNames rightNames leftDom rightDom
+            && go leftNames rightNames leftCod rightCod
+        (STBase leftName, STBase rightName) -> leftName == rightName
+        (STCon leftName leftArgs, STCon rightName rightArgs) ->
+          leftName == rightName
+            && length (toListNE leftArgs) == length (toListNE rightArgs)
+            && and (zipWith (go leftNames rightNames) (toListNE leftArgs) (toListNE rightArgs))
+        (STVarApp leftName leftArgs, STVarApp rightName rightArgs) ->
+          sameTypeVar leftNames rightNames leftName rightName
+            && length (toListNE leftArgs) == length (toListNE rightArgs)
+            && and (zipWith (go leftNames rightNames) (toListNE leftArgs) (toListNE rightArgs))
+        (STForall leftName leftMb leftBody, STForall rightName rightMb rightBody) ->
+          sameBounds leftMb rightMb
+            && go
+              (Map.insert leftName rightName leftNames)
+              (Map.insert rightName leftName rightNames)
+              leftBody
+              rightBody
+        (STMu leftName leftBody, STMu rightName rightBody) ->
+          go
+            (Map.insert leftName rightName leftNames)
+            (Map.insert rightName leftName rightNames)
+            leftBody
+            rightBody
+        (STBottom, STBottom) -> True
+        _ -> False
+      where
+        sameBounds Nothing Nothing = True
+        sameBounds (Just (SrcBound leftBound)) (Just (SrcBound rightBound)) =
+          go leftNames rightNames leftBound rightBound
+        sameBounds _ _ = False
+
+    sameTypeVar leftNames rightNames leftName rightName =
+      case (Map.lookup leftName leftNames, Map.lookup rightName rightNames) of
+        (Just mappedRight, Just mappedLeft) -> mappedRight == rightName && mappedLeft == leftName
+        (Nothing, Nothing) -> leftName == rightName
+        _ -> False
 
 refreshLetSchemes :: Env -> ElabTerm -> Either ProgramError ElabTerm
 refreshLetSchemes = go
@@ -1042,14 +1088,7 @@ matchRecoverType params subst renames template actual =
                 (zip (toListNE args) (toListNE args'))
         _ -> Nothing
     STVarApp name args ->
-      case actual of
-        STVarApp name' args'
-          | name == name' && length (toListNE args) == length (toListNE args') ->
-              foldM
-                (\acc (leftTy, rightTy) -> matchRecoverType params acc renames leftTy rightTy)
-                subst
-                (zip (toListNE args) (toListNE args'))
-        _ -> Nothing
+      matchRecoverVarApp params subst renames name args actual
     STForall name _mb body ->
       case actual of
         STForall name' _mb' body' ->
@@ -1066,13 +1105,66 @@ matchRecoverType params subst renames template actual =
         STBottom -> Just subst
         _ -> Nothing
 
+matchRecoverVarApp ::
+  Set String ->
+  Map String SrcType ->
+  Map String String ->
+  String ->
+  NonEmpty SrcType ->
+  SrcType ->
+  Maybe (Map String SrcType)
+matchRecoverVarApp params subst renames name args actual
+  | name `Set.member` params =
+      case actual of
+        STCon actualName actualArgs ->
+          matchAppliedHead actualName toConHead (toListNE actualArgs)
+        STVarApp actualName actualArgs ->
+          matchAppliedHead actualName toVarHead (toListNE actualArgs)
+        _ -> Nothing
+  | Just actualName <- Map.lookup name renames =
+      matchRigidVarAppHead actualName
+  | otherwise =
+      matchRigidVarAppHead name
+  where
+    expectedArgs = toListNE args
+    expectedArgCount = length expectedArgs
+
+    matchAppliedHead actualName headFromPrefix actualArgs
+      | length actualArgs < expectedArgCount = Nothing
+      | otherwise = do
+          let (headArgs, appliedArgs) = splitAt (length actualArgs - expectedArgCount) actualArgs
+          subst' <- bindRecoverParam name (headFromPrefix actualName headArgs) subst
+          foldM
+            (\acc (leftTy, rightTy) -> matchRecoverType params acc renames leftTy rightTy)
+            subst'
+            (zip expectedArgs appliedArgs)
+
+    matchRigidVarAppHead expectedName =
+      case actual of
+        STVarApp actualName actualArgs
+          | expectedName == actualName && expectedArgCount == length (toListNE actualArgs) ->
+              foldM
+                (\acc (leftTy, rightTy) -> matchRecoverType params acc renames leftTy rightTy)
+                subst
+                (zip expectedArgs (toListNE actualArgs))
+        _ -> Nothing
+
+    toConHead actualName [] = STBase actualName
+    toConHead actualName (arg : rest) = STCon actualName (arg :| rest)
+
+    toVarHead actualName [] = STVar actualName
+    toVarHead actualName (arg : rest) = STVarApp actualName (arg :| rest)
+
 bindRecoverParam :: String -> SrcType -> Map String SrcType -> Maybe (Map String SrcType)
 bindRecoverParam name actual subst =
   case Map.lookup name subst of
     Nothing -> Just (Map.insert name actual subst)
     Just existing
-      | alphaEqType (srcTypeToElabType existing) (srcTypeToElabType actual)
-          || churchAwareEqType (srcTypeToElabType existing) (srcTypeToElabType actual) ->
+      | alphaEqSrcType existing actual ->
+          Just subst
+      | Just existingTy <- srcTypeToElabTypeMaybe existing,
+        Just actualTy <- srcTypeToElabTypeMaybe actual,
+        alphaEqType existingTy actualTy || churchAwareEqType existingTy actualTy ->
           Just subst
       | otherwise -> Nothing
 
@@ -1131,6 +1223,20 @@ srcTypeToElabType ty = case ty of
   STMu name body -> X.TMu name (srcTypeToElabType body)
   STBottom -> X.TBottom
 
+srcTypeToElabTypeMaybe :: SrcTy n v -> Maybe ElabType
+srcTypeToElabTypeMaybe ty = case ty of
+  STVar name -> Just (X.TVar name)
+  STArrow dom cod -> X.TArrow <$> srcTypeToElabTypeMaybe dom <*> srcTypeToElabTypeMaybe cod
+  STBase name -> Just (X.TBase (Graph.BaseTy name))
+  STCon name args -> X.TCon (Graph.BaseTy name) <$> traverse srcTypeToElabTypeMaybe args
+  STVarApp {} -> Nothing
+  STForall name mb body ->
+    X.TForall name
+      <$> maybe (Just Nothing) srcBoundToElabBoundMaybe mb
+      <*> srcTypeToElabTypeMaybe body
+  STMu name body -> X.TMu name <$> srcTypeToElabTypeMaybe body
+  STBottom -> Just X.TBottom
+
 srcBoundToElabBound :: SrcBound n -> Maybe X.BoundType
 srcBoundToElabBound (SrcBound boundTy) =
   case srcTypeToElabType boundTy of
@@ -1141,3 +1247,15 @@ srcBoundToElabBound (SrcBound boundTy) =
     X.TCon con args -> Just (X.TCon con args)
     X.TForall name mb body -> Just (X.TForall name mb body)
     X.TMu name body -> Just (X.TMu name body)
+
+srcBoundToElabBoundMaybe :: SrcBound n -> Maybe (Maybe X.BoundType)
+srcBoundToElabBoundMaybe (SrcBound boundTy) =
+  case srcTypeToElabTypeMaybe boundTy of
+    Just (X.TVar {}) -> Just Nothing
+    Just X.TBottom -> Just Nothing
+    Just (X.TArrow dom cod) -> Just (Just (X.TArrow dom cod))
+    Just (X.TBase base) -> Just (Just (X.TBase base))
+    Just (X.TCon con args) -> Just (Just (X.TCon con args))
+    Just (X.TForall name mb body) -> Just (Just (X.TForall name mb body))
+    Just (X.TMu name body) -> Just (Just (X.TMu name body))
+    Nothing -> Nothing

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -3,6 +3,7 @@
 module MLF.Frontend.Program.Finalize
   ( finalizeBinding,
     recoverSourceType,
+    sourceForallMatches,
   )
 where
 
@@ -357,14 +358,18 @@ sourceForallMatches expected actual =
   where
     match bound subst template actualTy =
       case template of
-        STForall name _ body -> match (Set.insert name bound) subst body actualTy
+        STForall name _ body ->
+          case actualTy of
+            STForall actualName _ actualBody ->
+              match
+                (Set.insert name bound)
+                (Map.insert name (STVar actualName) (Map.delete name subst))
+                body
+                actualBody
+            _ -> match (Set.insert name bound) (Map.delete name subst) body actualTy
         STVar name
           | name `Set.member` bound ->
-              case Map.lookup name subst of
-                Nothing -> Just (Map.insert name actualTy subst)
-                Just existing
-                  | alphaEqType (srcTypeToElabType existing) (srcTypeToElabType actualTy) -> Just subst
-                  | otherwise -> Nothing
+              matchBoundVar subst name actualTy
           | otherwise ->
               case actualTy of
                 STVar actualName | actualName == name -> Just subst
@@ -394,10 +399,11 @@ sourceForallMatches expected actual =
         STVarApp name args ->
           case actualTy of
             STVarApp actualName actualArgs
-              | actualName == name && length (toListNE args) == length (toListNE actualArgs) ->
+              | length (toListNE args) == length (toListNE actualArgs) -> do
+                  subst' <- matchVarAppHead bound subst name actualName
                   foldM
                     (\acc (leftTy, rightTy) -> match bound acc leftTy rightTy)
-                    subst
+                    subst'
                     (zip (toListNE args) (toListNE actualArgs))
             _ -> Nothing
         STMu _ body -> match bound subst body actualTy
@@ -427,6 +433,18 @@ sourceForallMatches expected actual =
                 `Set.union` go (Set.insert name boundVars) body
             STMu name body -> go (Set.insert name boundVars) body
             STBottom -> Set.empty
+
+    matchVarAppHead bound subst expectedName actualName
+      | expectedName `Set.member` bound = matchBoundVar subst expectedName (STVar actualName)
+      | actualName == expectedName = Just subst
+      | otherwise = Nothing
+
+    matchBoundVar subst name actualTy =
+      case Map.lookup name subst of
+        Nothing -> Just (Map.insert name actualTy subst)
+        Just existing
+          | alphaEqType (srcTypeToElabType existing) (srcTypeToElabType actualTy) -> Just subst
+          | otherwise -> Nothing
 
 refreshLetSchemes :: Env -> ElabTerm -> Either ProgramError ElabTerm
 refreshLetSchemes = go

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -82,10 +82,10 @@ finalizeBinding scope lowered = do
     finalizeDeferredObligations scope (loweredBindingDeferredObligations lowered) tcEnv term0 actualTy0 (loweredBindingExpectedType lowered)
   let isUncheckedConstructor = constructorBindingNeedsUnchecked scope (loweredBindingName lowered)
       acceptedTerm = repairConstructorBindingTerm scope (loweredBindingName lowered) term
-      acceptedTy =
-        if isUncheckedConstructor
-          then srcTypeToElabType (loweredBindingExpectedType lowered)
-          else actualTy
+  acceptedTy <-
+    if isUncheckedConstructor
+      then srcTypeToElabType (loweredBindingExpectedType lowered)
+      else Right actualTy
   if isUncheckedConstructor
     then
       Right
@@ -99,9 +99,9 @@ finalizeBinding scope lowered = do
           }
     else do
       let actualTyForCompare = stripVacuousForalls actualTy
-          expectedTyForCompare = stripVacuousForalls (srcTypeToElabType (loweredBindingExpectedType lowered))
           recoveredActualSrcTy = recoverSourceType scope (elabTypeToSrcType actualTyForCompare)
-          recoveredActualTy = srcTypeToElabType (lowerType scope recoveredActualSrcTy)
+      expectedTyForCompare <- stripVacuousForalls <$> srcTypeToElabType (loweredBindingExpectedType lowered)
+      recoveredActualTy <- srcTypeToElabType (lowerType scope recoveredActualSrcTy)
       if alphaEqType actualTyForCompare expectedTyForCompare
         || churchAwareEqType actualTyForCompare expectedTyForCompare
         || alphaEqType recoveredActualTy expectedTyForCompare
@@ -199,18 +199,9 @@ runSurfacePipeline :: ElaborateScope -> Bool -> Map String DeferredProgramObliga
 runSurfacePipeline scope forceUnchecked deferredObligations externalTypes surfaceExpr = do
   let freeVars = sort (Set.toList (surfaceFreeVars surfaceExpr))
   envBindings <- traverse resolveRuntimeType freeVars
+  extEnvEntries <- traverse externalBindingFor envBindings
   let extEnv :: ExternalBindings
-      extEnv =
-        Map.fromList
-          [ ( name,
-              ExternalBinding
-                { externalBindingType = normTy,
-                  externalBindingMode = externalBindingModeFor name
-                }
-            )
-            | (name, ty) <- envBindings,
-              let normTy = either (error . show) id (normalizeType ty)
-          ]
+      extEnv = Map.fromList extEnvEntries
   normExpr <- either (Left . ProgramPipelineError . show) Right (normalizeExpr surfaceExpr)
   let runPipeline =
         if not forceUnchecked && Map.null deferredObligations
@@ -224,6 +215,16 @@ runSurfacePipeline scope forceUnchecked deferredObligations externalTypes surfac
       case Map.lookup name runtimeTypes of
         Just ty -> Right (name, ty)
         Nothing -> Left (ProgramUnknownValue name)
+
+    externalBindingFor (name, ty) = do
+      normTy <- either (Left . ProgramPipelineError . show) Right (normalizeType ty)
+      Right
+        ( name,
+          ExternalBinding
+            { externalBindingType = normTy,
+              externalBindingMode = externalBindingModeFor name
+            }
+        )
 
     externalBindingModeFor name =
       case Map.lookup name deferredObligations of
@@ -275,8 +276,8 @@ finalizeDeferredObligations ::
 finalizeDeferredObligations _ deferredObligations _ term inferredTy _
   | Map.null deferredObligations = Right (term, inferredTy)
 finalizeDeferredObligations scope deferredObligations tcEnv term _ _ = do
-  let rewriteEnv = extendTypeCheckEnvWithRuntimeScope scope tcEnv
-      constructorObligations = Map.mapMaybe onlyConstructor deferredObligations
+  rewriteEnv <- extendTypeCheckEnvWithRuntimeScope scope tcEnv
+  let constructorObligations = Map.mapMaybe onlyConstructor deferredObligations
       caseObligations = Map.mapMaybe onlyCase deferredObligations
       methodObligations = Map.mapMaybe onlyMethod deferredObligations
   constructorsRewritten <- resolveDeferredConstructors scope rewriteEnv constructorObligations term
@@ -302,13 +303,15 @@ finalizeDeferredObligations scope deferredObligations tcEnv term _ _ = do
       DeferredMethod deferred -> Just deferred
       _ -> Nothing
 
-extendTypeCheckEnvWithRuntimeScope :: ElaborateScope -> Env -> Env
-extendTypeCheckEnvWithRuntimeScope scope env =
-  env
-    { termEnv =
-        termEnv env
-          `Map.union` Map.map srcTypeToElabType (elaborateScopeRuntimeTypes scope)
-    }
+extendTypeCheckEnvWithRuntimeScope :: ElaborateScope -> Env -> Either ProgramError Env
+extendTypeCheckEnvWithRuntimeScope scope env = do
+  runtimeEnv <- traverse srcTypeToElabType (elaborateScopeRuntimeTypes scope)
+  Right
+    env
+      { termEnv =
+          termEnv env
+            `Map.union` runtimeEnv
+      }
 
 inlineTypeEnvBounds :: Env -> ElabType -> ElabType
 inlineTypeEnvBounds env = go Set.empty
@@ -643,15 +646,17 @@ resolveDeferredConstructors scope env deferredConstructors = go env
               Nothing -> substFromArgs
       case filter (`Map.notMember` substFinal) instBinders of
         [] -> do
-          let ctorHead =
-                foldl
-                  ( \headAcc varName ->
-                      case Map.lookup varName substFinal of
-                        Just ty -> X.ETyInst headAcc (X.InstApp (srcTypeToElabType (lowerType scope ty)))
-                        Nothing -> headAcc
-                  )
-                  (X.EVar runtimeName)
-                  instBinders
+          ctorHead <-
+            foldM
+              ( \headAcc varName ->
+                  case Map.lookup varName substFinal of
+                    Just ty -> do
+                      instTy <- srcTypeToElabType (lowerType scope ty)
+                      Right (X.ETyInst headAcc (X.InstApp instTy))
+                    Nothing -> Right headAcc
+              )
+              (X.EVar runtimeName)
+              instBinders
           Right (foldl X.EApp ctorHead args)
         _ -> Left (ProgramAmbiguousConstructorUse (ctorName ctorInfo))
 
@@ -669,8 +674,11 @@ resolveDeferredConstructors scope env deferredConstructors = go env
       case Map.lookup name subst of
         Nothing -> Just (Map.insert name actual subst)
         Just existing
-          | alphaEqType (srcTypeToElabType (lowerType scope existing)) (srcTypeToElabType (lowerType scope actual))
-              || churchAwareEqType (srcTypeToElabType (lowerType scope existing)) (srcTypeToElabType (lowerType scope actual)) ->
+          | alphaEqSrcType existing actual ->
+              Just subst
+          | Just existingTy <- srcTypeToElabTypeMaybe (lowerType scope existing),
+            Just actualTy <- srcTypeToElabTypeMaybe (lowerType scope actual),
+            alphaEqType existingTy actualTy || churchAwareEqType existingTy actualTy ->
               Just subst
           | otherwise -> Nothing
 
@@ -730,9 +738,9 @@ resolveDeferredCases scope deferredCases = go
           | length args == deferredCaseExpectedArgCount deferred -> do
               (_scrutineeElabTy, scrutineeRawTy, scrutineeRecoveredTy) <- inferDeferredArgType env scrutinee
               validateCaseScrutineeType (deferredCaseDataInfo deferred) scrutineeRecoveredTy
-              let resultTy = srcTypeToElabType (lowerType scope (deferredCaseResultType deferred))
-                  caseHead = caseEliminator resultTy scrutinee
-                  env' = extendCaseResultEnv (deferredCaseDataInfo deferred) scrutineeRawTy resultTy env
+              resultTy <- srcTypeToElabType (lowerType scope (deferredCaseResultType deferred))
+              env' <- extendCaseResultEnv (deferredCaseDataInfo deferred) scrutineeRawTy resultTy env
+              let caseHead = caseEliminator resultTy scrutinee
               Right (env', foldl X.EApp caseHead handlers)
         _ -> Left (ProgramCaseOnNonDataType STBottom)
 
@@ -758,9 +766,9 @@ resolveDeferredCases scope deferredCases = go
 
     extendCaseResultEnv dataInfo scrutineeRawTy resultTy env =
       case matchDataInfoEncoding scope dataInfo scrutineeRawTy of
-        Just (sourceHeadTy, subst) ->
+        Just (sourceHeadTy, subst) -> do
+          headTy <- srcTypeToElabType (lowerType scope sourceHeadTy)
           let resultName = "$" ++ dataName dataInfo ++ "_result"
-              headTy = srcTypeToElabType (lowerType scope sourceHeadTy)
               resultBinding =
                 case Map.lookup resultName subst of
                   Just (STVar resultVar) -> Map.singleton resultVar resultTy
@@ -777,8 +785,8 @@ resolveDeferredCases scope deferredCases = go
                           alias `notElem` dataParams dataInfo
                       ]
                   _ -> Map.empty
-           in env {typeEnv = selfAliasBindings `Map.union` resultBinding `Map.union` typeEnv env}
-        Nothing -> env
+          Right env {typeEnv = selfAliasBindings `Map.union` resultBinding `Map.union` typeEnv env}
+        Nothing -> Right env
 
     mapAccumCaseEnv env [] = Right (env, [])
     mapAccumCaseEnv env (arg : rest) = do
@@ -854,7 +862,7 @@ resolveDeferredMethods scope deferredMethods = go
                   constraintGround
                   (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
           evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
-          let methodHead = instantiateMethodValue scope methodSubst methodValue
+          methodHead <- instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
     inferDeferredArgType env arg =
@@ -916,7 +924,8 @@ resolveConstraintEvidenceTerm scope seen constraint = do
           scope
           seen'
           eagerConstraints
-      pure (foldl X.EApp (instantiateMethodValue scope subst valueInfo) nestedEvidence)
+      methodHead <- instantiateMethodValue scope subst valueInfo
+      pure (foldl X.EApp methodHead nestedEvidence)
 
 constraintDeterminedByTypeVars :: Set String -> ConstraintInfo -> Bool
 constraintDeterminedByTypeVars typeVars constraint =
@@ -930,27 +939,27 @@ methodValueConstraints :: ValueInfo -> [ConstraintInfo]
 methodValueConstraints OrdinaryValue {valueConstraintInfos = constraints} = constraints
 methodValueConstraints _ = []
 
-instantiateMethodValue :: ElaborateScope -> Map String TypeView -> ValueInfo -> ElabTerm
+instantiateMethodValue :: ElaborateScope -> Map String TypeView -> ValueInfo -> Either ProgramError ElabTerm
 instantiateMethodValue scope subst OrdinaryValue {valueRuntimeName = runtimeName, valueType = visibleTy} =
-  foldl
-    X.ETyInst
-    (X.EVar runtimeName)
-    (methodForallInstantiations scope subst (fst (splitForalls visibleTy)))
+  foldl X.ETyInst (X.EVar runtimeName)
+    <$> methodForallInstantiations scope subst (fst (splitForalls visibleTy))
 instantiateMethodValue _ _ ConstructorValue {valueRuntimeName = runtimeName} =
-  X.EVar runtimeName
+  Right (X.EVar runtimeName)
 instantiateMethodValue _ _ OverloadedMethod {} =
-  X.EVar "<overloaded-method>"
+  Right (X.EVar "<overloaded-method>")
 
-methodForallInstantiations :: ElaborateScope -> Map String TypeView -> [(String, Maybe SrcType)] -> [X.Instantiation]
+methodForallInstantiations :: ElaborateScope -> Map String TypeView -> [(String, Maybe SrcType)] -> Either ProgramError [X.Instantiation]
 methodForallInstantiations scope subst = go
   where
-    go [] = []
+    go [] = Right []
     go ((name, _) : rest) =
       case Map.lookup name subst of
-        Just ty -> X.InstApp (srcTypeToElabType (lowerTypeView scope ty)) : go rest
+        Just ty -> do
+          instTy <- srcTypeToElabType (lowerTypeView scope ty)
+          (X.InstApp instTy :) <$> go rest
         Nothing
-          | any ((`Map.member` subst) . fst) rest -> X.InstElim : go rest
-          | otherwise -> []
+          | any ((`Map.member` subst) . fst) rest -> (X.InstElim :) <$> go rest
+          | otherwise -> Right []
 
 collectElabApps :: ElabTerm -> (ElabTerm, [ElabTerm])
 collectElabApps = go []
@@ -1238,17 +1247,25 @@ elabTypeToSrcType ty = case ty of
   X.TMu name body -> STMu name (elabTypeToSrcType body)
   X.TBottom -> STBottom
 
-srcTypeToElabType :: SrcTy n v -> ElabType
+srcTypeToElabType :: SrcTy n v -> Either ProgramError ElabType
 srcTypeToElabType ty = case ty of
-  STVar name -> X.TVar name
-  STArrow dom cod -> X.TArrow (srcTypeToElabType dom) (srcTypeToElabType cod)
-  STBase name -> X.TBase (Graph.BaseTy name)
-  STCon name args -> X.TCon (Graph.BaseTy name) (fmap srcTypeToElabType args)
+  STVar name -> Right (X.TVar name)
+  STArrow dom cod -> X.TArrow <$> srcTypeToElabType dom <*> srcTypeToElabType cod
+  STBase name -> Right (X.TBase (Graph.BaseTy name))
+  STCon name args -> X.TCon (Graph.BaseTy name) <$> traverse srcTypeToElabType args
   STVarApp name _ ->
-    error ("variable-headed source type application `" ++ name ++ "` cannot be lowered before higher-kinded elaboration is implemented")
-  STForall name mb body -> X.TForall name (mb >>= srcBoundToElabBound) (srcTypeToElabType body)
-  STMu name body -> X.TMu name (srcTypeToElabType body)
-  STBottom -> X.TBottom
+    Left (unsupportedVariableHeadType name)
+  STForall name mb body ->
+    X.TForall name
+      <$> maybe (Right Nothing) srcBoundToElabBound mb
+      <*> srcTypeToElabType body
+  STMu name body -> X.TMu name <$> srcTypeToElabType body
+  STBottom -> Right X.TBottom
+
+unsupportedVariableHeadType :: String -> ProgramError
+unsupportedVariableHeadType name =
+  ProgramPipelineError
+    ("variable-headed source type application `" ++ name ++ "` is not supported before higher-kinded elaboration")
 
 srcTypeToElabTypeMaybe :: SrcTy n v -> Maybe ElabType
 srcTypeToElabTypeMaybe ty = case ty of
@@ -1264,16 +1281,17 @@ srcTypeToElabTypeMaybe ty = case ty of
   STMu name body -> X.TMu name <$> srcTypeToElabTypeMaybe body
   STBottom -> Just X.TBottom
 
-srcBoundToElabBound :: SrcBound n -> Maybe X.BoundType
+srcBoundToElabBound :: SrcBound n -> Either ProgramError (Maybe X.BoundType)
 srcBoundToElabBound (SrcBound boundTy) =
   case srcTypeToElabType boundTy of
-    X.TVar {} -> Nothing
-    X.TBottom -> Nothing
-    X.TArrow dom cod -> Just (X.TArrow dom cod)
-    X.TBase base -> Just (X.TBase base)
-    X.TCon con args -> Just (X.TCon con args)
-    X.TForall name mb body -> Just (X.TForall name mb body)
-    X.TMu name body -> Just (X.TMu name body)
+    Left err -> Left err
+    Right (X.TVar {}) -> Right Nothing
+    Right X.TBottom -> Right Nothing
+    Right (X.TArrow dom cod) -> Right (Just (X.TArrow dom cod))
+    Right (X.TBase base) -> Right (Just (X.TBase base))
+    Right (X.TCon con args) -> Right (Just (X.TCon con args))
+    Right (X.TForall name mb body) -> Right (Just (X.TForall name mb body))
+    Right (X.TMu name body) -> Right (Just (X.TMu name body))
 
 srcBoundToElabBoundMaybe :: SrcBound n -> Maybe (Maybe X.BoundType)
 srcBoundToElabBoundMaybe (SrcBound boundTy) =

--- a/src/MLF/Frontend/Program/Resolve.hs
+++ b/src/MLF/Frontend/Program/Resolve.hs
@@ -537,6 +537,9 @@ resolveType scope = \case
     headRef <- resolveTypeName scope name
     (args', argRefs) <- mapAndRefs (resolveType scope) (toListNE args)
     pure (RSTCon (resolvedReferenceSymbol headRef) (toNonEmpty args'), headRef : argRefs)
+  STVarApp name args -> do
+    (args', argRefs) <- mapAndRefs (resolveType scope) (toListNE args)
+    pure (RSTVarApp name (toNonEmpty args'), argRefs)
   STArrow dom cod -> do
     (dom', domRefs) <- resolveType scope dom
     (cod', codRefs) <- resolveType scope cod

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -257,6 +257,12 @@ substDataParams subst ty =
     STArrow dom cod -> STArrow (substDataParams subst dom) (substDataParams subst cod)
     STBase {} -> ty
     STCon name args -> STCon name (fmap (substDataParams subst) args)
+    STVarApp name args ->
+      let args' = fmap (substDataParams subst) args
+       in case Map.lookup name subst of
+            Just (STVar replacementName) -> STVarApp replacementName args'
+            Just (STBase replacementName) -> STCon replacementName args'
+            _ -> STVarApp name args'
     STForall name mb body ->
       let subst' = Map.delete name subst
        in STForall name (fmap (SrcBound . substDataParams subst' . unSrcBound) mb) (substDataParams subst' body)
@@ -279,6 +285,7 @@ canonicalFieldType checked ownerInfo = canonical
            in case lookupDataInfoInModule checked (dataModule ownerInfo) name of
                 Just info -> STCon (qualifiedDataName info) args'
                 Nothing -> STCon name args'
+        STVarApp name args -> STVarApp name (fmap canonical args)
         STArrow dom cod -> STArrow (canonical dom) (canonical cod)
         STForall name mb body ->
           STForall name (fmap (SrcBound . canonical . unSrcBound) mb) (canonical body)

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -262,6 +262,8 @@ substDataParams subst ty =
        in case Map.lookup name subst of
             Just (STVar replacementName) -> STVarApp replacementName args'
             Just (STBase replacementName) -> STCon replacementName args'
+            Just (STCon replacementName replacementArgs) -> STCon replacementName (replacementArgs <> args')
+            Just (STVarApp replacementName replacementArgs) -> STVarApp replacementName (replacementArgs <> args')
             _ -> STVarApp name args'
     STForall name mb body ->
       let subst' = Map.delete name subst

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -705,6 +705,8 @@ substituteTypeVar needle replacement = go
           case replacement of
             STVar replacementName -> Just (STVarApp replacementName args)
             STBase replacementName -> Just (STCon replacementName args)
+            STCon replacementName replacementArgs -> Just (STCon replacementName (replacementArgs <> args))
+            STVarApp replacementName replacementArgs -> Just (STVarApp replacementName (replacementArgs <> args))
             _ -> Nothing
 
 freeTypeVarsSrcType :: SrcType -> Set String

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -106,6 +106,7 @@ data ProgramError
   | ProgramExportNotLocal String
   | ProgramDuplicateVisibleName String
   | ProgramDuplicateType String
+  | ProgramDuplicateTypeParameter String
   | ProgramDuplicateConstructor String
   | ProgramDuplicateClass String
   | ProgramDuplicateValue String
@@ -187,6 +188,7 @@ spanForError err index =
     ProgramExportNotLocal name -> firstSpan name (P.spanExportItems index) <|> lookupAnyName name index
     ProgramDuplicateVisibleName name -> lookupAnyName name index
     ProgramDuplicateType name -> firstSpan name (P.spanTypes index)
+    ProgramDuplicateTypeParameter name -> lookupAnyName name index
     ProgramDuplicateConstructor name -> firstSpan name (P.spanConstructors index)
     ProgramDuplicateClass name -> firstSpan name (P.spanClasses index)
     ProgramDuplicateValue name -> firstSpan name (P.spanValues index)
@@ -241,6 +243,7 @@ programErrorMessage err =
     ProgramExportNotLocal name -> "export is not local: `" ++ name ++ "`"
     ProgramDuplicateVisibleName name -> "duplicate visible name `" ++ name ++ "`"
     ProgramDuplicateType name -> "duplicate type `" ++ name ++ "`"
+    ProgramDuplicateTypeParameter name -> "duplicate type parameter `" ++ name ++ "`"
     ProgramDuplicateConstructor name -> "duplicate constructor `" ++ name ++ "`"
     ProgramDuplicateClass name -> "duplicate class `" ++ name ++ "`"
     ProgramDuplicateValue name -> "duplicate value `" ++ name ++ "`"
@@ -406,6 +409,7 @@ data DataInfo = DataInfo
   { dataName :: P.TypeName,
     dataInfoSymbol :: SymbolIdentity,
     dataModule :: P.ModuleName,
+    dataTypeParams :: [P.TypeParam],
     dataParams :: [String],
     dataConstructors :: [ConstructorInfo]
   }
@@ -421,6 +425,7 @@ data MethodInfo = MethodInfo
     methodTypeIdentity :: SrcType,
     methodConstraints :: [P.ClassConstraint],
     methodConstraintInfos :: [ConstraintInfo],
+    methodTypeParam :: P.TypeParam,
     methodParamName :: String
   }
   deriving (Eq, Show)
@@ -429,6 +434,7 @@ data ClassInfo = ClassInfo
   { className :: P.ClassName,
     classInfoSymbol :: SymbolIdentity,
     classModule :: P.ModuleName,
+    classTypeParam :: P.TypeParam,
     classParamName :: String,
     classMethods :: Map P.MethodName MethodInfo
   }
@@ -680,6 +686,11 @@ substituteTypeVar needle replacement = go
       STArrow dom cod -> STArrow (go dom) (go cod)
       STBase _ -> ty
       STCon name args -> STCon name (fmap go args)
+      STVarApp name args ->
+        let args' = fmap go args
+         in case replacementHead name args' of
+              Just ty' -> ty'
+              Nothing -> STVarApp name args'
       STForall name mb body
         | name == needle -> STForall name mb body
         | otherwise -> STForall name (fmap (SrcBound . go . unSrcBound) mb) (go body)
@@ -687,6 +698,14 @@ substituteTypeVar needle replacement = go
         | name == needle -> STMu name body
         | otherwise -> STMu name (go body)
       STBottom -> STBottom
+
+    replacementHead name args
+      | name /= needle = Nothing
+      | otherwise =
+          case replacement of
+            STVar replacementName -> Just (STVarApp replacementName args)
+            STBase replacementName -> Just (STCon replacementName args)
+            _ -> Nothing
 
 freeTypeVarsSrcType :: SrcType -> Set String
 freeTypeVarsSrcType = go Set.empty
@@ -698,6 +717,12 @@ freeTypeVarsSrcType = go Set.empty
       STArrow dom cod -> go bound dom `Set.union` go bound cod
       STBase {} -> Set.empty
       STCon _ args -> foldMap (go bound) args
+      STVarApp name args ->
+        let headVars =
+              if name `Set.member` bound
+                then Set.empty
+                else Set.singleton name
+         in headVars `Set.union` foldMap (go bound) args
       STForall name mb body ->
         maybe Set.empty (go bound . unSrcBound) mb `Set.union` go (Set.insert name bound) body
       STMu name body -> go (Set.insert name bound) body
@@ -729,6 +754,7 @@ constrainedVisibleType constrained
       STArrow dom cod -> freeVars dom ++ freeVars cod
       STBase {} -> []
       STCon _ args -> concatMap freeVars (toList args)
+      STVarApp name args -> name : concatMap freeVars (toList args)
       STForall name mb body ->
         filter (/= name) (maybe [] (freeVars . unSrcBound) mb ++ freeVars body)
       STMu name body -> filter (/= name) (freeVars body)

--- a/src/MLF/Frontend/Syntax.hs
+++ b/src/MLF/Frontend/Syntax.hs
@@ -11,6 +11,11 @@
 module MLF.Frontend.Syntax
   ( VarName,
     Lit (..),
+    SrcKind (..),
+    TypeParam (..),
+    firstOrderTypeParam,
+    typeParamNames,
+    typeParamIsFirstOrder,
     ExprStage (..),
     Expr (..),
     SurfaceExprF (..),
@@ -51,12 +56,14 @@ module MLF.Frontend.Syntax
     pattern NSTArrow,
     pattern NSTBase,
     pattern NSTCon,
+    pattern NSTVarApp,
     pattern NSTForall,
     pattern NSTMu,
     pattern NSTBottom,
     pattern SBArrow,
     pattern SBBase,
     pattern SBCon,
+    pattern SBVarApp,
     pattern SBForall,
     pattern SBMu,
     pattern SBBottom,
@@ -139,6 +146,28 @@ data Lit
   | LString String
   deriving (Eq, Show)
 
+-- | Source-level kind syntax for `.mlfp` declaration parameters.
+data SrcKind
+  = KType
+  | KArrow SrcKind SrcKind
+  deriving (Eq, Show)
+
+-- | A source-level type parameter with its declared kind.
+data TypeParam = TypeParam
+  { typeParamName :: String,
+    typeParamKind :: SrcKind
+  }
+  deriving (Eq, Show)
+
+firstOrderTypeParam :: String -> TypeParam
+firstOrderTypeParam name = TypeParam name KType
+
+typeParamNames :: [TypeParam] -> [String]
+typeParamNames = map typeParamName
+
+typeParamIsFirstOrder :: TypeParam -> Bool
+typeParamIsFirstOrder param = typeParamKind param == KType
+
 {- Note [Staged frontend types]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Frontend types use one indexed AST ('SrcTy'), tracked by two indices:
@@ -188,6 +217,7 @@ data SrcTy (n :: SrcNorm) (v :: SrcTopVar) where
   STArrow :: SrcTy n 'TopVarAllowed -> SrcTy n 'TopVarAllowed -> SrcTy n v
   STBase :: String -> SrcTy n v
   STCon :: String -> NonEmpty (SrcTy n 'TopVarAllowed) -> SrcTy n v
+  STVarApp :: String -> NonEmpty (SrcTy n 'TopVarAllowed) -> SrcTy n v
   STForall :: String -> Maybe (SrcBound n) -> SrcTy n 'TopVarAllowed -> SrcTy n v
   STMu :: String -> SrcTy n 'TopVarAllowed -> SrcTy n v
   STBottom :: SrcTy n v
@@ -213,6 +243,7 @@ data ResolvedSrcTy (n :: SrcNorm) (v :: SrcTopVar) where
   RSTArrow :: ResolvedSrcTy n 'TopVarAllowed -> ResolvedSrcTy n 'TopVarAllowed -> ResolvedSrcTy n v
   RSTBase :: ResolvedSymbol -> ResolvedSrcTy n v
   RSTCon :: ResolvedSymbol -> NonEmpty (ResolvedSrcTy n 'TopVarAllowed) -> ResolvedSrcTy n v
+  RSTVarApp :: String -> NonEmpty (ResolvedSrcTy n 'TopVarAllowed) -> ResolvedSrcTy n v
   RSTForall :: String -> Maybe (ResolvedSrcBound n) -> ResolvedSrcTy n 'TopVarAllowed -> ResolvedSrcTy n v
   RSTMu :: String -> ResolvedSrcTy n 'TopVarAllowed -> ResolvedSrcTy n v
   RSTBottom :: ResolvedSrcTy n v
@@ -237,6 +268,7 @@ resolvedSrcTypeToSrcType ty =
     RSTArrow dom cod -> STArrow (resolvedSrcTypeToSrcType dom) (resolvedSrcTypeToSrcType cod)
     RSTBase symbol -> STBase (resolvedTypeHeadDisplay symbol)
     RSTCon symbol args -> STCon (resolvedTypeHeadDisplay symbol) (fmap resolvedSrcTypeToSrcType args)
+    RSTVarApp name args -> STVarApp name (fmap resolvedSrcTypeToSrcType args)
     RSTForall name mb body ->
       STForall
         name
@@ -252,6 +284,7 @@ resolvedSrcTypeIdentityType ty =
     RSTArrow dom cod -> STArrow (resolvedSrcTypeIdentityType dom) (resolvedSrcTypeIdentityType cod)
     RSTBase symbol -> STBase (resolvedTypeHeadIdentityName symbol)
     RSTCon symbol args -> STCon (resolvedTypeHeadIdentityName symbol) (fmap resolvedSrcTypeIdentityType args)
+    RSTVarApp name args -> STVarApp name (fmap resolvedSrcTypeIdentityType args)
     RSTForall name mb body ->
       STForall
         name
@@ -289,6 +322,9 @@ pattern NSTBase b = STBase b
 pattern NSTCon :: String -> NonEmpty NormSrcType -> NormSrcType
 pattern NSTCon c args = STCon c args
 
+pattern NSTVarApp :: String -> NonEmpty NormSrcType -> NormSrcType
+pattern NSTVarApp v args = STVarApp v args
+
 pattern NSTForall :: String -> Maybe StructBound -> NormSrcType -> NormSrcType
 pattern NSTForall v mb body <- STForall v (fmap unNormBound -> mb) body
   where
@@ -309,6 +345,9 @@ pattern SBBase b = STBase b
 pattern SBCon :: String -> NonEmpty NormSrcType -> StructBound
 pattern SBCon c args = STCon c args
 
+pattern SBVarApp :: String -> NonEmpty NormSrcType -> StructBound
+pattern SBVarApp v args = STVarApp v args
+
 pattern SBForall :: String -> Maybe StructBound -> NormSrcType -> StructBound
 pattern SBForall v mb body <- STForall v (fmap unNormBound -> mb) body
   where
@@ -320,15 +359,16 @@ pattern SBMu v body = STMu v body
 pattern SBBottom :: StructBound
 pattern SBBottom = STBottom
 
-{-# COMPLETE NSTVar, NSTArrow, NSTBase, NSTCon, NSTForall, NSTMu, NSTBottom #-}
+{-# COMPLETE NSTVar, NSTArrow, NSTBase, NSTCon, NSTVarApp, NSTForall, NSTMu, NSTBottom #-}
 
-{-# COMPLETE SBArrow, SBBase, SBCon, SBForall, SBMu, SBBottom #-}
+{-# COMPLETE SBArrow, SBBase, SBCon, SBVarApp, SBForall, SBMu, SBBottom #-}
 
 data SrcTypeF a
   = STVarF String
   | STArrowF a a
   | STBaseF String
   | STConF String (NonEmpty a)
+  | STVarAppF String (NonEmpty a)
   | STForallF String (Maybe a) a
   | STMuF String a
   | STBottomF
@@ -342,6 +382,7 @@ instance Recursive (SrcTy 'RawN 'TopVarAllowed) where
     STArrow a b -> STArrowF a b
     STBase b -> STBaseF b
     STCon c args -> STConF c args
+    STVarApp v args -> STVarAppF v args
     STForall v mb body -> STForallF v (fmap unSrcBound mb) body
     STMu v body -> STMuF v body
     STBottom -> STBottomF
@@ -352,6 +393,7 @@ instance Corecursive (SrcTy 'RawN 'TopVarAllowed) where
     STArrowF a b -> STArrow a b
     STBaseF b -> STBase b
     STConF c args -> STCon c args
+    STVarAppF v args -> STVarApp v args
     STForallF v mb body -> STForall v (fmap mkSrcBound mb) body
     STMuF v body -> STMu v body
     STBottomF -> STBottom

--- a/src/MLF/Frontend/Syntax/Program.hs
+++ b/src/MLF/Frontend/Syntax/Program.hs
@@ -13,6 +13,11 @@ module MLF.Frontend.Syntax.Program
     ( ProgramPhase (..)
     , ModuleName
     , TypeName
+    , SrcKind (..)
+    , TypeParam (..)
+    , firstOrderTypeParam
+    , typeParamNames
+    , typeParamIsFirstOrder
     , ConstructorName
     , ClassName
     , MethodName
@@ -119,9 +124,14 @@ import MLF.Frontend.Symbol
 import MLF.Frontend.Syntax
     ( Lit (..)
     , ResolvedSrcType
+    , SrcKind (..)
     , SrcType
+    , TypeParam (..)
+    , firstOrderTypeParam
     , resolvedSrcTypeIdentityType
     , resolvedSrcTypeToSrcType
+    , typeParamIsFirstOrder
+    , typeParamNames
     )
 
 data ProgramPhase = Parsed | Resolved
@@ -420,7 +430,7 @@ type ResolvedDecl = DeclF 'Resolved
 
 data ClassDeclF (p :: ProgramPhase) = ClassDecl
     { classDeclName :: ClassName
-    , classDeclParam :: String
+    , classDeclParam :: TypeParam
     , classDeclMethods :: [MethodSigF p]
     }
 
@@ -479,7 +489,7 @@ type ResolvedMethodDef = MethodDefF 'Resolved
 
 data DataDeclF (p :: ProgramPhase) = DataDecl
     { dataDeclName :: TypeName
-    , dataDeclParams :: [String]
+    , dataDeclParams :: [TypeParam]
     , dataDeclConstructors :: [ConstructorDeclF p]
     , dataDeclDeriving :: [ClassRef p]
     }

--- a/test/FrontendNormalizeSpec.hs
+++ b/test/FrontendNormalizeSpec.hs
@@ -112,6 +112,14 @@ substSpec = describe "substSrcType" $ do
         substSrcType "f" (STVar "g") (STVarApp "f" (STVar "a" :| []))
             `shouldBe` STVarApp "g" (STVar "a" :| [])
 
+    it "composes variable-headed type application heads when substituted by a partially applied constructor" $
+        substSrcType "f" (STCon "Either" (STBase "Int" :| [])) (STVarApp "f" (STVar "a" :| []))
+            `shouldBe` STCon "Either" (STBase "Int" :| [STVar "a"])
+
+    it "composes variable-headed type application heads when substituted by a partially applied variable head" $
+        substSrcType "f" (STVarApp "g" (STBase "Int" :| [])) (STVarApp "f" (STVar "a" :| []))
+            `shouldBe` STVarApp "g" (STBase "Int" :| [STVar "a"])
+
 -- -----------------------------------------------------------------------
 -- Type normalization
 -- -----------------------------------------------------------------------

--- a/test/FrontendNormalizeSpec.hs
+++ b/test/FrontendNormalizeSpec.hs
@@ -60,6 +60,10 @@ freeVarsSpec = describe "freeVarsSrcType" $ do
             (STMu "a" (STArrow (STVar "a") (STVar "b")))
             `shouldBe` Set.fromList ["b"]
 
+    it "variable-headed type application keeps head and argument variables free" $
+        freeVarsSrcType (STVarApp "f" (STVar "a" :| [STVar "b"]))
+            `shouldBe` Set.fromList ["f", "a", "b"]
+
 -- -----------------------------------------------------------------------
 -- Capture-avoiding substitution
 -- -----------------------------------------------------------------------
@@ -103,6 +107,10 @@ substSpec = describe "substSrcType" $ do
         substSrcType "a" (STBase "Int")
             (STMu "a" (STArrow (STVar "a") (STVar "b")))
             `shouldBe` STMu "a" (STArrow (STVar "a") (STVar "b"))
+
+    it "renames variable-headed type application heads when substituted by a variable" $
+        substSrcType "f" (STVar "g") (STVarApp "f" (STVar "a" :| []))
+            `shouldBe` STVarApp "g" (STVar "a" :| [])
 
 -- -----------------------------------------------------------------------
 -- Type normalization
@@ -177,6 +185,10 @@ normalizeTypeSpec = describe "normalizeType" $ do
     it "normalizes constructor types" $
         normalizeType (STCon "List" (STVar "a" :| []))
             `shouldBe` Right (STCon "List" (STVar "a" :| []))
+
+    it "normalizes variable-headed type applications without lowering the head" $
+        normalizeType (STVarApp "f" (STVar "a" :| [STVar "b"]))
+            `shouldBe` Right (STVarApp "f" (STVar "a" :| [STVar "b"]))
 
     it "preserves recursive wrappers while normalizing nested alias bounds" $
         let input =

--- a/test/FrontendPrettySpec.hs
+++ b/test/FrontendPrettySpec.hs
@@ -7,6 +7,7 @@ import MLF.API
     ( Expr (..)
     , NormSrcType
     , SrcTy (..)
+    , SrcType
     , mkSrcBound
     , prettyEmlfExpr
     , prettyEmlfType
@@ -44,6 +45,14 @@ spec = describe "Frontend eMLF pretty printer" $ do
     it "prints canonical recursive annotation syntax" $ do
         let expr = EAnn (EVar "x") (STMu "a" (STCon "List" (STVar "a" :| [])))
         prettyEmlfExpr expr `shouldBe` "(x : μa. List a)"
+
+    it "pretty-prints variable-headed type application ASTs" $ do
+        let unary :: SrcType
+            unary = STVarApp "f" (STVar "a" :| [])
+            binary :: SrcType
+            binary = STVarApp "p" (STVar "a" :| [STVar "b"])
+        prettyEmlfType unary `shouldBe` "f a"
+        prettyEmlfType binary `shouldBe` "p a b"
 
     it "roundtrips expression parse(pretty(expr))" $ do
         let expr =

--- a/test/PipelineSpec.hs
+++ b/test/PipelineSpec.hs
@@ -10,6 +10,7 @@ import Data.IntMap.Strict qualified as IntMap
 import Data.IntSet qualified as IntSet
 import Data.List (isInfixOf, isPrefixOf, nub, sort)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, isJust, listToMaybe)
 import Data.Set qualified as Set
 import MLF.Binding.Tree qualified as Binding
@@ -353,8 +354,24 @@ resultTypeInputsForArtifacts
             defaultTraceConfig
      in (inputs, annCanon, ann0)
 
+expectUnsupportedVarApp :: Either Elab.PipelineError a -> Expectation
+expectUnsupportedVarApp result =
+  case result of
+    Left (Elab.PipelineConstraintError (InternalConstraintError msg)) ->
+      msg `shouldSatisfy` isInfixOf "variable-headed source type application `f` is not supported"
+    Left err ->
+      expectationFailure ("expected typed constraint error, got " ++ renderPipelineError err)
+    Right _ ->
+      expectationFailure "expected unsupported variable-headed source type application error"
+
 spec :: Spec
 spec = describe "Pipeline (Phases 1-5)" $ do
+  describe "External binding validation" $ do
+    it "fails closed for variable-headed external env types" $ do
+      let extEnv = Map.singleton "x" (STVarApp "f" (STVar "a" :| []))
+          result = Elab.runPipelineElabWithEnv Set.empty extEnv (EVar "x")
+      expectUnsupportedVarApp result
+
   describe "Shared candidate selection" $ do
     it "deduplicates repeated equal candidates instead of treating repeats as ambiguity" $ do
       selectUniqueCandidate [1 :: Int, 1, 1]

--- a/test/PipelineSpec.hs
+++ b/test/PipelineSpec.hs
@@ -359,8 +359,10 @@ expectUnsupportedVarApp result =
   case result of
     Left (Elab.PipelineConstraintError (InternalConstraintError msg)) ->
       msg `shouldSatisfy` isInfixOf "variable-headed source type application `f` is not supported"
+    Left (Elab.PipelineElabError (Elab.InstantiationError msg)) ->
+      msg `shouldSatisfy` isInfixOf "variable-headed source type application `f` is not supported"
     Left err ->
-      expectationFailure ("expected typed constraint error, got " ++ renderPipelineError err)
+      expectationFailure ("expected typed variable-headed source type error, got " ++ renderPipelineError err)
     Right _ ->
       expectationFailure "expected unsupported variable-headed source type application error"
 
@@ -371,6 +373,15 @@ spec = describe "Pipeline (Phases 1-5)" $ do
       let extEnv = Map.singleton "x" (STVarApp "f" (STVar "a" :| []))
           result = Elab.runPipelineElabWithEnv Set.empty extEnv (EVar "x")
       expectUnsupportedVarApp result
+
+  describe "Source annotation validation" $ do
+    it "fails closed for variable-headed term annotations" $ do
+      let expr = EAnn (ELit (LInt 1)) (STVarApp "f" (STBase "Int" :| []))
+      expectUnsupportedVarApp (runPipelineElab Set.empty (unsafeNormalizeExpr expr))
+
+    it "fails closed for variable-headed annotated lambda parameters" $ do
+      let expr = ELamAnn "x" (STVarApp "f" (STBase "Int" :| [])) (EVar "x")
+      expectUnsupportedVarApp (runPipelineElab Set.empty (unsafeNormalizeExpr expr))
 
   describe "Shared candidate selection" $ do
     it "deduplicates repeated equal candidates instead of treating repeats as ambiguity" $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -6,8 +6,13 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import MLF.API (SrcTy (..))
 import MLF.Frontend.Program.Check (checkResolvedProgram)
-import MLF.Frontend.Program.Finalize (sourceForallMatches)
-import MLF.Frontend.Program.Types (mkResolvedSymbol)
+import MLF.Frontend.Program.Elaborate (lowerType, mkElaborateScope)
+import MLF.Frontend.Program.Finalize (recoverSourceType, sourceForallMatches)
+import MLF.Frontend.Program.Types
+    ( ConstructorInfo (..)
+    , DataInfo (..)
+    , mkResolvedSymbol
+    )
 import MLF.Frontend.Syntax (ResolvedSrcTy (..))
 import MLF.Program
 import MLF.Program.CLI (runProgramFile)
@@ -2238,6 +2243,69 @@ spec = do
                         (STVarApp "g" (STVar "a" :| []))
                         (STVarApp "h" (STVar "a" :| []))
             sourceForallMatches expected actual `shouldBe` False
+
+        it "rejects bound variable applications without lowering STVarApp" $ do
+            let expected =
+                    STForall
+                        "f"
+                        Nothing
+                        (STArrow (STVar "f") (STVar "f"))
+                actual =
+                    STForall
+                        "g"
+                        Nothing
+                        ( STArrow
+                            (STVar "g")
+                            (STVarApp "g" (STVar "a" :| []))
+                        )
+            sourceForallMatches expected actual `shouldBe` False
+
+        it "recovers higher-kinded data heads with partially applied constructor parameters" $ do
+            let typeIdentity =
+                    SymbolIdentity
+                        { symbolNamespace = SymbolType
+                        , symbolDefiningModule = "Main"
+                        , symbolDefiningName = "Apply"
+                        , symbolOwnerIdentity = Nothing
+                        }
+                ctorIdentity =
+                    SymbolIdentity
+                        { symbolNamespace = SymbolConstructor
+                        , symbolDefiningModule = "Main"
+                        , symbolDefiningName = "Apply"
+                        , symbolOwnerIdentity = Just (SymbolOwnerType "Main" "Apply")
+                        }
+                applyResult = STCon "Apply" (STVar "f" :| [STVar "a"])
+                applyCtor =
+                    ConstructorInfo
+                        { ctorName = "Apply"
+                        , ctorInfoSymbol = ctorIdentity
+                        , ctorRuntimeName = "$Apply"
+                        , ctorType = STArrow (STVarApp "f" (STVar "a" :| [])) applyResult
+                        , ctorForalls = []
+                        , ctorArgs = [STVarApp "f" (STVar "a" :| [])]
+                        , ctorResult = applyResult
+                        , ctorOwningType = "Apply"
+                        , ctorOwningTypeIdentity = typeIdentity
+                        , ctorIndex = 0
+                        }
+                applyInfo =
+                    DataInfo
+                        { dataName = "Apply"
+                        , dataInfoSymbol = typeIdentity
+                        , dataModule = "Main"
+                        , dataTypeParams = []
+                        , dataParams = ["f", "a"]
+                        , dataConstructors = [applyCtor]
+                        }
+                scope = mkElaborateScope Map.empty (Map.singleton "Apply" applyInfo) Map.empty []
+                visible =
+                    STCon
+                        "Apply"
+                        ( STCon "Either" (STBase "Int" :| [])
+                            :| [STBase "String"]
+                        )
+            recoverSourceType scope (lowerType scope visible) `shouldBe` visible
 
     describe "MLF.Program parse/pretty" $ do
         mapM_ roundtripFixture fixturePaths

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -4,7 +4,7 @@ import Data.Either (isRight)
 import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
-import MLF.API (SrcTy (..))
+import MLF.API (Lit (..), SrcTy (..))
 import MLF.Frontend.Program.Check (checkResolvedProgram)
 import MLF.Frontend.Program.Elaborate (lowerType, mkElaborateScope)
 import MLF.Frontend.Program.Finalize (recoverSourceType, sourceForallMatches)
@@ -2412,6 +2412,32 @@ spec = do
                 (const False)
 
     describe "MLF.Program diagnostics" $ do
+        it "reports variable-headed direct AST types as program errors" $ do
+            let program =
+                    Program
+                        [ Module
+                            { moduleName = "Main"
+                            , moduleExports = Just [ExportValue "main"]
+                            , moduleImports = []
+                            , moduleDecls =
+                                [ DeclDef
+                                    DefDecl
+                                        { defDeclName = "main"
+                                        , defDeclType = ConstrainedType [] (STVarApp "f" (STBase "Int" :| []))
+                                        , defDeclExpr = ELit (LInt 1)
+                                        }
+                                ]
+                            }
+                        ]
+            checkProgram program `shouldSatisfy` either
+                ( \err ->
+                    case err of
+                        ProgramPipelineError msg ->
+                            "variable-headed source type application `f`" `isInfixOf` msg
+                        _ -> False
+                )
+                (const False)
+
         it "rejects duplicate data type parameter names" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2246,6 +2246,16 @@ spec = do
                         (bounded "b")
             sourceForallMatches expected actual `shouldBe` True
 
+        it "rejects alpha-renamed foralls with incompatible bounds" $ do
+            let bounded name bound =
+                    STForall
+                        name
+                        (Just (mkSrcBound bound))
+                        (STArrow (STVar name) (STVar name))
+                expected = bounded "f" (STBase "Int")
+                actual = bounded "g" (STBase "Bool")
+            sourceForallMatches expected actual `shouldBe` False
+
         it "matches bound variable-headed applications against instantiated constructor heads" $ do
             let expected =
                     STForall

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2,9 +2,11 @@ module ProgramSpec (spec) where
 
 import Data.Either (isRight)
 import Data.List (isInfixOf)
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import MLF.API (SrcTy (..))
 import MLF.Frontend.Program.Check (checkResolvedProgram)
+import MLF.Frontend.Program.Finalize (sourceForallMatches)
 import MLF.Frontend.Program.Types (mkResolvedSymbol)
 import MLF.Frontend.Syntax (ResolvedSrcTy (..))
 import MLF.Program
@@ -2202,6 +2204,41 @@ emlfBoundaryMatrix =
 
 spec :: Spec
 spec = do
+    describe "MLF.Program source type finalization" $ do
+        it "matches variable-headed applications through forall alpha-renaming" $ do
+            let expected =
+                    STForall
+                        "f"
+                        Nothing
+                        ( STArrow
+                            (STVarApp "f" (STVar "a" :| []))
+                            (STVarApp "f" (STVar "a" :| []))
+                        )
+                actual =
+                    STForall
+                        "g"
+                        Nothing
+                        ( STArrow
+                            (STVarApp "g" (STVar "a" :| []))
+                            (STVarApp "g" (STVar "a" :| []))
+                        )
+            sourceForallMatches expected actual `shouldBe` True
+
+        it "rejects inconsistent variable-headed application alpha-renaming" $ do
+            let expected =
+                    STForall
+                        "f"
+                        Nothing
+                        ( STArrow
+                            (STVarApp "f" (STVar "a" :| []))
+                            (STVarApp "f" (STVar "a" :| []))
+                        )
+                actual =
+                    STArrow
+                        (STVarApp "g" (STVar "a" :| []))
+                        (STVarApp "h" (STVar "a" :| []))
+            sourceForallMatches expected actual `shouldBe` False
+
     describe "MLF.Program parse/pretty" $ do
         mapM_ roundtripFixture fixturePaths
 

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2229,6 +2229,21 @@ spec = do
                         )
             sourceForallMatches expected actual `shouldBe` True
 
+        it "matches bound variable-headed applications against instantiated constructor heads" $ do
+            let expected =
+                    STForall
+                        "f"
+                        Nothing
+                        ( STArrow
+                            (STVarApp "f" (STVar "a" :| []))
+                            (STVarApp "f" (STVar "a" :| []))
+                        )
+                actual =
+                    STArrow
+                        (STCon "Either" (STBase "Int" :| [STVar "a"]))
+                        (STCon "Either" (STBase "Int" :| [STVar "a"]))
+            sourceForallMatches expected actual `shouldBe` True
+
         it "rejects inconsistent variable-headed application alpha-renaming" $ do
             let expected =
                     STForall
@@ -2242,6 +2257,21 @@ spec = do
                     STArrow
                         (STVarApp "g" (STVar "a" :| []))
                         (STVarApp "h" (STVar "a" :| []))
+            sourceForallMatches expected actual `shouldBe` False
+
+        it "rejects inconsistent instantiated constructor heads" $ do
+            let expected =
+                    STForall
+                        "f"
+                        Nothing
+                        ( STArrow
+                            (STVarApp "f" (STVar "a" :| []))
+                            (STVarApp "f" (STVar "a" :| []))
+                        )
+                actual =
+                    STArrow
+                        (STCon "Either" (STBase "Int" :| [STVar "a"]))
+                        (STCon "Maybe" (STVar "a" :| []))
             sourceForallMatches expected actual `shouldBe` False
 
         it "rejects bound variable applications without lowering STVarApp" $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -13,7 +13,7 @@ import MLF.Frontend.Program.Types
     , DataInfo (..)
     , mkResolvedSymbol
     )
-import MLF.Frontend.Syntax (ResolvedSrcTy (..))
+import MLF.Frontend.Syntax (ResolvedSrcTy (..), mkSrcBound)
 import MLF.Program
 import MLF.Program.CLI (runProgramFile)
 import Test.Hspec
@@ -2227,6 +2227,23 @@ spec = do
                             (STVarApp "g" (STVar "a" :| []))
                             (STVarApp "g" (STVar "a" :| []))
                         )
+            sourceForallMatches expected actual `shouldBe` True
+
+        it "matches repeated substitutions whose forall bounds rename their own binder" $ do
+            let bounded name =
+                    STForall
+                        name
+                        (Just (mkSrcBound (STArrow (STVar name) (STBase "Int"))))
+                        (STVar name)
+                expected =
+                    STForall
+                        "f"
+                        Nothing
+                        (STArrow (STVar "f") (STVar "f"))
+                actual =
+                    STArrow
+                        (bounded "a")
+                        (bounded "b")
             sourceForallMatches expected actual `shouldBe` True
 
         it "matches bound variable-headed applications against instantiated constructor heads" $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2205,6 +2205,43 @@ spec = do
     describe "MLF.Program parse/pretty" $ do
         mapM_ roundtripFixture fixturePaths
 
+        it "roundtrips first-order declaration parameters unchanged" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Eq, Box(..)) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , ""
+                        , "  data Box a ="
+                        , "      Box : a -> Box a;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            parseRawProgram (prettyProgram program) `shouldBe` Right program
+
+        it "roundtrips higher-kinded declaration parameter annotations" $ do
+            let hk = KArrow KType KType
+                hk2 = KArrow KType (KArrow KType KType)
+                programText =
+                    unlines
+                        [ "module Main export (Functor, Higher(..)) {"
+                        , "  class Functor (f :: * -> *) {"
+                        , "    identity : forall a. a -> a;"
+                        , "  }"
+                        , ""
+                        , "  data Higher (p :: * -> * -> *) a ="
+                        , "      Higher : a -> Higher p a;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            case program of
+                Program [Module {moduleDecls = [DeclClass classDecl, DeclData dataDecl]}] -> do
+                    classDeclParam classDecl `shouldBe` TypeParam "f" hk
+                    dataDeclParams dataDecl `shouldBe` [TypeParam "p" hk2, firstOrderTypeParam "a"]
+                other -> expectationFailure ("unexpected program shape: " ++ show other)
+            parseRawProgram (prettyProgram program) `shouldBe` Right program
+
     describe "MLF.Program execution corpus" $ do
         mapM_ runFixture fixturePaths
 
@@ -2240,6 +2277,17 @@ spec = do
                 (const False)
 
     describe "MLF.Program diagnostics" $ do
+        it "rejects duplicate data type parameter names" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Bad(..)) {"
+                        , "  data Bad a a ="
+                        , "      Bad : Bad a a;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramDuplicateTypeParameter "a")
+
         it "rejects importing constructors from an abstract type export" $ do
             let programText =
                     unlines

--- a/test/ResolvedSymbolSpec.hs
+++ b/test/ResolvedSymbolSpec.hs
@@ -1,12 +1,13 @@
 module ResolvedSymbolSpec (spec) where
 
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import MLF.Frontend.Program.Types
 import MLF.Frontend.Syntax (SrcTy (..), firstOrderTypeParam)
 import Test.Hspec
 
 spec :: Spec
-spec =
+spec = do
   describe "MLF.Program resolved symbol identities" $ do
     it "keeps imported value identity stable across unqualified and aliased spellings" $ do
       let unqualified = resolvedValueInfoSymbol (SymbolUnqualifiedImport "Lib") valueInfo
@@ -58,6 +59,15 @@ spec =
       resolvedSymbolIdentity importedModule
         `shouldBe` SymbolIdentity SymbolModule "Lib" "Lib" Nothing
       symbolDisplayName (resolvedSymbolSpelling importedModule) `shouldBe` "L"
+
+  describe "substituteTypeVar" $ do
+    it "composes variable-headed type application heads with partially applied constructors" $
+      substituteTypeVar "f" (STCon "Either" (STBase "Int" :| [])) (STVarApp "f" (STVar "a" :| []))
+        `shouldBe` STCon "Either" (STBase "Int" :| [STVar "a"])
+
+    it "composes variable-headed type application heads with partially applied variable heads" $
+      substituteTypeVar "f" (STVarApp "g" (STBase "Int" :| [])) (STVarApp "f" (STVar "a" :| []))
+        `shouldBe` STVarApp "g" (STBase "Int" :| [STVar "a"])
 
 valueInfo :: ValueInfo
 valueInfo =

--- a/test/ResolvedSymbolSpec.hs
+++ b/test/ResolvedSymbolSpec.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE GADTs #-}
+
 module ResolvedSymbolSpec (spec) where
 
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
+import MLF.Frontend.Program.Elaborate (lowerType, mkElaborateScope)
 import MLF.Frontend.Program.Types
-import MLF.Frontend.Syntax (SrcTy (..), firstOrderTypeParam)
+import MLF.Frontend.Syntax (SrcBound (..), SrcTy (..), SrcType, firstOrderTypeParam)
 import Test.Hspec
 
 spec :: Spec
@@ -69,6 +72,43 @@ spec = do
       substituteTypeVar "f" (STVarApp "g" (STBase "Int" :| [])) (STVarApp "f" (STVar "a" :| []))
         `shouldBe` STVarApp "g" (STBase "Int" :| [STVar "a"])
 
+  describe "higher-kinded source type lowering" $ do
+    it "composes variable-headed constructor fields with partially applied constructor arguments" $ do
+      let scope = mkElaborateScope Map.empty (Map.singleton "Higher" higherDataInfo) Map.empty []
+          lowered = lowerType scope (STCon "Higher" (STCon "Either" (STBase "Int" :| []) :| [STBase "Bool"]))
+          expectedField = STCon "Either" (STBase "Int" :| [STBase "Bool"])
+      lowered `shouldSatisfy` containsSrcType expectedField
+      lowered `shouldSatisfy` (not . containsVarAppHead "f")
+
+containsSrcType :: SrcType -> SrcType -> Bool
+containsSrcType needle ty
+  | needle == ty = True
+  | otherwise =
+      case ty of
+        STArrow dom cod -> containsSrcType needle dom || containsSrcType needle cod
+        STCon _ args -> any (containsSrcType needle) (toListNE args)
+        STVarApp _ args -> any (containsSrcType needle) (toListNE args)
+        STForall _ mb body -> maybe False (containsSrcType needle . unSrcBound) mb || containsSrcType needle body
+        STMu _ body -> containsSrcType needle body
+        STVar {} -> False
+        STBase {} -> False
+        STBottom -> False
+
+containsVarAppHead :: String -> SrcType -> Bool
+containsVarAppHead needle ty =
+  case ty of
+    STArrow dom cod -> containsVarAppHead needle dom || containsVarAppHead needle cod
+    STCon _ args -> any (containsVarAppHead needle) (toListNE args)
+    STVarApp name args -> name == needle || any (containsVarAppHead needle) (toListNE args)
+    STForall _ mb body -> maybe False (containsVarAppHead needle . unSrcBound) mb || containsVarAppHead needle body
+    STMu _ body -> containsVarAppHead needle body
+    STVar {} -> False
+    STBase {} -> False
+    STBottom -> False
+
+toListNE :: NonEmpty a -> [a]
+toListNE (x :| xs) = x : xs
+
 valueInfo :: ValueInfo
 valueInfo =
   OrdinaryValue
@@ -124,6 +164,40 @@ tokenDataInfo =
       dataTypeParams = [],
       dataParams = [],
       dataConstructors = [someCtor]
+    }
+
+higherCtor :: ConstructorInfo
+higherCtor =
+  ConstructorInfo
+    { ctorName = "Higher",
+      ctorInfoSymbol =
+        SymbolIdentity
+          SymbolConstructor
+          "Lib"
+          "Higher"
+          (Just (SymbolOwnerType "Lib" "Higher")),
+      ctorRuntimeName = "Lib__Higher",
+      ctorType =
+        STArrow
+          (STVarApp "f" (STVar "a" :| []))
+          (STCon "Higher" (STVar "f" :| [STVar "a"])),
+      ctorForalls = [],
+      ctorArgs = [STVarApp "f" (STVar "a" :| [])],
+      ctorResult = STCon "Higher" (STVar "f" :| [STVar "a"]),
+      ctorOwningType = "Higher",
+      ctorOwningTypeIdentity = SymbolIdentity SymbolType "Lib" "Higher" Nothing,
+      ctorIndex = 0
+    }
+
+higherDataInfo :: DataInfo
+higherDataInfo =
+  DataInfo
+    { dataName = "Higher",
+      dataInfoSymbol = SymbolIdentity SymbolType "Lib" "Higher" Nothing,
+      dataModule = "Lib",
+      dataTypeParams = [firstOrderTypeParam "f", firstOrderTypeParam "a"],
+      dataParams = ["f", "a"],
+      dataConstructors = [higherCtor]
     }
 
 eqMethodInfo :: MethodInfo

--- a/test/ResolvedSymbolSpec.hs
+++ b/test/ResolvedSymbolSpec.hs
@@ -2,7 +2,7 @@ module ResolvedSymbolSpec (spec) where
 
 import qualified Data.Map.Strict as Map
 import MLF.Frontend.Program.Types
-import MLF.Frontend.Syntax (SrcTy (..))
+import MLF.Frontend.Syntax (SrcTy (..), firstOrderTypeParam)
 import Test.Hspec
 
 spec :: Spec
@@ -111,6 +111,7 @@ tokenDataInfo =
     { dataName = "Token",
       dataInfoSymbol = SymbolIdentity SymbolType "Lib" "Token" Nothing,
       dataModule = "Lib",
+      dataTypeParams = [],
       dataParams = [],
       dataConstructors = [someCtor]
     }
@@ -132,6 +133,7 @@ eqMethodInfo =
       methodTypeIdentity = STArrow (STVar "a") (STArrow (STVar "a") (STBase "Bool")),
       methodConstraints = [],
       methodConstraintInfos = [],
+      methodTypeParam = firstOrderTypeParam "a",
       methodParamName = "a"
     }
 
@@ -145,6 +147,7 @@ eqClassInfo =
     { className = "Eq",
       classInfoSymbol = SymbolIdentity SymbolClass "Lib" "Eq" Nothing,
       classModule = "Lib",
+      classTypeParam = firstOrderTypeParam "a",
       classParamName = "a",
       classMethods = Map.singleton "eq" eqMethodInfo
     }
@@ -155,6 +158,7 @@ qualifiedEqClassInfo =
     { className = "L.Eq",
       classInfoSymbol = SymbolIdentity SymbolClass "Lib" "Eq" Nothing,
       classModule = "Lib",
+      classTypeParam = firstOrderTypeParam "a",
       classParamName = "a",
       classMethods = Map.singleton "eq" qualifiedEqMethodInfo
     }


### PR DESCRIPTION
Closes #15.

## Implementation Plan

---
issue_number: 15
pr_number: 36
branch: codex/issue-15
---

## Implementation Plan

1. Re-verify implementation context before editing: stay on `codex/issue-15`, confirm PR #36 still points at `codex/issue-15` into `master`, and check `git status --short` for unrelated dirty files.

2. Add the source model in `src/MLF/Frontend/Syntax.hs` and re-export it through `MLF.Frontend.Syntax.Program` / public shims as needed:
   - Define `SrcKind = KType | KArrow SrcKind SrcKind` (or equivalent names) for `*`, `* -> *`, and higher arities by right-association.
   - Define `TypeParam` with `typeParamName :: String` and `typeParamKind :: SrcKind`, plus helpers such as `firstOrderTypeParam`, `typeParamNames`, and kind/default accessors.
   - Extend `SrcTy` and `ResolvedSrcTy` with an explicit variable-headed type application constructor, e.g. `STVarApp String (NonEmpty SrcType)` / `RSTVarApp String (NonEmpty ResolvedSrcType)`, so `f a` can be represented without treating `f` as an uppercase/global type constructor. Update `resolvedSrcTypeToSrcType`, `resolvedSrcTypeIdentityType`, recursion-scheme base functor support, pattern synonyms/complete pragmas if needed, normalization, free-variable, and substitution helpers to recurse through the new constructor.

3. Thread typed parameters through the `.mlfp` declaration AST in `src/MLF/Frontend/Syntax/Program.hs`:
   - Change `classDeclParam` and `dataDeclParams` to carry `TypeParam` values.
   - Use helper functions where downstream code only needs names, keeping existing first-order behavior equivalent to all params defaulting to `KType`.
   - Update `unresolve*` functions and resolved syntax types without changing module/import/export semantics.

4. Add parser support for declaration parameter kind annotations, but do not implement #16 variable-headed type-application parsing yet:
   - In `src/MLF/Frontend/Parse/Program.hs`, parse bare lowercase params as `firstOrderTypeParam name`.
   - Parse parenthesized kind annotations such as `(f :: * -> *)`, with right-associative kind arrows and bare `*` for first-order types.
   - Apply the same grammar to `class` parameters and `data` parameters.
   - Keep existing first-order `.mlfp` syntax unchanged.

5. Update pretty-printing and docs:
   - In `src/MLF/Frontend/Pretty/Program.hs`, pretty-print first-order params as bare names and higher-kinded params as `(name :: kind)`.
   - In `src/MLF/Frontend/Pretty.hs`, add rendering for variable-headed type application so directly constructed AST values have a stable representation for #16.
   - Update `docs/mlfp-language-reference.md` to document declaration parameter kind annotations/default `*`, and explicitly note that full variable-headed type-application parsing/kind checking/elaboration are handled by follow-up issues #16-#18.

6. Add narrow checker/model validation without implementing full kind checking from #17:
   - Ensure duplicate data type parameter names are rejected with a clear `ProgramError` and diagnostic span where feasible.
   - Preserve current constructor-result arity validation by comparing against `length (typeParamNames dataDeclParams)`.
   - Update `DataInfo`, `ClassInfo`, deriving, instance skeletons, constructor metadata, and elaboration helpers to use parameter names through helpers while retaining parameter kind metadata for later phases.
   - For any variable-headed type applications that reach downstream phases before #17/#18, keep behavior fail-closed and explicit rather than silently lowering them to named `TCon`s.

7. Add tests focused on #15 boundaries:
   - Parser/pretty round-trip for existing first-order declarations to prove no source migration is needed.
   - Parser/pretty round-trip for `class Functor (f :: * -> *)` and `data Higher (f :: * -> *) a = ...` using signatures that do not require #16 parsing.
   - Direct AST/unit tests showing representative higher-kinded method/constructor types can be represented with the new variable-headed application constructor, e.g. `f a` and `p a b`.
   - Negative test for duplicate data type parameter names if the new checker validation is added.

8. Validation and publish for the implementation turn:
   - Run the narrow relevant slice first, e.g. `cabal test mlf2-test --test-options '--match "MLF.Program"'` plus parser/pretty specs if touched.
   - Run the full required gate before completion: `cabal build all && cabal test`.
   - Inspect `git status --short` and relevant diffs, stage only issue-related source/docs/tests, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, push `codex/issue-15`, and leave PR #36 ready for review without resolving review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.