### PR TITLE
Implement #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
   ordinary type constructor application, variable-headed type application,
   class constraints, method signatures, and instance heads. Ill-kinded source
   types now fail before lowering with `ProgramKindMismatch` or
-  `ProgramTypeArityMismatch`, while higher-kinded elaboration and runtime
-  semantics remain fail-closed for the later semantic slice.
+  `ProgramTypeArityMismatch`, while the lower raw eMLF pipeline still fails
+  closed for unresolved variable-headed source types that bypass the `.mlfp`
+  program checker.
 - Added syntax-level `.mlfp` parsing and pretty-printing for variable-headed
   source type applications such as `f a`, including nested and parenthesized
-  argument round trips. Higher-kinded elaboration still fails closed until the
-  follow-up semantic slice.
+  argument round trips. The language reference now documents the supported
+  higher-kinded `.mlfp` subset and remaining unsupported forms.
 - Added `.mlfp` declaration parameter kind metadata. Data and class parameters
   now carry default `*` or parenthesized higher-kinded annotations, the program
   pretty-printer preserves non-first-order declarations, variable-headed source

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -96,31 +96,72 @@ data Option a =
 
 Higher-kinded parameters can be declared with a parenthesized kind annotation.
 Kind arrows associate to the right, so `* -> * -> *` means `* -> (* -> *)`.
+The supported kind language is `*` plus arrows between kinds.
 
 ```mlf
 class Functor (f :: * -> *) {
-  identity : forall a. a -> a;
+  map : forall a b. (a -> b) -> f a -> f b;
 }
 
-data Higher (f :: * -> *) a =
-    Higher : a -> Higher f a;
+class Monad (m :: * -> *) {
+  bind : forall a b. m a -> (a -> m b) -> m b;
+}
+
+class Profunctor (p :: * -> * -> *) {
+  dimap : forall a b c d. (a -> b) -> (c -> d) -> p b c -> p a d;
+}
+
+data Wrap (f :: * -> *) a =
+    Wrap : f a -> Wrap f a;
+
+data WrappedP (p :: * -> * -> *) a b =
+    WrappedP : p a b -> WrappedP p a b;
 ```
 
-Variable-headed type applications such as `f a` are accepted in source types
-and pretty-print back to the same structure:
+These are still single-parameter classes: `Profunctor` takes one class
+parameter `p`, but that parameter itself has kind `* -> * -> *`. The checker
+does not enforce class laws.
+
+Variable-headed type applications such as `f a` and `p a b` are accepted in
+source types and pretty-print back to the same structure:
 
 ```mlf
-data Applied (f :: * -> *) a =
-    Applied : f a -> Applied f a;
+data Box a =
+    Box : a -> Box a;
+
+data MaybeF (f :: * -> *) a =
+    NothingF : MaybeF f a
+  | JustF : f a -> MaybeF f a;
+
+class Boxed (f :: * -> *) {
+  truthy : f Bool -> Bool;
+}
+
+instance Boxed Box {
+  truthy = \box true;
+}
+
+class Uses marker {
+  use : (Boxed f, Functor f) => marker -> marker;
+}
 ```
 
 The checker validates declaration parameter kinds, ordinary and
 variable-headed type applications, class method constraints, instance heads,
 and constructor signatures before lowering. Kind errors are reported as
-`ProgramKindMismatch` or `ProgramTypeArityMismatch`. Higher-kinded
-elaboration and runtime semantics remain follow-up work for #18, so checked
-programs still fail closed if they require lowering a variable-headed source
-type application such as a constructor field of type `f a`.
+`ProgramKindMismatch` or `ProgramTypeArityMismatch`.
+
+Well-kinded higher-kinded classes and data declarations elaborate through the
+`.mlfp` program layer, including representative runtime cases where a
+higher-kinded parameter is instantiated with a concrete constructor head such
+as `Box` in `MaybeF Box Bool`. Direct raw eMLF pipeline inputs that bypass the
+program checker and still contain an unresolved variable-headed type
+application remain fail-closed.
+
+Unsupported forms include using a first-order parameter as a type function,
+unsaturated or over-applied type constructors, mismatched higher-kinded
+arguments such as passing `Bool` where `* -> *` is required, kind polymorphism,
+type lambdas, and type-level computation.
 
 ## Case Expressions And Patterns
 

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -3152,6 +3152,53 @@ spec = do
             program <- requireParsed programText
             checkProgram program `shouldSatisfy` isRight
 
