### PR TITLE
Implement #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,22 @@
 ## Unreleased
 
 ### Changed
+- Added `.mlfp` source kind checking for declaration parameter annotations,
+  ordinary type constructor application, variable-headed type application,
+  class constraints, method signatures, and instance heads. Ill-kinded source
+  types now fail before lowering with `ProgramKindMismatch` or
+  `ProgramTypeArityMismatch`, while higher-kinded elaboration and runtime
+  semantics remain fail-closed for the later semantic slice.
 - Added syntax-level `.mlfp` parsing and pretty-printing for variable-headed
   source type applications such as `f a`, including nested and parenthesized
-  argument round trips. Kind checking and higher-kinded elaboration still fail
-  closed until the follow-up semantic slices.
+  argument round trips. Higher-kinded elaboration still fails closed until the
+  follow-up semantic slice.
 - Added `.mlfp` declaration parameter kind metadata. Data and class parameters
   now carry default `*` or parenthesized higher-kinded annotations, the program
   pretty-printer preserves non-first-order declarations, variable-headed source
-  type applications have an explicit AST representation for follow-up kinding
-  work, and duplicate data type parameters are rejected during program checks.
+  type applications have an explicit AST representation for source kind
+  checking, and duplicate data type parameters are rejected during program
+  checks.
 - Documented the `.mlfp` module compilation contract: modules are checked as
   one parsed `Program` compilation unit, the CLI Prelude is added explicitly,
   and separate compilation/interface files remain future work. Added regression

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -114,11 +114,13 @@ data Applied (f :: * -> *) a =
     Applied : f a -> Applied f a;
 ```
 
-This syntax slice records and pretty-prints declaration parameter kinds and
-variable-headed type application structure while keeping existing first-order
-declarations unchanged. Source kind checking and higher-kinded elaboration
-remain follow-up work for #17 and #18, so checked programs still fail closed if
-they require those later semantics.
+The checker validates declaration parameter kinds, ordinary and
+variable-headed type applications, class method constraints, instance heads,
+and constructor signatures before lowering. Kind errors are reported as
+`ProgramKindMismatch` or `ProgramTypeArityMismatch`. Higher-kinded
+elaboration and runtime semantics remain follow-up work for #18, so checked
+programs still fail closed if they require lowering a variable-headed source
+type application such as a constructor field of type `f a`.
 
 ## Case Expressions And Patterns
 

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -123,8 +123,16 @@ data DisplayNameEnv = DisplayNameEnv
 
 data KindEnv = KindEnv
   { kindTypeConstructors :: Map SymbolIdentity P.SrcKind,
-    kindTypeVariables :: Map String P.SrcKind
+    kindTypeVariables :: Map String KindTerm,
+    kindMetaSubst :: Map Int KindTerm,
+    kindNextMeta :: Int
   }
+  deriving (Eq, Show)
+
+data KindTerm
+  = KTType
+  | KTArrow KindTerm KindTerm
+  | KTMeta Int
   deriving (Eq, Show)
 
 emptyScope :: Scope
@@ -1144,7 +1152,9 @@ kindEnvFromScope scope =
           [ (dataInfoSymbolIdentity dataInfo, dataKind (dataTypeParams dataInfo))
             | dataInfo <- Map.elems (scopeTypes scope)
           ],
-      kindTypeVariables = Map.empty
+      kindTypeVariables = Map.empty,
+      kindMetaSubst = Map.empty,
+      kindNextMeta = 0
     }
 
 dataKind :: [P.TypeParam] -> P.SrcKind
@@ -1196,111 +1206,177 @@ validateClassConstraintKind scope env constraint = do
 extendKindParams :: [P.TypeParam] -> KindEnv -> TcM KindEnv
 extendKindParams params env =
   foldM
-    (\acc param -> bindKindVariable (P.typeParamName param) (P.typeParamKind param) acc)
+    (\acc param -> bindKindVariable (P.typeParamName param) (kindFromSrc (P.typeParamKind param)) acc)
     env
     params
 
 checkResolvedKind :: KindEnv -> ResolvedSrcType -> P.SrcKind -> TcM KindEnv
 checkResolvedKind env ty expected =
+  checkResolvedKindTerm env ty (kindFromSrc expected)
+
+checkResolvedKindTerm :: KindEnv -> ResolvedSrcType -> KindTerm -> TcM KindEnv
+checkResolvedKindTerm env ty expected =
   case ty of
     RSTVar name -> bindKindVariable name expected env
-    RSTArrow dom cod
-      | expected == P.KType -> do
-          env1 <- checkResolvedKind env dom P.KType
-          checkResolvedKind env1 cod P.KType
-      | otherwise -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected P.KType)
-    RSTForall name mb body
-      | expected == P.KType -> do
-          env1 <-
-            case mb of
-              Nothing -> pure env
-              Just bound -> checkResolvedKind env (unResolvedSrcBound bound) P.KType
-          withScopedKindVariable name P.KType env1 $ \env2 ->
-            checkResolvedKind env2 body P.KType
-      | otherwise -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected P.KType)
-    RSTMu name body
-      | expected == P.KType ->
-          withScopedKindVariable name P.KType env $ \env1 ->
-            checkResolvedKind env1 body P.KType
-      | otherwise -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected P.KType)
+    RSTArrow dom cod -> do
+      env1 <- requireKindTerm env ty expected KTType
+      env2 <- checkResolvedKindTerm env1 dom KTType
+      checkResolvedKindTerm env2 cod KTType
+    RSTForall name mb body -> do
+      env1 <- requireKindTerm env ty expected KTType
+      env2 <-
+        case mb of
+          Nothing -> pure env1
+          Just bound -> checkResolvedKindTerm env1 (unResolvedSrcBound bound) KTType
+      withScopedKindVariable name KTType env2 $ \env3 ->
+        checkResolvedKindTerm env3 body KTType
+    RSTMu name body -> do
+      env1 <- requireKindTerm env ty expected KTType
+      withScopedKindVariable name KTType env1 $ \env2 ->
+        checkResolvedKindTerm env2 body KTType
     RSTVarApp name args -> checkVarAppKind env name args expected
     _ -> do
-      (actual, env1) <- inferResolvedKind env ty
-      requireKind env1 ty expected actual
+      (actual, env1) <- inferResolvedKindTerm env ty
+      requireKindTerm env1 ty expected actual
 
-inferResolvedKind :: KindEnv -> ResolvedSrcType -> TcM (P.SrcKind, KindEnv)
-inferResolvedKind env ty =
+inferResolvedKindTerm :: KindEnv -> ResolvedSrcType -> TcM (KindTerm, KindEnv)
+inferResolvedKindTerm env ty =
   case ty of
-    RSTVar name ->
-      case Map.lookup name (kindTypeVariables env) of
-        Just kind0 -> pure (kind0, env)
-        Nothing -> pure (P.KType, env {kindTypeVariables = Map.insert name P.KType (kindTypeVariables env)})
+    RSTVar name -> kindTermForVariable name env
     RSTBase symbol -> do
       kind0 <- resolvedTypeHeadKind env symbol
-      pure (kind0, env)
+      pure (kindFromSrc kind0, env)
     RSTCon symbol args -> do
-      headKind <- resolvedTypeHeadKind env symbol
+      headKind <- kindFromSrc <$> resolvedTypeHeadKind env symbol
       applyKindArgs env (resolvedSymbolDisplayName symbol) headKind args
-    RSTVarApp name args ->
-      checkVarAppKind env name args P.KType >>= \env1 -> pure (P.KType, env1)
+    RSTVarApp name args -> inferVarAppKind env name args
     RSTArrow dom cod -> do
-      env1 <- checkResolvedKind env dom P.KType
-      env2 <- checkResolvedKind env1 cod P.KType
-      pure (P.KType, env2)
+      env1 <- checkResolvedKindTerm env dom KTType
+      env2 <- checkResolvedKindTerm env1 cod KTType
+      pure (KTType, env2)
     RSTForall name mb body -> do
       env1 <-
         case mb of
           Nothing -> pure env
-          Just bound -> checkResolvedKind env (unResolvedSrcBound bound) P.KType
+          Just bound -> checkResolvedKindTerm env (unResolvedSrcBound bound) KTType
       env2 <-
-        withScopedKindVariable name P.KType env1 $ \env3 ->
-          checkResolvedKind env3 body P.KType
-      pure (P.KType, env2)
+        withScopedKindVariable name KTType env1 $ \env3 ->
+          checkResolvedKindTerm env3 body KTType
+      pure (KTType, env2)
     RSTMu name body -> do
       env1 <-
-        withScopedKindVariable name P.KType env $ \env2 ->
-          checkResolvedKind env2 body P.KType
-      pure (P.KType, env1)
-    RSTBottom -> pure (P.KType, env)
+        withScopedKindVariable name KTType env $ \env2 ->
+          checkResolvedKindTerm env2 body KTType
+      pure (KTType, env1)
+    RSTBottom -> pure (KTType, env)
 
-checkVarAppKind :: KindEnv -> String -> NonEmpty ResolvedSrcType -> P.SrcKind -> TcM KindEnv
-checkVarAppKind env name args expected =
-  case Map.lookup name (kindTypeVariables env) of
-    Just headKind -> do
-      (actual, env1) <- applyKindArgs env name headKind args
-      requireKind env1 (RSTVarApp name args) expected actual
-    Nothing -> do
-      (argKinds, env1) <- inferArgumentKinds env (NE.toList args)
-      let headKind = foldr P.KArrow expected argKinds
-      bindKindVariable name headKind env1
+checkVarAppKind :: KindEnv -> String -> NonEmpty ResolvedSrcType -> KindTerm -> TcM KindEnv
+checkVarAppKind env name args expected = do
+  (actual, env1) <- inferVarAppKind env name args
+  requireKindTerm env1 (RSTVarApp name args) expected actual
 
-inferArgumentKinds :: KindEnv -> [ResolvedSrcType] -> TcM ([P.SrcKind], KindEnv)
-inferArgumentKinds env [] = pure ([], env)
-inferArgumentKinds env (arg : rest) = do
-  (argKind, env1) <- inferResolvedKind env arg
-  (argKinds, env2) <- inferArgumentKinds env1 rest
-  pure (argKind : argKinds, env2)
+inferVarAppKind :: KindEnv -> String -> NonEmpty ResolvedSrcType -> TcM (KindTerm, KindEnv)
+inferVarAppKind env name args = do
+  (headKind, env1) <- kindTermForVariable name env
+  applyKindArgs env1 name headKind args
 
-applyKindArgs :: KindEnv -> String -> P.SrcKind -> NonEmpty ResolvedSrcType -> TcM (P.SrcKind, KindEnv)
+applyKindArgs :: KindEnv -> String -> KindTerm -> NonEmpty ResolvedSrcType -> TcM (KindTerm, KindEnv)
 applyKindArgs env headName headKind args =
   go 0 env headKind (NE.toList args)
   where
-    go _ env0 kind0 [] = pure (kind0, env0)
-    go consumed env0 (P.KArrow expected result) (arg : rest) = do
-      env1 <- checkResolvedKind env0 arg expected
-      go (consumed + 1) env1 result rest
-    go consumed _ P.KType remaining =
-      throwError (ProgramTypeArityMismatch headName consumed (consumed + length remaining))
+    go _ env0 kind0 [] = pure (zonkKindTerm env0 kind0, env0)
+    go consumed env0 kind0 (arg : rest) =
+      case zonkKindTerm env0 kind0 of
+        KTArrow expected result -> do
+          env1 <- checkResolvedKindTerm env0 arg expected
+          go (consumed + 1) env1 result rest
+        KTMeta meta -> do
+          (argKind, env1) <- inferResolvedKindTerm env0 arg
+          let (resultKind, env2) = freshKindMeta env1
+          env3 <- requireKindTerm env2 (RSTVar headName) (KTMeta meta) (KTArrow argKind resultKind)
+          go (consumed + 1) env3 resultKind rest
+        KTType ->
+          throwError (ProgramTypeArityMismatch headName consumed (consumed + length rest + 1))
 
-requireKind :: KindEnv -> ResolvedSrcType -> P.SrcKind -> P.SrcKind -> TcM KindEnv
-requireKind env ty expected actual
-  | expected == actual = pure env
-  | otherwise =
+requireKindTerm :: KindEnv -> ResolvedSrcType -> KindTerm -> KindTerm -> TcM KindEnv
+requireKindTerm env ty expected actual =
+  case unifyKindTerm env expected actual of
+    Right env1 -> pure env1
+    Left (KindUnifyMismatch expectedKind actualKind) ->
       case typeHeadArity env ty of
         Just (headName, expectedArgs, actualArgs)
-          | expected == P.KType && isArrowKind actual ->
+          | expectedKind == P.KType && isArrowKind actualKind ->
               throwError (ProgramTypeArityMismatch headName expectedArgs actualArgs)
-        _ -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected actual)
+        _ -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expectedKind actualKind)
+
+data KindUnifyMismatch = KindUnifyMismatch P.SrcKind P.SrcKind
+  deriving (Eq, Show)
+
+unifyKindTerm :: KindEnv -> KindTerm -> KindTerm -> Either KindUnifyMismatch KindEnv
+unifyKindTerm env left right =
+  case (zonkKindTerm env left, zonkKindTerm env right) of
+    (KTType, KTType) -> Right env
+    (KTArrow leftDom leftCod, KTArrow rightDom rightCod) -> do
+      env1 <- unifyKindTerm env leftDom rightDom
+      unifyKindTerm env1 leftCod rightCod
+    (KTMeta meta, term) -> bindKindMeta meta term env
+    (term, KTMeta meta) -> bindKindMeta meta term env
+    (leftTerm, rightTerm) ->
+      Left (KindUnifyMismatch (kindTermToSrcKind env leftTerm) (kindTermToSrcKind env rightTerm))
+
+bindKindMeta :: Int -> KindTerm -> KindEnv -> Either KindUnifyMismatch KindEnv
+bindKindMeta meta term env =
+  let term0 = zonkKindTerm env term
+   in case term0 of
+        KTMeta other
+          | other == meta -> Right env
+        _
+          | kindMetaOccurs meta term0 env ->
+              Left (KindUnifyMismatch (kindTermToSrcKind env (KTMeta meta)) (kindTermToSrcKind env term0))
+          | otherwise ->
+              Right env {kindMetaSubst = Map.insert meta term0 (kindMetaSubst env)}
+
+kindMetaOccurs :: Int -> KindTerm -> KindEnv -> Bool
+kindMetaOccurs meta term env =
+  case zonkKindTerm env term of
+    KTType -> False
+    KTArrow dom cod -> kindMetaOccurs meta dom env || kindMetaOccurs meta cod env
+    KTMeta other -> meta == other
+
+kindTermForVariable :: String -> KindEnv -> TcM (KindTerm, KindEnv)
+kindTermForVariable name env =
+  case Map.lookup name (kindTypeVariables env) of
+    Just kind0 -> pure (zonkKindTerm env kind0, env)
+    Nothing ->
+      let (kind0, env1) = freshKindMeta env
+       in pure (kind0, env1 {kindTypeVariables = Map.insert name kind0 (kindTypeVariables env1)})
+
+freshKindMeta :: KindEnv -> (KindTerm, KindEnv)
+freshKindMeta env =
+  (KTMeta (kindNextMeta env), env {kindNextMeta = kindNextMeta env + 1})
+
+kindFromSrc :: P.SrcKind -> KindTerm
+kindFromSrc kind0 =
+  case kind0 of
+    P.KType -> KTType
+    P.KArrow dom cod -> KTArrow (kindFromSrc dom) (kindFromSrc cod)
+
+kindTermToSrcKind :: KindEnv -> KindTerm -> P.SrcKind
+kindTermToSrcKind env kind0 =
+  case zonkKindTerm env kind0 of
+    KTType -> P.KType
+    KTArrow dom cod -> P.KArrow (kindTermToSrcKind env dom) (kindTermToSrcKind env cod)
+    KTMeta _ -> P.KType
+
+zonkKindTerm :: KindEnv -> KindTerm -> KindTerm
+zonkKindTerm env kind0 =
+  case kind0 of
+    KTType -> KTType
+    KTArrow dom cod -> KTArrow (zonkKindTerm env dom) (zonkKindTerm env cod)
+    KTMeta meta ->
+      case Map.lookup meta (kindMetaSubst env) of
+        Just replacement -> zonkKindTerm env replacement
+        Nothing -> KTMeta meta
 
 typeHeadArity :: KindEnv -> ResolvedSrcType -> Maybe (String, Int, Int)
 typeHeadArity env ty =
@@ -1320,7 +1396,7 @@ typeHeadArity env ty =
 
     kindForVar name =
       case Map.lookup name (kindTypeVariables env) of
-        Just kind0 -> Just (name, kindArity kind0)
+        Just kind0 -> Just (name, kindTermArity env kind0)
         Nothing -> Nothing
 
     kindForHead symbol =
@@ -1334,22 +1410,27 @@ kindArity kind0 =
     P.KType -> 0
     P.KArrow _ result -> 1 + kindArity result
 
+kindTermArity :: KindEnv -> KindTerm -> Int
+kindTermArity env kind0 =
+  case zonkKindTerm env kind0 of
+    KTType -> 0
+    KTArrow _ result -> 1 + kindTermArity env result
+    KTMeta _ -> 0
+
 isArrowKind :: P.SrcKind -> Bool
 isArrowKind kind0 =
   case kind0 of
     P.KArrow {} -> True
     P.KType -> False
 
-bindKindVariable :: String -> P.SrcKind -> KindEnv -> TcM KindEnv
+bindKindVariable :: String -> KindTerm -> KindEnv -> TcM KindEnv
 bindKindVariable name expected env =
   case Map.lookup name (kindTypeVariables env) of
-    Just actual
-      | actual == expected -> pure env
-      | otherwise -> throwError (ProgramKindMismatch (STVar name) expected actual)
+    Just actual -> requireKindTerm env (RSTVar name) expected actual
     Nothing ->
-      pure env {kindTypeVariables = Map.insert name expected (kindTypeVariables env)}
+      pure env {kindTypeVariables = Map.insert name (zonkKindTerm env expected) (kindTypeVariables env)}
 
-withScopedKindVariable :: String -> P.SrcKind -> KindEnv -> (KindEnv -> TcM KindEnv) -> TcM KindEnv
+withScopedKindVariable :: String -> KindTerm -> KindEnv -> (KindEnv -> TcM KindEnv) -> TcM KindEnv
 withScopedKindVariable name kind0 env action = do
   let previous = Map.lookup name (kindTypeVariables env)
       envWithBinder = env {kindTypeVariables = Map.insert name kind0 (kindTypeVariables env)}

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -121,6 +121,12 @@ data DisplayNameEnv = DisplayNameEnv
   }
   deriving (Eq, Show)
 
+data KindEnv = KindEnv
+  { kindTypeConstructors :: Map SymbolIdentity P.SrcKind,
+    kindTypeVariables :: Map String P.SrcKind
+  }
+  deriving (Eq, Show)
+
 emptyScope :: Scope
 emptyScope = mkScope builtinValues Map.empty Map.empty []
 
@@ -477,6 +483,7 @@ checkModule resolvedModule priorModules = do
   classScope <- liftEither =<< pure (addClasses (scopeClasses importScope) localClasses)
   let scope0 = mkScope valueScope typeScope classScope (scopeInstances importScope ++ visibleImportedInstances)
       fullNameEnv = valueNameEnv `preferDisplayNames` displayNameEnvFromScope scope0
+  validateModuleKinds scope0 resolvedSyntax
   validateLocalClassMethodConstraints scope0 resolvedSyntax
   derivedInstances <- synthesizeDerivedInstances fullNameEnv scope0 resolvedModule resolvedSyntax
   instanceSkeletons <- buildInstanceSkeletons fullNameEnv scope0 resolvedSyntax derivedInstances
@@ -1118,6 +1125,253 @@ displayNameForSymbol namesByIdentity symbol =
       | resolvedSymbolDisplayName symbol `elem` names -> Just (resolvedSymbolDisplayName symbol)
       | name : _ <- names -> Just name
     _ -> Nothing
+
+-- Source kind checking -------------------------------------------------------
+
+validateModuleKinds :: Scope -> P.ResolvedModuleSyntax -> TcM ()
+validateModuleKinds scope mod0 = do
+  let baseEnv = kindEnvFromScope scope
+  mapM_ (validateDataDeclKinds baseEnv) (moduleDataDecls mod0)
+  mapM_ (validateClassDeclKinds scope baseEnv) (moduleClassDecls mod0)
+  mapM_ (validateDefDeclKinds scope baseEnv) (moduleDefDecls mod0)
+  mapM_ (validateInstanceDeclKinds scope baseEnv) (explicitInstances mod0)
+
+kindEnvFromScope :: Scope -> KindEnv
+kindEnvFromScope scope =
+  KindEnv
+    { kindTypeConstructors =
+        Map.fromList
+          [ (dataInfoSymbolIdentity dataInfo, dataKind (dataTypeParams dataInfo))
+            | dataInfo <- Map.elems (scopeTypes scope)
+          ],
+      kindTypeVariables = Map.empty
+    }
+
+dataKind :: [P.TypeParam] -> P.SrcKind
+dataKind params =
+  foldr P.KArrow P.KType (map P.typeParamKind params)
+
+validateDataDeclKinds :: KindEnv -> P.ResolvedDataDecl -> TcM ()
+validateDataDeclKinds baseEnv dataDecl = do
+  env <- extendKindParams (P.dataDeclParams dataDecl) baseEnv
+  mapM_ (validateConstructorDeclKind env) (P.dataDeclConstructors dataDecl)
+
+validateConstructorDeclKind :: KindEnv -> P.ResolvedConstructorDecl -> TcM ()
+validateConstructorDeclKind env ctorDecl = do
+  _ <- checkResolvedKind env (P.constructorDeclType ctorDecl) P.KType
+  pure ()
+
+validateClassDeclKinds :: Scope -> KindEnv -> P.ResolvedClassDecl -> TcM ()
+validateClassDeclKinds scope baseEnv classDecl = do
+  env <- extendKindParams [P.classDeclParam classDecl] baseEnv
+  mapM_ (validateMethodSigKind scope env) (P.classDeclMethods classDecl)
+
+validateMethodSigKind :: Scope -> KindEnv -> P.ResolvedMethodSig -> TcM ()
+validateMethodSigKind scope env methodSig = do
+  _ <- validateConstrainedTypeKinds scope env (P.methodSigType methodSig)
+  pure ()
+
+validateDefDeclKinds :: Scope -> KindEnv -> P.ResolvedDefDecl -> TcM ()
+validateDefDeclKinds scope env defDecl = do
+  _ <- validateConstrainedTypeKinds scope env (P.defDeclType defDecl)
+  pure ()
+
+validateInstanceDeclKinds :: Scope -> KindEnv -> P.ResolvedInstanceDecl -> TcM ()
+validateInstanceDeclKinds scope env0 instDecl = do
+  classInfo <- lookupClassInfoBySymbol scope (P.instanceDeclClass instDecl)
+  env1 <- foldM (validateClassConstraintKind scope) env0 (P.instanceDeclConstraints instDecl)
+  _ <- checkResolvedKind env1 (P.instanceDeclType instDecl) (P.typeParamKind (classTypeParam classInfo))
+  pure ()
+
+validateConstrainedTypeKinds :: Scope -> KindEnv -> P.ResolvedConstrainedType -> TcM KindEnv
+validateConstrainedTypeKinds scope env0 ty = do
+  env1 <- foldM (validateClassConstraintKind scope) env0 (P.constrainedConstraints ty)
+  checkResolvedKind env1 (P.constrainedBody ty) P.KType
+
+validateClassConstraintKind :: Scope -> KindEnv -> P.ResolvedClassConstraint -> TcM KindEnv
+validateClassConstraintKind scope env constraint = do
+  classInfo <- lookupClassInfoBySymbol scope (P.constraintClassName constraint)
+  checkResolvedKind env (P.constraintType constraint) (P.typeParamKind (classTypeParam classInfo))
+
+extendKindParams :: [P.TypeParam] -> KindEnv -> TcM KindEnv
+extendKindParams params env =
+  foldM
+    (\acc param -> bindKindVariable (P.typeParamName param) (P.typeParamKind param) acc)
+    env
+    params
+
+checkResolvedKind :: KindEnv -> ResolvedSrcType -> P.SrcKind -> TcM KindEnv
+checkResolvedKind env ty expected =
+  case ty of
+    RSTVar name -> bindKindVariable name expected env
+    RSTArrow dom cod
+      | expected == P.KType -> do
+          env1 <- checkResolvedKind env dom P.KType
+          checkResolvedKind env1 cod P.KType
+      | otherwise -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected P.KType)
+    RSTForall name mb body
+      | expected == P.KType -> do
+          env1 <-
+            case mb of
+              Nothing -> pure env
+              Just bound -> checkResolvedKind env (unResolvedSrcBound bound) P.KType
+          withScopedKindVariable name P.KType env1 $ \env2 ->
+            checkResolvedKind env2 body P.KType
+      | otherwise -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected P.KType)
+    RSTMu name body
+      | expected == P.KType ->
+          withScopedKindVariable name P.KType env $ \env1 ->
+            checkResolvedKind env1 body P.KType
+      | otherwise -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected P.KType)
+    RSTVarApp name args -> checkVarAppKind env name args expected
+    _ -> do
+      (actual, env1) <- inferResolvedKind env ty
+      requireKind env1 ty expected actual
+
+inferResolvedKind :: KindEnv -> ResolvedSrcType -> TcM (P.SrcKind, KindEnv)
+inferResolvedKind env ty =
+  case ty of
+    RSTVar name ->
+      case Map.lookup name (kindTypeVariables env) of
+        Just kind0 -> pure (kind0, env)
+        Nothing -> pure (P.KType, env {kindTypeVariables = Map.insert name P.KType (kindTypeVariables env)})
+    RSTBase symbol -> do
+      kind0 <- resolvedTypeHeadKind env symbol
+      pure (kind0, env)
+    RSTCon symbol args -> do
+      headKind <- resolvedTypeHeadKind env symbol
+      applyKindArgs env (resolvedSymbolDisplayName symbol) headKind args
+    RSTVarApp name args ->
+      checkVarAppKind env name args P.KType >>= \env1 -> pure (P.KType, env1)
+    RSTArrow dom cod -> do
+      env1 <- checkResolvedKind env dom P.KType
+      env2 <- checkResolvedKind env1 cod P.KType
+      pure (P.KType, env2)
+    RSTForall name mb body -> do
+      env1 <-
+        case mb of
+          Nothing -> pure env
+          Just bound -> checkResolvedKind env (unResolvedSrcBound bound) P.KType
+      env2 <-
+        withScopedKindVariable name P.KType env1 $ \env3 ->
+          checkResolvedKind env3 body P.KType
+      pure (P.KType, env2)
+    RSTMu name body -> do
+      env1 <-
+        withScopedKindVariable name P.KType env $ \env2 ->
+          checkResolvedKind env2 body P.KType
+      pure (P.KType, env1)
+    RSTBottom -> pure (P.KType, env)
+
+checkVarAppKind :: KindEnv -> String -> NonEmpty ResolvedSrcType -> P.SrcKind -> TcM KindEnv
+checkVarAppKind env name args expected =
+  case Map.lookup name (kindTypeVariables env) of
+    Just headKind -> do
+      (actual, env1) <- applyKindArgs env name headKind args
+      requireKind env1 (RSTVarApp name args) expected actual
+    Nothing -> do
+      (argKinds, env1) <- inferArgumentKinds env (NE.toList args)
+      let headKind = foldr P.KArrow expected argKinds
+      bindKindVariable name headKind env1
+
+inferArgumentKinds :: KindEnv -> [ResolvedSrcType] -> TcM ([P.SrcKind], KindEnv)
+inferArgumentKinds env [] = pure ([], env)
+inferArgumentKinds env (arg : rest) = do
+  (argKind, env1) <- inferResolvedKind env arg
+  (argKinds, env2) <- inferArgumentKinds env1 rest
+  pure (argKind : argKinds, env2)
+
+applyKindArgs :: KindEnv -> String -> P.SrcKind -> NonEmpty ResolvedSrcType -> TcM (P.SrcKind, KindEnv)
+applyKindArgs env headName headKind args =
+  go 0 env headKind (NE.toList args)
+  where
+    go _ env0 kind0 [] = pure (kind0, env0)
+    go consumed env0 (P.KArrow expected result) (arg : rest) = do
+      env1 <- checkResolvedKind env0 arg expected
+      go (consumed + 1) env1 result rest
+    go consumed _ P.KType remaining =
+      throwError (ProgramTypeArityMismatch headName consumed (consumed + length remaining))
+
+requireKind :: KindEnv -> ResolvedSrcType -> P.SrcKind -> P.SrcKind -> TcM KindEnv
+requireKind env ty expected actual
+  | expected == actual = pure env
+  | otherwise =
+      case typeHeadArity env ty of
+        Just (headName, expectedArgs, actualArgs)
+          | expected == P.KType && isArrowKind actual ->
+              throwError (ProgramTypeArityMismatch headName expectedArgs actualArgs)
+        _ -> throwError (ProgramKindMismatch (resolvedSrcTypeToSrcType ty) expected actual)
+
+typeHeadArity :: KindEnv -> ResolvedSrcType -> Maybe (String, Int, Int)
+typeHeadArity env ty =
+  case ty of
+    RSTVar name ->
+      withActualArity 0 <$> kindForVar name
+    RSTBase symbol ->
+      withActualArity 0 <$> kindForHead symbol
+    RSTVarApp name args ->
+      withActualArity (NE.length args) <$> kindForVar name
+    RSTCon symbol args ->
+      withActualArity (NE.length args) <$> kindForHead symbol
+    _ -> Nothing
+  where
+    withActualArity actualArgs (headName, expectedArgs) =
+      (headName, expectedArgs, actualArgs)
+
+    kindForVar name =
+      case Map.lookup name (kindTypeVariables env) of
+        Just kind0 -> Just (name, kindArity kind0)
+        Nothing -> Nothing
+
+    kindForHead symbol =
+      case resolvedTypeHeadKindMaybe env symbol of
+        Just kind0 -> Just (resolvedSymbolDisplayName symbol, kindArity kind0)
+        Nothing -> Nothing
+
+kindArity :: P.SrcKind -> Int
+kindArity kind0 =
+  case kind0 of
+    P.KType -> 0
+    P.KArrow _ result -> 1 + kindArity result
+
+isArrowKind :: P.SrcKind -> Bool
+isArrowKind kind0 =
+  case kind0 of
+    P.KArrow {} -> True
+    P.KType -> False
+
+bindKindVariable :: String -> P.SrcKind -> KindEnv -> TcM KindEnv
+bindKindVariable name expected env =
+  case Map.lookup name (kindTypeVariables env) of
+    Just actual
+      | actual == expected -> pure env
+      | otherwise -> throwError (ProgramKindMismatch (STVar name) expected actual)
+    Nothing ->
+      pure env {kindTypeVariables = Map.insert name expected (kindTypeVariables env)}
+
+withScopedKindVariable :: String -> P.SrcKind -> KindEnv -> (KindEnv -> TcM KindEnv) -> TcM KindEnv
+withScopedKindVariable name kind0 env action = do
+  let previous = Map.lookup name (kindTypeVariables env)
+      envWithBinder = env {kindTypeVariables = Map.insert name kind0 (kindTypeVariables env)}
+  envAfter <- action envWithBinder
+  pure
+    envAfter
+      { kindTypeVariables =
+          case previous of
+            Just previousKind -> Map.insert name previousKind (kindTypeVariables envAfter)
+            Nothing -> Map.delete name (kindTypeVariables envAfter)
+      }
+
+resolvedTypeHeadKind :: KindEnv -> ResolvedSymbol -> TcM P.SrcKind
+resolvedTypeHeadKind env symbol =
+  case resolvedTypeHeadKindMaybe env symbol of
+    Just kind0 -> pure kind0
+    Nothing -> throwError (ProgramUnknownType (resolvedSymbolDisplayName symbol))
+
+resolvedTypeHeadKindMaybe :: KindEnv -> ResolvedSymbol -> Maybe P.SrcKind
+resolvedTypeHeadKindMaybe env symbol
+  | isBuiltinTypeSymbol symbol = Just P.KType
+  | otherwise = Map.lookup (resolvedSymbolIdentity symbol) (kindTypeConstructors env)
 
 buildLocalDataInfo :: DisplayNameEnv -> ResolvedModule -> P.ResolvedModuleSyntax -> TcM (Map String DataInfo)
 buildLocalDataInfo displayEnv resolvedModule mod0 = do

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -120,6 +120,8 @@ data ProgramError
   | ProgramUnknownClass String
   | ProgramUnknownMethod String
   | ProgramAmbiguousUnqualifiedReference String
+  | ProgramKindMismatch SrcType P.SrcKind P.SrcKind
+  | ProgramTypeArityMismatch String Int Int
   | ProgramInvalidConstructorResult P.ConstructorName SrcType P.TypeName
   | ProgramUnsupportedDeriving P.ClassName
   | ProgramDerivingRequiresNullaryType P.TypeName
@@ -202,6 +204,8 @@ spanForError err index =
     ProgramUnknownClass name -> firstSpan name (P.spanClasses index)
     ProgramUnknownMethod name -> firstSpan name (P.spanValues index)
     ProgramAmbiguousUnqualifiedReference name -> lookupAnyName name index
+    ProgramKindMismatch ty _ _ -> sourceTypeHeadSpan ty index
+    ProgramTypeArityMismatch name _ _ -> lookupAnyName name index
     ProgramInvalidConstructorResult ctor _ _ -> firstSpan ctor (P.spanConstructors index)
     ProgramUnsupportedDeriving className0 -> firstSpan className0 (P.spanClasses index)
     ProgramDerivingRequiresNullaryType typeName -> firstSpan typeName (P.spanTypes index)
@@ -257,6 +261,23 @@ programErrorMessage err =
     ProgramUnknownClass name -> "unknown class `" ++ name ++ "`"
     ProgramUnknownMethod name -> "unknown method `" ++ name ++ "`"
     ProgramAmbiguousUnqualifiedReference name -> "ambiguous unqualified reference `" ++ name ++ "`"
+    ProgramKindMismatch ty expected actual ->
+      "kind mismatch in `"
+        ++ show ty
+        ++ "`: expected `"
+        ++ renderSrcKind expected
+        ++ "`, got `"
+        ++ renderSrcKind actual
+        ++ "`"
+    ProgramTypeArityMismatch name expected actual ->
+      "type constructor `"
+        ++ name
+        ++ "` expects "
+        ++ show expected
+        ++ " type argument"
+        ++ plural expected
+        ++ ", but got "
+        ++ show actual
     ProgramInvalidConstructorResult ctor resultTy owner -> "constructor `" ++ ctor ++ "` returns `" ++ show resultTy ++ "` instead of owning type `" ++ owner ++ "`"
     ProgramUnsupportedDeriving className0 -> "unsupported deriving class `" ++ className0 ++ "`"
     ProgramDerivingRequiresNullaryType typeName -> "deriving currently requires a nullary type, but `" ++ typeName ++ "` has parameters"
