### PR TITLE
Implement #20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   programs into the typed backend IR, including backend type conversion,
   fail-closed unsupported-shape diagnostics, explicit ADT construct/case
   recovery, and regression coverage.
+- Preserved constructor-local `forall` bounds in typed backend constructor
+  metadata and enforced those bounds at backend construct/case validation
+  boundaries.
 - Added `.mlfp` source kind checking for declaration parameter annotations,
   ordinary type constructor application, variable-headed type application,
   class constraints, method signatures, and instance heads. Ill-kinded source

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,8 @@ The boundary invariants are:
   `validateBackendProgram`;
 - ADT construction and case analysis are explicit backend nodes checked against
   program constructor metadata for known constructors, constructor arity,
-  argument/result types, case scrutinee type, and alternative result type.
+  constructor-local `forall` bounds, argument/result types, case scrutinee
+  type, and alternative result type.
 
 This module intentionally lives in the private `mlf2-internal` library for now.
 Future conversion/lowering modules should depend on this IR rather than reaching

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1158,7 +1158,11 @@ matchBackendTypeParameters typeBounds parameterBounds =
               True
         Just (Just boundTy)
           | not (alphaEqBackendType boundTy BTBottom) ->
-              let expectedBound = substituteBackendTypes (Map.delete name substitution) boundTy
+              let dependencySubstitution =
+                    completeBackendParameterSubstitution
+                      (Map.delete name parameterBounds)
+                      (Map.delete name substitution)
+                  expectedBound = substituteBackendTypes dependencySubstitution boundTy
                in alphaEqBackendType actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
         _ ->
           True
@@ -1176,11 +1180,40 @@ matchBackendTypeParameters typeBounds parameterBounds =
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map String BackendType -> Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =
-  foldl insertBoundDefault substitution0 (Map.toList parameterBounds)
+  resolveDefaultedBounds defaultedNames substitution1
   where
+    substitution1 =
+      foldl insertBoundDefault substitution0 (Map.toList parameterBounds)
+
+    defaultedNames =
+      Set.fromList
+        [ name
+          | (name, Just boundTy) <- Map.toList parameterBounds,
+            Map.notMember name substitution0,
+            not (alphaEqBackendType boundTy BTBottom)
+        ]
+
     insertBoundDefault substitution (name, Just boundTy)
       | Map.member name substitution = substitution
       | alphaEqBackendType boundTy BTBottom = substitution
       | otherwise = Map.insert name (substituteBackendTypes substitution boundTy) substitution
     insertBoundDefault substitution _ =
       substitution
+
+    resolveDefaultedBounds names =
+      go (Set.size names + Map.size parameterBounds + 1)
+      where
+        go remaining substitution
+          | remaining <= 0 = substitution
+          | substitution' == substitution = substitution
+          | otherwise = go (remaining - 1) substitution'
+          where
+            substitution' =
+              foldl resolveDefaultedBound substitution (Set.toList names)
+
+    resolveDefaultedBound substitution name =
+      case Map.lookup name substitution of
+        Just ty ->
+          Map.insert name (substituteBackendTypes (Map.delete name substitution) ty) substitution
+        Nothing ->
+          substitution

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1163,20 +1163,31 @@ matchBackendTypeParameters typeBounds parameterBounds =
                       (Map.delete name parameterBounds)
                       (Map.delete name substitution)
                   expectedBound = substituteBackendTypes dependencySubstitution boundTy
-               in alphaEqBackendType actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
+               in typeBoundDependenciesMatch actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
         _ ->
           True
+
+    typeBoundDependenciesMatch actual expectedBound =
+      alphaEqBackendType
+        (resolveTypeBoundDependencies actual)
+        (resolveTypeBoundDependencies expectedBound)
 
     actualTypeVariableBoundMatches actual expectedBound =
       case actual of
         BTVar actualName ->
           case Map.lookup actualName typeBounds of
             Just (Just actualBound) ->
-              alphaEqBackendType actualBound expectedBound
+              typeBoundDependenciesMatch actualBound expectedBound
             _ ->
               False
         _ ->
           False
+
+    resolveTypeBoundDependencies =
+      substituteBackendTypes resolvedTypeBounds
+
+    resolvedTypeBounds =
+      completeBackendParameterSubstitution typeBounds Map.empty
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map String BackendType -> Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -82,6 +82,8 @@ data DataMeta = DataMeta
 
 type BackendParameterBounds = Map String (Maybe BackendType)
 
+type BackendTypeBounds = Map String (Maybe BackendType)
+
 data BackendTypeAbsBinder = BackendTypeAbsBinder String (Maybe BackendType)
 
 convertCheckedProgram :: CheckedProgram -> Either BackendConversionError BackendProgram
@@ -196,7 +198,7 @@ sourceBoundToElabBound (SrcBound boundTy) =
 
 constructorBindingResultMatches :: BackendType -> ConstructorMeta -> Bool
 constructorBindingResultMatches bindingTy constructorMeta =
-  case matchBackendTypeParameters parameters Map.empty (backendConstructorResult constructor) resultTy of
+  case matchBackendTypeParameters Map.empty parameters Map.empty (backendConstructorResult constructor) resultTy of
     Just _ -> True
     Nothing -> False
   where
@@ -712,9 +714,10 @@ convertConstructorApplication context env term resultTy =
                   rawFields = backendConstructorFields constructor
               if length args == length rawFields
                 then do
+                  typeBounds <- backendTypeBoundsFromEnv env
                   initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
                   resultSubstitution <-
-                    case matchBackendTypeParameters parameters initialSubstitution (backendConstructorResult constructor) resultTy of
+                    case matchBackendTypeParameters typeBounds parameters initialSubstitution (backendConstructorResult constructor) resultTy of
                       Just substitution -> Right substitution
                       Nothing ->
                         Left
@@ -723,7 +726,7 @@ convertConstructorApplication context env term resultTy =
                           )
                   substitution <-
                     foldM
-                      (matchConstructorApplicationArgument env parameters)
+                      (matchConstructorApplicationArgument env typeBounds parameters)
                       resultSubstitution
                       (zip rawFields args)
                   let completedSubstitution = completeBackendParameterSubstitution parameters substitution
@@ -836,7 +839,9 @@ convertCaseApplication context env term resultTy =
           dataMeta <-
             case mbScrutineeData of
               Just scrutineeData -> Right scrutineeData
-              Nothing -> requireCaseData context (backendExprType scrutineeExpr)
+              Nothing -> do
+                typeBounds <- backendTypeBoundsFromEnv env
+                requireCaseData context typeBounds (backendExprType scrutineeExpr)
           let constructors = backendDataConstructors (dmBackend dataMeta)
           case compare (length args) (length constructors) of
             EQ -> Just <$> convertCaseWithHandlers context env resultTy scrutineeExpr constructors args
@@ -917,10 +922,11 @@ constructorApplicationResultType context env term =
           case Map.lookup constructorName (ccConstructors context) of
             Just constructorMeta
               | length args == length fields -> do
+                  typeBounds <- backendTypeBoundsFromEnv env
                   initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
                   substitution <-
                     foldM
-                      (matchConstructorApplicationArgument env parameters)
+                      (matchConstructorApplicationArgument env typeBounds parameters)
                       initialSubstitution
                       (zip fields args)
                   let resultTy =
@@ -938,24 +944,25 @@ constructorApplicationResultType context env term =
 
 matchConstructorApplicationArgument ::
   Env ->
+  BackendTypeBounds ->
   BackendParameterBounds ->
   Map String BackendType ->
   (BackendType, ElabTerm) ->
   Either BackendConversionError (Map String BackendType)
-matchConstructorApplicationArgument env parameters substitution (expectedTy, arg) =
+matchConstructorApplicationArgument env typeBounds parameters substitution (expectedTy, arg) =
   -- This is only a best-effort way to recover constructor type parameters.
   -- Expected-type conversion of the argument remains authoritative because it
   -- can canonicalize nested constructor applications before validation.
   case inferBackendType env arg of
     Right actualTy ->
-      case matchBackendTypeParameters parameters substitution expectedTy actualTy of
+      case matchBackendTypeParameters typeBounds parameters substitution expectedTy actualTy of
         Just substitution' -> Right substitution'
         Nothing -> Right substitution
     Left _ -> Right substitution
 
-requireCaseData :: ConvertContext -> BackendType -> Either BackendConversionError DataMeta
-requireCaseData context scrutineeTy =
-  case filter (dataMatchesScrutinee scrutineeTy) (ccData context) of
+requireCaseData :: ConvertContext -> BackendTypeBounds -> BackendType -> Either BackendConversionError DataMeta
+requireCaseData context typeBounds scrutineeTy =
+  case filter (dataMatchesScrutinee typeBounds scrutineeTy) (ccData context) of
     [dataMeta] -> Right dataMeta
     [] -> Left (BackendUnsupportedCaseShape ("no backend data matches scrutinee type " ++ show scrutineeTy))
     matches ->
@@ -964,11 +971,11 @@ requireCaseData context scrutineeTy =
             ("ambiguous backend data matches scrutinee type " ++ show scrutineeTy ++ ": " ++ show (map (backendDataName . dmBackend) matches))
         )
 
