### PR TITLE
Implement #10

### DIFF
--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -2,7 +2,7 @@ module BackendConvertSpec (spec) where
 
 import Control.Applicative ((<|>))
 import Data.Foldable (toList)
-import Data.List (find)
+import Data.List (find, intercalate)
 import Data.List.NonEmpty (NonEmpty (..))
 import MLF.Backend.Convert
 import MLF.Backend.IR
@@ -10,6 +10,9 @@ import MLF.Constraint.Types.Graph (BaseTy (..))
 import qualified MLF.Elab.Types as Elab
 import MLF.Frontend.Syntax (Lit (..), SrcTy (..), SrcType)
 import MLF.Program
+import System.Directory (createDirectoryIfMissing)
+import System.Environment (lookupEnv)
+import System.FilePath (takeDirectory)
 import Test.Hspec
 
 spec :: Spec
@@ -33,6 +36,12 @@ spec = describe "MLF.Backend.Convert" $ do
           resultTy `shouldBe` intTy
       other -> expectationFailure ("expected backend application, got " ++ show other)
 
+  it "matches the checked backend IR snapshot for a primitive function program" $ do
+    checked <- requireChecked simpleFunctionProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    backendIRGolden "test/golden/backend-ir-simple-function.golden" backend
+
   it "recovers explicit backend constructors and cases from checked ADT paths" $ do
     checked <- requireChecked adtCaseProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -44,6 +53,12 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendCase
     collectConstructNames (backendBindingExpr mainBinding) `shouldSatisfy` (not . null)
+
+  it "matches the checked backend IR snapshot for a simple ADT case program" $ do
+    checked <- requireChecked adtCaseProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    backendIRGolden "test/golden/backend-ir-adt-case.golden" backend
 
   it "recovers backend cases when the result type differs from the scrutinee ADT" $ do
     checked <- requireChecked intCaseProgram
@@ -507,6 +522,198 @@ requireRight result =
   case result of
     Left err -> expectationFailure (show err) >> fail "unexpected Left"
     Right value -> pure value