@@ -298,7 +319,44 @@ programErrorHints err =
       ["add missing constructor branches or a final wildcard branch"]
     ProgramImportNotExported {} ->
       ["export the name from the source module or remove it from the import exposing list"]
+    ProgramKindMismatch {} ->
+      ["check higher-kinded parameter annotations and type constructor application arguments"]
+    ProgramTypeArityMismatch {} ->
+      ["apply the type constructor to exactly the number of arguments required by its kind"]
     _ -> []
+
+renderSrcKind :: P.SrcKind -> String
+renderSrcKind = go 0
+  where
+    go :: Int -> P.SrcKind -> String
+    go prec kind0 =
+      case kind0 of
+        P.KType -> "*"
+        P.KArrow left right ->
+          let rendered = go 1 left ++ " -> " ++ go 0 right
+           in if prec > 0 then "(" ++ rendered ++ ")" else rendered
+
+plural :: Int -> String
+plural 1 = ""
+plural _ = "s"
+
+sourceTypeHeadSpan :: SrcType -> P.ProgramSpanIndex -> Maybe P.SourceSpan
+sourceTypeHeadSpan ty index =
+  case sourceTypeHeadName ty of
+    Just name -> lookupAnyName name index
+    Nothing -> Nothing
+
+sourceTypeHeadName :: SrcType -> Maybe String
+sourceTypeHeadName ty =
+  case ty of
+    STVar name -> Just name
+    STBase name -> Just name
+    STCon name _ -> Just name
+    STVarApp name _ -> Just name
+    STArrow dom _ -> sourceTypeHeadName dom
+    STForall _ _ body -> sourceTypeHeadName body
+    STMu _ body -> sourceTypeHeadName body
+    STBottom -> Nothing
 
 data ResolvedScope = ResolvedScope
   { resolvedScopeValues :: Map String ResolvedSymbol,

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2756,6 +2756,48 @@ spec = do
             program <- requireParsed programText
             checkProgram program `shouldSatisfy` isRight
 
+        it "accepts method constraints whose unknown kinds are solved out of order" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (C, Functor, Uses, main) {"
+                        , "  class C a {"
+                        , "  }"
+                        , ""
+                        , "  class Functor (f :: * -> *) {"
+                        , "  }"
+                        , ""
+                        , "  class Uses marker {"
+                        , "    use : (C (f a), Functor a) => marker -> marker;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldSatisfy` isRight
+
+        it "accepts instance constraints whose unknown kinds are solved out of order" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (C, Functor, Higher, main) {"
+                        , "  class C a {"
+                        , "  }"
+                        , ""
+                        , "  class Functor (f :: * -> *) {"
+                        , "  }"
+                        , ""
+                        , "  class Higher (h :: * -> *) {"
+                        , "  }"
+                        , ""
+                        , "  instance (C (f a), Functor a) => Higher a {"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldSatisfy` isRight
+
         it "rejects too many constructor type arguments before later lowering" $ do
             let programText =
                     unlines

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -2735,6 +2735,146 @@ spec = do
             program <- requireParsed programText
             checkProgram program `shouldSatisfy` isRight
 
+        it "accepts higher-kinded declarations when applications match declared kinds" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Functor, Lifted, Higher(..), main) {"
+                        , "  class Functor (f :: * -> *) {"
+                        , "    map : forall a b. (a -> b) -> f a -> f b;"
+                        , "  }"
+                        , ""
+                        , "  class Lifted (f :: * -> *) {"
+                        , "    lift : Functor f => forall a. f a -> f a;"
+                        , "  }"
+                        , ""
+                        , "  data Higher (f :: * -> *) a ="
+                        , "      Higher : a -> Higher f a;"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldSatisfy` isRight
+
+        it "rejects too many constructor type arguments before later lowering" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Bad, main) {"
+                        , "  data Option a ="
+                        , "      None : Option a"
+                        , "    | Some : a -> Option a;"
+                        , ""
+                        , "  data Bad ="
+                        , "      Bad : Option Int Bool -> Bad;"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramTypeArityMismatch "Option" 1 2)
+
+        it "rejects unsaturated type constructors in definition signatures" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Option, main) {"
+                        , "  data Option a ="
+                        , "      None : Option a"
+                        , "    | Some : a -> Option a;"
+                        , ""
+                        , "  def main : Option = None;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramTypeArityMismatch "Option" 1 0)
+
+        it "rejects variable-headed applications whose parameter is first-order" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Bad, main) {"
+                        , "  data Bad (f :: *) ="
+                        , "      Bad : f Int -> Bad f;"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramTypeArityMismatch "f" 0 1)
+
+        it "rejects higher-kinded arguments with first-order types" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Higher, main) {"
+                        , "  data Higher (f :: * -> *) a ="
+                        , "      Higher : a -> Higher Bool a;"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramKindMismatch (STBase "Bool") (KArrow KType KType) KType)
+
+        it "rejects instance constraints that do not match the class parameter kind" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Functor, Eq, main) {"
+                        , "  class Functor (f :: * -> *) {"
+                        , "    map : forall a. f a -> f a;"
+                        , "  }"
+                        , ""
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , ""
+                        , "  instance Functor Bool => Eq Int {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramKindMismatch (STBase "Bool") (KArrow KType KType) KType)
+
+        it "rejects unsaturated type constructors in instance heads" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Eq, Option, main) {"
+                        , "  class Eq a {"
+                        , "    eq : a -> a -> Bool;"
+                        , "  }"
+                        , ""
+                        , "  data Option a ="
+                        , "      None : Option a"
+                        , "    | Some : a -> Option a;"
+                        , ""
+                        , "  instance Eq Option {"
+                        , "    eq = \\x \\y true;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramTypeArityMismatch "Option" 1 0)
+
+        it "rejects instance heads that do not match the class parameter kind" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Functor, main) {"
+                        , "  class Functor (f :: * -> *) {"
+                        , "    map : forall a. f a -> f a;"
+                        , "  }"
+                        , ""
+                        , "  instance Functor Bool {"
+                        , "    map = \\x x;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldBe` Left (ProgramKindMismatch (STBase "Bool") (KArrow KType KType) KType)
+
         it "renders located diagnostics with a mechanically justified hint" $ do
             let programText =
                     unlines


### PR DESCRIPTION
Closes #17.

## Implementation Plan

---
issue_number: 17
pr_number: 39
branch: codex/issue-17
---

## Implementation Plan

1. Refresh branch state before editing: run `git fetch origin`, verify the remote default branch includes merged #15/#16, update local `origin/HEAD` if needed, then rebase `codex/issue-17` onto the refreshed base. If the dependency rebase is not clean, stop and report blocked.

2. Build the kind checker on the #15/#16 source model: use existing `SrcKind`, `TypeParam`, and `STVarApp`; keep the implementation inside the internal `.mlfp` checker boundary, preferably `MLF.Frontend.Program.Check`, unless extracting a small private helper clearly reduces complexity.

3. Add typed program errors and diagnostics for kind failures, including kind mismatch and type-constructor/type-variable application arity mismatch. Messages should name the offending type head or source type, expected kind, and actual kind where possible.

4. Construct a kind environment after symbol resolution and scope assembly: imported/local data types get kind `param1 -> ... -> *` from `dataTypeParams`; local type parameters come from data/class declarations; forall and `mu` binders default to `*`; built-in ground types such as `Int`, `Bool`, and `String` remain `*`.

5. Validate source declarations before elaboration/runtime lowering:
   - data parameter names remain distinct and each constructor signature has kind `*`;
   - constructor result types still target the owning data type and now also satisfy parameter kinds;
   - class method signatures and class constraints are kind-checked, with class constraints requiring the argument kind declared by the class parameter;
   - instance heads and instance constraints are kind-checked against the target class parameter kind;
   - `STCon` and `STVarApp` applications consume arrow kinds one argument at a time, reject too many arguments as arity errors, and reject partially applied results wherever `*` is required.

6. Preserve the #17 boundary: do not implement higher-kinded elaboration/runtime behavior from #18. If valid higher-kinded declarations would otherwise trip existing `STVarApp` runtime lowering, keep the check as a source/static validation pass and avoid changing executable semantics beyond failing earlier with kind diagnostics for ill-kinded programs.

7. Add focused tests in `test/ProgramSpec.hs` covering: valid higher-kinded class/data declarations; invalid variable-head arity; invalid type-constructor arity; kind mismatch in constructor fields/results; kind mismatch in instance heads; class constraints over higher-kinded parameters; and mixed first-order/higher-kinded programs. Keep existing first-order matrix expectations passing.

8. Update docs for the implemented static contract, especially `docs/mlfp-language-reference.md`; update `CHANGELOG.md` because this is meaningful feature progress. Avoid touching watcher-owned state files.

9. Validate with a narrow Hspec slice for the new kind-checking examples, then run `cabal build all && cabal test`. Before publishing, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, and push the existing `codex/issue-17` branch for PR #39.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.