-dataMatchesScrutinee :: BackendType -> DataMeta -> Bool
-dataMatchesScrutinee scrutineeTy dataMeta =
+dataMatchesScrutinee :: BackendTypeBounds -> BackendType -> DataMeta -> Bool
+dataMatchesScrutinee typeBounds scrutineeTy dataMeta =
   any
     ( \constructor ->
-        case matchBackendTypeParameters (constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor) Map.empty (backendConstructorResult constructor) scrutineeTy of
+        case matchBackendTypeParameters typeBounds (constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor) Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just _ -> True
           Nothing -> False
     )
@@ -1048,6 +1055,13 @@ extendTypeEnv :: String -> ElabType -> Env -> Env
 extendTypeEnv name ty env =
   env {typeEnv = Map.insert name ty (typeEnv env)}
 
+backendTypeBoundsFromEnv :: Env -> Either BackendConversionError BackendTypeBounds
+backendTypeBoundsFromEnv env =
+  traverse convertTypeBound (typeEnv env)
+  where
+    convertTypeBound TBottom = Right Nothing
+    convertTypeBound boundTy = Just <$> convertElabType boundTy
+
 zipWithMCase ::
   (BackendConstructor -> ElabTerm -> Either BackendConversionError BackendAlternative) ->
   [BackendConstructor] ->
@@ -1061,12 +1075,13 @@ zipWithMCase f constructors handlers =
       Left (BackendUnsupportedCaseShape "case expression has no alternatives")
 
 matchBackendTypeParameters ::
+  BackendTypeBounds ->
   BackendParameterBounds ->
   Map String BackendType ->
   BackendType ->
   BackendType ->
   Maybe (Map String BackendType)
-matchBackendTypeParameters parameterBounds =
+matchBackendTypeParameters typeBounds parameterBounds =
   go Map.empty Map.empty
   where
     go leftEnv rightEnv substitution expected actual =
@@ -1143,9 +1158,21 @@ matchBackendTypeParameters parameterBounds =
               True
         Just (Just boundTy)
           | not (alphaEqBackendType boundTy BTBottom) ->
-              alphaEqBackendType actual (substituteBackendTypes (Map.delete name substitution) boundTy)
+              let expectedBound = substituteBackendTypes (Map.delete name substitution) boundTy
+               in alphaEqBackendType actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
         _ ->
           True
+
+    actualTypeVariableBoundMatches actual expectedBound =
+      case actual of
+        BTVar actualName ->
+          case Map.lookup actualName typeBounds of
+            Just (Just actualBound) ->
+              alphaEqBackendType actualBound expectedBound
+            _ ->
+              False
+        _ ->
+          False
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map String BackendType -> Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -80,7 +80,9 @@ data DataMeta = DataMeta
     dmBackend :: BackendData
   }
 
-data BackendTypeBinder = BackendTypeBinder String (Maybe BackendType)
+type BackendParameterBounds = Map String (Maybe BackendType)
+
+data BackendTypeAbsBinder = BackendTypeAbsBinder String (Maybe BackendType)
 
 convertCheckedProgram :: CheckedProgram -> Either BackendConversionError BackendProgram
 convertCheckedProgram checked = do
@@ -199,7 +201,7 @@ constructorBindingResultMatches bindingTy constructorMeta =
     Nothing -> False
   where
     constructor = cmBackend constructorMeta
-    parameters = Set.fromList (backendDataParameters (dmBackend (cmData constructorMeta)))
+    parameters = constructorTypeParameters constructorMeta
     (_, bodyTy) = splitBackendForalls bindingTy
     (_, resultTy) = splitBackendArrows bodyTy
 
@@ -232,13 +234,13 @@ synthesizeConstructorBinding bindingTy constructorMeta = do
       )
   Right expr
 
-splitBackendForalls :: BackendType -> ([BackendTypeBinder], BackendType)
+splitBackendForalls :: BackendType -> ([BackendTypeAbsBinder], BackendType)
 splitBackendForalls =
   go []
   where
     go binders ty =
       case ty of
-        BTForall name mbBound body -> go (binders ++ [BackendTypeBinder name mbBound]) body
+        BTForall name mbBound body -> go (binders ++ [BackendTypeAbsBinder name mbBound]) body
         _ -> (binders, ty)
 
 splitBackendArrows :: BackendType -> ([BackendType], BackendType)
@@ -250,11 +252,11 @@ splitBackendArrows =
         BTArrow arg result -> go (args ++ [arg]) result
         _ -> (args, ty)
 
-wrapBackendTypeAbs :: [BackendTypeBinder] -> BackendExpr -> BackendExpr
+wrapBackendTypeAbs :: [BackendTypeAbsBinder] -> BackendExpr -> BackendExpr
 wrapBackendTypeAbs binders body =
   foldr wrap body binders
   where
