### PR TITLE
Implement #44

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,12 +114,26 @@ after eMLF type recovery.
 - Presolution state access should go through `MonadPresolution` plus `MLF.Constraint.Presolution.Ops` and `StateAccess`; edge processing is split across planner/interpreter passes with typed `EdgePlan`.
 - Elaboration entrypoints bundle inputs as `ElabConfig`/`ElabEnv`, and tracing is explicit via `TraceConfig`.
 
-## Typed backend IR boundary
+## Typed backend IR and lowering boundary
 
-`MLF.Backend.IR` is the first backend-owned representation after a `.mlfp`
-program has already passed the existing checker and xMLF typecheck guard.
-`MLF.Backend.Convert` is the only conversion boundary from checked program
-artifacts into that IR. It is not a second inference or typing authority.
+The current checked-program backend path is:
+
+1. `MLF.Frontend.Program.Resolve` assigns resolved symbol identities.
+2. `MLF.Frontend.Program.Check` and `MLF.Frontend.Program.Finalize` accept the
+   `.mlfp` program only after the existing eMLF/xMLF checker boundary and xMLF
+   typecheck guard have succeeded.
+3. `MLF.Backend.Convert` converts the resulting checked program artifacts into
+   the typed backend IR in `MLF.Backend.IR`.
+4. `MLF.Backend.Text` consumes that typed backend IR and emits the first
+   deterministic LLVM-like inspection text for the currently supported subset.
+
+`MLF.Backend.IR` is therefore the first backend-owned representation after a
+`.mlfp` program has already passed the existing checker and xMLF typecheck
+guard. `MLF.Backend.Convert` is the only conversion boundary from checked
+program artifacts into that IR. It is not a second inference or typing
+authority: if the checked artifact cannot be represented faithfully, conversion
+must report an unsupported checked shape instead of inventing frontend
+semantics or repairing types.
 
 The boundary invariants are:
 
@@ -140,8 +154,14 @@ The boundary invariants are:
   type, and alternative result type.
 
 This module intentionally lives in the private `mlf2-internal` library for now.
-Future conversion/lowering modules should depend on this IR rather than reaching
+Conversion and lowering modules should depend on this IR rather than reaching
 back into `MLF.Frontend.Program.*` internals for backend decisions.
+`MLF.Backend.Text` preserves that boundary by validating the IR before
+rendering, rendering only the supported functional subset, and producing
+explicit unsupported-node diagnostics for backend constructs that do not yet
+have textual lowering. Those diagnostics do not weaken source inference,
+checking, module visibility, or runtime semantics; they only describe the
+current IR-to-text lowering surface.
 
 ## `Solved` boundary and thesis-exact cleanup rule
 

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -268,12 +268,39 @@ field-specific deriving diagnostic.
 ## Backend Boundary
 
 Successful `.mlfp` checking may be followed by conversion into the internal
-typed backend IR owned by `MLF.Backend.IR`. That IR is after the existing
-eMLF/xMLF checker boundary and before textual or LLVM-like lowering. It does
-not change source typing, inference, diagnostics, runtime value rendering, or
-the explicit-import Prelude contract documented here. Its validator is scoped to
-backend-local invariants such as typed expression nodes, lexical/global
-references, and constructor metadata consistency for construct/case nodes.
+typed backend IR owned by `MLF.Backend.IR`. The path is checked `.mlfp`
+program -> existing eMLF/xMLF typecheck guard -> `MLF.Backend.Convert` ->
+typed backend IR -> `MLF.Backend.Text` for the first LLVM-like textual
+inspection boundary.
+
+The backend path does not change source typing, inference, checker diagnostics,
+module/import visibility, runtime value rendering, or the explicit-import
+Prelude contract documented here. Its validator is scoped to backend-local
+invariants such as typed expression nodes, lexical/global references, and
+constructor metadata consistency for construct/case nodes.
+
+The executable exposes this boundary with:
+
+```bash
+cabal run mlf2 -- emit-backend path/to/file.mlfp
+```
+
+Like `run-program`, `emit-backend` parses one source file and prepends the
+built-in Prelude as an explicit module before checking. The emitted text is a
+deterministic inspection format, not a stable ABI or a promise of executable
+LLVM. The initial supported text subset covers checked function bindings,
+literals, variables, lambda/application, let, type abstraction/application,
+global references, and referenced Prelude bindings retained for backend output.
+
+The typed backend IR can also represent data metadata, constructor nodes, case
+nodes, and recursive roll/unroll nodes. The current text lowering intentionally
+rejects backend nodes that are not yet supported instead of silently dropping or
+rewriting them. Diagnostics are high-level and name the backend context and
+node, for example:
+
+```text
+Unsupported backend text node at binding "main": case
+```
 
 ## Built-In Prelude
 


### PR DESCRIPTION
Closes #44.

## Implementation Plan

---
issue_number: 44
pr_number: 49
branch: codex/issue-44
---

## Implementation Plan

1. Verify the workspace is still on `codex/issue-44`, based on `origin/master` / `origin/HEAD`, and that PR #49 is still the open PR for this branch. Re-check `git status --short --branch` before editing.

2. Keep the change docs-only. Update `docs/architecture.md` to make the checked `.mlfp` backend path explicit as: resolved/checked `.mlfp` program -> existing eMLF/xMLF typecheck guard -> `MLF.Backend.Convert` -> typed `MLF.Backend.IR` -> `MLF.Backend.Text` LLVM-like textual boundary. Spell out that `MLF.Backend.Convert` is not a second inference/typechecking authority, and that `MLF.Backend.Text` consumes only typed backend IR and reports unsupported backend nodes rather than weakening frontend semantics.

3. Update `docs/mlfp-language-reference.md` under `Backend Boundary` with user-visible backend behavior from the implemented APIs: `mlf2 emit-backend <file.mlfp>` prepends the explicit Prelude like `run-program`; supported initial text output covers checked functions, literals, variables, application, let, type abstraction/application, global references, and retained referenced Prelude bindings; backend IR can represent ADT metadata, construct, and case nodes, but current text lowering rejects unsupported nodes such as `construct`, `case`, `roll`, and `unroll` with diagnostics shaped like `Unsupported backend text node at binding "...": case`.

4. Ensure the language reference states what does not change: source typing/inference, existing checker diagnostics, runtime value rendering, module/import visibility, and the explicit Prelude import contract remain owned by the existing `.mlfp` frontend and eMLF/xMLF checker.

5. Do not add backend IR examples that imply executable LLVM or a stable ABI. If an example is useful, use the existing CLI command and a small description of the deterministic inspection format, not a new frontend semantic promise.

6. Check whether documentation guard tests need updates. Avoid changing `README.md`, `CHANGELOG.md`, or tests unless the edited wording invalidates an existing guard or the docs need a cross-reference to stay consistent.

7. Validate with at least `cabal test mlf2-test --test-show-details=direct --test-options='--match "Repository guardrails"'` after the docs edits. Because this is docs-only, the full `cabal build all && cabal test` gate is not required unless implementation files or test code are changed.

8. Inspect `git diff` and `git status --short`; stage only issue-related documentation/test files, never watcher runtime state. Commit as the configured `codex-watcher` identity with an imperative message such as `Document backend boundary`, then push `codex/issue-44` to the existing PR #49. Do not create another PR and do not resolve PR review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.