### PR TITLE
Implement #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Changed
+- Added syntax-level `.mlfp` parsing and pretty-printing for variable-headed
+  source type applications such as `f a`, including nested and parenthesized
+  argument round trips. Kind checking and higher-kinded elaboration still fail
+  closed until the follow-up semantic slices.
 - Added `.mlfp` declaration parameter kind metadata. Data and class parameters
   now carry default `*` or parenthesized higher-kinded annotations, the program
   pretty-printer preserves non-first-order declarations, variable-headed source

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -106,10 +106,19 @@ data Higher (f :: * -> *) a =
     Higher : a -> Higher f a;
 ```
 
-This slice records and pretty-prints declaration parameter kinds while keeping
-existing first-order declarations unchanged. Full variable-headed type
-application parsing such as `f a`, source kind checking, and higher-kinded
-elaboration remain follow-up work for #16, #17, and #18.
+Variable-headed type applications such as `f a` are accepted in source types
+and pretty-print back to the same structure:
+
+```mlf
+data Applied (f :: * -> *) a =
+    Applied : f a -> Applied f a;
+```
+
+This syntax slice records and pretty-prints declaration parameter kinds and
+variable-headed type application structure while keeping existing first-order
+declarations unchanged. Source kind checking and higher-kinded elaboration
+remain follow-up work for #17 and #18, so checked programs still fail closed if
+they require those later semantics.
 
 ## Case Expressions And Patterns
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -60,6 +60,7 @@ Expr        ::= x
 SrcType     ::= α
               | SrcType "->" SrcType
               | C SrcType+
+              | α SrcType+
               | "∀" Binder+ "." SrcType
               | "⊥"
 Binder      ::= α | "(" α "⩾" SrcType ")"
@@ -146,17 +147,33 @@ Import       ::= "import" UIdent ["as" UIdent] ["exposing" "(" ExportItem ("," E
 ExportItem   ::= lIdent | UIdent | UIdent "(..)"
 
 Decl         ::= DataDecl | ClassDecl | InstanceDecl | DefDecl
-DataDecl     ::= "data" UIdent lIdent* "=" CtorDecl ("|" CtorDecl)* ["deriving" QName ("," QName)*] ";"
+DataDecl     ::= "data" UIdent TypeParam* "=" CtorDecl ("|" CtorDecl)* ["deriving" QName ("," QName)*] ";"
 CtorDecl     ::= UIdent ":" SrcType
-ClassDecl    ::= "class" UIdent lIdent "{" MethodSig* "}"
+ClassDecl    ::= "class" UIdent TypeParam "{" MethodSig* "}"
 MethodSig    ::= lIdent ":" ConstrainedType ";"
 InstanceDecl ::= "instance" [ConstraintPrefix "=>"] QName SrcType "{" MethodDef* "}"
 MethodDef    ::= lIdent "=" Expr ";"
 DefDecl      ::= "def" lIdent ":" ConstrainedType "=" Expr ";"
 
+TypeParam    ::= lIdent | "(" lIdent "::" Kind ")"
+Kind         ::= KindAtom ["->" Kind]
+KindAtom     ::= "*" | "(" Kind ")"
+
 ConstrainedType ::= [ConstraintPrefix "=>"] SrcType
 ConstraintPrefix ::= ClassConstraint | "(" ClassConstraint ("," ClassConstraint)* ")"
 ClassConstraint ::= QName SrcType
+
+SrcType      ::= lIdent
+               | UIdent SrcTypeAtom*
+               | lIdent SrcTypeAtom+
+               | SrcType "->" SrcType
+               | "forall" Binder+ "." SrcType
+               | "∀" Binder+ "." SrcType
+               | "mu" lIdent "." SrcType
+               | "μ" lIdent "." SrcType
+               | "⊥"
+SrcTypeAtom  ::= lIdent | UIdent | "⊥" | "(" SrcType ")"
+Binder       ::= lIdent | "(" lIdent "⩾" SrcType ")" | "(" lIdent ">=" SrcType ")"
 
 Expr         ::= QName | Literal
                | "\" Param Expr

--- a/src/MLF/Frontend/Parse.hs
+++ b/src/MLF/Frontend/Parse.hs
@@ -150,6 +150,7 @@ frontendTypeConfig =
         , tpcMkArrow = STArrow
         , tpcMkBase = STBase
         , tpcMkCon = STCon
+        , tpcMkVarApp = \v args -> Just (STVarApp v args)
         , tpcMkForall = \v mb body -> STForall v (fmap mkSrcBound mb) body
         , tpcMkBottom = STBottom
         , tpcBoundedBinder = \pTy ->

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -80,6 +80,7 @@ reservedWords =
         , "instance"
         , "let"
         , "module"
+        , "mu"
         , "of"
         , "as"
         , "true"

--- a/src/MLF/Frontend/Parse/Program.hs
+++ b/src/MLF/Frontend/Parse/Program.hs
@@ -131,6 +131,7 @@ programTypeConfig =
         , tpcMkArrow = STArrow
         , tpcMkBase = STBase
         , tpcMkCon = STCon
+        , tpcMkVarApp = \v args -> Just (STVarApp v args)
         , tpcMkForall = \v mb body -> STForall v (fmap mkSrcBound mb) body
         , tpcMkBottom = STBottom
         , tpcBoundedBinder = \pTy ->

--- a/src/MLF/Parse/Type.hs
+++ b/src/MLF/Parse/Type.hs
@@ -9,6 +9,11 @@ import Data.List.NonEmpty (NonEmpty(..))
 import MLF.Parse.Common (Parser)
 import Text.Megaparsec (choice, many, optional, try, (<|>))
 
+data TypeAtom ty
+    = AtomCon String
+    | AtomVar String
+    | AtomOther ty
+
 data TypeParserConfig ty bound = TypeParserConfig
     { tpcForallTok :: Parser ()
     , tpcGeTok :: Parser ()
@@ -21,6 +26,7 @@ data TypeParserConfig ty bound = TypeParserConfig
     , tpcMkArrow :: ty -> ty -> ty
     , tpcMkBase :: String -> ty
     , tpcMkCon :: String -> NonEmpty ty -> ty
+    , tpcMkVarApp :: String -> NonEmpty ty -> Maybe ty
     , tpcMkForall :: String -> bound -> ty -> ty
     , tpcMkBottom :: ty
     , tpcBoundedBinder :: Parser ty -> Parser (String, bound)
@@ -50,21 +56,30 @@ parseArrowTypeWith cfg pType = do
     pTypeApp = do
         headTy <- pTypeAtom
         case headTy of
-            Left conName -> do
+            AtomCon conName -> do
                 args <- many pTypeArg
                 pure $ case args of
                     [] -> tpcMkBase cfg conName
                     (arg:rest) -> tpcMkCon cfg conName (arg :| rest)
-            Right ty -> pure ty
+            AtomVar varName -> do
+                args <- many pTypeArg
+                case args of
+                    [] -> pure (tpcMkVar cfg varName)
+                    (arg:rest) ->
+                        case tpcMkVarApp cfg varName (arg :| rest) of
+                            Just ty -> pure ty
+                            Nothing -> fail ("variable-headed type application `" ++ varName ++ "` is not supported")
+            AtomOther ty -> pure ty
 
     pTypeArg = pTypeAtom >>= \case
-        Left conName -> pure (tpcMkBase cfg conName)
-        Right ty -> pure ty
+        AtomCon conName -> pure (tpcMkBase cfg conName)
+        AtomVar varName -> pure (tpcMkVar cfg varName)
+        AtomOther ty -> pure ty
 
     pTypeAtom =
         choice
-            [ Left <$> tpcUpperIdent cfg
-            , Right . tpcMkVar cfg <$> tpcLowerIdent cfg
-            , Right (tpcMkBottom cfg) <$ tpcBottomTok cfg
-            , Right <$> tpcParens cfg pType
+            [ AtomCon <$> tpcUpperIdent cfg
+            , AtomVar <$> tpcLowerIdent cfg
+            , AtomOther (tpcMkBottom cfg) <$ tpcBottomTok cfg
+            , AtomOther <$> tpcParens cfg pType
             ]

--- a/src/MLF/XMLF/Parse.hs
+++ b/src/MLF/XMLF/Parse.hs
@@ -105,6 +105,7 @@ xmlfTypeConfig =
         , tpcMkArrow = XTArrow
         , tpcMkBase = XTBase
         , tpcMkCon = XTCon
+        , tpcMkVarApp = \_ _ -> Nothing
         , tpcMkForall = XTForall
         , tpcMkBottom = XTBottom
         , tpcBoundedBinder = \pTy ->

--- a/test/FrontendParseSpec.hs
+++ b/test/FrontendParseSpec.hs
@@ -107,12 +107,42 @@ spec = describe "Frontend eMLF parser" $ do
         it "parses constructor application" $
             parseRawEmlfType "List Int" `shouldBe` Right (STCon "List" (STBase "Int" :| []))
 
+        it "parses variable-headed type application" $ do
+            parseRawEmlfType "f a"
+                `shouldBe` Right (STVarApp "f" (STVar "a" :| []))
+            parseRawEmlfType "p a b"
+                `shouldBe` Right (STVarApp "p" (STVar "a" :| [STVar "b"]))
+
+        it "parses nested variable-headed type application arguments" $
+            parseRawEmlfType "f (g a)"
+                `shouldBe` Right (STVarApp "f" (STVarApp "g" (STVar "a" :| []) :| []))
+
+        it "parses arrow and forall arguments to variable-headed applications when parenthesized" $ do
+            parseRawEmlfType "f (a -> b)"
+                `shouldBe` Right (STVarApp "f" (STArrow (STVar "a") (STVar "b") :| []))
+            parseRawEmlfType "f (forall a. a -> a)"
+                `shouldBe` Right
+                    ( STVarApp
+                        "f"
+                        (STForall "a" Nothing (STArrow (STVar "a") (STVar "a")) :| [])
+                    )
+
         it "parses unicode mu recursive types" $
             parseRawEmlfType "μa. List a"
                 `shouldBe` Right (STMu "a" (STCon "List" (STVar "a" :| [])))
 
         it "rejects malformed forall binders" $
             parseRawEmlfType "∀(a) a" `shouldSatisfy` isLeft
+
+        it "rejects malformed variable-headed type applications with diagnostics" $
+            case parseRawEmlfType "f ()" of
+                Left err -> renderEmlfParseError err `shouldSatisfy` (not . null)
+                Right ty -> expectationFailure ("expected parse error, got: " ++ show ty)
+
+        it "rejects unparenthesized forall arguments to variable-headed applications" $
+            case parseRawEmlfType "f forall a. a" of
+                Left err -> renderEmlfParseError err `shouldSatisfy` (not . null)
+                Right ty -> expectationFailure ("expected parse error, got: " ++ show ty)
 
     describe "normalized types" $ do
         it "normalizes simple variable type" $

--- a/test/FrontendPrettySpec.hs
+++ b/test/FrontendPrettySpec.hs
@@ -69,6 +69,15 @@ spec = describe "Frontend eMLF pretty printer" $ do
         let ty = STMu "a" (STCon "List" (STVar "a" :| []))
         parseRawEmlfType (prettyEmlfType ty) `shouldBe` Right ty
 
+    it "roundtrips variable-headed type application parse(pretty(type))" $ do
+        let ty =
+                STVarApp
+                    "f"
+                    ( STVarApp "g" (STVar "a" :| [])
+                        :| [STArrow (STVar "a") (STVar "b")]
+                    )
+        parseRawEmlfType (prettyEmlfType ty) `shouldBe` Right ty
+
     it "roundtrips recursive expression parse(pretty(expr))" $ do
         let expr = EAnn (EVar "x") (STMu "a" (STArrow (STVar "a") (STBase "Int")))
         parseRawEmlfExpr (prettyEmlfExpr expr) `shouldBe` Right expr

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2449,6 +2449,17 @@ spec = do
                 other -> expectationFailure ("unexpected program shape: " ++ show other)
             parseRawProgram (prettyProgram program) `shouldBe` Right program
 
+        it "rejects malformed ascii recursive types before variable-headed application fallback" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  def main : mu a = 1;"
+                        , "}"
+                        ]
+            case parseRawProgram programText of
+                Left err -> renderProgramParseError err `shouldSatisfy` (not . null)
+                Right program -> expectationFailure ("expected parse error, got: " ++ show program)
+
     describe "MLF.Program execution corpus" $ do
         mapM_ runFixture fixturePaths
 

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2404,6 +2404,51 @@ spec = do
                 other -> expectationFailure ("unexpected program shape: " ++ show other)
             parseRawProgram (prettyProgram program) `shouldBe` Right program
 
+        it "parses and pretty-prints variable-headed higher-kinded field types" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Functor, Higher(..)) {"
+                        , "  class Functor (f :: * -> *) {"
+                        , "    map : forall a b. (a -> b) -> f a -> f b;"
+                        , "  }"
+                        , ""
+                        , "  data Higher (f :: * -> *) a ="
+                        , "      Higher : f a -> Higher f a;"
+                        , "}"
+                        ]
+                expectedMethodTy =
+                    STForall
+                        "a"
+                        Nothing
+                        ( STForall
+                            "b"
+                            Nothing
+                            ( STArrow
+                                (STArrow (STVar "a") (STVar "b"))
+                                ( STArrow
+                                    (STVarApp "f" (STVar "a" :| []))
+                                    (STVarApp "f" (STVar "b" :| []))
+                                )
+                            )
+                        )
+                expectedCtorTy =
+                    STArrow
+                        (STVarApp "f" (STVar "a" :| []))
+                        (STCon "Higher" (STVar "f" :| [STVar "a"]))
+            program <- requireParsed programText
+            case program of
+                Program [Module {moduleDecls = [DeclClass classDecl, DeclData dataDecl]}] -> do
+                    case classDeclMethods classDecl of
+                        [MethodSig {methodSigType = ConstrainedType [] methodTy}] ->
+                            methodTy `shouldBe` expectedMethodTy
+                        other -> expectationFailure ("unexpected method shape: " ++ show other)
+                    case dataDeclConstructors dataDecl of
+                        [ConstructorDecl {constructorDeclType = ctorTy}] ->
+                            ctorTy `shouldBe` expectedCtorTy
+                        other -> expectationFailure ("unexpected constructor shape: " ++ show other)
+                other -> expectationFailure ("unexpected program shape: " ++ show other)
+            parseRawProgram (prettyProgram program) `shouldBe` Right program
+
     describe "MLF.Program execution corpus" $ do
         mapM_ runFixture fixturePaths
 

--- a/test/PublicSurfaceSpec.hs
+++ b/test/PublicSurfaceSpec.hs
@@ -22,6 +22,10 @@ spec = describe "Public surface contracts" $ do
       let ty = STMu "a" (STCon "List" (STVar "a" :| []))
       parseRawEmlfType (prettyEmlfType ty) `shouldBe` Right ty
 
+    it "roundtrips variable-headed surface types through parse(pretty(type))" $ do
+      let ty = STVarApp "f" (STVarApp "g" (STVar "a" :| []) :| [STVar "b"])
+      parseRawEmlfType (prettyEmlfType ty) `shouldBe` Right ty
+
     it "normalizes raw surface types through the umbrella API" $ do
       expectRight (parseRawEmlfType "∀(b ⩾ a). b") $ \ty ->
         normalizeType ty `shouldBe` Right (STVar "a")


### PR DESCRIPTION
Closes #16.

## Implementation Plan

---
issue_number: 16
pr_number: 38
branch: codex/issue-16
---

**Implementation Plan**

1. Start the implementation turn by rereading the watcher-written issue plan, confirming `git status --short --branch` is still clean on `codex/issue-16`, and verifying PR #38 is still the existing open PR for `codex/issue-16` into `master`. Do not create another PR or touch watcher-owned state.

2. Implement syntax-level variable-headed type application in the shared type parser, centered on `src/MLF/Parse/Type.hs`. Refactor the type-application parser so it distinguishes constructor heads, variable heads, and non-head atoms. Add a `TypeParserConfig` hook for variable-headed applications; set it to `STVarApp` in `src/MLF/Frontend/Parse.hs` and `src/MLF/Frontend/Parse/Program.hs`, and leave XMLF unsupported so existing xMLF behavior stays unchanged.

3. Keep this strictly parser/pretty-printer scope. Do not add kind-checking or higher-kinded elaboration rules from #17/#18, and do not remove the existing fail-closed paths that reject `STVarApp` during checking/elaboration before the later issues implement them.

4. Preserve pretty-printer round trips in `src/MLF/Frontend/Pretty.hs`. The existing `STVarApp` rendering is close to the target; verify or adjust parenthesization so nested variable apps, constructor apps as arguments, arrows, foralls, and recursive types parse back to the same AST.

5. Add focused regression coverage:
- `test/FrontendParseSpec.hs`: parse `f a`, multi-argument `p a b`, nested `f (g a)`, and arrow/forall-containing cases into `STVarApp`; add malformed/ambiguous syntax rejections with non-empty rendered diagnostics.
- `test/FrontendPrettySpec.hs` and `test/PublicSurfaceSpec.hs`: add parse-pretty round trips for `STVarApp` shapes, including nested applications.
- `test/ProgramSpec.hs`: add `.mlfp` parse/pretty coverage for higher-kinded declarations using variable-headed constructor fields and method signatures such as `f a`, while avoiding `checkProgram` assertions that would belong to #17/#18.

6. Update relevant durable docs for the behavior change: `docs/syntax.md` should include variable-headed source type application in `SrcType` and `.mlfp` grammar, `docs/mlfp-language-reference.md` should stop calling `f a` parsing follow-up work while still saying kind checking/elaboration remain later work, and `CHANGELOG.md` should add a concise Unreleased entry for the #16 parser/pretty slice.

7. Validate in layers: run a focused test slice for parser/pretty/program specs, then run `git diff --check`, then run the full required gate `cabal build all && cabal test`. If full validation is blocked by environment or pre-existing failures, report the exact blocker and do not claim completion.

8. Before publishing, inspect `git status --short` and the relevant diff. Stage only issue-related source, test, and doc files; commit with the prepared `codex-watcher <codex-watcher@users.noreply.github.com>` identity; run `gh auth status` and `gh auth setup-git`; push `codex/issue-16` to the existing PR #38 without resolving PR review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.