-    wrap (BackendTypeBinder name mbBound) expr =
+    wrap (BackendTypeAbsBinder name mbBound) expr =
       BackendTyAbs
         { backendExprType = BTForall name mbBound (backendExprType expr),
           backendTyParamName = name,
@@ -456,15 +458,20 @@ convertDataInfo context info =
 
 convertConstructorInfo :: ElaborateScope -> ConstructorInfo -> Either BackendConversionError BackendConstructor
 convertConstructorInfo scope info = do
+  foralls <- mapM (convertConstructorForall scope) (ctorForalls info)
   fields <- mapM (convertLoweredSourceType scope) (ctorArgs info)
   resultTy <- convertLoweredSourceType scope (ctorResult info)
   Right
     BackendConstructor
       { backendConstructorName = ctorRuntimeName info,
-        backendConstructorForalls = map fst (ctorForalls info),
+        backendConstructorForalls = foralls,
         backendConstructorFields = fields,
         backendConstructorResult = resultTy
       }
+
+convertConstructorForall :: ElaborateScope -> (String, Maybe SrcType) -> Either BackendConversionError BackendTypeBinder
+convertConstructorForall scope (name, mbBound) =
+  BackendTypeBinder name <$> traverse (convertLoweredSourceType scope) mbBound
 
 convertLoweredSourceType :: ElaborateScope -> SrcType -> Either BackendConversionError BackendType
 convertLoweredSourceType scope =
@@ -719,7 +726,8 @@ convertConstructorApplication context env term resultTy =
                       (matchConstructorApplicationArgument env parameters)
                       resultSubstitution
                       (zip rawFields args)
-                  let fields = map (substituteBackendTypes substitution) rawFields
+                  let completedSubstitution = completeBackendParameterSubstitution parameters substitution
+                      fields = map (substituteBackendTypes completedSubstitution) rawFields
                   argExprs <- zipWithM (convertTermExpected context env . Just) fields args
                   Right
                     ( Just
@@ -733,9 +741,17 @@ convertConstructorApplication context env term resultTy =
             Nothing -> Right Nothing
         Nothing -> Right Nothing
 
-constructorTypeParameters :: ConstructorMeta -> Set.Set String
+constructorTypeParameters :: ConstructorMeta -> BackendParameterBounds
 constructorTypeParameters constructorMeta =
-  Set.fromList (backendDataParameters (dmBackend (cmData constructorMeta)) ++ backendConstructorForalls (cmBackend constructorMeta))
+  constructorTypeParameterBoundsFor (dmBackend (cmData constructorMeta)) (cmBackend constructorMeta)
+
+constructorTypeParameterBoundsFor :: BackendData -> BackendConstructor -> BackendParameterBounds
+constructorTypeParameterBoundsFor dataDecl constructor =
+  Map.fromList $
+    [(name, Nothing) | name <- backendDataParameters dataDecl]
+      ++ [ (backendTypeBinderName binder, backendTypeBinderBound binder)
+           | binder <- backendConstructorForalls constructor
+         ]
 
 constructorTypeApplicationSubstitution ::
   ConstructorMeta ->
@@ -749,7 +765,7 @@ constructorTypeApplicationSubstitution constructorMeta typeArgs =
 constructorTypeApplicationParameterNames :: ConstructorMeta -> [String]
 constructorTypeApplicationParameterNames constructorMeta =
   sort (Set.toList (freeSourceTypeVars (ctorType (cmInfo constructorMeta))))
-    ++ map fst (ctorForalls (cmInfo constructorMeta))
+    ++ map backendTypeBinderName (backendConstructorForalls (cmBackend constructorMeta))
 
 freeSourceTypeVars :: SrcType -> Set.Set String
 freeSourceTypeVars =
@@ -907,7 +923,10 @@ constructorApplicationResultType context env term =
                       (matchConstructorApplicationArgument env parameters)
                       initialSubstitution
                       (zip fields args)
-                  let resultTy = substituteBackendTypes substitution (backendConstructorResult constructor)
+                  let resultTy =
+                        substituteBackendTypes
+                          (completeBackendParameterSubstitution parameters substitution)
+                          (backendConstructorResult constructor)
                   Right (Just (resultTy, Just (cmData constructorMeta)))
               | otherwise -> Right Nothing
               where
@@ -919,7 +938,7 @@ constructorApplicationResultType context env term =
 
 matchConstructorApplicationArgument ::
   Env ->
-  Set.Set String ->
+  BackendParameterBounds ->
   Map String BackendType ->
   (BackendType, ElabTerm) ->
   Either BackendConversionError (Map String BackendType)
@@ -949,7 +968,7 @@ dataMatchesScrutinee :: BackendType -> DataMeta -> Bool
 dataMatchesScrutinee scrutineeTy dataMeta =
   any
     ( \constructor ->
-        case matchBackendTypeParameters (Set.fromList (backendDataParameters (dmBackend dataMeta) ++ backendConstructorForalls constructor)) Map.empty (backendConstructorResult constructor) scrutineeTy of
+        case matchBackendTypeParameters (constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor) Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just _ -> True
           Nothing -> False
     )
@@ -1042,18 +1061,18 @@ zipWithMCase f constructors handlers =
       Left (BackendUnsupportedCaseShape "case expression has no alternatives")
 
 matchBackendTypeParameters ::
-  Set.Set String ->
+  BackendParameterBounds ->
   Map String BackendType ->
   BackendType ->
   BackendType ->
   Maybe (Map String BackendType)
-matchBackendTypeParameters parameters =
+matchBackendTypeParameters parameterBounds =
   go Map.empty Map.empty
   where
     go leftEnv rightEnv substitution expected actual =
       case expected of
         BTVar name
-          | Set.member name parameters,
+          | Map.member name parameterBounds,
             Map.notMember name leftEnv ->
               insertParameterSubstitution name actual substitution
         _ ->
@@ -1108,7 +1127,33 @@ matchBackendTypeParameters parameters =
 
     insertParameterSubstitution name actual substitution =
       case Map.lookup name substitution of
-        Nothing -> Just (Map.insert name actual substitution)
+        Nothing ->
+          if backendParameterBoundMatches name actual substitution
+            then Just (Map.insert name actual substitution)
+            else Nothing
         Just previous
-          | alphaEqBackendType previous actual -> Just substitution
+          | alphaEqBackendType previous actual && backendParameterBoundMatches name previous substitution -> Just substitution
         _ -> Nothing
+
+    backendParameterBoundMatches name actual substitution =
+      case Map.lookup name parameterBounds of
+        Just (Just _)
+          | BTVar actualName <- actual,
+            actualName == name ->
+              True
+        Just (Just boundTy)
+          | not (alphaEqBackendType boundTy BTBottom) ->
+              alphaEqBackendType actual (substituteBackendTypes (Map.delete name substitution) boundTy)
+        _ ->
+          True
+
+completeBackendParameterSubstitution :: BackendParameterBounds -> Map String BackendType -> Map String BackendType
+completeBackendParameterSubstitution parameterBounds substitution0 =
+  foldl insertBoundDefault substitution0 (Map.toList parameterBounds)
+  where
+    insertBoundDefault substitution (name, Just boundTy)
+      | Map.member name substitution = substitution
+      | alphaEqBackendType boundTy BTBottom = substitution
+      | otherwise = Map.insert name (substituteBackendTypes substitution boundTy) substitution
+    insertBoundDefault substitution _ =
+      substitution

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -518,8 +518,26 @@ validateBackendVariable (Just context0) name actualTy =
     Nothing ->
       Left (BackendUnknownVariable name)
     Just expectedTy ->
-      unless (alphaEqBackendType actualTy expectedTy) $
+      unless (backendVariableTypeMatches (bvcTypeBounds context0) expectedTy actualTy) $
         Left (BackendVariableTypeMismatch name expectedTy actualTy)
+
+backendVariableTypeMatches :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
+backendVariableTypeMatches typeBounds expectedTy actualTy =
+  alphaEqBackendType actualTy expectedTy
+    || typeVariableBoundMatches expectedTy actualTy
+    || typeVariableBoundMatches actualTy expectedTy
+  where
+    typeVariableBoundMatches ty otherTy =
+      case ty of
+        BTVar name ->
+          case Map.lookup name typeBounds of
+            Just (Just boundTy)
+              | not (alphaEqBackendType boundTy BTBottom) ->
+                  alphaEqBackendType otherTy boundTy
+            _ ->
+              False
+        _ ->
+          False
 
 validateBackendTypeArgumentBound :: Maybe BackendType -> BackendType -> Either BackendValidationError ()
 validateBackendTypeArgumentBound Nothing _ =
@@ -551,6 +569,10 @@ extendLocals context0 bindings =
 extendTypeBoundMaybe :: Maybe BackendValidationContext -> String -> Maybe BackendType -> Maybe BackendValidationContext
 extendTypeBoundMaybe mbContext name mbBound =
   fmap (\context0 -> context0 {bvcTypeBounds = Map.insert name mbBound (bvcTypeBounds context0)}) mbContext
+
+extendTypeBounds :: BackendValidationContext -> [(String, Maybe BackendType)] -> BackendValidationContext
+extendTypeBounds context0 bounds =
+  context0 {bvcTypeBounds = foldr (uncurry Map.insert) (bvcTypeBounds context0) bounds}
 
 validateBackendConstructorUse :: Maybe BackendValidationContext -> String -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
 validateBackendConstructorUse Nothing _ _ _ =
@@ -622,8 +644,21 @@ validateBackendPattern (Just context0) scrutineeTy (BackendConstructorPattern na
         case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
-      let instantiatedFields = map (substituteBackendTypes (completeBackendParameterSubstitution parameters substitution)) fields
-      pure (Just (extendLocals context0 (zip binders instantiatedFields)))
+      let instantiatedFields = map (substituteBackendTypes substitution) fields
+          contextForBody =
+            extendTypeBounds
+              context0
+              (constructorPatternTypeBounds substitution constructor)
+      pure (Just (extendLocals contextForBody (zip binders instantiatedFields)))
+
+constructorPatternTypeBounds :: Map.Map String BackendType -> BackendConstructor -> [(String, Maybe BackendType)]
+constructorPatternTypeBounds substitution constructor =
+  [ (name, fmap (substituteBackendTypes substitution) mbBound)
+    | binder <- backendConstructorForalls constructor,
+      let name = backendTypeBinderName binder,
+      let mbBound = backendTypeBinderBound binder,
+      Map.notMember name substitution
+  ]
 
 constructorTypeParameterBounds :: BackendConstructorInfo -> BackendParameterBounds
 constructorTypeParameterBounds constructorInfo =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -825,7 +825,11 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
       case Map.lookup name parameterBounds of
         Just (Just boundTy)
           | not (alphaEqBackendType boundTy BTBottom) ->
-              let expectedBound = substituteBackendTypes (Map.delete name substitution) boundTy
+              let dependencySubstitution =
+                    completeBackendParameterSubstitution
+                      (Map.delete name parameterBounds)
+                      (Map.delete name substitution)
+                  expectedBound = substituteBackendTypes dependencySubstitution boundTy
                in alphaEqBackendType actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
         _ ->
           True
@@ -843,14 +847,43 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map.Map String BackendType -> Map.Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =
-  foldl insertBoundDefault substitution0 (Map.toList parameterBounds)
+  resolveDefaultedBounds defaultedNames substitution1
   where
+    substitution1 =
+      foldl insertBoundDefault substitution0 (Map.toList parameterBounds)
+
+    defaultedNames =
+      Set.fromList
+        [ name
+          | (name, Just boundTy) <- Map.toList parameterBounds,
+            Map.notMember name substitution0,
+            not (alphaEqBackendType boundTy BTBottom)
+        ]
+
     insertBoundDefault substitution (name, Just boundTy)
       | Map.member name substitution = substitution
       | alphaEqBackendType boundTy BTBottom = substitution
       | otherwise = Map.insert name (substituteBackendTypes substitution boundTy) substitution
     insertBoundDefault substitution _ =
       substitution
+
+    resolveDefaultedBounds names =
+      go (Set.size names + Map.size parameterBounds + 1)
+      where
+        go remaining substitution
+          | remaining <= 0 = substitution
+          | substitution' == substitution = substitution
+          | otherwise = go (remaining - 1) substitution'
+          where
+            substitution' =
+              foldl resolveDefaultedBound substitution (Set.toList names)
+
+    resolveDefaultedBound substitution name =
+      case Map.lookup name substitution of
+        Just ty ->
+          Map.insert name (substituteBackendTypes (Map.delete name substitution) ty) substitution
+        Nothing ->
+          substitution
 
 requireUnique :: (String -> BackendValidationError) -> [String] -> Either BackendValidationError ()
 requireUnique mkError names =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -691,21 +691,62 @@ validateBackendPattern (Just context0) scrutineeTy (BackendConstructorPattern na
         case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
-      let instantiatedFields = map (substituteBackendTypes substitution) fields
+      let fresheningSubstitution = constructorPatternFresheningSubstitution context0 substitution constructor
+          patternSubstitution = Map.union fresheningSubstitution substitution
+          instantiatedFields = map (substituteBackendTypes patternSubstitution) fields
           contextForBody =
             extendTypeBounds
               context0
-              (constructorPatternTypeBounds substitution constructor)
+              (constructorPatternTypeBounds substitution fresheningSubstitution constructor)
       pure (Just (extendLocals contextForBody (zip binders instantiatedFields)))
 
-constructorPatternTypeBounds :: Map.Map String BackendType -> BackendConstructor -> [(String, Maybe BackendType)]
-constructorPatternTypeBounds substitution constructor =
-  [ (name, fmap (substituteBackendTypes substitution) mbBound)
+constructorPatternFresheningSubstitution ::
+  BackendValidationContext ->
+  Map.Map String BackendType ->
+  BackendConstructor ->
+  Map.Map String BackendType
+constructorPatternFresheningSubstitution context0 substitution constructor =
+  snd (foldl freshen (reservedNames0, Map.empty) unresolvedNames)
+  where
+    unresolvedNames =
+      [ backendTypeBinderName binder
+        | binder <- backendConstructorForalls constructor,
+          Map.notMember (backendTypeBinderName binder) substitution
+      ]
+
+    externalNames =
+      Set.union (Map.keysSet (bvcTypeBounds context0)) (freeBackendTypeVarsIn substitution)
+
+    reservedNames0 =
+      Set.union externalNames (Set.fromList unresolvedNames)
+
+    freshen (reservedNames, freshening) name
+      | Set.member name externalNames =
+          let freshName = freshNameLike name reservedNames
+           in (Set.insert freshName reservedNames, Map.insert name (BTVar freshName) freshening)
+      | otherwise =
+          (Set.insert name reservedNames, freshening)
+
+constructorPatternTypeBounds ::
+  Map.Map String BackendType ->
+  Map.Map String BackendType ->
+  BackendConstructor ->
+  [(String, Maybe BackendType)]
+constructorPatternTypeBounds substitution fresheningSubstitution constructor =
+  [ (freshenedName name, fmap (substituteBackendTypes patternSubstitution) mbBound)
     | binder <- backendConstructorForalls constructor,
       let name = backendTypeBinderName binder,
       let mbBound = backendTypeBinderBound binder,
       Map.notMember name substitution
   ]
+  where
+    patternSubstitution =
+      Map.union fresheningSubstitution substitution
+
+    freshenedName name =
+      case Map.lookup name fresheningSubstitution of
+        Just (BTVar freshName) -> freshName
+        _ -> name
 
 constructorTypeParameterBounds :: BackendConstructorInfo -> BackendParameterBounds
 constructorTypeParameterBounds constructorInfo =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -39,6 +39,7 @@ module MLF.Backend.IR
     BackendBinding (..),
     BackendData (..),
     BackendConstructor (..),
+    BackendTypeBinder (..),
     BackendType (..),
     BackendExpr (..),
     BackendAlternative (..),
@@ -95,9 +96,15 @@ data BackendData = BackendData
 
 data BackendConstructor = BackendConstructor
   { backendConstructorName :: String,
-    backendConstructorForalls :: [String],
+    backendConstructorForalls :: [BackendTypeBinder],
     backendConstructorFields :: [BackendType],
     backendConstructorResult :: BackendType
+  }
+  deriving (Eq, Show)
+
+data BackendTypeBinder = BackendTypeBinder
+  { backendTypeBinderName :: String,
+    backendTypeBinderBound :: Maybe BackendType
   }
   deriving (Eq, Show)
 
@@ -228,13 +235,16 @@ data BackendValidationError
 data BackendValidationContext = BackendValidationContext
   { bvcGlobals :: Map.Map String BackendType,
     bvcConstructors :: Map.Map String BackendConstructorInfo,
-    bvcLocals :: Map.Map String BackendType
+    bvcLocals :: Map.Map String BackendType,
+    bvcTypeBounds :: Map.Map String (Maybe BackendType)
   }
 
 data BackendConstructorInfo = BackendConstructorInfo
   { bciDataParameters :: [String],
     bciConstructor :: BackendConstructor
   }
+
+type BackendParameterBounds = Map.Map String (Maybe BackendType)
 
 literalBackendType :: Lit -> BackendType
 literalBackendType = \case
@@ -400,7 +410,8 @@ validateBackendProgram program = do
       BackendValidationContext
         { bvcGlobals = Map.fromList [(backendBindingName binding, backendBindingType binding) | binding <- bindings],
           bvcConstructors = Map.fromList constructorInfos,
-          bvcLocals = Map.empty
+          bvcLocals = Map.empty,
+          bvcTypeBounds = Map.empty
         }
 
 -- | Validate a binding without a program context. This checks local carried
@@ -462,7 +473,7 @@ validateBackendExprWith mbContext expr =
       unless (alphaEqBackendType (backendExprType body) resultTy) $
         Left (BackendLetBodyTypeMismatch resultTy (backendExprType body))
     BackendTyAbs resultTy name mbBound body -> do
-      validateBackendExprWith mbContext body
+      validateBackendExprWith (extendTypeBoundMaybe mbContext name mbBound) body
       let expected = BTForall name mbBound (backendExprType body)
       unless (alphaEqBackendType resultTy expected) $
         Left (BackendTypeAbsTypeMismatch name resultTy expected)
@@ -537,6 +548,10 @@ extendLocals :: BackendValidationContext -> [(String, BackendType)] -> BackendVa
 extendLocals context0 bindings =
   context0 {bvcLocals = foldr (uncurry Map.insert) (bvcLocals context0) bindings}
 
+extendTypeBoundMaybe :: Maybe BackendValidationContext -> String -> Maybe BackendType -> Maybe BackendValidationContext
+extendTypeBoundMaybe mbContext name mbBound =
+  fmap (\context0 -> context0 {bvcTypeBounds = Map.insert name mbBound (bvcTypeBounds context0)}) mbContext
+
 validateBackendConstructorUse :: Maybe BackendValidationContext -> String -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
 validateBackendConstructorUse Nothing _ _ _ =
   pure ()
@@ -546,29 +561,30 @@ validateBackendConstructorUse (Just context0) name resultTy args =
       Left (BackendUnknownConstructor name)
     Just constructorInfo -> do
       let constructor = bciConstructor constructorInfo
-          parameters = constructorTypeParameters constructorInfo
+          parameters = constructorTypeParameterBounds constructorInfo
           fields = backendConstructorFields constructor
       unless (length fields == length args) $
         Left (BackendConstructorArityMismatch name (length fields) (length args))
       substitution <-
-        case matchBackendTypeParameters parameters Map.empty (backendConstructorResult constructor) resultTy of
+        case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) parameters Map.empty (backendConstructorResult constructor) resultTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
       _ <-
         foldM
-          (validateBackendConstructorArgument parameters name)
+          (validateBackendConstructorArgument (bvcTypeBounds context0) parameters name)
           substitution
           (zip [0 ..] (zip fields args))
       pure ()
 
 validateBackendConstructorArgument ::
-  Set.Set String ->
+  Map.Map String (Maybe BackendType) ->
+  BackendParameterBounds ->
   String ->
   Map.Map String BackendType ->
   (Int, (BackendType, BackendExpr)) ->
   Either BackendValidationError (Map.Map String BackendType)
-validateBackendConstructorArgument parameters name substitution (index0, (expectedTy, arg)) =
-  case matchBackendTypeParameters parameters substitution expectedTy (backendExprType arg) of
+validateBackendConstructorArgument typeBounds parameters name substitution (index0, (expectedTy, arg)) =
+  case matchBackendTypeParametersWithTypeBounds typeBounds parameters substitution expectedTy (backendExprType arg) of
     Just substitution' ->
       pure substitution'
     Nothing ->
@@ -576,7 +592,7 @@ validateBackendConstructorArgument parameters name substitution (index0, (expect
         ( BackendConstructorArgumentMismatch
             name
             index0
-            (substituteBackendTypes substitution expectedTy)
+            (substituteBackendTypes (completeBackendParameterSubstitution parameters substitution) expectedTy)
             (backendExprType arg)
         )
 
@@ -597,40 +613,45 @@ validateBackendPattern (Just context0) scrutineeTy (BackendConstructorPattern na
       Left (BackendUnknownConstructor name)
     Just constructorInfo -> do
       let constructor = bciConstructor constructorInfo
-          parameters = constructorTypeParameters constructorInfo
+          parameters = constructorTypeParameterBounds constructorInfo
           fields = backendConstructorFields constructor
       requireUnique BackendDuplicatePatternBinding binders
       unless (length fields == length binders) $
         Left (BackendPatternArityMismatch name (length fields) (length binders))
       substitution <-
-        case matchBackendTypeParameters parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
+        case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
-      let instantiatedFields = map (substituteBackendTypes substitution) fields
+      let instantiatedFields = map (substituteBackendTypes (completeBackendParameterSubstitution parameters substitution)) fields
       pure (Just (extendLocals context0 (zip binders instantiatedFields)))
 
-constructorTypeParameters :: BackendConstructorInfo -> Set.Set String
-constructorTypeParameters constructorInfo =
-  Set.fromList (bciDataParameters constructorInfo ++ backendConstructorForalls (bciConstructor constructorInfo))
+constructorTypeParameterBounds :: BackendConstructorInfo -> BackendParameterBounds
+constructorTypeParameterBounds constructorInfo =
+  Map.fromList $
+    [(name, Nothing) | name <- bciDataParameters constructorInfo]
+      ++ [ (backendTypeBinderName binder, backendTypeBinderBound binder)
+           | binder <- backendConstructorForalls (bciConstructor constructorInfo)
+         ]
 
 validateCaseAlternative :: BackendType -> BackendAlternative -> Either BackendValidationError ()
 validateCaseAlternative resultTy alternative =
   unless (alphaEqBackendType (backendExprType (backendAltBody alternative)) resultTy) $
     Left (BackendCaseResultMismatch resultTy (backendExprType (backendAltBody alternative)))
 
-matchBackendTypeParameters ::
-  Set.Set String ->
+matchBackendTypeParametersWithTypeBounds ::
+  Map.Map String (Maybe BackendType) ->
+  BackendParameterBounds ->
   Map.Map String BackendType ->
   BackendType ->
   BackendType ->
   Maybe (Map.Map String BackendType)
-matchBackendTypeParameters parameters =
+matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
   go Set.empty
   where
     go bound substitution expected actual =
       case expected of
         BTVar name
-          | Set.member name parameters && Set.notMember name bound ->
+          | Map.member name parameterBounds && Set.notMember name bound ->
               insertParameterSubstitution name actual substitution
         _ ->
           case (expected, actual) of
@@ -666,7 +687,7 @@ matchBackendTypeParameters parameters =
                       [ Set.fromList [expectedName, actualName],
                         Map.keysSet substitution',
                         freeBackendTypeVarsIn substitution',
-                        parameters,
+                        Map.keysSet parameterBounds,
                         freeBackendTypeVars expectedBody,
                         freeBackendTypeVars actualBody,
                         maybe Set.empty freeBackendTypeVars expectedBound,
@@ -682,7 +703,7 @@ matchBackendTypeParameters parameters =
                       [ Set.fromList [expectedName, actualName],
                         Map.keysSet substitution,
                         freeBackendTypeVarsIn substitution,
-                        parameters,
+                        Map.keysSet parameterBounds,
                         freeBackendTypeVars expectedBody,
                         freeBackendTypeVars actualBody
                       ]
@@ -709,12 +730,45 @@ matchBackendTypeParameters parameters =
     insertParameterSubstitution name actual substitution =
       case Map.lookup name substitution of
         Nothing ->
-          Just (Map.insert name actual substitution)
+          if backendParameterBoundMatches name actual substitution
+            then Just (Map.insert name actual substitution)
+            else Nothing
         Just previous
-          | alphaEqBackendType previous actual ->
+          | alphaEqBackendType previous actual && backendParameterBoundMatches name previous substitution ->
               Just substitution
         _ ->
           Nothing
+
+    backendParameterBoundMatches name actual substitution =
+      case Map.lookup name parameterBounds of
+        Just (Just boundTy)
+          | not (alphaEqBackendType boundTy BTBottom) ->
+              let expectedBound = substituteBackendTypes (Map.delete name substitution) boundTy
+               in alphaEqBackendType actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
+        _ ->
+          True
+
+    actualTypeVariableBoundMatches actual expectedBound =
+      case actual of
+        BTVar actualName ->
+          case Map.lookup actualName typeBounds of
+            Just (Just actualBound) ->
+              alphaEqBackendType actualBound expectedBound
+            _ ->
+              False
+        _ ->
+          False
+
+completeBackendParameterSubstitution :: BackendParameterBounds -> Map.Map String BackendType -> Map.Map String BackendType
+completeBackendParameterSubstitution parameterBounds substitution0 =
+  foldl insertBoundDefault substitution0 (Map.toList parameterBounds)
+  where
+    insertBoundDefault substitution (name, Just boundTy)
+      | Map.member name substitution = substitution
+      | alphaEqBackendType boundTy BTBottom = substitution
+      | otherwise = Map.insert name (substituteBackendTypes substitution boundTy) substitution
+    insertBoundDefault substitution _ =
+      substitution
 
 requireUnique :: (String -> BackendValidationError) -> [String] -> Either BackendValidationError ()
 requireUnique mkError names =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -830,20 +830,31 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
                       (Map.delete name parameterBounds)
                       (Map.delete name substitution)
                   expectedBound = substituteBackendTypes dependencySubstitution boundTy
-               in alphaEqBackendType actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
+               in typeBoundDependenciesMatch actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
         _ ->
           True
+
+    typeBoundDependenciesMatch actual expectedBound =
+      alphaEqBackendType
+        (resolveTypeBoundDependencies actual)
+        (resolveTypeBoundDependencies expectedBound)
 
     actualTypeVariableBoundMatches actual expectedBound =
       case actual of
         BTVar actualName ->
           case Map.lookup actualName typeBounds of
             Just (Just actualBound) ->
-              alphaEqBackendType actualBound expectedBound
+              typeBoundDependenciesMatch actualBound expectedBound
             _ ->
               False
         _ ->
           False
+
+    resolveTypeBoundDependencies =
+      substituteBackendTypes resolvedTypeBounds
+
+    resolvedTypeBounds =
+      completeBackendParameterSubstitution typeBounds Map.empty
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map.Map String BackendType -> Map.Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -523,21 +523,68 @@ validateBackendVariable (Just context0) name actualTy =
 
 backendVariableTypeMatches :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
 backendVariableTypeMatches typeBounds expectedTy actualTy =
-  alphaEqBackendType actualTy expectedTy
-    || typeVariableBoundMatches expectedTy actualTy
-    || typeVariableBoundMatches actualTy expectedTy
+  go Set.empty expectedTy actualTy
   where
-    typeVariableBoundMatches ty otherTy =
+    go bound expected actual =
+      alphaEqBackendType actual expected
+        || typeVariableBoundMatches bound expected actual
+        || typeVariableBoundMatches bound actual expected
+        || case (expected, actual) of
+          (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
+            go bound expectedDom actualDom && go bound expectedCod actualCod
+          (BTBase expectedBase, BTBase actualBase) ->
+            expectedBase == actualBase
+          (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
+            expectedCon == actualCon
+              && zipAllWith (go bound) (NE.toList expectedArgs) (NE.toList actualArgs)
+          (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) ->
+            maybeBoundMatches bound expectedBound actualBound
+              && let freshName = freshBinderName expectedName actualName expectedBound actualBound expectedBody actualBody
+                     expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                     actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                  in go (Set.insert freshName bound) expectedBody' actualBody'
+          (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
+            let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
+                expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+             in go (Set.insert freshName bound) expectedBody' actualBody'
+          (BTBottom, BTBottom) ->
+            True
+          _ ->
+            False
+
+    maybeBoundMatches _ Nothing Nothing =
+      True
+    maybeBoundMatches bound (Just expectedBound) (Just actualBound) =
+      go bound expectedBound actualBound
+    maybeBoundMatches _ _ _ =
+      False
+
+    typeVariableBoundMatches bound ty otherTy =
       case ty of
-        BTVar name ->
-          case Map.lookup name typeBounds of
-            Just (Just boundTy)
-              | not (alphaEqBackendType boundTy BTBottom) ->
-                  alphaEqBackendType otherTy boundTy
-            _ ->
-              False
+        BTVar name
+          | Set.notMember name bound ->
+              case Map.lookup name typeBounds of
+                Just (Just boundTy)
+                  | not (alphaEqBackendType boundTy BTBottom) ->
+                      go bound boundTy otherTy
+                _ ->
+                  False
         _ ->
           False
+
+    freshBinderName leftName rightName leftBound rightBound leftBody rightBody =
+      freshNameLike
+        leftName
+        ( Set.unions
+            [ Set.fromList [leftName, rightName],
+              Map.keysSet typeBounds,
+              maybe Set.empty freeBackendTypeVars leftBound,
+              maybe Set.empty freeBackendTypeVars rightBound,
+              freeBackendTypeVars leftBody,
+              freeBackendTypeVars rightBody
+            ]
+        )
 
 validateBackendTypeArgumentBound :: Maybe BackendType -> BackendType -> Either BackendValidationError ()
 validateBackendTypeArgumentBound Nothing _ =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -172,6 +172,34 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__Pack"]
 
+  it "preserves bounded constructor foralls in backend metadata" $ do
+    checked <- requireChecked boundedConstructorForallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+    constructor <- requireConstructor "Main__Pack" backend
+    backendConstructorForalls constructor `shouldBe` [BackendTypeBinder "a" (Just intTy)]
+
+    let corruptedExpr =
+          BackendConstruct
+            { backendExprType = backendConstructorResult constructor,
+              backendConstructName = backendConstructorName constructor,
+              backendConstructArgs = [BackendLit boolTy (LBool True)]
+            }
+        corruptedBackend =
+          mapBackendMainBinding
+            ( \binding ->
+                binding
+                  { backendBindingExpr = corruptedExpr,
+                    backendBindingType = backendConstructorResult constructor
+                  }
+            )
+            backend
+
+    validateBackendProgram corruptedBackend
+      `shouldBe` Left (BackendConstructorArgumentMismatch "Main__Pack" 0 intTy boolTy)
+
   it "converts nested constructor arguments under expected constructor field types" $ do
     checked <- requireChecked =<< readFile "test/programs/recursive-adt/typeclass-integration.mlfp"
     backend <- requireRight (convertCheckedProgram checked)
@@ -334,6 +362,17 @@ constructorForallApplicationProgram =
     [ "module Main export (Pack(..), main) {",
       "  data Pack =",
       "      Pack : forall a. a -> Pack;",
+      "",
+      "  def main : Pack = Pack 1;",
+      "}"
+    ]
+
+boundedConstructorForallProgram :: String
+boundedConstructorForallProgram =
+  unlines
+    [ "module Main export (Pack(..), main) {",
+      "  data Pack =",
+      "      Pack : forall (a >= Int). a -> Pack;",
       "",
       "  def main : Pack = Pack 1;",
       "}"
@@ -514,6 +553,10 @@ intTy :: BackendType
 intTy =
   BTBase (BaseTy "Int")
 
+boolTy :: BackendType
+boolTy =
+  BTBase (BaseTy "Bool")
+
 intElabTy :: Elab.ElabType
 intElabTy =
   Elab.TBase (BaseTy "Int")
@@ -574,6 +617,23 @@ mapMainBinding f checked =
 
     updateBinding binding
       | checkedBindingName binding == checkedProgramMain checked = f binding
+      | otherwise = binding
+
+mapBackendMainBinding :: (BackendBinding -> BackendBinding) -> BackendProgram -> BackendProgram
+mapBackendMainBinding f backend =
+  backend
+    { backendProgramModules =
+        map updateModule (backendProgramModules backend)
+    }
+  where
+    updateModule backendModule =
+      backendModule
+        { backendModuleBindings =
+            map updateBinding (backendModuleBindings backendModule)
+        }
+
+    updateBinding binding
+      | backendBindingName binding == backendProgramMain backend = f binding
       | otherwise = binding
 
 addStaleConstructorHeadInstantiation :: String -> Elab.ElabType -> Elab.ElabTerm -> Elab.ElabTerm

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -200,6 +200,25 @@ spec = describe "MLF.Backend.Convert" $ do
     validateBackendProgram corruptedBackend
       `shouldBe` Left (BackendConstructorArgumentMismatch "Main__Pack" 0 intTy boolTy)
 
+  it "matches bounded constructor foralls against type variables with equivalent bounds" $ do
+    checked0 <- requireChecked boundedConstructorForallProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = boundedWrapElabTy (checkedBindingType binding),
+                    checkedBindingTerm = boundedWrapTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding
+      `shouldSatisfy` containsConstructArgType "Main__Pack" (BTVar "b")
+
   it "converts nested constructor arguments under expected constructor field types" $ do
     checked <- requireChecked =<< readFile "test/programs/recursive-adt/typeclass-integration.mlfp"
     backend <- requireRight (convertCheckedProgram checked)
@@ -517,6 +536,26 @@ containsBackendTyApp expr =
     BackendUnroll {backendUnrollPayload = body} -> containsBackendTyApp body
     _ -> False
 
+containsConstructArgType :: String -> BackendType -> BackendExpr -> Bool
+containsConstructArgType constructorName argTy expr =
+  case expr of
+    BackendConstruct {backendConstructName = name, backendConstructArgs = args} ->
+      (name == constructorName && any (alphaEqBackendType argTy . backendExprType) args)
+        || any (containsConstructArgType constructorName argTy) args
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsConstructArgType constructorName argTy scrutinee
+        || any (containsConstructArgType constructorName argTy . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsConstructArgType constructorName argTy body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsConstructArgType constructorName argTy fun || containsConstructArgType constructorName argTy arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsConstructArgType constructorName argTy rhs || containsConstructArgType constructorName argTy body
+    BackendTyAbs {backendTyAbsBody = body} -> containsConstructArgType constructorName argTy body
+    BackendTyApp {backendTyFunction = fun} -> containsConstructArgType constructorName argTy fun
+    BackendRoll {backendRollPayload = body} -> containsConstructArgType constructorName argTy body
+    BackendUnroll {backendUnrollPayload = body} -> containsConstructArgType constructorName argTy body
+    _ -> False
+
 findBackendCase :: BackendExpr -> Maybe BackendExpr
 findBackendCase expr =
   case expr of
@@ -564,6 +603,25 @@ intElabTy =
 boolElabTy :: Elab.ElabType
 boolElabTy =
   Elab.TBase (BaseTy "Bool")
+
+intElabBoundTy :: Elab.BoundType
+intElabBoundTy =
+  Elab.TBase (BaseTy "Int")
+
+boundedWrapElabTy :: Elab.ElabType -> Elab.ElabType
+boundedWrapElabTy resultTy =
+  Elab.TForall "b" (Just intElabBoundTy) (Elab.TArrow (Elab.TVar "b") resultTy)
+
+boundedWrapTerm :: Elab.ElabTerm
+boundedWrapTerm =
+  Elab.ETyAbs
+    "b"
+    (Just intElabBoundTy)
+    ( Elab.ELam
+        "x"
+        (Elab.TVar "b")
+        (Elab.EApp (Elab.EVar "Main__Pack") (Elab.EVar "x"))
+    )
 
 polymorphicIdentityElabTy :: Elab.ElabType
 polymorphicIdentityElabTy =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -219,6 +219,25 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding
       `shouldSatisfy` containsConstructArgType "Main__Pack" (BTVar "b")
 
+  it "matches bounded constructor foralls through dependent type-variable bounds" $ do
+    checked0 <- requireChecked dependentBoundedConstructorForallProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = dependentBoundedWrapElabTy (checkedBindingType binding),
+                    checkedBindingTerm = dependentBoundedWrapTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding
+      `shouldSatisfy` containsConstructArgType "Main__Pack" (BTVar "b")
+
   it "converts nested constructor arguments under expected constructor field types" $ do
     checked <- requireChecked =<< readFile "test/programs/recursive-adt/typeclass-integration.mlfp"
     backend <- requireRight (convertCheckedProgram checked)
@@ -394,6 +413,18 @@ boundedConstructorForallProgram =
       "      Pack : forall (a >= Int). a -> Pack;",
       "",
       "  def main : Pack = Pack 1;",
+      "}"
+    ]
+
+dependentBoundedConstructorForallProgram :: String
+dependentBoundedConstructorForallProgram =
+  unlines
+    [ "module Main export (Pack(..), main) {",
+      "  data Pack =",
+      "      Pack : forall (a >= Int -> Int). a -> Pack;",
+      "",
+      "  def id : Int -> Int = \\x x;",
+      "  def main : Pack = Pack id;",
       "}"
     ]
 
@@ -622,6 +653,36 @@ boundedWrapTerm =
         (Elab.TVar "b")
         (Elab.EApp (Elab.EVar "Main__Pack") (Elab.EVar "x"))
     )
+
+dependentBoundedWrapElabTy :: Elab.ElabType -> Elab.ElabType
+dependentBoundedWrapElabTy resultTy =
+  Elab.TForall
+    "z"
+    (Just intElabBoundTy)
+    ( Elab.TForall
+        "b"
+        (Just (dependentArrowElabBoundTy (Elab.TVar "z")))
+        (Elab.TArrow (Elab.TVar "b") resultTy)
+    )
+
+dependentBoundedWrapTerm :: Elab.ElabTerm
+dependentBoundedWrapTerm =
+  Elab.ETyAbs
+    "z"
+    (Just intElabBoundTy)
+    ( Elab.ETyAbs
+        "b"
+        (Just (dependentArrowElabBoundTy (Elab.TVar "z")))
+        ( Elab.ELam
+            "x"
+            (Elab.TVar "b")
+            (Elab.EApp (Elab.EVar "Main__Pack") (Elab.EVar "x"))
+        )
+    )
+
+dependentArrowElabBoundTy :: Elab.ElabType -> Elab.BoundType
+dependentArrowElabBoundTy ty =
+  Elab.TArrow ty ty
 
 polymorphicIdentityElabTy :: Elab.ElabType
 polymorphicIdentityElabTy =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -217,6 +217,12 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram boundedListPackWrongBoundUseCaseProgram
       `shouldBe` Left (BackendVariableTypeMismatch "n" (listTy (BTVar "a")) (listTy boolTy))
 
+    validateBackendProgram (programWithDataAndMainExpr [dependentBoundedPackData] dependentBoundedPackIntExpr)
+      `shouldBe` Right ()
+
+    validateBackendProgram (programWithDataAndMainExpr [dependentBoundedPackData] dependentBoundedPackBoolExpr)
+      `shouldBe` Left (BackendConstructorArgumentMismatch "DependentBoundedPack" 0 intTy boolTy)
+
   it "rejects matcher capture from inferred constructor parameters" $ do
     validateBackendProgram captureForallConstructProgram
       `shouldBe` Left (BackendConstructorArgumentMismatch "CaptureForall" 0 captureForallInstantiatedTy captureForallActualTy)
@@ -385,6 +391,20 @@ boundedListPackData =
       backendDataConstructors = [BackendConstructor "BoundedListPack" [BackendTypeBinder "a" (Just intTy)] [listTy (BTVar "a")] boundedListPackTy]
     }
 
+dependentBoundedPackData :: BackendData
+dependentBoundedPackData =
+  BackendData
+    { backendDataName = "DependentBoundedPack",
+      backendDataParameters = [],
+      backendDataConstructors =
+        [ BackendConstructor
+            "DependentBoundedPack"
+            [BackendTypeBinder "z" (Just intTy), BackendTypeBinder "a" (Just (BTVar "z"))]
+            [BTVar "a"]
+            dependentBoundedPackTy
+        ]
+    }
+
 captureForallData :: BackendData
 captureForallData =
   BackendData
@@ -446,6 +466,14 @@ boundedPackIntExpr =
 boundedPackBoolExpr :: BackendExpr
 boundedPackBoolExpr =
   BackendConstruct boundedPackTy "BoundedPack" [boolLit True]
+
+dependentBoundedPackIntExpr :: BackendExpr
+dependentBoundedPackIntExpr =
+  BackendConstruct dependentBoundedPackTy "DependentBoundedPack" [intLit 1]
+
+dependentBoundedPackBoolExpr :: BackendExpr
+dependentBoundedPackBoolExpr =
+  BackendConstruct dependentBoundedPackTy "DependentBoundedPack" [boolLit True]
 
 boundedPackCaseExpr :: BackendExpr
 boundedPackCaseExpr =
@@ -623,6 +651,10 @@ boundedPackTy =
 boundedListPackTy :: BackendType
 boundedListPackTy =
   BTBase (BaseTy "BoundedListPack")
+
+dependentBoundedPackTy :: BackendType
+dependentBoundedPackTy =
+  BTBase (BaseTy "DependentBoundedPack")
 
 listTy :: BackendType -> BackendType
 listTy ty =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -205,6 +205,12 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackCaseExpr)
       `shouldBe` Right ()
 
+    validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackRepackCaseExpr)
+      `shouldBe` Right ()
+
+    validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackWrongBoundUseCaseExpr)
+      `shouldBe` Left (BackendVariableTypeMismatch "n" (BTVar "a") boolTy)
+
   it "rejects matcher capture from inferred constructor parameters" $ do
     validateBackendProgram captureForallConstructProgram
       `shouldBe` Left (BackendConstructorArgumentMismatch "CaptureForall" 0 captureForallInstantiatedTy captureForallActualTy)
@@ -433,6 +439,30 @@ boundedPackCaseExpr =
     { backendExprType = intTy,
       backendScrutinee = boundedPackIntExpr,
       backendAlternatives = BackendAlternative (BackendConstructorPattern "BoundedPack" ["n"]) (BackendVar intTy "n") :| []
+    }
+
+boundedPackRepackCaseExpr :: BackendExpr
+boundedPackRepackCaseExpr =
+  BackendCase
+    { backendExprType = boundedPackTy,
+      backendScrutinee = boundedPackIntExpr,
+      backendAlternatives =
+        BackendAlternative
+          (BackendConstructorPattern "BoundedPack" ["n"])
+          (BackendConstruct boundedPackTy "BoundedPack" [BackendVar (BTVar "a") "n"])
+          :| []
+    }
+
+boundedPackWrongBoundUseCaseExpr :: BackendExpr
+boundedPackWrongBoundUseCaseExpr =
+  BackendCase
+    { backendExprType = boolTy,
+      backendScrutinee = boundedPackIntExpr,
+      backendAlternatives =
+        BackendAlternative
+          (BackendConstructorPattern "BoundedPack" ["n"])
+          (BackendVar boolTy "n")
+          :| []
     }
 
 captureForallConstructProgram :: BackendProgram

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -195,6 +195,16 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithDataAndMainExpr [packData] packIntExpr)
       `shouldBe` Right ()
 
+  it "enforces constructor-level forall bounds at construct and case boundaries" $ do
+    validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackIntExpr)
+      `shouldBe` Right ()
+
+    validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackBoolExpr)
+      `shouldBe` Left (BackendConstructorArgumentMismatch "BoundedPack" 0 intTy boolTy)
+
+    validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackCaseExpr)
+      `shouldBe` Right ()
+
   it "rejects matcher capture from inferred constructor parameters" $ do
     validateBackendProgram captureForallConstructProgram
       `shouldBe` Left (BackendConstructorArgumentMismatch "CaptureForall" 0 captureForallInstantiatedTy captureForallActualTy)
@@ -344,7 +354,15 @@ packData =
   BackendData
     { backendDataName = "Pack",
       backendDataParameters = [],
-      backendDataConstructors = [BackendConstructor "Pack" ["a"] [BTVar "a"] packTy]
+      backendDataConstructors = [BackendConstructor "Pack" [BackendTypeBinder "a" Nothing] [BTVar "a"] packTy]
+    }
+
+boundedPackData :: BackendData
+boundedPackData =
+  BackendData
+    { backendDataName = "BoundedPack",
+      backendDataParameters = [],
+      backendDataConstructors = [BackendConstructor "BoundedPack" [BackendTypeBinder "a" (Just intTy)] [BTVar "a"] boundedPackTy]
     }
 
 captureForallData :: BackendData
@@ -400,6 +418,22 @@ someBoolAsOptionIntExpr =
 packIntExpr :: BackendExpr
 packIntExpr =
   BackendConstruct packTy "Pack" [intLit 1]
+
+boundedPackIntExpr :: BackendExpr
+boundedPackIntExpr =
+  BackendConstruct boundedPackTy "BoundedPack" [intLit 1]
+
+boundedPackBoolExpr :: BackendExpr
+boundedPackBoolExpr =
+  BackendConstruct boundedPackTy "BoundedPack" [boolLit True]
+
+boundedPackCaseExpr :: BackendExpr
+boundedPackCaseExpr =
+  BackendCase
+    { backendExprType = intTy,
+      backendScrutinee = boundedPackIntExpr,
+      backendAlternatives = BackendAlternative (BackendConstructorPattern "BoundedPack" ["n"]) (BackendVar intTy "n") :| []
+    }
 
 captureForallConstructProgram :: BackendProgram
 captureForallConstructProgram =
@@ -495,6 +529,10 @@ boxTy =
 packTy :: BackendType
 packTy =
   BTBase (BaseTy "Pack")
+
+boundedPackTy :: BackendType
+boundedPackTy =
+  BTBase (BaseTy "BoundedPack")
 
 optionTy :: BackendType -> BackendType
 optionTy ty =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -211,6 +211,12 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackWrongBoundUseCaseExpr)
       `shouldBe` Left (BackendVariableTypeMismatch "n" (BTVar "a") boolTy)
 
+    validateBackendProgram boundedListPackCaseProgram
+      `shouldBe` Right ()
+
+    validateBackendProgram boundedListPackWrongBoundUseCaseProgram
+      `shouldBe` Left (BackendVariableTypeMismatch "n" (listTy (BTVar "a")) (listTy boolTy))
+
   it "rejects matcher capture from inferred constructor parameters" $ do
     validateBackendProgram captureForallConstructProgram
       `shouldBe` Left (BackendConstructorArgumentMismatch "CaptureForall" 0 captureForallInstantiatedTy captureForallActualTy)
@@ -371,6 +377,14 @@ boundedPackData =
       backendDataConstructors = [BackendConstructor "BoundedPack" [BackendTypeBinder "a" (Just intTy)] [BTVar "a"] boundedPackTy]
     }
 
+boundedListPackData :: BackendData
+boundedListPackData =
+  BackendData
+    { backendDataName = "BoundedListPack",
+      backendDataParameters = [],
+      backendDataConstructors = [BackendConstructor "BoundedListPack" [BackendTypeBinder "a" (Just intTy)] [listTy (BTVar "a")] boundedListPackTy]
+    }
+
 captureForallData :: BackendData
 captureForallData =
   BackendData
@@ -464,6 +478,48 @@ boundedPackWrongBoundUseCaseExpr =
           (BackendVar boolTy "n")
           :| []
     }