+        it "accepts the higher-kinded language-reference examples" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (Functor, Monad, Profunctor, Box(..), Wrap(..), WrappedP(..), MaybeF(..), main) {"
+                        , "  class Functor (f :: * -> *) {"
+                        , "    map : forall a b. (a -> b) -> f a -> f b;"
+                        , "  }"
+                        , ""
+                        , "  class Monad (m :: * -> *) {"
+                        , "    bind : forall a b. m a -> (a -> m b) -> m b;"
+                        , "  }"
+                        , ""
+                        , "  class Profunctor (p :: * -> * -> *) {"
+                        , "    dimap : forall a b c d. (a -> b) -> (c -> d) -> p b c -> p a d;"
+                        , "  }"
+                        , ""
+                        , "  data Box a ="
+                        , "      Box : a -> Box a;"
+                        , ""
+                        , "  data Wrap (f :: * -> *) a ="
+                        , "      Wrap : f a -> Wrap f a;"
+                        , ""
+                        , "  data WrappedP (p :: * -> * -> *) a b ="
+                        , "      WrappedP : p a b -> WrappedP p a b;"
+                        , ""
+                        , "  data MaybeF (f :: * -> *) a ="
+                        , "      NothingF : MaybeF f a"
+                        , "    | JustF : f a -> MaybeF f a;"
+                        , ""
+                        , "  class Boxed (f :: * -> *) {"
+                        , "    truthy : f Bool -> Bool;"
+                        , "  }"
+                        , ""
+                        , "  instance Boxed Box {"
+                        , "    truthy = \\box true;"
+                        , "  }"
+                        , ""
+                        , "  class Uses marker {"
+                        , "    use : (Boxed f, Functor f) => marker -> marker;"
+                        , "  }"
+                        , ""
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checkProgram program `shouldSatisfy` isRight
+
         it "accepts method constraints whose unknown kinds are solved out of order" $ do
             let programText =
                     unlines


### PR DESCRIPTION
Closes #37.

## Implementation Plan

---
issue_number: 37
pr_number: 41
branch: codex/issue-37
---

## Implementation Plan

Context confirmed during planning:
- Issue #37 is documentation-focused and depends on #16, #17, and #18; all three dependency issues are closed.
- PR #41 is open from `codex/issue-37` to `master`, and the branch currently only has the watcher bootstrap commit.
- `docs/mlfp-language-reference.md` already has a `Type Parameter Kinds` section, but it still says higher-kinded elaboration/runtime semantics are follow-up work for #18. Current tests show representative higher-kinded `.mlfp` programs now run, including higher-kinded class methods, data fields over concrete constructor heads, and mixed higher-kinded constructors.

Steps:
1. Preflight in the implementation turn: read the watcher-written `issue-plan.md`, confirm `git status --short --branch` is on `codex/issue-37`, and avoid staging unrelated dirty files.
2. Update `docs/mlfp-language-reference.md` only where needed around higher-kinded `.mlfp` support:
   - Keep first-order behavior unchanged: data/class parameters default to `*`.
   - Document kind annotations such as `(f :: * -> *)` and `(p :: * -> * -> *)`, with right-associated kind arrows.
   - Expand variable-headed type application syntax examples for `f a` and `p a b` in method signatures, constructor fields/results, constraints, and instance heads.
   - Add representative examples for `Functor`, `Monad`-style unary higher-kinded classes, `Profunctor`-style binary higher-kinded classes, and higher-kinded data declarations such as `Wrap (f :: * -> *) a` / `MaybeF (f :: * -> *) a`.
   - Replace the stale #18 follow-up wording with the current boundary: checked `.mlfp` higher-kinded class/data declarations and representative runtime cases are supported, while unsupported direct low-level variable-headed source types still fail closed.
   - Add a concise unsupported/limits paragraph covering first-order parameters used as type functions, unsaturated or over-applied constructors, kind mismatches, lack of kind polymorphism/type lambdas/type-level computation, and the current single-parameter class lane.
3. Update directly related documentation state if it would otherwise contradict the reference:
   - In `CHANGELOG.md`, revise the existing Unreleased higher-kinded bullets that still say elaboration/runtime semantics remain future work, or add a short correction bullet that points to the documented supported subset and remaining fail-closed limits.
   - Do not update `Bugs.md` for this guidance-only issue.
4. Keep examples synchronized with tests:
   - Prefer examples already represented by `ProgramSpec` higher-kinded rows when possible.
   - If the reference introduces a new exact example shape not covered by existing tests, add one focused `ProgramSpec` check/run case or a small `.mlfp` fixture and wire it through the existing test harness; otherwise avoid test churn.
5. Validate:
   - Always run `git diff --check`.
   - Run focused tests for the documented behavior, at minimum `cabal test mlf2-test --test-show-details=direct --test-options='--match "higher-kinded"'` and `cabal test mlf2-test --test-show-details=direct --test-options='--match "variable-headed"'`.
   - If tests or fixtures are added, also run the relevant `MLF.Program` focused matcher. A full `cabal build all && cabal test` is not required for a pure docs-only edit, but run it if implementation expands beyond documentation/test synchronization.
6. Publish through the existing PR branch only:
   - Run `gh auth status` and `gh auth setup-git` before pushing.
   - Inspect `git status --short` and relevant diffs; stage only issue-related docs/tests.
   - Commit as `codex-watcher <codex-watcher@users.noreply.github.com>` with an imperative message such as `Document higher-kinded mlfp support`.
   - Push `codex/issue-37` to the existing PR #41. Do not create another PR and do not resolve review threads in the implementation turn.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.