+
+backendIRGolden :: FilePath -> BackendProgram -> Expectation
+backendIRGolden goldenPath backend = do
+  validateBackendProgram backend `shouldBe` Right ()
+  goldenText goldenPath (renderBackendIRSnapshot backend)
+
+goldenText :: FilePath -> String -> Expectation
+goldenText goldenPath actual = do
+  accept <- lookupEnv "GOLDEN_ACCEPT"
+  case accept of
+    Just "1" -> do
+      createDirectoryIfMissing True (takeDirectory goldenPath)
+      writeFile goldenPath actual
+    _ -> do
+      expected <- readFile goldenPath
+      length expected `seq` actual `shouldBe` expected
+
+renderBackendIRSnapshot :: BackendProgram -> String
+renderBackendIRSnapshot backend =
+  unlines $
+    [ "backend-program",
+      "  main: " ++ backendProgramMain backend,
+      "  modules:"
+    ]
+      ++ concatMap renderBackendIRModule (backendProgramModules backend)
+
+renderBackendIRModule :: BackendModule -> [String]
+renderBackendIRModule backendModule =
+  [ indent 4 ("module " ++ backendModuleName backendModule),
+    indent 6 "data:"
+  ]
+    ++ renderListOrEmpty 8 renderBackendIRData (backendModuleData backendModule)
+    ++ [indent 6 "bindings:"]
+    ++ renderListOrEmpty 8 renderBackendIRBinding (backendModuleBindings backendModule)
+
+renderBackendIRData :: BackendData -> [String]
+renderBackendIRData backendData =
+  [ indent 8 ("data " ++ backendDataName backendData ++ renderPlainTypeParameters (backendDataParameters backendData)),
+    indent 10 "constructors:"
+  ]
+    ++ renderListOrEmpty 12 renderBackendIRConstructor (backendDataConstructors backendData)
+
+renderBackendIRConstructor :: BackendConstructor -> [String]
+renderBackendIRConstructor constructor =
+  [ indent 12 ("ctor " ++ backendConstructorName constructor ++ renderBackendTypeBinders (backendConstructorForalls constructor)),
+    indent 14 ("fields: " ++ renderTypeList (backendConstructorFields constructor)),
+    indent 14 ("result: " ++ renderBackendIRType (backendConstructorResult constructor))
+  ]
+
+renderBackendIRBinding :: BackendBinding -> [String]
+renderBackendIRBinding binding =
+  [ indent 8 ("binding " ++ backendBindingName binding ++ " : " ++ renderBackendIRType (backendBindingType binding)),
+    indent 10 ("exported-main: " ++ renderBool (backendBindingExportedAsMain binding)),
+    indent 10 "expr:"
+  ]
+    ++ renderBackendIRExpr 12 (backendBindingExpr binding)
+
+renderBackendIRExpr :: Int -> BackendExpr -> [String]
+renderBackendIRExpr level expr =
+  case expr of
+    BackendVar resultTy name ->
+      [indent level ("var " ++ name ++ " : " ++ renderBackendIRType resultTy)]
+    BackendLit resultTy lit ->
+      [indent level ("lit " ++ renderLit lit ++ " : " ++ renderBackendIRType resultTy)]
+    BackendLam resultTy name paramTy body ->
+      [ indent level ("lam " ++ name ++ " : " ++ renderBackendIRType paramTy ++ " -> " ++ renderBackendIRType resultTy),
+        indent (level + 2) "body:"
+      ]
+        ++ renderBackendIRExpr (level + 4) body
+    BackendApp resultTy fun arg ->
+      [ indent level ("app : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "function:"
+      ]
+        ++ renderBackendIRExpr (level + 4) fun
+        ++ [indent (level + 2) "argument:"]
+        ++ renderBackendIRExpr (level + 4) arg
+    BackendLet resultTy name bindingTy rhs body ->
+      [ indent level ("let " ++ name ++ " : " ++ renderBackendIRType bindingTy ++ " -> " ++ renderBackendIRType resultTy),
+        indent (level + 2) "rhs:"
+      ]
+        ++ renderBackendIRExpr (level + 4) rhs
+        ++ [indent (level + 2) "body:"]
+        ++ renderBackendIRExpr (level + 4) body
+    BackendTyAbs resultTy name mbBound body ->
+      [ indent level ("type-lam " ++ renderTypeBinder name mbBound ++ " -> " ++ renderBackendIRType resultTy),
+        indent (level + 2) "body:"
+      ]
+        ++ renderBackendIRExpr (level + 4) body
+    BackendTyApp resultTy fun tyArg ->
+      [ indent level ("type-app [" ++ renderBackendIRType tyArg ++ "] : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "function:"
+      ]
+        ++ renderBackendIRExpr (level + 4) fun
+    BackendConstruct resultTy name args ->
+      [ indent level ("construct " ++ name ++ " : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "args:"
+      ]
+        ++ renderExprList (level + 4) args
+    BackendCase resultTy scrutinee alternatives ->
+      [ indent level ("case : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "scrutinee:"
+      ]
+        ++ renderBackendIRExpr (level + 4) scrutinee
+        ++ [indent (level + 2) "alternatives:"]
+        ++ concatMap (renderBackendIRAlternative (level + 4)) (toList alternatives)
+    BackendRoll resultTy payload ->
+      [ indent level ("roll : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "payload:"
+      ]
+        ++ renderBackendIRExpr (level + 4) payload
+    BackendUnroll resultTy payload ->
+      [ indent level ("unroll : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "payload:"
+      ]
+        ++ renderBackendIRExpr (level + 4) payload
+
+renderBackendIRAlternative :: Int -> BackendAlternative -> [String]
+renderBackendIRAlternative level alternative =
+  [ indent level ("alternative " ++ renderBackendIRPattern (backendAltPattern alternative)),
+    indent (level + 2) "body:"
+  ]
+    ++ renderBackendIRExpr (level + 4) (backendAltBody alternative)
+
+renderBackendIRPattern :: BackendPattern -> String
+renderBackendIRPattern pattern0 =
+  case pattern0 of
+    BackendDefaultPattern ->
+      "default"
+    BackendConstructorPattern name binders ->
+      name ++ "(" ++ intercalate ", " binders ++ ")"
+
+renderExprList :: Int -> [BackendExpr] -> [String]
+renderExprList level exprs =
+  renderListOrEmpty level renderArg (zip [0 :: Int ..] exprs)
+  where
+    renderArg (ix, expr) =
+      indent level ("arg " ++ show ix ++ ":") : renderBackendIRExpr (level + 2) expr
+
+renderBackendIRType :: BackendType -> String
+renderBackendIRType backendTy =
+  case backendTy of
+    BTVar name -> "$" ++ name
+    BTArrow dom cod -> "(" ++ renderBackendIRType dom ++ " -> " ++ renderBackendIRType cod ++ ")"
+    BTBase (BaseTy name) -> name
+    BTCon (BaseTy name) args -> name ++ "<" ++ intercalate ", " (map renderBackendIRType (toList args)) ++ ">"
+    BTForall name mbBound body -> "forall " ++ renderTypeBinder name mbBound ++ ". " ++ renderBackendIRType body
+    BTMu name body -> "mu " ++ name ++ ". " ++ renderBackendIRType body
+    BTBottom -> "bottom"
+
+renderBackendTypeBinders :: [BackendTypeBinder] -> String
+renderBackendTypeBinders binders =
+  case binders of
+    [] -> ""
+    _ -> "<" ++ intercalate ", " [renderTypeBinder name mbBound | BackendTypeBinder name mbBound <- binders] ++ ">"
+
+renderTypeBinder :: String -> Maybe BackendType -> String
+renderTypeBinder name mbBound =
+  "$" ++ name ++ maybe "" ((" >= " ++) . renderBackendIRType) mbBound
+
+renderPlainTypeParameters :: [String] -> String
+renderPlainTypeParameters params =
+  case params of
+    [] -> ""
+    _ -> "<" ++ intercalate ", " (map ("$" ++) params) ++ ">"
+
+renderTypeList :: [BackendType] -> String
+renderTypeList types0 =
+  "[" ++ intercalate ", " (map renderBackendIRType types0) ++ "]"
+
+renderLit :: Lit -> String
+renderLit lit =
+  case lit of
+    LInt n -> show n
+    LBool True -> "true"
+    LBool False -> "false"
+    LString value -> show value
+
+renderBool :: Bool -> String
+renderBool value =
+  case value of
+    True -> "true"
+    False -> "false"
+
+renderListOrEmpty :: Int -> (a -> [String]) -> [a] -> [String]
+renderListOrEmpty level render items =
+  case items of
+    [] -> [indent level "<none>"]
+    _ -> concatMap render items
+
+indent :: Int -> String -> String
+indent level line =
+  replicate level ' ' ++ line
 
 requireBinding :: String -> BackendProgram -> IO BackendBinding
 requireBinding name backend =

--- a/test/golden/backend-ir-adt-case.golden
+++ b/test/golden/backend-ir-adt-case.golden
@@ -1,0 +1,56 @@
+backend-program
+  main: Main__main
+  modules:
+    module Main
+      data:
+        data Main.Nat
+          constructors:
+            ctor Main__Zero
+              fields: []
+              result: mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+            ctor Main__Succ
+              fields: [mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))]
+              result: mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+      bindings:
+        binding Main__Zero : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+          exported-main: false
+          expr:
+            construct Main__Zero : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+              args:
+                <none>
+        binding Main__Succ : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
+          exported-main: false
+          expr:
+            lam $Succ_arg1 : mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
+              body:
+                type-lam $a1 -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
+                  body:
+                    lam $Succ_k1 : $a1 -> ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
+                      body:
+                        lam $Succ_k2 : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)
+                          body:
+                            app : $a1
+                              function:
+                                var $Succ_k2 : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1)
+                              argument:
+                                var $Succ_arg1 : mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result))
+        binding Main__main : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+          exported-main: true
+          expr:
+            case : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+              scrutinee:
+                construct Main__Succ : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+                  args:
+                    arg 0:
+                      construct Main__Zero : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+                        args:
+                          <none>
+              alternatives:
+                alternative Main__Zero()
+                  body:
+                    construct Main__Zero : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+                      args:
+                        <none>
+                alternative Main__Succ($case1#3)
+                  body:
+                    var $case1#3 : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))

--- a/test/golden/backend-ir-simple-function.golden
+++ b/test/golden/backend-ir-simple-function.golden
@@ -1,0 +1,21 @@
+backend-program
+  main: Main__main
+  modules:
+    module Main
+      data:
+        <none>
+      bindings:
+        binding Main__id : (Int -> Int)
+          exported-main: false
+          expr:
+            lam $x#0 : Int -> (Int -> Int)
+              body:
+                var $x#0 : Int
+        binding Main__main : Int
+          exported-main: true
+          expr:
+            app : Int
+              function:
+                var Main__id : (Int -> Int)
+              argument:
+                lit 1 : Int


### PR DESCRIPTION
Closes #10.

## Implementation Plan

---
issue_number: 10
pr_number: 60
branch: codex/issue-10-11
---

## Implementation Plan

1. Confirm the implementation turn starts from `codex/issue-10-11`, reads this plan, verifies PR #60 is still open with head `codex/issue-10-11`, and checks `git status --short` before editing.

2. Add checked backend IR snapshot coverage in the existing `test/BackendConvertSpec.hs` rather than creating a new spec module. This avoids extra `mlf2.cabal` and `test/Main.hs` wiring while directly covering the conversion boundary requested by issue #10.

3. Add two golden/snapshot examples under `test/golden/`:
   - `backend-ir-simple-function.golden` from `simpleFunctionProgram`, covering a primitive/function-only checked `.mlfp` program converted to `BackendProgram`.
   - `backend-ir-adt-case.golden` from `adtCaseProgram`, covering simple ADT metadata, constructor construction, and backend case representation.

4. In `BackendConvertSpec`, add a small test-local deterministic IR snapshot renderer over `BackendProgram`, `BackendModule`, `BackendData`, `BackendConstructor`, `BackendBinding`, `BackendExpr`, `BackendAlternative`, `BackendPattern`, and `BackendType`. Prefer explicit pattern matching and stable indentation over raw `show`, so the snapshot reads as backend IR output and changes only when the IR shape changes. Keep it test-local to avoid widening the production backend API.

5. Add a local golden comparison helper for the new snapshots. If practical, support `GOLDEN_ACCEPT=1` consistently with `GoldenSpec`; otherwise check in the generated golden files manually and compare with exact file contents.

6. Validate narrowly first with `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.Convert"'`. Then run the full gate before handoff: `cabal build all && cabal test`.

7. Before committing, inspect `git status --short` and `git diff`; stage only `test/BackendConvertSpec.hs` and the new `test/golden/backend-ir-*.golden` files. Do not touch watcher-owned runtime state. Commit as the prepared `codex-watcher` identity with an imperative message such as `Add backend IR golden snapshots`.

8. Publish through the existing branch only: run `gh auth status`, `gh auth setup-git`, then `git push origin codex/issue-10-11`. Do not create a duplicate PR. Confirm PR #60 still points at `codex/issue-10-11` after pushing, then return `complete` with validation and publish summary.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.