+
+boundedListPackCaseProgram :: BackendProgram
+boundedListPackCaseProgram =
+  programWithDataAndBindings
+    [boundedListPackData]
+    [ mainBinding
+        BackendCase
+          { backendExprType = listTy intTy,
+            backendScrutinee = boundedListPackListIntExpr,
+            backendAlternatives =
+              BackendAlternative
+                (BackendConstructorPattern "BoundedListPack" ["n"])
+                (BackendVar (listTy intTy) "n")
+                :| []
+          },
+      listArgBinding
+    ]
+
+boundedListPackWrongBoundUseCaseProgram :: BackendProgram
+boundedListPackWrongBoundUseCaseProgram =
+  programWithDataAndBindings
+    [boundedListPackData]
+    [ mainBinding
+        BackendCase
+          { backendExprType = listTy boolTy,
+            backendScrutinee = boundedListPackListIntExpr,
+            backendAlternatives =
+              BackendAlternative
+                (BackendConstructorPattern "BoundedListPack" ["n"])
+                (BackendVar (listTy boolTy) "n")
+                :| []
+          },
+      listArgBinding
+    ]
+
+boundedListPackListIntExpr :: BackendExpr
+boundedListPackListIntExpr =
+  BackendConstruct boundedListPackTy "BoundedListPack" [BackendVar (listTy intTy) "listArg"]
+
+listArgBinding :: BackendBinding
+listArgBinding =
+  binding "listArg" (listTy intTy) (BackendVar (listTy intTy) "listArg")
 
 captureForallConstructProgram :: BackendProgram
 captureForallConstructProgram =
@@ -563,6 +619,14 @@ packTy =
 boundedPackTy :: BackendType
 boundedPackTy =
   BTBase (BaseTy "BoundedPack")
+
+boundedListPackTy :: BackendType
+boundedListPackTy =
+  BTBase (BaseTy "BoundedListPack")
+
+listTy :: BackendType -> BackendType
+listTy ty =
+  BTCon (BaseTy "List") (ty :| [])
 
 optionTy :: BackendType -> BackendType
 optionTy ty =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -208,6 +208,12 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackRepackCaseExpr)
       `shouldBe` Right ()
 
+    validateBackendProgram boundedPackOuterNameCollisionCaseProgram
+      `shouldBe` Right ()
+
+    validateBackendProgram boundedPackOuterNameCollisionWrongOuterUseProgram
+      `shouldBe` Left (BackendVariableTypeMismatch "outer" (BTVar "a") intTy)
+
     validateBackendProgram (programWithDataAndMainExpr [boundedPackData] boundedPackWrongBoundUseCaseExpr)
       `shouldBe` Left (BackendVariableTypeMismatch "n" (BTVar "a") boolTy)
 
@@ -555,6 +561,41 @@ boundedPackRepackCaseExpr =
           (BackendConstruct boundedPackTy "BoundedPack" [BackendVar (BTVar "a") "n"])
           :| []
     }
+
+boundedPackOuterNameCollisionCaseProgram :: BackendProgram
+boundedPackOuterNameCollisionCaseProgram =
+  boundedPackOuterNameCollisionCaseWith (BackendVar intTy "n")
+
+boundedPackOuterNameCollisionWrongOuterUseProgram :: BackendProgram
+boundedPackOuterNameCollisionWrongOuterUseProgram =
+  boundedPackOuterNameCollisionCaseWith (BackendVar intTy "outer")
+
+boundedPackOuterNameCollisionCaseWith :: BackendExpr -> BackendProgram
+boundedPackOuterNameCollisionCaseWith branchBody =
+  programWithDataAndMainExpr
+    [boundedPackData]
+    ( BackendTyAbs
+        { backendExprType = BTForall "a" (Just boolTy) (BTArrow (BTVar "a") intTy),
+          backendTyParamName = "a",
+          backendTyParamBound = Just boolTy,
+          backendTyAbsBody =
+            BackendLam
+              { backendExprType = BTArrow (BTVar "a") intTy,
+                backendParamName = "outer",
+                backendParamType = BTVar "a",
+                backendBody =
+                  BackendCase
+                    { backendExprType = intTy,
+                      backendScrutinee = boundedPackIntExpr,
+                      backendAlternatives =
+                        BackendAlternative
+                          (BackendConstructorPattern "BoundedPack" ["n"])
+                          branchBody
+                          :| []
+                    }
+              }
+        }
+    )
 
 boundedPackWrongBoundUseCaseExpr :: BackendExpr
 boundedPackWrongBoundUseCaseExpr =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -223,6 +223,12 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithDataAndMainExpr [dependentBoundedPackData] dependentBoundedPackBoolExpr)
       `shouldBe` Left (BackendConstructorArgumentMismatch "DependentBoundedPack" 0 intTy boolTy)
 
+    validateBackendProgram dependentActualBoundPackProgram
+      `shouldBe` Right ()
+
+    validateBackendProgram dependentActualBoundPackWrongProgram
+      `shouldBe` Left (BackendConstructorArgumentMismatch "DependentActualBoundPack" 0 (listTy intTy) (BTVar "b"))
+
   it "rejects matcher capture from inferred constructor parameters" $ do
     validateBackendProgram captureForallConstructProgram
       `shouldBe` Left (BackendConstructorArgumentMismatch "CaptureForall" 0 captureForallInstantiatedTy captureForallActualTy)
@@ -405,6 +411,20 @@ dependentBoundedPackData =
         ]
     }
 
+dependentActualBoundPackData :: BackendData
+dependentActualBoundPackData =
+  BackendData
+    { backendDataName = "DependentActualBoundPack",
+      backendDataParameters = [],
+      backendDataConstructors =
+        [ BackendConstructor
+            "DependentActualBoundPack"
+            [BackendTypeBinder "a" (Just (listTy intTy))]
+            [BTVar "a"]
+            dependentActualBoundPackTy
+        ]
+    }
+
 captureForallData :: BackendData
 captureForallData =
   BackendData
@@ -474,6 +494,47 @@ dependentBoundedPackIntExpr =
 dependentBoundedPackBoolExpr :: BackendExpr
 dependentBoundedPackBoolExpr =
   BackendConstruct dependentBoundedPackTy "DependentBoundedPack" [boolLit True]
+
+dependentActualBoundPackProgram :: BackendProgram
+dependentActualBoundPackProgram =
+  programWithDataAndMainExpr [dependentActualBoundPackData] (dependentActualBoundPackWrapper intTy)
+
+dependentActualBoundPackWrongProgram :: BackendProgram
+dependentActualBoundPackWrongProgram =
+  programWithDataAndMainExpr [dependentActualBoundPackData] (dependentActualBoundPackWrapper boolTy)
+
+dependentActualBoundPackWrapper :: BackendType -> BackendExpr
+dependentActualBoundPackWrapper zBound =
+  BackendTyAbs
+    { backendExprType = dependentActualBoundPackWrapperTy zBound,
+      backendTyParamName = "z",
+      backendTyParamBound = Just zBound,
+      backendTyAbsBody =
+        BackendTyAbs
+          { backendExprType = dependentActualBoundPackInnerTy,
+            backendTyParamName = "b",
+            backendTyParamBound = Just (listTy (BTVar "z")),
+            backendTyAbsBody =
+              BackendLam
+                { backendExprType = BTArrow (BTVar "b") dependentActualBoundPackTy,
+                  backendParamName = "x",
+                  backendParamType = BTVar "b",
+                  backendBody =
+                    BackendConstruct
+                      dependentActualBoundPackTy
+                      "DependentActualBoundPack"
+                      [BackendVar (BTVar "b") "x"]
+                }
+          }
+    }
+
+dependentActualBoundPackWrapperTy :: BackendType -> BackendType
+dependentActualBoundPackWrapperTy zBound =
+  BTForall "z" (Just zBound) dependentActualBoundPackInnerTy
+
+dependentActualBoundPackInnerTy :: BackendType
+dependentActualBoundPackInnerTy =
+  BTForall "b" (Just (listTy (BTVar "z"))) (BTArrow (BTVar "b") dependentActualBoundPackTy)
 
 boundedPackCaseExpr :: BackendExpr
 boundedPackCaseExpr =
@@ -655,6 +716,10 @@ boundedListPackTy =
 dependentBoundedPackTy :: BackendType
 dependentBoundedPackTy =
   BTBase (BaseTy "DependentBoundedPack")
+
+dependentActualBoundPackTy :: BackendType
+dependentActualBoundPackTy =
+  BTBase (BaseTy "DependentActualBoundPack")
 
 listTy :: BackendType -> BackendType
 listTy ty =


### PR DESCRIPTION
Closes #20.

## Implementation Plan

---
issue_number: 20
pr_number: 47
branch: codex/issue-20-2
---

## Implementation Plan

1. Start from the prepared PR branch.
   - Work in `/workspace/artifacts/issue-workdirs/soulomoon_mlf2__issue20` on `codex/issue-20-2` for PR #47.
   - Re-check `git status --short --branch` before editing. The previous local `issue-plan.md` mentions PR #46 / `codex/issue-20`; treat that as stale.

2. Preserve constructor-local `forall` bounds in backend metadata.
   - In `src/MLF/Backend/IR.hs`, add an exported backend type-binder representation, e.g. `BackendTypeBinder { backendTypeBinderName :: String, backendTypeBinderBound :: Maybe BackendType }`.
   - Change `BackendConstructor.backendConstructorForalls` from `[String]` to `[BackendTypeBinder]` so constructor-local bounds are part of the typed IR.
   - Add small internal helpers for binder names and parameter-bound maps rather than open-coding tuple/list logic.

3. Convert source constructor bounds instead of dropping them.
   - In `src/MLF/Backend/Convert.hs`, update `convertConstructorInfo` to convert each `(name, Maybe SrcType)` from `ctorForalls` into a backend binder, using the module-aware lowered type path for bounds.
   - Update all constructor parameter-name logic, including `constructorTypeParameters`, `constructorTypeApplicationParameterNames`, and `dataMatchesScrutinee`, to use binder names from the new metadata.

4. Enforce bounds while matching constructor parameters.
   - Replace the current `Set String` parameter matcher in both `MLF.Backend.IR` and the converter-local matcher with a `Map String (Maybe BackendType)` or equivalent.
   - Data type parameters should remain unbounded; constructor-local binders should carry their converted bounds.
   - When inserting or reusing a substitution for a bounded parameter, require the actual type to match the substituted bound, following the existing backend type-application semantics: `Nothing`/`BTBottom` permits any type, `Just bound` requires `alphaEqBackendType` after applying known substitutions.
   - Preserve the existing alpha-equivalent repeated-substitution behavior.

5. Apply the bound-aware matcher everywhere constructor metadata is trusted.
   - Update constructor validation for `BackendConstruct` arguments.
   - Update constructor-pattern validation so bounded constructor-local parameters left unresolved by the scrutinee/result are instantiated from their bounds before pattern binder field types are exposed.
   - Update converter paths that infer constructor application results, recover explicit `BackendConstruct`, recover `BackendCase`, synthesize constructor bindings, and select matching data metadata.

6. Add regression tests in existing spec modules.
   - In `test/BackendIRSpec.hs`, add a bounded constructor metadata fixture such as `Pack : forall (a >= Int). a -> Pack`.
   - Assert that `BackendConstruct Pack [Int]` validates and `BackendConstruct Pack [Bool]` fails with a constructor argument mismatch using `Int` as the expected type.
   - Add a case-pattern check proving a bounded constructor field binder is typed as the bound, not as an unconstrained free `BTVar`.
   - In `test/BackendConvertSpec.hs`, add a checked `.mlfp` program with `Pack : forall (a >= Int). a -> Pack`; assert conversion preserves `Just intTy` in `backendConstructorForalls`, the converted program validates, and a manually corrupted Bool construction using the converted metadata is rejected.

7. Update durable docs for the changed IR contract.
   - In `docs/architecture.md`, mention that backend constructor metadata preserves constructor-local `forall` bounds and validation enforces them at construct/case boundaries.
   - Add a concise `CHANGELOG.md` entry because this fixes a meaningful backend IR type-preservation gap.

8. Validate before publish.
   - Run a narrow Hspec slice for backend specs, for example `cabal test mlf2-test --test-options='--match MLF.Backend'`.
   - Run the required full gate before completion: `cabal build all && cabal test`.
   - Before committing, inspect `git status --short` and relevant diffs; stage only issue-related files.
   - Commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, then push `codex/issue-20-2` to the existing PR #47. Do not create another PR or resolve PR review threads in this implementation turn.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.