### PR TITLE
Implement #71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fixed LLVM evidence lowering so ordinary function-valued class method
   arguments, including let-bound local helper functions, keep the local
   function inlining path instead of being treated as hidden class evidence.
+- Rejected generated LLVM evidence wrappers for expressions that capture local
+  term bindings instead of emitting top-level wrappers with free local
+  references.
 - Tightened Backend IR recursive-type compatibility so vacuous `mu` wrappers
   are dropped only by continuing the underlying body comparison, preventing
   unrelated wrapped types from passing variable and constructor validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fixed LLVM evidence lowering so ordinary function-valued class method
   arguments, including let-bound local helper functions, keep the local
   function inlining path instead of being treated as hidden class evidence.
+- Tightened Backend IR recursive-type compatibility so vacuous `mu` wrappers
+  are dropped only by continuing the underlying body comparison, preventing
+  unrelated wrapped types from passing variable and constructor validation.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   parameterized instances, recursive `List` deriving, recursive ADT deriving
   fixtures, and mixed qualified/imported instance evidence now lower through
   first-order function references or generated evidence wrappers.
+- Fixed LLVM evidence lowering so ordinary function-valued class method
+  arguments keep the local function inlining path instead of being treated as
+  hidden class evidence.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   fixtures, and mixed qualified/imported instance evidence now lower through
   first-order function references or generated evidence wrappers.
 - Fixed LLVM evidence lowering so ordinary function-valued class method
-  arguments keep the local function inlining path instead of being treated as
-  hidden class evidence.
+  arguments, including let-bound local helper functions, keep the local
+  function inlining path instead of being treated as hidden class evidence.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Fixed LLVM evidence wrapper and inlined-call lowering so generated
   higher-order wrapper parameters lower as pointer-backed arguments and
   lexical local function calls shadow captured evidence values.
+- Fixed LLVM function-reference lowering so local function aliases shadow
+  captured evidence values when passed as function-valued arguments to opaque
+  indirect evidence calls.
 - Rejected generated LLVM evidence wrappers for expressions that capture local
   term bindings instead of emitting top-level wrappers with free local
   references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fixed LLVM evidence lowering so ordinary function-valued class method
   arguments, including let-bound local helper functions, keep the local
   function inlining path instead of being treated as hidden class evidence.
+- Fixed LLVM evidence wrapper and inlined-call lowering so generated
+  higher-order wrapper parameters lower as pointer-backed arguments and
+  lexical local function calls shadow captured evidence values.
 - Rejected generated LLVM evidence wrappers for expressions that capture local
   term bindings instead of emitting top-level wrappers with free local
   references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Changed
+- Extended LLVM backend support for resolved typeclass evidence and derived
+  `Eq`: constrained helper aliases, method-level evidence constraints,
+  parameterized instances, recursive `List` deriving, recursive ADT deriving
+  fixtures, and mixed qualified/imported instance evidence now lower through
+  first-order function references or generated evidence wrappers.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,16 @@
+## 2026-04-28 - Typeclass evidence reaches LLVM backend
+
+- Function-valued Eq evidence now lowers as first-order LLVM function
+  references or private wrappers instead of escaping as unsupported arrow
+  values. Hidden class evidence parameters lower to opaque pointers and calls
+  through evidence use indirect calls.
+- Backend conversion preserves source data identity through evidence, case, and
+  derived `Eq` paths so parameterized and qualified ADTs do not recover the
+  wrong same-shaped data declaration during LLVM conversion.
+- Recursive derived `Eq` helpers that capture only hidden evidence are lifted to
+  backend helper bindings with explicit evidence/type parameters; ordinary
+  lexical captures remain unsupported.
+
 ## 2026-04-28 - Shared Program-to-LLVM parity matrix
 
 - Extracted the `.mlfp` interpreter-success surface from `ProgramSpec` into

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -763,7 +763,7 @@ renameTermTypeVariable old new =
           ELet name (renameElabSchemeTypeVariable old new scheme) (go rhs) (go body)
         ETyAbs name mbBound body
           | name == old ->
-              ETyAbs name mbBound body
+              ETyAbs name (fmap (renameElabTypeVariable old new) mbBound) body
           | otherwise ->
               ETyAbs name (fmap (renameElabTypeVariable old new) mbBound) (go body)
         ETyInst inner inst ->

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -32,12 +32,14 @@ import MLF.Elab.Inst (schemeToType)
 import MLF.Elab.TypeCheck (Env (..), typeCheckWithEnv)
 import MLF.Elab.Types
   ( ElabTerm (..),
+    ElabScheme,
     ElabType,
     BoundType,
     Instantiation (..),
     Ty (..),
     TypeCheckError,
     elabToBound,
+    schemeFromType,
     tyToElab,
   )
 import MLF.Frontend.Program.Elaborate (ElaborateScope, lowerType, mkElaborateScope)
@@ -54,6 +56,7 @@ import MLF.Frontend.Program.Types
     SymbolIdentity (..),
   )
 import MLF.Frontend.Syntax (SrcBound (..), SrcTy (..), SrcType)
+import MLF.Util.Names (freshNameLike)
 
 data BackendConversionError
   = BackendUnsupportedSourceType SrcType
@@ -244,7 +247,7 @@ liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
         then do
           bindingTy <- liftEitherConversion (convertElabType schemeTy)
           termCaptures <- capturedTermBindings lexicalTerms rhs
-          typeCaptures <- capturedTypeBindings lexicalTypes schemeTy termCaptures
+          typeCaptures <- capturedTypeBindings lexicalTypes schemeTy termCaptures rhs
           ensureLiftableRecursiveLet name bindingTy termCaptures rhs
           helperName <- freshLiftedRecursiveLetName context name
           rhs' <- liftRecursiveLetsInTerm context bodyTerms lexicalTypes rhs
@@ -287,8 +290,8 @@ capturedTermBindings lexicalTerms rhs =
   where
     freeVars = freeTermVariables rhs
 
-capturedTypeBindings :: Map String (Maybe BoundType) -> ElabType -> [(String, ElabType)] -> LiftM [(String, Maybe BoundType)]
-capturedTypeBindings lexicalTypes schemeTy termCaptures =
+capturedTypeBindings :: Map String (Maybe BoundType) -> ElabType -> [(String, ElabType)] -> ElabTerm -> LiftM [(String, Maybe BoundType)]
+capturedTypeBindings lexicalTypes schemeTy termCaptures rhs =
   pure
     [ (name, mbBound)
     | (name, mbBound) <- Map.toAscList lexicalTypes,
@@ -298,6 +301,7 @@ capturedTypeBindings lexicalTypes schemeTy termCaptures =
     freeVars =
       freeElabTypeVars schemeTy
         `Set.union` Set.unions (map (freeElabTypeVars . snd) termCaptures)
+        `Set.union` freeElabTermTypeVars rhs
 
 helperType :: [(String, Maybe BoundType)] -> [(String, ElabType)] -> ElabType -> ElabType
 helperType typeCaptures termCaptures bodyTy =
@@ -470,12 +474,16 @@ freeTermVariables =
 
 freeElabTypeVars :: ElabType -> Set.Set String
 freeElabTypeVars =
+  freeElabTypeVarsIn Set.empty
+
+freeElabTypeVarsIn :: Set.Set String -> ElabType -> Set.Set String
+freeElabTypeVarsIn initialBound =
   go Set.empty
   where
     go bound =
       \case
         TVar name
-          | Set.member name bound -> Set.empty
+          | Set.member name (initialBound `Set.union` bound) -> Set.empty
           | otherwise -> Set.singleton name
         TArrow dom cod ->
           go bound dom `Set.union` go bound cod
@@ -484,40 +492,336 @@ freeElabTypeVars =
         TBase {} ->
           Set.empty
         TForall name mb body ->
-          maybe Set.empty (go bound . tyToElab) mb `Set.union` go (Set.insert name bound) body
+          maybe Set.empty (go bound . tyToElab) mb
+            `Set.union` go (Set.insert name bound) body
         TMu name body ->
           go (Set.insert name bound) body
         TBottom ->
           Set.empty
 
-replaceFreeTermVariable :: String -> ElabTerm -> ElabTerm -> ElabTerm
-replaceFreeTermVariable needle replacement =
+freeElabTermTypeVars :: ElabTerm -> Set.Set String
+freeElabTermTypeVars =
   go Set.empty
   where
     go bound =
       \case
+        EVar {} ->
+          Set.empty
+        ELit {} ->
+          Set.empty
+        ELam _ ty body ->
+          freeElabTypeVarsIn bound ty `Set.union` go bound body
+        EApp fun arg ->
+          go bound fun `Set.union` go bound arg
+        ELet _ scheme rhs body ->
+          Set.unions
+            [ freeElabTypeVarsIn bound (schemeToType scheme),
+              go bound rhs,
+              go bound body
+            ]
+        ETyAbs name mbBound body ->
+          maybe Set.empty (freeElabTypeVarsIn bound . tyToElab) mbBound
+            `Set.union` go (Set.insert name bound) body
+        ETyInst inner inst ->
+          go bound inner `Set.union` freeInstantiationTypeVarsIn bound inst
+        ERoll ty body ->
+          freeElabTypeVarsIn bound ty `Set.union` go bound body
+        EUnroll body ->
+          go bound body
+
+freeInstantiationTypeVarsIn :: Set.Set String -> Instantiation -> Set.Set String
+freeInstantiationTypeVarsIn bound =
+  \case
+    InstId ->
+      Set.empty
+    InstApp ty ->
+      freeElabTypeVarsIn bound ty
+    InstBot ty ->
+      freeElabTypeVarsIn bound ty
+    InstIntro ->
+      Set.empty
+    InstElim ->
+      Set.empty
+    InstAbstr name
+      | Set.member name bound -> Set.empty
+      | otherwise -> Set.singleton name
+    InstUnder name inner ->
+      freeInstantiationTypeVarsIn (Set.insert name bound) inner
+    InstInside inner ->
+      freeInstantiationTypeVarsIn bound inner
+    InstSeq left right ->
+      freeInstantiationTypeVarsIn bound left `Set.union` freeInstantiationTypeVarsIn bound right
+
+termVariableNames :: ElabTerm -> Set.Set String
+termVariableNames =
+  \case
+    EVar name ->
+      Set.singleton name
+    ELit {} ->
+      Set.empty
+    ELam name _ body ->
+      Set.insert name (termVariableNames body)
+    EApp fun arg ->
+      termVariableNames fun `Set.union` termVariableNames arg
+    ELet name _ rhs body ->
+      Set.insert name (termVariableNames rhs `Set.union` termVariableNames body)
+    ETyAbs _ _ body ->
+      termVariableNames body
+    ETyInst inner _ ->
+      termVariableNames inner
+    ERoll _ body ->
+      termVariableNames body
+    EUnroll body ->
+      termVariableNames body
+
+elabTermTypeVariableNames :: ElabTerm -> Set.Set String
+elabTermTypeVariableNames =
+  \case
+    EVar {} ->
+      Set.empty
+    ELit {} ->
+      Set.empty
+    ELam _ ty body ->
+      elabTypeVariableNames ty `Set.union` elabTermTypeVariableNames body
+    EApp fun arg ->
+      elabTermTypeVariableNames fun `Set.union` elabTermTypeVariableNames arg
+    ELet _ scheme rhs body ->
+      Set.unions
+        [ elabTypeVariableNames (schemeToType scheme),
+          elabTermTypeVariableNames rhs,
+          elabTermTypeVariableNames body
+        ]
+    ETyAbs name mbBound body ->
+      Set.insert name $
+        maybe Set.empty (elabTypeVariableNames . tyToElab) mbBound
+          `Set.union` elabTermTypeVariableNames body
+    ETyInst inner inst ->
+      elabTermTypeVariableNames inner `Set.union` instantiationTypeVariableNames inst
+    ERoll ty body ->
+      elabTypeVariableNames ty `Set.union` elabTermTypeVariableNames body
+    EUnroll body ->
+      elabTermTypeVariableNames body
+
+elabTypeVariableNames :: ElabType -> Set.Set String
+elabTypeVariableNames =
+  \case
+    TVar name ->
+      Set.singleton name
+    TArrow dom cod ->
+      elabTypeVariableNames dom `Set.union` elabTypeVariableNames cod
+    TCon _ args ->
+      Set.unions (map elabTypeVariableNames (NE.toList args))
+    TBase {} ->
+      Set.empty
+    TForall name mbBound body ->
+      Set.insert name $
+        maybe Set.empty (elabTypeVariableNames . tyToElab) mbBound
+          `Set.union` elabTypeVariableNames body
+    TMu name body ->
+      Set.insert name (elabTypeVariableNames body)
+    TBottom ->
+      Set.empty
+
+instantiationTypeVariableNames :: Instantiation -> Set.Set String
+instantiationTypeVariableNames =
+  \case
+    InstId ->
+      Set.empty
+    InstApp ty ->
+      elabTypeVariableNames ty
+    InstBot ty ->
+      elabTypeVariableNames ty
+    InstIntro ->
+      Set.empty
+    InstElim ->
+      Set.empty
+    InstAbstr name ->
+      Set.singleton name
+    InstUnder name inner ->
+      Set.insert name (instantiationTypeVariableNames inner)
+    InstInside inner ->
+      instantiationTypeVariableNames inner
+    InstSeq left right ->
+      instantiationTypeVariableNames left `Set.union` instantiationTypeVariableNames right
+
+replaceFreeTermVariable :: String -> ElabTerm -> ElabTerm -> ElabTerm
+replaceFreeTermVariable needle replacement =
+  go
+  where
+    replacementFreeTerms = freeTermVariables replacement
+    replacementFreeTypes = freeElabTermTypeVars replacement
+
+    go =
+      \case
         EVar name
-          | name == needle && Set.notMember name bound -> replacement
+          | name == needle -> replacement
           | otherwise -> EVar name
         ELit lit ->
           ELit lit
-        ELam name ty body ->
-          ELam name ty (go (Set.insert name bound) body)
+        ELam name ty body
+          | name == needle ->
+              ELam name ty body
+          | shouldRenameTermBinder name body ->
+              let used = Set.unions [termVariableNames body, termVariableNames replacement, Set.singleton needle]
+                  name' = freshNameLike name used
+                  body' = renameBoundTermVariable name name' body
+               in ELam name' ty (go body')
+          | otherwise ->
+              ELam name ty (go body)
         EApp fun arg ->
-          EApp (go bound fun) (go bound arg)
+          EApp (go fun) (go arg)
         ELet name scheme rhs body
           | name == needle ->
               ELet name scheme rhs body
+          | shouldRenameTermBinder name (EApp rhs body) ->
+              let used =
+                    Set.unions
+                      [ termVariableNames rhs,
+                        termVariableNames body,
+                        termVariableNames replacement,
+                        Set.singleton needle
+                      ]
+                  name' = freshNameLike name used
+                  rhs' = renameBoundTermVariable name name' rhs
+                  body' = renameBoundTermVariable name name' body
+               in ELet name' scheme (go rhs') (go body')
           | otherwise ->
-              ELet name scheme (go bound rhs) (go (Set.insert name bound) body)
-        ETyAbs name mbBound body ->
-          ETyAbs name mbBound (go bound body)
+              ELet name scheme (go rhs) (go body)
+        ETyAbs name mbBound body
+          | shouldRenameTypeBinder name body ->
+              let used =
+                    Set.unions
+                      [ elabTermTypeVariableNames body,
+                        maybe Set.empty (elabTypeVariableNames . tyToElab) mbBound,
+                        elabTermTypeVariableNames replacement
+                      ]
+                  name' = freshNameLike name used
+                  body' = renameTermTypeVariable name name' body
+               in ETyAbs name' mbBound (go body')
+          | otherwise ->
+              ETyAbs name mbBound (go body)
         ETyInst inner inst ->
-          ETyInst (go bound inner) inst
+          ETyInst (go inner) inst
         ERoll ty body ->
-          ERoll ty (go bound body)
+          ERoll ty (go body)
         EUnroll body ->
-          EUnroll (go bound body)
+          EUnroll (go body)
+
+    shouldRenameTermBinder name body =
+      Set.member name replacementFreeTerms && termMentionsFreeVariable needle body
+
+    shouldRenameTypeBinder name body =
+      Set.member name replacementFreeTypes && termMentionsFreeVariable needle body
+
+renameBoundTermVariable :: String -> String -> ElabTerm -> ElabTerm
+renameBoundTermVariable old new =
+  go
+  where
+    go =
+      \case
+        EVar name
+          | name == old -> EVar new
+          | otherwise -> EVar name
+        ELit lit ->
+          ELit lit
+        ELam name ty body
+          | name == old -> ELam name ty body
+          | otherwise -> ELam name ty (go body)
+        EApp fun arg ->
+          EApp (go fun) (go arg)
+        ELet name scheme rhs body
+          | name == old -> ELet name scheme rhs body
+          | otherwise -> ELet name scheme (go rhs) (go body)
+        ETyAbs name mbBound body ->
+          ETyAbs name mbBound (go body)
+        ETyInst inner inst ->
+          ETyInst (go inner) inst
+        ERoll ty body ->
+          ERoll ty (go body)
+        EUnroll body ->
+          EUnroll (go body)
+
+renameTermTypeVariable :: String -> String -> ElabTerm -> ElabTerm
+renameTermTypeVariable old new =
+  go
+  where
+    go =
+      \case
+        EVar name ->
+          EVar name
+        ELit lit ->
+          ELit lit
+        ELam name ty body ->
+          ELam name (renameElabTypeVariable old new ty) (go body)
+        EApp fun arg ->
+          EApp (go fun) (go arg)
+        ELet name scheme rhs body ->
+          ELet name (renameElabSchemeTypeVariable old new scheme) (go rhs) (go body)
+        ETyAbs name mbBound body
+          | name == old ->
+              ETyAbs name (fmap (renameElabTypeVariable old new) mbBound) body
+          | otherwise ->
+              ETyAbs name (fmap (renameElabTypeVariable old new) mbBound) (go body)
+        ETyInst inner inst ->
+          ETyInst (go inner) (renameInstantiationTypeVariable old new inst)
+        ERoll ty body ->
+          ERoll (renameElabTypeVariable old new ty) (go body)
+        EUnroll body ->
+          EUnroll (go body)
+
+renameElabSchemeTypeVariable :: String -> String -> ElabScheme -> ElabScheme
+renameElabSchemeTypeVariable old new =
+  schemeFromType . renameElabTypeVariable old new . schemeToType
+
+renameElabTypeVariable :: String -> String -> Ty var -> Ty var
+renameElabTypeVariable old new =
+  \case
+    TVar name
+      | name == old -> TVar new
+      | otherwise -> TVar name
+    TArrow dom cod ->
+      TArrow (renameElabTypeVariable old new dom) (renameElabTypeVariable old new cod)
+    TCon con args ->
+      TCon con (fmap (renameElabTypeVariable old new) args)
+    TBase base ->
+      TBase base
+    TForall name mbBound body
+      | name == old ->
+          TForall name (fmap (renameElabTypeVariable old new) mbBound) body
+      | otherwise ->
+          TForall name (fmap (renameElabTypeVariable old new) mbBound) (renameElabTypeVariable old new body)
+    TMu name body
+      | name == old -> TMu name body
+      | otherwise -> TMu name (renameElabTypeVariable old new body)
+    TBottom ->
+      TBottom
+
+renameInstantiationTypeVariable :: String -> String -> Instantiation -> Instantiation
+renameInstantiationTypeVariable old new =
+  go
+  where
+    go =
+      \case
+        InstId ->
+          InstId
+        InstApp ty ->
+          InstApp (renameElabTypeVariable old new ty)
+        InstBot ty ->
+          InstBot (renameElabTypeVariable old new ty)
+        InstIntro ->
+          InstIntro
+        InstElim ->
+          InstElim
+        InstAbstr name
+          | name == old -> InstAbstr new
+          | otherwise -> InstAbstr name
+        InstUnder name inner
+          | name == old -> InstUnder name inner
+          | otherwise -> InstUnder name (go inner)
+        InstInside inner ->
+          InstInside (go inner)
+        InstSeq left right ->
+          InstSeq (go left) (go right)
 
 checkedBindingCanonicalType :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError ElabType
 checkedBindingCanonicalType context checkedModule binding =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -20,7 +20,7 @@ where
 
 import Control.Monad (foldM, forM, unless, when, zipWithM)
 import Control.Monad.State.Strict (StateT (StateT), get, modify, runStateT)
-import Data.List (find, intercalate, sort)
+import Data.List (find, intercalate, nub, sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -37,6 +37,7 @@ import MLF.Elab.Types
     Instantiation (..),
     Ty (..),
     TypeCheckError,
+    elabToBound,
     tyToElab,
   )
 import MLF.Frontend.Program.Elaborate (ElaborateScope, lowerType, mkElaborateScope)
@@ -161,7 +162,10 @@ convertCheckedBinding :: ConvertContext -> Env -> CheckedModule -> CheckedBindin
 convertCheckedBinding context env checkedModule binding = do
   let bindingContext = context {ccCurrentBindingName = checkedBindingName binding}
   canonicalElabTy <- checkedBindingCanonicalType context checkedModule binding
-  bindingTy <- convertElabType canonicalElabTy
+  rawBindingTy <- convertElabType canonicalElabTy
+  let bindingTy =
+        canonicalizeBackendType context $
+          applySourceTypeIdentity context (checkedBindingSourceType binding) rawBindingTy
   (expr, liftedBindings) <-
     case Map.lookup (checkedBindingName binding) (ccConstructors context) of
       Just constructorMeta
@@ -192,7 +196,7 @@ liftRecursiveLetsInBinding :: ConvertContext -> ElabTerm -> Either BackendConver
 liftRecursiveLetsInBinding context term = do
   (term', state') <-
     runStateT
-      (liftRecursiveLetsInTerm context Set.empty term)
+      (liftRecursiveLetsInTerm context Map.empty Map.empty term)
       LiftState
         { lsNextHelperIndex = 0,
           lsLiftedRecursiveLets = [],
@@ -202,82 +206,153 @@ liftRecursiveLetsInBinding context term = do
 
 convertLiftedRecursiveLet :: ConvertContext -> Env -> LiftedRecursiveLet -> Either BackendConversionError BackendBinding
 convertLiftedRecursiveLet context env lifted = do
-  expr <- convertTermExpected context env (Just (lrlBackendType lifted)) (lrlTerm lifted)
+  let bindingTy = canonicalizeBackendType context (lrlBackendType lifted)
+  expr <- convertTermExpected context env (Just bindingTy) (lrlTerm lifted)
   Right
     BackendBinding
       { backendBindingName = lrlName lifted,
-        backendBindingType = lrlBackendType lifted,
+        backendBindingType = bindingTy,
         backendBindingExpr = expr,
         backendBindingExportedAsMain = False
       }
 
-liftRecursiveLetsInTerm :: ConvertContext -> Set.Set String -> ElabTerm -> LiftM ElabTerm
-liftRecursiveLetsInTerm context lexicalLocals term =
+liftRecursiveLetsInTerm ::
+  ConvertContext ->
+  Map String ElabType ->
+  Map String (Maybe BoundType) ->
+  ElabTerm ->
+  LiftM ElabTerm
+liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
   case term of
     EVar {} ->
       pure term
     ELit {} ->
       pure term
     ELam name ty body ->
-      ELam name ty <$> liftRecursiveLetsInTerm context (Set.insert name lexicalLocals) body
+      ELam name ty <$> liftRecursiveLetsInTerm context (Map.insert name ty lexicalTerms) lexicalTypes body
     EApp fun arg ->
       EApp
-        <$> liftRecursiveLetsInTerm context lexicalLocals fun
-        <*> liftRecursiveLetsInTerm context lexicalLocals arg
+        <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes fun
+        <*> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes arg
     ELet name scheme rhs body -> do
       let schemeTy = schemeToType scheme
-          bodyLocals = Set.insert name lexicalLocals
+          bodyTerms = Map.insert name schemeTy lexicalTerms
       if termMentionsFreeVariable name rhs
         then do
           bindingTy <- liftEitherConversion (convertElabType schemeTy)
-          ensureLiftableRecursiveLet lexicalLocals name bindingTy rhs
+          termCaptures <- capturedTermBindings lexicalTerms rhs
+          typeCaptures <- capturedTypeBindings lexicalTypes schemeTy termCaptures
+          ensureLiftableRecursiveLet name bindingTy termCaptures rhs
           helperName <- freshLiftedRecursiveLetName context name
-          rhs' <- liftRecursiveLetsInTerm context (Set.insert name lexicalLocals) rhs
-          let helperTerm = renameFreeTermVariable name helperName rhs'
+          rhs' <- liftRecursiveLetsInTerm context bodyTerms lexicalTypes rhs
+          let helperRef = applyHelperCaptures helperName typeCaptures termCaptures
+              helperElabType = helperType typeCaptures termCaptures schemeTy
+              helperTerm =
+                wrapHelperTypeCaptures typeCaptures $
+                  wrapHelperTermCaptures termCaptures $
+                    replaceFreeTermVariable name helperRef rhs'
+          helperBackendType <- liftEitherConversion (canonicalizeBackendType context <$> convertElabType helperElabType)
           emitLiftedRecursiveLet
             LiftedRecursiveLet
               { lrlName = helperName,
-                lrlElabType = schemeTy,
-                lrlBackendType = bindingTy,
+                lrlElabType = helperElabType,
+                lrlBackendType = helperBackendType,
                 lrlTerm = helperTerm
               }
-          body' <- liftRecursiveLetsInTerm context bodyLocals body
-          pure (ELet name scheme (EVar helperName) body')
+          body' <- liftRecursiveLetsInTerm context bodyTerms lexicalTypes body
+          pure (ELet name scheme helperRef body')
         else
           ELet name scheme
-            <$> liftRecursiveLetsInTerm context lexicalLocals rhs
-            <*> liftRecursiveLetsInTerm context bodyLocals body
+            <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes rhs
+            <*> liftRecursiveLetsInTerm context bodyTerms lexicalTypes body
     ETyAbs name mbBound body ->
-      ETyAbs name mbBound <$> liftRecursiveLetsInTerm context lexicalLocals body
+      ETyAbs name mbBound <$> liftRecursiveLetsInTerm context lexicalTerms (Map.insert name mbBound lexicalTypes) body
     ETyInst inner inst ->
-      ETyInst <$> liftRecursiveLetsInTerm context lexicalLocals inner <*> pure inst
+      ETyInst <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes inner <*> pure inst
     ERoll ty body ->
-      ERoll ty <$> liftRecursiveLetsInTerm context lexicalLocals body
+      ERoll ty <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes body
     EUnroll body ->
-      EUnroll <$> liftRecursiveLetsInTerm context lexicalLocals body
+      EUnroll <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes body
 
-ensureLiftableRecursiveLet :: Set.Set String -> String -> BackendType -> ElabTerm -> LiftM ()
-ensureLiftableRecursiveLet lexicalLocals name bindingTy rhs = do
-  let captures =
-        Set.toList $
-          freeTermVariables rhs
-            `Set.intersection` lexicalLocals
-      unsupported reason =
+capturedTermBindings :: Map String ElabType -> ElabTerm -> LiftM [(String, ElabType)]
+capturedTermBindings lexicalTerms rhs =
+  pure
+    [ (name, ty)
+    | (name, ty) <- Map.toAscList lexicalTerms,
+      Set.member name freeVars
+    ]
+  where
+    freeVars = freeTermVariables rhs
+
+capturedTypeBindings :: Map String (Maybe BoundType) -> ElabType -> [(String, ElabType)] -> LiftM [(String, Maybe BoundType)]
+capturedTypeBindings lexicalTypes schemeTy termCaptures =
+  pure
+    [ (name, mbBound)
+    | (name, mbBound) <- Map.toAscList lexicalTypes,
+      Set.member name freeVars
+    ]
+  where
+    freeVars =
+      freeElabTypeVars schemeTy
+        `Set.union` Set.unions (map (freeElabTypeVars . snd) termCaptures)
+
+helperType :: [(String, Maybe BoundType)] -> [(String, ElabType)] -> ElabType -> ElabType
+helperType typeCaptures termCaptures bodyTy =
+  foldr wrapType (foldr (TArrow . snd) bodyTy termCaptures) typeCaptures
+  where
+    wrapType (name, mbBound) acc =
+      TForall name mbBound acc
+
+wrapHelperTypeCaptures :: [(String, Maybe BoundType)] -> ElabTerm -> ElabTerm
+wrapHelperTypeCaptures typeCaptures body =
+  foldr wrap body typeCaptures
+  where
+    wrap (name, mbBound) acc =
+      ETyAbs name mbBound acc
+
+wrapHelperTermCaptures :: [(String, ElabType)] -> ElabTerm -> ElabTerm
+wrapHelperTermCaptures termCaptures body =
+  foldr wrap body termCaptures
+  where
+    wrap (name, ty) acc =
+      ELam name ty acc
+
+applyHelperCaptures :: String -> [(String, Maybe BoundType)] -> [(String, ElabType)] -> ElabTerm
+applyHelperCaptures helperName typeCaptures termCaptures =
+  foldl EApp typedHelper [EVar name | (name, _) <- termCaptures]
+  where
+    typedHelper =
+      foldl
+        (\acc (name, _) -> ETyInst acc (InstApp (TVar name)))
+        (EVar helperName)
+        typeCaptures
+
+ensureLiftableRecursiveLet :: String -> BackendType -> [(String, ElabType)] -> ElabTerm -> LiftM ()
+ensureLiftableRecursiveLet name bindingTy captures rhs = do
+  let unsupported reason =
         BackendUnsupportedRecursiveLet
           ( name
               ++ " ("
               ++ reason
               ++ ")"
           )
-  unless (null captures) $
+  unless (all (isEvidenceCaptureName . fst) captures) $
     throwLiftError
       ( unsupported
-          ("captures lexical bindings: " ++ intercalate ", " captures)
+          ("captures lexical bindings: " ++ intercalate ", " (map fst captures))
       )
   unless (isMonomorphicFirstOrderFunctionType bindingTy) $
     throwLiftError (unsupported "expected a monomorphic first-order function type")
   unless (isFunctionValueTerm rhs) $
     throwLiftError (unsupported "expected a function-valued recursive right-hand side")
+
+isEvidenceCaptureName :: String -> Bool
+isEvidenceCaptureName name =
+  "$evidence_" `prefixOf` name
+  where
+    prefixOf [] _ = True
+    prefixOf _ [] = False
+    prefixOf (p : ps) (x : xs) = p == x && prefixOf ps xs
 
 freshLiftedRecursiveLetName :: ConvertContext -> String -> LiftM String
 freshLiftedRecursiveLetName context localName = do
@@ -390,18 +465,37 @@ freeTermVariables =
         EUnroll body ->
           go bound body
 
-renameFreeTermVariable :: String -> String -> ElabTerm -> ElabTerm
-renameFreeTermVariable needle replacement =
+freeElabTypeVars :: ElabType -> Set.Set String
+freeElabTypeVars =
   go Set.empty
   where
-    renameName bound name
-      | name == needle && Set.notMember name bound = replacement
-      | otherwise = name
-
     go bound =
       \case
-        EVar name ->
-          EVar (renameName bound name)
+        TVar name
+          | Set.member name bound -> Set.empty
+          | otherwise -> Set.singleton name
+        TArrow dom cod ->
+          go bound dom `Set.union` go bound cod
+        TCon _ args ->
+          Set.unions (map (go bound) (NE.toList args))
+        TBase {} ->
+          Set.empty
+        TForall name mb body ->
+          maybe Set.empty (go bound . tyToElab) mb `Set.union` go (Set.insert name bound) body
+        TMu name body ->
+          go (Set.insert name bound) body
+        TBottom ->
+          Set.empty
+
+replaceFreeTermVariable :: String -> ElabTerm -> ElabTerm -> ElabTerm
+replaceFreeTermVariable needle replacement =
+  go Set.empty
+  where
+    go bound =
+      \case
+        EVar name
+          | name == needle && Set.notMember name bound -> replacement
+          | otherwise -> EVar name
         ELit lit ->
           ELit lit
         ELam name ty body ->
@@ -671,7 +765,46 @@ bindingDataHint dataMetas binding =
 sourceTypeDataMeta :: [DataMeta] -> SrcType -> Maybe DataMeta
 sourceTypeDataMeta dataMetas ty =
   sourceTypeDataHead ty >>= \name ->
-    find (\dataMeta -> backendDataName (dmBackend dataMeta) == name) dataMetas
+    case filter (sourceDataNameMatches name) dataMetas of
+      [dataMeta] -> Just dataMeta
+      _ -> Nothing
+  where
+    sourceDataNameMatches name dataMeta =
+      backendDataName (dmBackend dataMeta) == name
+        || qualifiedDataName (dmInfo dataMeta) == name
+        || dataName (dmInfo dataMeta) == name
+
+applySourceTypeIdentity :: ConvertContext -> SrcType -> BackendType -> BackendType
+applySourceTypeIdentity context sourceTy backendTy =
+  case (sourceTy, backendTy) of
+    (STArrow sourceDom sourceCod, BTArrow backendDom backendCod) ->
+      BTArrow
+        (applySourceTypeIdentity context sourceDom backendDom)
+        (applySourceTypeIdentity context sourceCod backendCod)
+    (STForall _sourceName sourceBound sourceBody, BTForall backendName backendBound backendForallBody) ->
+      BTForall
+        backendName
+        (applySourceTypeIdentity context (maybe STBottom unSrcBound sourceBound) <$> backendBound)
+        (applySourceTypeIdentity context sourceBody backendForallBody)
+    _
+      | Just dataMeta <- sourceTypeDataMeta (ccData context) sourceTy,
+        Just dataTy <- canonicalDataTypeForSource dataMeta backendTy ->
+          dataTy
+    _ ->
+      backendTy
+
+canonicalDataTypeForSource :: DataMeta -> BackendType -> Maybe BackendType
+canonicalDataTypeForSource dataMeta backendTy =
+  case candidates of
+    candidate : _ -> Just candidate
+    [] -> Nothing
+  where
+    candidates =
+      nub
+        [ candidate
+        | constructor <- backendDataConstructors (dmBackend dataMeta),
+          candidate <- candidateConstructorResultTypes (dmBackend dataMeta) constructor backendTy
+        ]
 
 sourceTypeDataHead :: SrcType -> Maybe String
 sourceTypeDataHead =
@@ -794,6 +927,64 @@ convertElabType =
     TMu name body -> BTMu name <$> convertElabType body
     TBottom -> Right BTBottom
 
+backendTypeToElab :: BackendType -> ElabType
+backendTypeToElab =
+  \case
+    BTVar name -> TVar name
+    BTArrow dom cod -> TArrow (backendTypeToElab dom) (backendTypeToElab cod)
+    BTBase base -> TBase base
+    BTCon con args -> TCon con (fmap backendTypeToElab args)
+    BTForall name mb body ->
+      TForall name (mb >>= backendTypeToBound) (backendTypeToElab body)
+    BTMu name body -> TMu name (backendTypeToElab body)
+    BTBottom -> TBottom
+
+backendTypeToBound :: BackendType -> Maybe BoundType
+backendTypeToBound ty =
+  case elabToBound (backendTypeToElab ty) of
+    Right boundTy -> Just boundTy
+    Left _ -> Nothing
+
+canonicalizeBackendType :: ConvertContext -> BackendType -> BackendType
+canonicalizeBackendType context =
+  canonicalizeDataResult . go
+  where
+    go =
+      \case
+        BTArrow dom cod ->
+          BTArrow (go dom) (go cod)
+        BTCon con args ->
+          BTCon con (fmap go args)
+        BTForall name mb body ->
+          BTForall name (fmap go mb) (go body)
+        BTMu name body ->
+          BTMu name (go body)
+        ty ->
+          ty
+
+    canonicalizeDataResult ty =
+      case exactMatches of
+        [candidate] -> candidate
+        _ ->
+          case structuralMatches of
+            [candidate] -> candidate
+            _ -> ty
+      where
+        candidates = candidateDataResultTypes context ty
+        exactMatches = [candidate | candidate <- candidates, candidate == ty]
+        structuralMatches = candidates
+
+candidateDataResultTypes :: ConvertContext -> BackendType -> [BackendType]
+candidateDataResultTypes context ty =
+  nub
+    [ substituteBackendTypes completed (backendConstructorResult constructor)
+    | dataMeta <- ccData context,
+      constructor <- backendDataConstructors (dmBackend dataMeta),
+      let parameters = constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor,
+      Just substitution <- [matchBackendTypeParameters Map.empty parameters Map.empty (backendConstructorResult constructor) ty],
+      let completed = completeBackendParameterSubstitution parameters substitution
+    ]
+
 convertTerm :: ConvertContext -> Env -> ElabTerm -> Either BackendConversionError BackendExpr
 convertTerm context env =
   convertTermExpected context env Nothing
@@ -801,13 +992,14 @@ convertTerm context env =
 convertTermExpected :: ConvertContext -> Env -> Maybe BackendType -> ElabTerm -> Either BackendConversionError BackendExpr
 convertTermExpected context env mbExpectedTy term =
   case mbExpectedTy of
-    Just resultTy ->
-      convertSpecialTerm context env term resultTy
-        >>= \case
-          Just expr -> Right expr
-          Nothing -> convertOrdinaryTerm context env term resultTy
+    Just resultTy0 ->
+      let resultTy = canonicalizeBackendType context resultTy0
+       in convertSpecialTerm context env term resultTy
+            >>= \case
+              Just expr -> Right expr
+              Nothing -> convertOrdinaryTerm context env term resultTy
     Nothing -> do
-      resultTy <- inferBackendType env term
+      resultTy <- canonicalizeBackendType context <$> inferBackendType env term
       convertSpecialTerm context env term resultTy
         >>= \case
           Just expr -> Right expr
@@ -842,12 +1034,12 @@ convertOrdinaryTerm context env term resultTy =
             backendLit = lit
           }
     ELam name paramTy body -> do
-      paramBackendTy <- convertElabType paramTy
-      let bodyExpected =
+      rawParamBackendTy <- convertElabType paramTy
+      let (paramBackendTy, bodyExpected) =
             case resultTy of
-              BTArrow _ cod -> Just cod
-              _ -> Nothing
-      bodyExpr <- convertTermExpected context (extendTermEnv name paramTy env) bodyExpected body
+              BTArrow expectedParam cod -> (expectedParam, Just cod)
+              _ -> (canonicalizeBackendType context rawParamBackendTy, Nothing)
+      bodyExpr <- convertTermExpected context (extendTermEnv name (backendTypeToElab paramBackendTy) env) bodyExpected body
       Right
         BackendLam
           { backendExprType = resultTy,
@@ -871,9 +1063,9 @@ convertOrdinaryTerm context env term resultTy =
       let schemeTy = schemeToType scheme
       when (termMentionsFreeVariable name rhs) $
         Left (BackendUnsupportedRecursiveLet name)
-      bindingTy <- convertElabType schemeTy
+      bindingTy <- canonicalizeBackendType context <$> convertElabType schemeTy
       rhsExpr <- convertTermExpected context env (Just bindingTy) rhs
-      bodyExpr <- convertTermExpected context (extendTermEnv name schemeTy env) (Just resultTy) body
+      bodyExpr <- convertTermExpected context (extendTermEnv name (backendTypeToElab bindingTy) env) (Just resultTy) body
       Right
         BackendLet
           { backendExprType = resultTy,
@@ -883,7 +1075,7 @@ convertOrdinaryTerm context env term resultTy =
             backendLetBody = bodyExpr
           }
     ETyAbs name mbBound body -> do
-      mbBackendBound <- traverse (convertElabType . tyToElab) mbBound
+      mbBackendBound <- traverse (fmap (canonicalizeBackendType context) . convertElabType . tyToElab) mbBound
       let boundTy = maybe TBottom tyToElab mbBound
           bodyExpected =
             case resultTy of
@@ -962,7 +1154,7 @@ convertTypeInstantiation context env resultTy inner inst =
           innerExpr <- convertTerm context env inner
           case backendExprType innerExpr of
             BTForall {} -> do
-              backendTyArg <- convertElabType tyArg
+              backendTyArg <- canonicalizeBackendType context <$> convertElabType tyArg
               Right
                 BackendTyApp
                   { backendExprType = resultTy,
@@ -1006,10 +1198,19 @@ convertConstructorApplication context env term resultTy =
                     case matchBackendTypeParameters typeBounds parameters initialSubstitution (backendConstructorResult constructor) resultTy of
                       Just substitution -> Right substitution
                       Nothing ->
-                        Left
-                          ( BackendUnsupportedCaseShape
-                              ("constructor result type does not match expected result for `" ++ backendConstructorName constructor ++ "`")
-                          )
+                        case looseConstructorResultSubstitution initialSubstitution (backendConstructorResult constructor) resultTy of
+                          Just substitution -> Right substitution
+                          Nothing ->
+                            Left
+                              ( BackendUnsupportedCaseShape
+                                  ( "constructor result type does not match expected result for `"
+                                      ++ backendConstructorName constructor
+                                      ++ "`: expected "
+                                      ++ show resultTy
+                                      ++ ", constructor result "
+                                      ++ show (backendConstructorResult constructor)
+                                  )
+                              )
                   substitution <-
                     foldM
                       (matchConstructorApplicationArgument env typeBounds parameters)
@@ -1033,6 +1234,35 @@ convertConstructorApplication context env term resultTy =
 constructorTypeParameters :: ConstructorMeta -> BackendParameterBounds
 constructorTypeParameters constructorMeta =
   constructorTypeParameterBoundsFor (dmBackend (cmData constructorMeta)) (cmBackend constructorMeta)
+
+looseConstructorResultSubstitution :: Map String BackendType -> BackendType -> BackendType -> Maybe (Map String BackendType)
+looseConstructorResultSubstitution substitution constructorResult expectedResult =
+  case (constructorResult, expectedResult) of
+    (BTMu {}, BTMu expectedName expectedBody)
+      | Set.notMember expectedName (freeBackendTypeVars expectedBody) -> Just substitution
+    _ -> Nothing
+
+freeBackendTypeVars :: BackendType -> Set.Set String
+freeBackendTypeVars =
+  go Set.empty
+  where
+    go bound =
+      \case
+        BTVar name
+          | Set.member name bound -> Set.empty
+          | otherwise -> Set.singleton name
+        BTArrow dom cod ->
+          go bound dom `Set.union` go bound cod
+        BTBase {} ->
+          Set.empty
+        BTCon _ args ->
+          Set.unions (map (go bound) (NE.toList args))
+        BTForall name mb body ->
+          maybe Set.empty (go bound) mb `Set.union` go (Set.insert name bound) body
+        BTMu name body ->
+          go (Set.insert name bound) body
+        BTBottom ->
+          Set.empty
 
 constructorTypeParameterBoundsFor :: BackendData -> BackendConstructor -> BackendParameterBounds
 constructorTypeParameterBoundsFor dataDecl constructor =
@@ -1130,13 +1360,13 @@ convertCaseApplication context env term resultTy =
                 requireCaseData context typeBounds (backendExprType scrutineeExpr)
           let constructors = backendDataConstructors (dmBackend dataMeta)
           case compare (length args) (length constructors) of
-            EQ -> Just <$> convertCaseWithHandlers context env resultTy scrutineeExpr constructors args
+            EQ -> Just <$> convertCaseWithHandlers context env resultTy scrutineeExpr dataMeta constructors args
             GT -> do
               let (handlers, extraArgs) = splitAt (length constructors) args
               extraArgTys <- mapM (inferBackendType env) extraArgs
               case scanr BTArrow resultTy extraArgTys of
                 caseResultTy : appliedResultTys -> do
-                  caseExpr <- convertCaseWithHandlers context env caseResultTy scrutineeExpr constructors handlers
+                  caseExpr <- convertCaseWithHandlers context env caseResultTy scrutineeExpr dataMeta constructors handlers
                   Just
                     <$> foldM
                       (applyCaseExtraArgument context env)
@@ -1150,11 +1380,12 @@ convertCaseWithHandlers ::
   Env ->
   BackendType ->
   BackendExpr ->
+  DataMeta ->
   [BackendConstructor] ->
   [ElabTerm] ->
   Either BackendConversionError BackendExpr
-convertCaseWithHandlers context env resultTy scrutineeExpr constructors handlers = do
-  alternatives <- zipWithMCase (convertCaseAlternative context env resultTy) constructors handlers
+convertCaseWithHandlers context env resultTy scrutineeExpr dataMeta constructors handlers = do
+  alternatives <- zipWithMCase (convertCaseAlternative context env resultTy dataMeta (backendExprType scrutineeExpr)) constructors handlers
   Right
     BackendCase
       { backendExprType = resultTy,
@@ -1248,14 +1479,74 @@ matchConstructorApplicationArgument env typeBounds parameters substitution (expe
 
 requireCaseData :: ConvertContext -> BackendTypeBounds -> BackendType -> Either BackendConversionError DataMeta
 requireCaseData context typeBounds scrutineeTy =
-  case filter (dataMatchesScrutinee typeBounds scrutineeTy) (ccData context) of
+  case filter (dataMatchesScrutineeExactly scrutineeTy) (ccData context) of
     [dataMeta] -> Right dataMeta
-    [] -> Left (BackendUnsupportedCaseShape ("no backend data matches scrutinee type " ++ show scrutineeTy))
+    [] ->
+      case filter (dataMatchesRecursiveBinderHint scrutineeTy) (ccData context) of
+        [dataMeta] -> Right dataMeta
+        _ ->
+          case filter (dataMatchesScrutinee typeBounds scrutineeTy) (ccData context) of
+            [dataMeta] -> Right dataMeta
+            [] -> Left (BackendUnsupportedCaseShape ("no backend data matches scrutinee type " ++ show scrutineeTy))
+            matches ->
+              Left
+                ( BackendUnsupportedCaseShape
+                    ("ambiguous backend data matches scrutinee type " ++ show scrutineeTy ++ ": " ++ show (map (backendDataName . dmBackend) matches))
+                )
     matches ->
       Left
         ( BackendUnsupportedCaseShape
-            ("ambiguous backend data matches scrutinee type " ++ show scrutineeTy ++ ": " ++ show (map (backendDataName . dmBackend) matches))
+            ("ambiguous exact backend data matches scrutinee type " ++ show scrutineeTy ++ ": " ++ show (map (backendDataName . dmBackend) matches))
         )
+
+dataMatchesScrutineeExactly :: BackendType -> DataMeta -> Bool
+dataMatchesScrutineeExactly scrutineeTy dataMeta =
+  any
+    ( \constructor ->
+        any
+          (== scrutineeTy)
+          (candidateConstructorResultTypes (dmBackend dataMeta) constructor scrutineeTy)
+    )
+    (backendDataConstructors (dmBackend dataMeta))
+
+dataMatchesRecursiveBinderHint :: BackendType -> DataMeta -> Bool
+dataMatchesRecursiveBinderHint scrutineeTy dataMeta =
+  case scrutineeTy of
+    BTMu binderName _ ->
+      dataName (dmInfo dataMeta) `elem` recursiveBinderNameHints binderName
+        || backendDataName (dmBackend dataMeta) `elem` recursiveBinderNameHints binderName
+    _ -> False
+
+recursiveBinderNameHints :: String -> [String]
+recursiveBinderNameHints binderName =
+  nub [raw, withoutDollar, beforeSelf withoutDollar, suffixAfterDot (beforeSelf withoutDollar)]
+  where
+    raw = binderName
+    withoutDollar =
+      case raw of
+        '$' : rest -> rest
+        _ -> raw
+
+    beforeSelf value =
+      case reverse value of
+        'f' : 'l' : 'e' : 's' : '_' : rest -> reverse rest
+        _ -> value
+
+    suffixAfterDot value =
+      case break (== '.') (reverse value) of
+        (suffix, _ : _) -> reverse suffix
+        _ -> value
+
+candidateConstructorResultTypes :: BackendData -> BackendConstructor -> BackendType -> [BackendType]
+candidateConstructorResultTypes dataDecl constructor scrutineeTy =
+  case matchBackendTypeParameters Map.empty parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
+    Just substitution ->
+      let completed = completeBackendParameterSubstitution parameters substitution
+       in [substituteBackendTypes completed (backendConstructorResult constructor)]
+    Nothing ->
+      []
+  where
+    parameters = constructorTypeParameterBoundsFor dataDecl constructor
 
 dataMatchesScrutinee :: BackendTypeBounds -> BackendType -> DataMeta -> Bool
 dataMatchesScrutinee typeBounds scrutineeTy dataMeta =
@@ -1271,12 +1562,14 @@ convertCaseAlternative ::
   ConvertContext ->
   Env ->
   BackendType ->
+  DataMeta ->
+  BackendType ->
   BackendConstructor ->
   ElabTerm ->
   Either BackendConversionError BackendAlternative
-convertCaseAlternative context env resultTy constructor handler = do
-  let fields = backendConstructorFields constructor
-      (params, body) = collectLeadingLams (length fields) handler
+convertCaseAlternative context env resultTy dataMeta scrutineeTy constructor handler = do
+  fields <- caseAlternativeFieldTypes env dataMeta scrutineeTy constructor
+  let (params, body) = collectLeadingLams (length fields) handler
   when (length params /= length fields) $
     Left
       ( BackendUnsupportedCaseShape
@@ -1284,9 +1577,9 @@ convertCaseAlternative context env resultTy constructor handler = do
       )
   let env' =
         foldr
-          (\(name, ty) acc -> extendTermEnv name ty acc)
+          (\(name, ty) acc -> extendTermEnv name (backendTypeToElab ty) acc)
           env
-          params
+          (zip (map fst params) fields)
   bodyExpr <- convertTermExpected context env' (Just resultTy) body
   unless (alphaEqBackendType (backendExprType bodyExpr) resultTy) $
     Left
@@ -1298,6 +1591,20 @@ convertCaseAlternative context env resultTy constructor handler = do
       { backendAltPattern = BackendConstructorPattern (backendConstructorName constructor) (map fst params),
         backendAltBody = bodyExpr
       }
+
+caseAlternativeFieldTypes :: Env -> DataMeta -> BackendType -> BackendConstructor -> Either BackendConversionError [BackendType]
+caseAlternativeFieldTypes env dataMeta scrutineeTy constructor = do
+  typeBounds <- backendTypeBoundsFromEnv env
+  let parameters = constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor
+  case matchBackendTypeParameters typeBounds parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
+    Just substitution ->
+      let completed = completeBackendParameterSubstitution parameters substitution
+       in Right (map (substituteBackendTypes completed) (backendConstructorFields constructor))
+    Nothing ->
+      Left
+        ( BackendUnsupportedCaseShape
+            ("constructor result type does not match case scrutinee for `" ++ backendConstructorName constructor ++ "`")
+        )
 
 collectLeadingLams :: Int -> ElabTerm -> ([(String, ElabType)], ElabTerm)
 collectLeadingLams arity =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -697,8 +697,7 @@ replaceFreeTermVariable needle replacement =
                       ]
                   name' = freshNameLike name used
                   body' = renameTermTypeVariable name name' body
-                  mbBound' = fmap (renameElabTypeVariable name name') mbBound
-               in ETyAbs name' mbBound' (go body')
+               in ETyAbs name' mbBound (go body')
           | otherwise ->
               ETyAbs name mbBound (go body)
         ETyInst inner inst ->

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1703,8 +1703,11 @@ constructorTypeParameters constructorMeta =
 looseConstructorResultSubstitution :: Map String BackendType -> BackendType -> BackendType -> Maybe (Map String BackendType)
 looseConstructorResultSubstitution substitution constructorResult expectedResult =
   case (constructorResult, expectedResult) of
-    (BTMu {}, BTMu expectedName expectedBody)
-      | Set.notMember expectedName (freeBackendTypeVars expectedBody) -> Just substitution
+    (BTMu constructorName constructorBody, BTMu expectedName expectedBody)
+      | Set.notMember constructorName (freeBackendTypeVars constructorBody),
+        Set.notMember expectedName (freeBackendTypeVars expectedBody),
+        alphaEqBackendType (substituteBackendTypes substitution constructorBody) expectedBody ->
+          Just substitution
     _ -> Nothing
 
 freeBackendTypeVars :: BackendType -> Set.Set String

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -202,7 +202,7 @@ liftRecursiveLetsInBinding :: ConvertContext -> ElabTerm -> Either BackendConver
 liftRecursiveLetsInBinding context term = do
   (term', state') <-
     runStateT
-      (liftRecursiveLetsInTerm context Map.empty Map.empty term)
+      (liftRecursiveLetsInTerm context Map.empty [] term)
       LiftState
         { lsNextHelperIndex = 0,
           lsLiftedRecursiveLets = [],
@@ -225,7 +225,7 @@ convertLiftedRecursiveLet context env lifted = do
 liftRecursiveLetsInTerm ::
   ConvertContext ->
   Map String ElabType ->
-  Map String (Maybe BoundType) ->
+  [(String, Maybe BoundType)] ->
   ElabTerm ->
   LiftM ElabTerm
 liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
@@ -243,11 +243,11 @@ liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
     ELet name scheme rhs body -> do
       let schemeTy = schemeToType scheme
           bodyTerms = Map.insert name schemeTy lexicalTerms
-          recursiveRhs = Map.notMember name lexicalTerms && termMentionsFreeVariable name rhs
+          recursiveRhs = isFunctionValueTerm rhs && termMentionsFreeVariable name rhs
       if recursiveRhs
         then do
           bindingTy <- liftEitherConversion (convertElabType schemeTy)
-          termCaptures <- capturedTermBindings lexicalTerms rhs
+          termCaptures <- capturedTermBindings (Map.delete name lexicalTerms) rhs
           typeCaptures <- capturedTypeBindings lexicalTypes schemeTy termCaptures rhs
           ensureLiftableRecursiveLet name bindingTy termCaptures rhs
           helperName <- freshLiftedRecursiveLetName context name
@@ -273,7 +273,7 @@ liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
             <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes rhs
             <*> liftRecursiveLetsInTerm context bodyTerms lexicalTypes body
     ETyAbs name mbBound body ->
-      ETyAbs name mbBound <$> liftRecursiveLetsInTerm context lexicalTerms (Map.insert name mbBound lexicalTypes) body
+      ETyAbs name mbBound <$> liftRecursiveLetsInTerm context lexicalTerms (insertLexicalTypeBinding name mbBound lexicalTypes) body
     ETyInst inner inst ->
       ETyInst <$> liftRecursiveLetsInTerm context lexicalTerms lexicalTypes inner <*> pure inst
     ERoll ty body ->
@@ -291,11 +291,15 @@ capturedTermBindings lexicalTerms rhs =
   where
     freeVars = freeTermVariables rhs
 
-capturedTypeBindings :: Map String (Maybe BoundType) -> ElabType -> [(String, ElabType)] -> ElabTerm -> LiftM [(String, Maybe BoundType)]
+insertLexicalTypeBinding :: String -> Maybe BoundType -> [(String, Maybe BoundType)] -> [(String, Maybe BoundType)]
+insertLexicalTypeBinding name mbBound lexicalTypes =
+  filter ((/= name) . fst) lexicalTypes ++ [(name, mbBound)]
+
+capturedTypeBindings :: [(String, Maybe BoundType)] -> ElabType -> [(String, ElabType)] -> ElabTerm -> LiftM [(String, Maybe BoundType)]
 capturedTypeBindings lexicalTypes schemeTy termCaptures rhs =
   pure
     [ (name, mbBound)
-    | (name, mbBound) <- Map.toAscList lexicalTypes,
+    | (name, mbBound) <- lexicalTypes,
       Set.member name freeVars
     ]
   where
@@ -759,7 +763,7 @@ renameTermTypeVariable old new =
           ELet name (renameElabSchemeTypeVariable old new scheme) (go rhs) (go body)
         ETyAbs name mbBound body
           | name == old ->
-              ETyAbs name (fmap (renameElabTypeVariable old new) mbBound) body
+              ETyAbs name mbBound body
           | otherwise ->
               ETyAbs name (fmap (renameElabTypeVariable old new) mbBound) (go body)
         ETyInst inner inst ->

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -243,7 +243,8 @@ liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
     ELet name scheme rhs body -> do
       let schemeTy = schemeToType scheme
           bodyTerms = Map.insert name schemeTy lexicalTerms
-      if termMentionsFreeVariable name rhs
+          recursiveRhs = Map.notMember name lexicalTerms && termMentionsFreeVariable name rhs
+      if recursiveRhs
         then do
           bindingTy <- liftEitherConversion (convertElabType schemeTy)
           termCaptures <- capturedTermBindings lexicalTerms rhs
@@ -462,7 +463,7 @@ freeTermVariables =
         EApp fun arg ->
           go bound fun `Set.union` go bound arg
         ELet name _ rhs body ->
-          go (Set.insert name bound) rhs `Set.union` go (Set.insert name bound) body
+          go bound rhs `Set.union` go (Set.insert name bound) body
         ETyAbs _ _ body ->
           go bound body
         ETyInst inner _ ->
@@ -672,8 +673,8 @@ replaceFreeTermVariable needle replacement =
           EApp (go fun) (go arg)
         ELet name scheme rhs body
           | name == needle ->
-              ELet name scheme rhs body
-          | shouldRenameTermBinder name (EApp rhs body) ->
+              ELet name scheme (go rhs) body
+          | shouldRenameTermBinder name body ->
               let used =
                     Set.unions
                       [ termVariableNames rhs,
@@ -682,9 +683,8 @@ replaceFreeTermVariable needle replacement =
                         Set.singleton needle
                       ]
                   name' = freshNameLike name used
-                  rhs' = renameBoundTermVariable name name' rhs
                   body' = renameBoundTermVariable name name' body
-               in ELet name' scheme (go rhs') (go body')
+               in ELet name' scheme (go rhs) (go body')
           | otherwise ->
               ELet name scheme (go rhs) (go body)
         ETyAbs name mbBound body
@@ -730,7 +730,7 @@ renameBoundTermVariable old new =
         EApp fun arg ->
           EApp (go fun) (go arg)
         ELet name scheme rhs body
-          | name == old -> ELet name scheme rhs body
+          | name == old -> ELet name scheme (go rhs) body
           | otherwise -> ELet name scheme (go rhs) (go body)
         ETyAbs name mbBound body ->
           ETyAbs name mbBound (go body)
@@ -1547,7 +1547,7 @@ termMentionsFreeVariable needle =
         EApp fun arg ->
           go fun || go arg
         ELet name _ rhs body
-          | name == needle -> False
+          | name == needle -> go rhs
           | otherwise -> go rhs || go body
         ETyAbs _ _ body ->
           go body

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -697,7 +697,8 @@ replaceFreeTermVariable needle replacement =
                       ]
                   name' = freshNameLike name used
                   body' = renameTermTypeVariable name name' body
-               in ETyAbs name' mbBound (go body')
+                  mbBound' = fmap (renameElabTypeVariable name name') mbBound
+               in ETyAbs name' mbBound' (go body')
           | otherwise ->
               ETyAbs name mbBound (go body)
         ETyInst inner inst ->

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -161,7 +161,10 @@ convertCheckedModule context env checkedModule = do
 convertCheckedBinding :: ConvertContext -> Env -> CheckedModule -> CheckedBinding -> Either BackendConversionError [BackendBinding]
 convertCheckedBinding context env checkedModule binding = do
   let bindingContext = context {ccCurrentBindingName = checkedBindingName binding}
-  canonicalElabTy <- checkedBindingCanonicalType context checkedModule binding
+  canonicalElabTyOpen <- checkedBindingCanonicalTypeOpen context checkedModule binding
+  let freeTypeBinders = Set.toAscList (freeElabTypeVars canonicalElabTyOpen)
+      canonicalElabTy = quantifyFreeElabTypeVars freeTypeBinders canonicalElabTyOpen
+      checkedBindingTermClosed = wrapElabTypeAbs freeTypeBinders (checkedBindingTerm binding)
   rawBindingTy <- convertElabType canonicalElabTy
   let bindingTy =
         canonicalizeBackendType context $
@@ -174,7 +177,7 @@ convertCheckedBinding context env checkedModule binding = do
               expr <- synthesizeConstructorBinding bindingTy constructorMeta
               Right (expr, [])
       _ -> do
-        (liftedTerm, liftedSpecs) <- liftRecursiveLetsInBinding bindingContext (checkedBindingTerm binding)
+        (liftedTerm, liftedSpecs) <- liftRecursiveLetsInBinding bindingContext checkedBindingTermClosed
         let envWithLifted =
               foldr
                 (\lifted acc -> extendTermEnv (lrlName lifted) (lrlElabType lifted) acc)
@@ -517,15 +520,78 @@ replaceFreeTermVariable needle replacement =
           EUnroll (go bound body)
 
 checkedBindingCanonicalType :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError ElabType
-checkedBindingCanonicalType context checkedModule binding = do
+checkedBindingCanonicalType context checkedModule binding =
+  closeFreeElabType <$> checkedBindingCanonicalTypeOpen context checkedModule binding
+
+checkedBindingCanonicalTypeOpen :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError ElabType
+checkedBindingCanonicalTypeOpen context checkedModule binding = do
   let checkedTy = checkedBindingType binding
       scope = scopeForModule context (checkedModuleName checkedModule)
   checkedBackendTy <- convertElabType checkedTy
   canonicalTy <- sourceTypeToElabType (lowerType scope (checkedBindingSourceType binding))
   canonicalBackendTy <- convertElabType canonicalTy
+  let strippedCheckedBackendTy = stripVacuousBackendForalls checkedBackendTy
   if alphaEqBackendType checkedBackendTy canonicalBackendTy
     then Right canonicalTy
-    else Right checkedTy
+    else
+      if alphaEqBackendType (normalizeBuiltinBackendType strippedCheckedBackendTy) (normalizeBuiltinBackendType canonicalBackendTy)
+        then Right (backendTypeToElab strippedCheckedBackendTy)
+        else Right checkedTy
+
+stripVacuousBackendForalls :: BackendType -> BackendType
+stripVacuousBackendForalls =
+  \case
+    BTArrow dom cod ->
+      BTArrow (stripVacuousBackendForalls dom) (stripVacuousBackendForalls cod)
+    BTCon con args ->
+      BTCon con (fmap stripVacuousBackendForalls args)
+    BTForall name mbBound body ->
+      let body' = stripVacuousBackendForalls body
+          mbBound' = fmap stripVacuousBackendForalls mbBound
+       in if Set.member name (freeBackendTypeVars body')
+            then BTForall name mbBound' body'
+            else body'
+    BTMu name body ->
+      BTMu name (stripVacuousBackendForalls body)
+    ty ->
+      ty
+
+normalizeBuiltinBackendType :: BackendType -> BackendType
+normalizeBuiltinBackendType =
+  \case
+    BTArrow dom cod ->
+      BTArrow (normalizeBuiltinBackendType dom) (normalizeBuiltinBackendType cod)
+    BTBase base ->
+      BTBase (normalizeBuiltinBase base)
+    BTCon con args ->
+      BTCon (normalizeBuiltinBase con) (fmap normalizeBuiltinBackendType args)
+    BTForall name mbBound body ->
+      BTForall name (fmap normalizeBuiltinBackendType mbBound) (normalizeBuiltinBackendType body)
+    BTMu name body ->
+      BTMu name (normalizeBuiltinBackendType body)
+    ty ->
+      ty
+
+normalizeBuiltinBase :: BaseTy -> BaseTy
+normalizeBuiltinBase (BaseTy name) =
+  BaseTy $
+    case name of
+      "<builtin>.Int" -> "Int"
+      "<builtin>.Bool" -> "Bool"
+      "<builtin>.String" -> "String"
+      _ -> name
+
+closeFreeElabType :: ElabType -> ElabType
+closeFreeElabType ty =
+  quantifyFreeElabTypeVars (Set.toAscList (freeElabTypeVars ty)) ty
+
+quantifyFreeElabTypeVars :: [String] -> ElabType -> ElabType
+quantifyFreeElabTypeVars names ty =
+  foldr (`TForall` Nothing) ty names
+
+wrapElabTypeAbs :: [String] -> ElabTerm -> ElabTerm
+wrapElabTypeAbs names term =
+  foldr (\name acc -> ETyAbs name Nothing acc) term names
 
 scopeForModule :: ConvertContext -> String -> ElaborateScope
 scopeForModule context moduleName =
@@ -1047,18 +1113,8 @@ convertOrdinaryTerm context env term resultTy =
             backendParamType = paramBackendTy,
             backendBody = bodyExpr
           }
-    EApp fun arg -> do
-      funExpr <- convertTerm context env fun
-      argExpr <-
-        case backendExprType funExpr of
-          BTArrow expectedArg _ -> convertTermExpected context env (Just expectedArg) arg
-          _ -> convertTerm context env arg
-      Right
-        BackendApp
-          { backendExprType = resultTy,
-            backendFunction = funExpr,
-            backendArgument = argExpr
-          }
+    EApp fun arg ->
+      convertApplication context env resultTy fun arg
     ELet name scheme rhs body -> do
       let schemeTy = schemeToType scheme
       when (termMentionsFreeVariable name rhs) $
@@ -1074,21 +1130,22 @@ convertOrdinaryTerm context env term resultTy =
             backendLetRhs = rhsExpr,
             backendLetBody = bodyExpr
           }
-    ETyAbs name mbBound body -> do
-      mbBackendBound <- traverse (fmap (canonicalizeBackendType context) . convertElabType . tyToElab) mbBound
-      let boundTy = maybe TBottom tyToElab mbBound
-          bodyExpected =
-            case resultTy of
-              BTForall expectedName _ bodyTy -> Just (substituteBackendType expectedName (BTVar name) bodyTy)
-              _ -> Nothing
-      bodyExpr <- convertTermExpected context (extendTypeEnv name boundTy env) bodyExpected body
-      Right
-        BackendTyAbs
-          { backendExprType = resultTy,
-            backendTyParamName = name,
-            backendTyParamBound = mbBackendBound,
-            backendTyAbsBody = bodyExpr
-          }
+    ETyAbs name mbBound body ->
+      case resultTy of
+        BTForall expectedName _ bodyTy -> do
+          mbBackendBound <- traverse (fmap (canonicalizeBackendType context) . convertElabType . tyToElab) mbBound
+          let boundTy = maybe TBottom tyToElab mbBound
+              bodyExpected = Just (substituteBackendType expectedName (BTVar name) bodyTy)
+          bodyExpr <- convertTermExpected context (extendTypeEnv name boundTy env) bodyExpected body
+          Right
+            BackendTyAbs
+              { backendExprType = resultTy,
+                backendTyParamName = name,
+                backendTyParamBound = mbBackendBound,
+                backendTyAbsBody = bodyExpr
+              }
+        _ ->
+          convertTermExpected context env (Just resultTy) body
     ETyInst inner inst ->
       convertTypeInstantiation context env resultTy inner inst
     ERoll _ body -> do
@@ -1106,6 +1163,69 @@ convertOrdinaryTerm context env term resultTy =
           { backendExprType = resultTy,
             backendUnrollPayload = bodyExpr
           }
+
+convertApplication ::
+  ConvertContext ->
+  Env ->
+  BackendType ->
+  ElabTerm ->
+  ElabTerm ->
+  Either BackendConversionError BackendExpr
+convertApplication context env resultTy fun arg =
+  convertApplicationFromFunction context env resultTy fun arg
+    `orElseConversion` convertApplicationFromExpectedResult context env resultTy fun arg
+
+convertApplicationFromFunction ::
+  ConvertContext ->
+  Env ->
+  BackendType ->
+  ElabTerm ->
+  ElabTerm ->
+  Either BackendConversionError BackendExpr
+convertApplicationFromFunction context env resultTy fun arg = do
+  funExpr <- convertTerm context env fun
+  argExpr <-
+    case backendExprType funExpr of
+      BTArrow expectedArg _ -> convertTermExpected context env (Just expectedArg) arg
+      _ -> convertTerm context env arg
+  Right (backendApplication (applicationResultType resultTy funExpr) funExpr argExpr)
+
+convertApplicationFromExpectedResult ::
+  ConvertContext ->
+  Env ->
+  BackendType ->
+  ElabTerm ->
+  ElabTerm ->
+  Either BackendConversionError BackendExpr
+convertApplicationFromExpectedResult context env resultTy fun arg =
+  case inferBackendType env arg of
+    Right rawArgTy -> do
+      let argTy = canonicalizeBackendType context rawArgTy
+      funExpr <- convertTermExpected context env (Just (BTArrow argTy resultTy)) fun
+      argExpr <- convertTermExpected context env (Just argTy) arg
+      Right (backendApplication resultTy funExpr argExpr)
+    Left err -> Left err
+
+backendApplication :: BackendType -> BackendExpr -> BackendExpr -> BackendExpr
+backendApplication resultTy funExpr argExpr =
+  BackendApp
+    { backendExprType = resultTy,
+      backendFunction = funExpr,
+      backendArgument = argExpr
+    }
+
+applicationResultType :: BackendType -> BackendExpr -> BackendType
+applicationResultType resultTy funExpr =
+  case backendExprType funExpr of
+    BTArrow _ actualResultTy
+      | not (alphaEqBackendType actualResultTy resultTy) -> actualResultTy
+    _ -> resultTy
+
+orElseConversion :: Either BackendConversionError a -> Either BackendConversionError a -> Either BackendConversionError a
+orElseConversion primary fallback =
+  case primary of
+    Right value -> Right value
+    Left _ -> fallback
 
 termMentionsFreeVariable :: String -> ElabTerm -> Bool
 termMentionsFreeVariable needle =
@@ -1151,13 +1271,18 @@ convertTypeInstantiation context env resultTy inner inst =
     _ ->
       case appLikeInstantiationType inst of
         Just tyArg -> do
-          innerExpr <- convertTerm context env inner
+          innerExpr <- convertAppLikeInstantiationFunction context env inner
           case backendExprType innerExpr of
-            BTForall {} -> do
+            BTForall name _ bodyTy -> do
               backendTyArg <- canonicalizeBackendType context <$> convertElabType tyArg
+              let appliedTy = canonicalizeBackendType context (substituteBackendType name backendTyArg bodyTy)
+                  resultTy' =
+                    if alphaEqBackendType appliedTy resultTy
+                      then resultTy
+                      else appliedTy
               Right
                 BackendTyApp
-                  { backendExprType = resultTy,
+                  { backendExprType = resultTy',
                     backendTyFunction = innerExpr,
                     backendTyArgument = backendTyArg
                   }
@@ -1165,6 +1290,42 @@ convertTypeInstantiation context env resultTy inner inst =
               | alphaEqBackendType (backendExprType innerExpr) resultTy -> Right innerExpr
               | otherwise -> Left (BackendUnsupportedInstantiation inst)
         Nothing -> Left (BackendUnsupportedInstantiation inst)
+
+convertAppLikeInstantiationFunction ::
+  ConvertContext ->
+  Env ->
+  ElabTerm ->
+  Either BackendConversionError BackendExpr
+convertAppLikeInstantiationFunction context env inner =
+  case convertTerm context env inner of
+    Right expr
+      | hasForallResult expr -> Right expr
+    Right expr ->
+      case convertStrippedElim of
+        Right strippedExpr
+          | hasForallResult strippedExpr -> Right strippedExpr
+        _ -> Right expr
+    Left err ->
+      case convertStrippedElim of
+        Right strippedExpr -> Right strippedExpr
+        Left _ -> Left err
+  where
+    hasForallResult expr =
+      case backendExprType expr of
+        BTForall {} -> True
+        _ -> False
+
+    convertStrippedElim =
+      let stripped = dropLeadingElimInstantiations inner
+       in if stripped == inner
+            then Left (BackendUnsupportedInstantiation InstElim)
+            else convertTerm context env stripped
+
+dropLeadingElimInstantiations :: ElabTerm -> ElabTerm
+dropLeadingElimInstantiations term =
+  case term of
+    ETyInst inner InstElim -> dropLeadingElimInstantiations inner
+    _ -> term
 
 appLikeInstantiationType :: Instantiation -> Maybe ElabType
 appLikeInstantiationType inst =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -562,11 +562,24 @@ backendVariableTypeMatches typeBounds expectedTy actualTy =
                      actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
                   in go (Set.insert freshName bound) expectedBody' actualBody'
           (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
-            looseRecursiveTypeCompatible expectedName expectedBody actualName actualBody
-              || let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
-                     expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
-                     actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
-                  in go (Set.insert freshName bound) expectedBody' actualBody'
+            case (isVacuousRecursiveBinder expectedName expectedBody, isVacuousRecursiveBinder actualName actualBody) of
+              (True, True) ->
+                go bound expectedBody actualBody
+              (True, False) ->
+                recursiveBodyCompatible actualName actualBody expectedBody || go bound expectedBody actual
+              (False, True) ->
+                recursiveBodyCompatible expectedName expectedBody actualBody || go bound expected actualBody
+              (False, False) ->
+                let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
+                    expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                    actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                 in go (Set.insert freshName bound) expectedBody' actualBody'
+          (BTMu expectedName expectedBody, _)
+            | isVacuousRecursiveBinder expectedName expectedBody ->
+                go bound expectedBody actual
+          (_, BTMu actualName actualBody)
+            | isVacuousRecursiveBinder actualName actualBody ->
+                go bound expected actualBody
           (BTBottom, BTBottom) ->
             True
           _ ->
@@ -840,10 +853,22 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
                   actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
               go (Set.insert freshName bound) substitution' expectedBody' actualBody'
             (BTMu expectedName expectedBody, BTMu actualName actualBody) -> do
-              if looseRecursiveTypeCompatible expectedName expectedBody actualName actualBody
-                && Set.null (freeBackendTypeVars expectedBody `Set.intersection` Map.keysSet parameterBounds)
-                then Just substitution
-                else do
+              case (isVacuousRecursiveBinder expectedName expectedBody, isVacuousRecursiveBinder actualName actualBody) of
+                (True, True) ->
+                  go bound substitution expectedBody actualBody
+                (True, False)
+                  | recursiveBodyCompatible actualName actualBody expectedBody
+                      && expectedBodyHasNoParameters expectedBody ->
+                      Just substitution
+                  | otherwise ->
+                      go bound substitution expectedBody actual
+                (False, True)
+                  | recursiveBodyCompatible expectedName expectedBody actualBody
+                      && expectedBodyHasNoParameters expectedBody ->
+                      Just substitution
+                  | otherwise ->
+                      go bound substitution expected actualBody
+                (False, False) -> do
                   let used =
                         Set.unions
                           [ Set.fromList [expectedName, actualName],
@@ -857,6 +882,12 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
                       expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
                       actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
                   go (Set.insert freshName bound) substitution expectedBody' actualBody'
+            (BTMu expectedName expectedBody, _)
+              | isVacuousRecursiveBinder expectedName expectedBody ->
+                  go bound substitution expectedBody actual
+            (_, BTMu actualName actualBody)
+              | isVacuousRecursiveBinder actualName actualBody ->
+                  go bound substitution expected actualBody
             (BTBottom, BTBottom) ->
               Just substitution
             _ ->
@@ -920,10 +951,111 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
     resolvedTypeBounds =
       completeBackendParameterSubstitution typeBounds Map.empty
 
-looseRecursiveTypeCompatible :: String -> BackendType -> String -> BackendType -> Bool
-looseRecursiveTypeCompatible leftName leftBody rightName rightBody =
-  Set.notMember leftName (freeBackendTypeVars leftBody)
-    || Set.notMember rightName (freeBackendTypeVars rightBody)
+    expectedBodyHasNoParameters expectedBody =
+      Set.null (freeBackendTypeVars expectedBody `Set.intersection` Map.keysSet parameterBounds)
+
+isVacuousRecursiveBinder :: String -> BackendType -> Bool
+isVacuousRecursiveBinder name body =
+  Set.notMember name (freeBackendTypeVars body)
+
+recursiveBodyCompatible :: String -> BackendType -> BackendType -> Bool
+recursiveBodyCompatible recursiveName recursiveBody plainBody =
+  case go Set.empty Map.empty Nothing recursiveBody plainBody of
+    Just _ -> True
+    Nothing -> False
+  where
+    go patternVars patternBindings recursiveAlias leftTy rightTy =
+      case (leftTy, rightTy) of
+        (BTVar name, _)
+          | name == recursiveName ->
+              matchRecursiveAlias patternBindings recursiveAlias rightTy
+          | Set.member name patternVars ->
+              matchPatternVar name patternBindings recursiveAlias rightTy
+        (BTVar leftName, BTVar rightName)
+          | leftName == rightName ->
+              Just (patternBindings, recursiveAlias)
+        (BTArrow leftDom leftCod, BTArrow rightDom rightCod) ->
+          go patternVars patternBindings recursiveAlias leftDom rightDom
+            >>= \(patternBindings', recursiveAlias') ->
+              go patternVars patternBindings' recursiveAlias' leftCod rightCod
+        (BTBase leftBase, BTBase rightBase)
+          | leftBase == rightBase ->
+              Just (patternBindings, recursiveAlias)
+        (BTCon leftCon leftArgs, BTCon rightCon rightArgs)
+          | leftCon == rightCon ->
+              foldM
+                ( \(patternBindingsAcc, recursiveAliasAcc) (leftArg, rightArg) ->
+                    go patternVars patternBindingsAcc recursiveAliasAcc leftArg rightArg
+                )
+                (patternBindings, recursiveAlias)
+                (zip (NE.toList leftArgs) (NE.toList rightArgs))
+                >>= \(patternBindings', recursiveAlias') ->
+                  if length leftArgs == length rightArgs
+                    then Just (patternBindings', recursiveAlias')
+                    else Nothing
+        (BTForall leftName Nothing leftBody, BTForall rightName Nothing rightBody) ->
+          let freshName = freshRecursiveBodyBinder leftName rightName leftBody rightBody
+              leftBody' = substituteBackendType leftName (BTVar freshName) leftBody
+              rightBody' = substituteBackendType rightName (BTVar freshName) rightBody
+           in go patternVars patternBindings recursiveAlias leftBody' rightBody'
+        (BTForall leftName (Just leftBound) leftBody, BTForall rightName (Just rightBound) rightBody)
+          | alphaEqBackendType leftBound rightBound ->
+              let freshName = freshRecursiveBodyBinder leftName rightName leftBody rightBody
+                  leftBody' = substituteBackendType leftName (BTVar freshName) leftBody
+                  rightBody' = substituteBackendType rightName (BTVar freshName) rightBody
+               in go patternVars patternBindings recursiveAlias leftBody' rightBody'
+        (BTForall leftName Nothing leftBody, _) ->
+          go (Set.insert leftName patternVars) patternBindings recursiveAlias leftBody rightTy
+        (_, BTForall rightName Nothing rightBody)
+          | Set.member recursiveName (freeBackendTypeVars leftTy) ->
+              let aliasName = freshNameLike rightName (freeBackendTypeVars leftTy `Set.union` freeBackendTypeVars rightBody)
+                  rightBody' = substituteBackendType rightName (BTVar aliasName) rightBody
+               in case recursiveAlias of
+                    Nothing ->
+                      go patternVars patternBindings (Just aliasName) leftTy rightBody'
+                    Just previous
+                      | previous == aliasName ->
+                          go patternVars patternBindings recursiveAlias leftTy rightBody'
+                    _ ->
+                      Nothing
+        (BTBottom, BTBottom) ->
+          Just (patternBindings, recursiveAlias)
+        _ ->
+          Nothing
+
+    matchPatternVar name patternBindings recursiveAlias rightTy =
+      case Map.lookup name patternBindings of
+        Nothing ->
+          Just (Map.insert name rightTy patternBindings, recursiveAlias)
+        Just previous
+          | alphaEqBackendType previous rightTy ->
+              Just (patternBindings, recursiveAlias)
+        _ ->
+          Nothing
+
+    matchRecursiveAlias patternBindings recursiveAlias rightTy =
+      case rightTy of
+        BTVar rightName ->
+          case recursiveAlias of
+            Nothing ->
+              Just (patternBindings, Just rightName)
+            Just expectedName
+              | expectedName == rightName ->
+                  Just (patternBindings, recursiveAlias)
+            _ ->
+              Nothing
+        _ ->
+          Nothing
+
+    freshRecursiveBodyBinder leftName rightName leftBody rightBody =
+      freshNameLike
+        leftName
+        ( Set.unions
+            [ Set.fromList [leftName, rightName, recursiveName],
+              freeBackendTypeVars leftBody,
+              freeBackendTypeVars rightBody
+            ]
+        )
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map.Map String BackendType -> Map.Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -471,9 +471,9 @@ validateBackendExprWith mbContext expr =
       validateBackendExprWith mbContext arg
       case backendExprType fun of
         BTArrow expectedArg expectedResult -> do
-          unless (alphaEqBackendType (backendExprType arg) expectedArg) $
+          unless (backendTypeMatches mbContext expectedArg (backendExprType arg)) $
             Left (BackendApplicationArgumentMismatch expectedArg (backendExprType arg))
-          unless (alphaEqBackendType resultTy expectedResult) $
+          unless (backendTypeMatches mbContext expectedResult resultTy) $
             Left (BackendApplicationResultMismatch resultTy expectedResult)
         other ->
           Left (BackendApplicationExpectedFunction other)
@@ -533,6 +533,12 @@ validateBackendVariable (Just context0) name actualTy =
       unless (backendVariableTypeMatches (bvcTypeBounds context0) expectedTy actualTy) $
         Left (BackendVariableTypeMismatch name expectedTy actualTy)
 
+backendTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
+backendTypeMatches mbContext expectedTy actualTy =
+  backendVariableTypeMatches typeBounds expectedTy actualTy
+  where
+    typeBounds = maybe Map.empty bvcTypeBounds mbContext
+
 backendVariableTypeMatches :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
 backendVariableTypeMatches typeBounds expectedTy actualTy =
   go Set.empty expectedTy actualTy
@@ -556,10 +562,11 @@ backendVariableTypeMatches typeBounds expectedTy actualTy =
                      actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
                   in go (Set.insert freshName bound) expectedBody' actualBody'
           (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
-            let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
-                expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
-                actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
-             in go (Set.insert freshName bound) expectedBody' actualBody'
+            looseRecursiveTypeCompatible expectedName expectedBody actualName actualBody
+              || let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
+                     expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                     actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                  in go (Set.insert freshName bound) expectedBody' actualBody'
           (BTBottom, BTBottom) ->
             True
           _ ->
@@ -833,19 +840,23 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
                   actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
               go (Set.insert freshName bound) substitution' expectedBody' actualBody'
             (BTMu expectedName expectedBody, BTMu actualName actualBody) -> do
-              let used =
-                    Set.unions
-                      [ Set.fromList [expectedName, actualName],
-                        Map.keysSet substitution,
-                        freeBackendTypeVarsIn substitution,
-                        Map.keysSet parameterBounds,
-                        freeBackendTypeVars expectedBody,
-                        freeBackendTypeVars actualBody
-                      ]
-                  freshName = freshNameLike expectedName used
-                  expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
-                  actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
-              go (Set.insert freshName bound) substitution expectedBody' actualBody'
+              if looseRecursiveTypeCompatible expectedName expectedBody actualName actualBody
+                && Set.null (freeBackendTypeVars expectedBody `Set.intersection` Map.keysSet parameterBounds)
+                then Just substitution
+                else do
+                  let used =
+                        Set.unions
+                          [ Set.fromList [expectedName, actualName],
+                            Map.keysSet substitution,
+                            freeBackendTypeVarsIn substitution,
+                            Map.keysSet parameterBounds,
+                            freeBackendTypeVars expectedBody,
+                            freeBackendTypeVars actualBody
+                          ]
+                      freshName = freshNameLike expectedName used
+                      expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                      actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                  go (Set.insert freshName bound) substitution expectedBody' actualBody'
             (BTBottom, BTBottom) ->
               Just substitution
             _ ->
@@ -908,6 +919,11 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
 
     resolvedTypeBounds =
       completeBackendParameterSubstitution typeBounds Map.empty
+
+looseRecursiveTypeCompatible :: String -> BackendType -> String -> BackendType -> Bool
+looseRecursiveTypeCompatible leftName leftBody rightName rightBody =
+  Set.notMember leftName (freeBackendTypeVars leftBody)
+    || Set.notMember rightName (freeBackendTypeVars rightBody)
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map.Map String BackendType -> Map.Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -166,13 +166,28 @@ lowerBackendProgram program = do
 shouldLowerReachableBinding :: BindingInfo -> Bool
 shouldLowerReachableBinding binding =
   null (ffTypeBinders form)
-    && (biExportedAsMain binding || not (requiresInlineCall form))
+    && (biExportedAsMain binding || canEmitFunctionForm form)
   where
     form = biForm binding
 
 shouldLowerSpecialization :: Specialization -> Bool
 shouldLowerSpecialization =
-  not . requiresInlineCall . spForm
+  canEmitFunctionForm . spForm
+
+canEmitFunctionForm :: FunctionForm -> Bool
+canEmitFunctionForm form =
+  not (requiresInlineCall form) || canEmitInlineOnlyFunctionParameters form
+
+canEmitInlineOnlyFunctionParameters :: FunctionForm -> Bool
+canEmitInlineOnlyFunctionParameters form =
+  not (containsInlineOnlyEvidenceParameterCall form)
+    && all (uncurry canEmitFunctionParameter) (ffParams form)
+
+canEmitFunctionParameter :: String -> BackendType -> Bool
+canEmitFunctionParameter paramName paramTy
+  | isFunctionLikeBackendType paramTy =
+      isEvidenceParameter paramName paramTy || isFirstOrderFunctionPointerType paramTy
+  | otherwise = True
 
 runtimeAndName :: String
 runtimeAndName =
@@ -1013,7 +1028,7 @@ lowerFunction env name private form = do
 
 lowerFunctionParameterType :: ProgramEnv -> String -> String -> BackendType -> Either BackendLLVMError LLVMType
 lowerFunctionParameterType env context paramName paramTy
-  | isEvidenceParameter paramName paramTy = Right LLVMPtr
+  | isEvidenceParameter paramName paramTy || isFirstOrderFunctionPointerType paramTy = Right LLVMPtr
   | otherwise = lowerBackendType env context paramTy
 
 lowerFunctionParameterTypeM :: ProgramEnv -> String -> Bool -> String -> BackendType -> LowerM LLVMType
@@ -1055,6 +1070,33 @@ isFunctionLikeBackendType =
     BTForall _ _ body -> isFunctionLikeBackendType body
     BTArrow {} -> True
     _ -> False
+
+isFirstOrderFunctionPointerType :: BackendType -> Bool
+isFirstOrderFunctionPointerType ty =
+  case ty of
+    BTArrow {} ->
+      let (params, returnTy) = collectArrowsType ty
+       in all isFirstOrderPointerValueType (returnTy : params)
+    _ ->
+      False
+
+isFirstOrderPointerValueType :: BackendType -> Bool
+isFirstOrderPointerValueType =
+  \case
+    BTVar {} ->
+      False
+    BTArrow {} ->
+      False
+    BTBase {} ->
+      True
+    BTCon _ args ->
+      all isFirstOrderPointerValueType args
+    BTForall {} ->
+      False
+    BTMu {} ->
+      True
+    BTBottom ->
+      False
 
 requiresInlineCall :: FunctionForm -> Bool
 requiresInlineCall form =
@@ -1421,7 +1463,7 @@ lowerCall env exprEnv context expr =
 
 lowerIndirectValueCall :: ProgramEnv -> ExprEnv -> String -> String -> LowerValue -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerIndirectValueCall env exprEnv context name callee typeArgs args = do
-  unless (isEvidenceCallableName name) $
+  unless (isEvidenceCallableName name || isFirstOrderFunctionPointerType (lvBackendType callee)) $
     liftEither (BackendLLVMUnsupportedExpression context ("escaping function value " ++ show name))
   form <- instantiateFunctionFormM context (functionFormFromType (lvBackendType callee)) typeArgs args
   unless (length args == length (ffParams form)) $

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -15,7 +15,7 @@ import Control.Monad (foldM, unless, when, zipWithM, zipWithM_)
 import Control.Monad.State.Strict (StateT (StateT), evalStateT, get, gets, modify)
 import Data.Bifunctor (first)
 import Data.Char (isAlphaNum, ord)
-import Data.List (intercalate, nub, sort, sortOn)
+import Data.List (intercalate, isPrefixOf, nub, sort, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -53,6 +53,7 @@ data ProgramBase = ProgramBase
 data ProgramEnv = ProgramEnv
   { peBase :: ProgramBase,
     peSpecializations :: Map String Specialization,
+    peEvidenceWrappers :: Map String EvidenceWrapper,
     peStringGlobals :: Map String String
   }
 
@@ -88,6 +89,14 @@ data Specialization = Specialization
   { spRequest :: SpecRequest,
     spFunctionName :: String,
     spForm :: FunctionForm
+  }
+  deriving (Eq, Show)
+
+data EvidenceWrapper = EvidenceWrapper
+  { ewKey :: String,
+    ewFunctionName :: String,
+    ewExpectedType :: BackendType,
+    ewExpr :: BackendExpr
   }
   deriving (Eq, Show)
 
@@ -127,17 +136,22 @@ lowerBackendProgram program = do
   base <- buildProgramBase program
   reachable <- reachableBindings base (backendProgramMain program)
   specializations <- collectRequiredSpecializations base reachable
-  let stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations)
+  let evidenceWrappers = collectEvidenceWrappers base reachable specializations
+      stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations)
       env =
         ProgramEnv
           { peBase = base,
             peSpecializations = Map.fromList [(specializationKey (spRequest spec), spec) | spec <- specializations],
+            peEvidenceWrappers = Map.fromList [(ewKey wrapper, wrapper) | wrapper <- evidenceWrappers],
             peStringGlobals = stringGlobals
           }
   functions <-
-    (++)
-      <$> traverse (lowerMonomorphicBinding env) (filter (null . ffTypeBinders . biForm) reachable)
-      <*> traverse (lowerSpecialization env) specializations
+    concat
+      <$> sequence
+        [ traverse (lowerMonomorphicBinding env) (filter (null . ffTypeBinders . biForm) reachable),
+          traverse (lowerSpecialization env) specializations,
+          traverse (lowerEvidenceWrapper env) evidenceWrappers
+        ]
   mainBinding <- requireBinding base (backendProgramMain program)
   when (not (null (ffTypeBinders (biForm mainBinding)))) $
     Left (BackendLLVMUnsupportedExpression "program main" "polymorphic main binding")
@@ -246,12 +260,30 @@ functionFormFromExpected :: BackendType -> BackendExpr -> FunctionForm
 functionFormFromExpected expectedTy expr =
   case functionFormFromExpr expr of
     form
+      | Just completed <- completeAliasFunctionForm form ->
+          completed
       | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
           form
       | otherwise ->
           case aliasFunctionForm expectedTy expr of
             Just aliasForm -> aliasForm
             Nothing -> form
+
+completeAliasFunctionForm :: FunctionForm -> Maybe FunctionForm
+completeAliasFunctionForm form
+  | not (isAliasExpr (ffBody form)) = Nothing
+  | null params = Nothing
+  | otherwise = do
+      body <- applyAliasArguments (ffBody form) (ffReturnType form) (zip argNames params)
+      pure
+        form
+          { ffParams = ffParams form ++ zip argNames params,
+            ffBody = body,
+            ffReturnType = returnTy
+          }
+  where
+    (params, returnTy) = collectArrowsType (ffReturnType form)
+    argNames = ["__mlfp_alias_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
 
 aliasFunctionForm :: BackendType -> BackendExpr -> Maybe FunctionForm
 aliasFunctionForm expectedTy expr
@@ -278,6 +310,26 @@ isAliasExpr =
   \case
     BackendVar {} -> True
     BackendTyApp _ fun _ -> isAliasExpr fun
+    BackendApp _ fun arg -> isAliasExpr fun && isAliasArgument arg
+    BackendLet _ _ _ rhs body -> isAliasLetRhs rhs && isAliasExpr body
+    _ -> False
+
+isAliasLetRhs :: BackendExpr -> Bool
+isAliasLetRhs =
+  \case
+    BackendVar {} -> True
+    BackendTyApp _ fun _ -> isAliasLetRhs fun
+    BackendApp _ fun arg -> isAliasLetRhs fun && isAliasArgument arg
+    BackendLet _ _ _ rhs body -> isAliasLetRhs rhs && isAliasLetRhs body
+    _ -> False
+
+isAliasArgument :: BackendExpr -> Bool
+isAliasArgument =
+  \case
+    BackendVar ty _ -> isFunctionLikeBackendType ty
+    BackendTyApp ty fun _ -> isFunctionLikeBackendType ty && isAliasArgument fun
+    BackendApp ty fun arg -> isFunctionLikeBackendType ty && isAliasExpr fun && isAliasArgument arg
+    BackendLet ty _ _ rhs body -> isFunctionLikeBackendType ty && isAliasLetRhs rhs && isAliasArgument body
     _ -> False
 
 collectForallsType :: BackendType -> ([(String, Maybe BackendType)], BackendType)
@@ -483,6 +535,108 @@ collectRequiredSpecializations base reachable =
       where
         key = specializationKey request
 
+collectEvidenceWrappers :: ProgramBase -> [BindingInfo] -> [Specialization] -> [EvidenceWrapper]
+collectEvidenceWrappers base reachable specializations =
+  zipWith assignName [(0 :: Int) ..] uniqueRequests
+  where
+    requests =
+      concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . biForm) reachable
+        ++ concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . spForm) specializations
+    uniqueRequests =
+      map snd (Map.toAscList (Map.fromList [(evidenceWrapperKey expected expr, (expected, expr)) | (expected, expr) <- requests]))
+    assignName index0 (expected, expr) =
+      EvidenceWrapper
+        { ewKey = evidenceWrapperKey expected expr,
+          ewFunctionName = "__mlfp_evidence_wrapper$" ++ show index0,
+          ewExpectedType = expected,
+          ewExpr = expr
+        }
+
+collectEvidenceWrappersInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
+collectEvidenceWrappersInForm base substitution bound form =
+  collectEvidenceWrappersInExpr
+    base
+    substitution
+    (Set.union (Set.fromList (map fst (ffParams form))) bound)
+    (ffBody form)
+
+collectEvidenceWrappersInExpr :: ProgramBase -> Map String BackendType -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
+collectEvidenceWrappersInExpr base substitution bound expr =
+  wrappersHere ++ childWrappers
+  where
+    wrappersHere =
+      case collectCall expr of
+        Just (BackendVar _ name, typeArgs, args)
+          | Set.notMember name bound,
+            Just binding <- Map.lookup name (pbBindings base) ->
+              let typeArgs' = map (substituteBackendTypes substitution) typeArgs
+                  args' = map (substituteExprTypes substitution) args
+               in case instantiateFunctionFormWithTypeArgs ("evidence wrapper request " ++ name) (biForm binding) typeArgs' args' of
+                    Right (_, form) ->
+                      [ (paramTy, arg)
+                      | ((paramName, paramTy), arg) <- zip (ffParams form) args',
+                        isEvidenceArgument False paramName paramTy,
+                        not (isSimpleFunctionReference arg)
+                      ]
+                    Left _ -> []
+        _ -> []
+
+    childWrappers =
+      case expr of
+        BackendVar {} -> []
+        BackendLit {} -> []
+        BackendLam _ name _ body ->
+          collectEvidenceWrappersInExpr base substitution (Set.insert name bound) body
+        BackendApp _ fun arg ->
+          collectEvidenceWrappersInExpr base substitution bound fun
+            ++ collectEvidenceWrappersInExpr base substitution bound arg
+        BackendLet _ name bindingTy rhs body ->
+          collectLetRhsWrappers bindingTy rhs
+            ++ collectEvidenceWrappersInExpr base substitution (Set.insert name bound) body
+        BackendTyAbs _ name _ body ->
+          collectEvidenceWrappersInExpr base (Map.delete name substitution) bound body
+        BackendTyApp _ fun _ ->
+          collectEvidenceWrappersInExpr base substitution bound fun
+        BackendConstruct _ _ args ->
+          concatMap (collectEvidenceWrappersInExpr base substitution bound) args
+        BackendCase _ scrutinee alternatives ->
+          collectEvidenceWrappersInExpr base substitution bound scrutinee
+            ++ concatMap collectAlternativeWrappers (NE.toList alternatives)
+        BackendRoll _ payload ->
+          collectEvidenceWrappersInExpr base substitution bound payload
+        BackendUnroll _ payload ->
+          collectEvidenceWrappersInExpr base substitution bound payload
+
+    collectLetRhsWrappers bindingTy rhs =
+      case functionFormFromExpected bindingTy rhs of
+        form
+          | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+              collectEvidenceWrappersInForm base substitution bound form
+        _ ->
+          collectEvidenceWrappersInExpr base substitution bound rhs
+
+    collectAlternativeWrappers alternative =
+      collectEvidenceWrappersInExpr
+        base
+        substitution
+        (Set.union (patternBinders (backendAltPattern alternative)) bound)
+        (backendAltBody alternative)
+
+    patternBinders =
+      \case
+        BackendDefaultPattern -> Set.empty
+        BackendConstructorPattern _ binders -> Set.fromList binders
+
+evidenceWrapperKey :: BackendType -> BackendExpr -> String
+evidenceWrapperKey expected expr =
+  backendTypeKey expected ++ "\0" ++ show expr
+
+isSimpleFunctionReference :: BackendExpr -> Bool
+isSimpleFunctionReference arg =
+  case collectTyApps arg of
+    (BackendVar {}, _) -> True
+    _ -> False
+
 collectSpecializationRequestsInForm :: ProgramBase -> Map String BackendType -> FunctionForm -> [SpecRequest]
 collectSpecializationRequestsInForm base substitution form =
   collectSpecializationRequestsInFormWithBound base substitution Set.empty form
@@ -536,12 +690,10 @@ collectSpecializationRequestsWithBound base substitution bound expr =
             (BackendVar _ name, typeArgs)
               | Set.notMember name bound,
                 Just binding <- Map.lookup name (pbBindings base),
-                not (null (ffTypeBinders (biForm binding))),
-                null (ffParams (biForm binding)) ->
+                not (null (ffTypeBinders (biForm binding))) ->
                   let typeArgs' = map (substituteBackendTypes substitution) typeArgs
                    in case instantiateFunctionFormWithTypeArgs ("specialization request " ++ name) (biForm binding) typeArgs' [] of
-                        Right (resolvedTypeArgs, form)
-                          | null (ffParams form) -> [SpecRequest name resolvedTypeArgs]
+                        Right (resolvedTypeArgs, _) -> [SpecRequest name resolvedTypeArgs]
                         _ -> []
             (fun, typeArgs) ->
               collectAdministrativeTypeAppRequests fun typeArgs
@@ -735,6 +887,34 @@ lowerSpecialization :: ProgramEnv -> Specialization -> Either BackendLLVMError L
 lowerSpecialization env specialization =
   lowerFunction env (spFunctionName specialization) True (spForm specialization)
 
+lowerEvidenceWrapper :: ProgramEnv -> EvidenceWrapper -> Either BackendLLVMError LLVMFunction
+lowerEvidenceWrapper env wrapper =
+  lowerFunction env (ewFunctionName wrapper) True (evidenceWrapperForm wrapper)
+
+evidenceWrapperForm :: EvidenceWrapper -> FunctionForm
+evidenceWrapperForm wrapper =
+  FunctionForm
+    { ffTypeBinders = [],
+      ffParams = zip paramNames params,
+      ffBody = body,
+      ffReturnType = returnTy
+    }
+  where
+    (params, returnTy) = collectArrowsType (ewExpectedType wrapper)
+    paramNames = ["__mlfp_evidence_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
+    paramExprs = [BackendVar paramTy name | (name, paramTy) <- zip paramNames params]
+    body = applyEvidenceWrapperArgs (ewExpr wrapper) (ewExpectedType wrapper) paramExprs
+
+applyEvidenceWrapperArgs :: BackendExpr -> BackendType -> [BackendExpr] -> BackendExpr
+applyEvidenceWrapperArgs expr _ [] =
+  expr
+applyEvidenceWrapperArgs expr ty (arg : rest) =
+  case ty of
+    BTArrow _ resultTy ->
+      applyEvidenceWrapperArgs (BackendApp resultTy expr arg) resultTy rest
+    _ ->
+      expr
+
 lowerFunction :: ProgramEnv -> String -> Bool -> FunctionForm -> Either BackendLLVMError LLVMFunction
 lowerFunction env name private form = do
   unless (null (ffTypeBinders form)) $
@@ -762,8 +942,43 @@ lowerFunction env name private form = do
       }
   where
     lowerParam (paramName, paramTy) = do
-      llvmTy <- lowerBackendType env ("parameter " ++ show paramName ++ " of " ++ name) paramTy
+      llvmTy <- lowerFunctionParameterType env ("parameter " ++ show paramName ++ " of " ++ name) paramName paramTy
       pure (LLVMParameter llvmTy paramName)
+
+lowerFunctionParameterType :: ProgramEnv -> String -> String -> BackendType -> Either BackendLLVMError LLVMType
+lowerFunctionParameterType env context paramName paramTy
+  | isEvidenceParameter paramName paramTy = Right LLVMPtr
+  | otherwise = lowerBackendType env context paramTy
+
+lowerFunctionParameterTypeM :: ProgramEnv -> String -> Bool -> String -> BackendType -> LowerM LLVMType
+lowerFunctionParameterTypeM env context allowNestedEvidence paramName paramTy =
+  case lowerArgumentType env context allowNestedEvidence paramName paramTy of
+    Right llvmTy -> pure llvmTy
+    Left err -> liftEither err
+
+lowerArgumentType :: ProgramEnv -> String -> Bool -> String -> BackendType -> Either BackendLLVMError LLVMType
+lowerArgumentType env context allowNestedEvidence paramName paramTy
+  | isEvidenceArgument allowNestedEvidence paramName paramTy = Right LLVMPtr
+  | otherwise = lowerBackendType env context paramTy
+
+isEvidenceArgument :: Bool -> String -> BackendType -> Bool
+isEvidenceArgument allowNestedEvidence paramName paramTy =
+  (allowNestedEvidence || isEvidenceName paramName) && isFunctionLikeBackendType paramTy
+
+isEvidenceParameter :: String -> BackendType -> Bool
+isEvidenceParameter =
+  isEvidenceArgument False
+
+isEvidenceName :: String -> Bool
+isEvidenceName =
+  isPrefixOf "$evidence_"
+
+isFunctionLikeBackendType :: BackendType -> Bool
+isFunctionLikeBackendType =
+  \case
+    BTForall _ _ body -> isFunctionLikeBackendType body
+    BTArrow {} -> True
+    _ -> False
 
 initialFunctionState :: FunctionState
 initialFunctionState =
@@ -1011,11 +1226,16 @@ lowerCall env exprEnv context expr =
     Just (headExpr, typeArgs, args) ->
       case headExpr of
         BackendVar _ name ->
-          case Map.lookup name (eeLocalFunctions exprEnv) of
-            Just localFunction ->
-              lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
-            Nothing ->
-              lowerGlobalCall env exprEnv context name typeArgs args
+          case Map.lookup name (eeValues exprEnv) of
+            Just value
+              | isFunctionLikeBackendType (lvBackendType value) ->
+                  lowerIndirectValueCall env exprEnv context name value typeArgs args
+            _ ->
+              case Map.lookup name (eeLocalFunctions exprEnv) of
+                Just localFunction ->
+                  lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
+                Nothing ->
+                  lowerGlobalCall env exprEnv context name typeArgs args
         BackendLam {} ->
           lowerDirectFunctionCall env exprEnv context (functionFormFromExpr headExpr) typeArgs args
         BackendTyAbs {} ->
@@ -1029,19 +1249,136 @@ lowerCall env exprEnv context expr =
             Left err ->
               liftEither err
 
+lowerIndirectValueCall :: ProgramEnv -> ExprEnv -> String -> String -> LowerValue -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
+lowerIndirectValueCall env exprEnv context name callee typeArgs args = do
+  unless (isEvidenceName name) $
+    liftEither (BackendLLVMUnsupportedExpression context ("escaping function value " ++ show name))
+  form <- instantiateFunctionFormM context (functionFormFromType (lvBackendType callee)) typeArgs args
+  unless (length args == length (ffParams form)) $
+    liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
+  callArgs <- zipWithM (lowerExprForArgument env exprEnv context True) (ffParams form) args
+  bindFunctionArguments env context True name form callArgs
+  resultTy <- lowerBackendTypeM env context (ffReturnType form)
+  result <- emitAssign "call" resultTy (LLVMCallOperand (lvOperand callee) [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+  pure (LowerValue (ffReturnType form) resultTy result)
+
+functionFormFromType :: BackendType -> FunctionForm
+functionFormFromType ty =
+  FunctionForm
+    { ffTypeBinders = typeBinders,
+      ffParams = zip paramNames params,
+      ffBody = BackendVar returnTy "__mlfp_callable_result",
+      ffReturnType = returnTy
+    }
+  where
+    (typeBinders, afterForalls) = collectForallsType ty
+    (params, returnTy) = collectArrowsType afterForalls
+    paramNames = ["__mlfp_callable_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
+
+lowerExprForArgument :: ProgramEnv -> ExprEnv -> String -> Bool -> (String, BackendType) -> BackendExpr -> LowerM LowerValue
+lowerExprForArgument env exprEnv context allowNestedEvidence (paramName, paramTy) arg
+  | isEvidenceArgument allowNestedEvidence paramName paramTy =
+      lowerEvidenceArgument env exprEnv context paramTy arg
+  | otherwise =
+      lowerExpr env exprEnv context arg
+
+lowerEvidenceArgument :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
+lowerEvidenceArgument env exprEnv context expectedTy arg =
+  case collectTyApps arg of
+    (BackendVar _ name, typeArgs) ->
+      lowerFunctionReference env exprEnv context expectedTy name typeArgs
+    _ ->
+      case Map.lookup (evidenceWrapperKey expectedTy arg) (peEvidenceWrappers env) of
+        Just wrapper ->
+          pure (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (ewFunctionName wrapper)))
+        Nothing ->
+          liftEither (BackendLLVMUnsupportedExpression context "unsupported evidence function argument")
+
+lowerFunctionReference :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendType] -> LowerM LowerValue
+lowerFunctionReference env exprEnv context expectedTy name typeArgs =
+  case Map.lookup name (eeValues exprEnv) of
+    Just value
+      | isFunctionLikeBackendType (lvBackendType value) -> do
+          actualTy <- instantiateCallableTypeM context (lvBackendType value) typeArgs []
+          requireEvidenceFunctionType context name expectedTy actualTy
+          pure (LowerValue expectedTy LLVMPtr (lvOperand value))
+    _ ->
+      case Map.lookup name (pbBindings (peBase env)) of
+        Just binding -> do
+          (resolvedTypeArgs, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs []
+          let actualTy = functionTypeFromForm form
+          requireEvidenceFunctionType context name expectedTy actualTy
+          functionName <- globalFunctionName env context binding resolvedTypeArgs
+          pure (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr functionName))
+        Nothing ->
+          liftEither (BackendLLVMUnknownFunction name)
+
+instantiateCallableTypeM :: String -> BackendType -> [BackendType] -> [BackendExpr] -> LowerM BackendType
+instantiateCallableTypeM context ty typeArgs args = do
+  form <- instantiateFunctionFormM context (functionFormFromType ty) typeArgs args
+  pure (functionTypeFromForm form)
+
+functionTypeFromForm :: FunctionForm -> BackendType
+functionTypeFromForm form =
+  foldr BTArrow (ffReturnType form) (map snd (ffParams form))
+
+requireEvidenceFunctionType :: String -> String -> BackendType -> BackendType -> LowerM ()
+requireEvidenceFunctionType context name expected actual =
+  unless (evidenceFunctionTypesCompatible expected actual) $
+    liftEither
+      ( BackendLLVMInternalError
+          ( "evidence function type mismatch for "
+              ++ name
+              ++ " at "
+              ++ context
+              ++ ": expected "
+              ++ show expected
+              ++ ", got "
+              ++ show actual
+          )
+      )
+
+evidenceFunctionTypesCompatible :: BackendType -> BackendType -> Bool
+evidenceFunctionTypesCompatible expected actual =
+  alphaEqBackendType expected actual || sameFunctionShape expected actual
+  where
+    sameFunctionShape left right =
+      case (left, right) of
+        (BTForall _ _ leftBody, BTForall _ _ rightBody) ->
+          sameFunctionShape leftBody rightBody
+        (BTArrow leftParam leftResult, BTArrow rightParam rightResult) ->
+          runtimeCompatibleValueType leftParam rightParam && sameFunctionShape leftResult rightResult
+        _ ->
+          runtimeCompatibleValueType left right
+
+runtimeCompatibleValueType :: BackendType -> BackendType -> Bool
+runtimeCompatibleValueType left right =
+  alphaEqBackendType left right
+    || case (left, right) of
+      (BTMu {}, BTMu {}) -> True
+      (BTArrow {}, BTArrow {}) -> True
+      (BTForall {}, BTForall {}) -> True
+      (BTBase leftBase, BTBase rightBase) -> leftBase == rightBase
+      (BTCon leftCon leftArgs, BTCon rightCon rightArgs) ->
+        leftCon == rightCon
+          && length leftArgs == length rightArgs
+          && and (zipWith runtimeCompatibleValueType (NE.toList leftArgs) (NE.toList rightArgs))
+      (BTBottom, BTBottom) -> True
+      _ -> False
+
 lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do
   form <- instantiateFunctionFormM context (lfForm localFunction) typeArgs args
-  callArgs <- traverse (lowerExpr env callEnv context) args
-  bindFunctionArguments env context name form callArgs
+  callArgs <- zipWithM (lowerExprForArgument env callEnv context False) (ffParams form) args
+  bindFunctionArguments env context False name form callArgs
   let bodyEnv = extendExprEnvWithArguments (lfCapturedEnv localFunction) form callArgs
   lowerExpr env bodyEnv context (ffBody form)
 
 lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do
   form <- instantiateFunctionFormM context form0 typeArgs args
-  callArgs <- traverse (lowerExpr env exprEnv context) args
-  bindFunctionArguments env context "lambda" form callArgs
+  callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
+  bindFunctionArguments env context False "lambda" form callArgs
   lowerExpr env (extendExprEnvWithArguments exprEnv form callArgs) context (ffBody form)
 
 lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> String -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
@@ -1051,8 +1388,8 @@ lowerGlobalCall env exprEnv context name typeArgs args =
       (resolvedTypeArgs, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
       unless (length args == length (ffParams form)) $
         liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-      callArgs <- traverse (lowerExpr env exprEnv context) args
-      bindFunctionArguments env context name form callArgs
+      callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
+      bindFunctionArguments env context False name form callArgs
       resultTy <- lowerBackendTypeM env context (ffReturnType form)
       functionName <- globalFunctionName env context binding resolvedTypeArgs
       result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
@@ -1081,11 +1418,11 @@ globalFunctionName env context binding typeArgs
   where
     request = SpecRequest (biName binding) typeArgs
 
-bindFunctionArguments :: ProgramEnv -> String -> String -> FunctionForm -> [LowerValue] -> LowerM ()
-bindFunctionArguments env context name form args = do
+bindFunctionArguments :: ProgramEnv -> String -> Bool -> String -> FunctionForm -> [LowerValue] -> LowerM ()
+bindFunctionArguments env context allowNestedEvidence name form args = do
   unless (length args == length (ffParams form)) $
     liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-  expectedTypes <- traverse (lowerBackendTypeM env context . snd) (ffParams form)
+  expectedTypes <- traverse (\(paramName, paramTy) -> lowerFunctionParameterTypeM env context allowNestedEvidence paramName paramTy) (ffParams form)
   zipWithM_ (requireLLVMType context name) expectedTypes args
 
 requireLLVMType :: String -> String -> LLVMType -> LowerValue -> LowerM ()

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -137,6 +137,7 @@ lowerBackendProgram program = do
   reachable <- reachableBindings base (backendProgramMain program)
   specializations <- collectRequiredSpecializations base reachable
   let evidenceWrappers = collectEvidenceWrappers base reachable specializations
+      referencedFunctionNames = collectReferencedFunctionNames base reachable specializations evidenceWrappers
       stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations)
       env =
         ProgramEnv
@@ -148,8 +149,8 @@ lowerBackendProgram program = do
   functions <-
     concat
       <$> sequence
-        [ traverse (lowerMonomorphicBinding env) (filter shouldLowerReachableBinding reachable),
-          traverse (lowerSpecialization env) (filter shouldLowerSpecialization specializations),
+        [ traverse (lowerMonomorphicBinding env) (filter (shouldLowerReachableBinding referencedFunctionNames) reachable),
+          traverse (lowerSpecialization env) (filter (shouldLowerSpecialization referencedFunctionNames) specializations),
           traverse (lowerEvidenceWrapper env) evidenceWrappers
         ]
   mainBinding <- requireBinding base (backendProgramMain program)
@@ -163,16 +164,22 @@ lowerBackendProgram program = do
         llvmModuleFunctions = functions
       }
 
-shouldLowerReachableBinding :: BindingInfo -> Bool
-shouldLowerReachableBinding binding =
+shouldLowerReachableBinding :: Set String -> BindingInfo -> Bool
+shouldLowerReachableBinding referencedFunctionNames binding =
   null (ffTypeBinders form)
-    && (biExportedAsMain binding || canEmitFunctionForm form)
+    && ( biExportedAsMain binding
+           || canEmitFunctionForm form
+           || (Set.member (biName binding) referencedFunctionNames && canEmitReferencedFunctionForm form)
+       )
   where
     form = biForm binding
 
-shouldLowerSpecialization :: Specialization -> Bool
-shouldLowerSpecialization =
-  canEmitFunctionForm . spForm
+shouldLowerSpecialization :: Set String -> Specialization -> Bool
+shouldLowerSpecialization referencedFunctionNames specialization =
+  canEmitFunctionForm form
+    || (Set.member (spFunctionName specialization) referencedFunctionNames && canEmitReferencedFunctionForm form)
+  where
+    form = spForm specialization
 
 canEmitFunctionForm :: FunctionForm -> Bool
 canEmitFunctionForm form =
@@ -181,7 +188,11 @@ canEmitFunctionForm form =
 canEmitInlineOnlyFunctionParameters :: FunctionForm -> Bool
 canEmitInlineOnlyFunctionParameters form =
   not (containsInlineOnlyEvidenceParameterCall form)
-    && all (uncurry canEmitFunctionParameter) (ffParams form)
+    && canEmitReferencedFunctionForm form
+
+canEmitReferencedFunctionForm :: FunctionForm -> Bool
+canEmitReferencedFunctionForm form =
+  all (uncurry canEmitFunctionParameter) (ffParams form)
 
 canEmitFunctionParameter :: String -> BackendType -> Bool
 canEmitFunctionParameter paramName paramTy
@@ -587,6 +598,105 @@ collectEvidenceWrappers base reachable specializations =
           ewExpectedType = expected,
           ewExpr = expr
         }
+
+collectReferencedFunctionNames :: ProgramBase -> [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> Set String
+collectReferencedFunctionNames base reachable specializations evidenceWrappers =
+  Set.unions
+    ( map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . biForm) reachable
+        ++ map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . spForm) specializations
+        ++ map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . evidenceWrapperForm) evidenceWrappers
+    )
+
+collectReferencedFunctionNamesInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> Set String
+collectReferencedFunctionNamesInForm base substitution bound form =
+  collectReferencedFunctionNamesInExpr
+    base
+    substitution
+    (Set.union (Set.fromList (map fst (ffParams form))) bound)
+    (ffBody form)
+
+collectReferencedFunctionNamesInExpr :: ProgramBase -> Map String BackendType -> Set String -> BackendExpr -> Set String
+collectReferencedFunctionNamesInExpr base substitution bound expr =
+  referencedHere `Set.union` childReferences
+  where
+    referencedHere =
+      case collectCall expr of
+        Just (callee, typeArgs, args) ->
+          let typeArgs' = map (substituteBackendTypes substitution) typeArgs
+              args' = map (substituteExprTypes substitution) args
+           in case instantiateFunctionFormWithTypeArgs "referenced function argument" (callableForm callee) typeArgs' args' of
+                Right (_, form) ->
+                  Set.fromList
+                    [ functionName
+                    | ((_, paramTy), arg) <- zip (ffParams form) args',
+                      isFunctionLikeBackendType paramTy,
+                      Just functionName <- [referencedFunctionArgumentName arg]
+                    ]
+                Left _ -> Set.empty
+        Nothing -> Set.empty
+
+    callableForm callee =
+      case callee of
+        BackendVar calleeTy _ -> functionFormFromType calleeTy
+        _ -> functionFormFromExpr callee
+
+    referencedFunctionArgumentName arg =
+      case collectTyApps arg of
+        (BackendVar _ name, typeArgs)
+          | Set.notMember name bound,
+            Just binding <- Map.lookup name (pbBindings base) ->
+              case instantiateFunctionFormWithTypeArgs ("referenced function argument " ++ name) (biForm binding) typeArgs [] of
+                Right (resolvedTypeArgs, _)
+                  | null (ffTypeBinders (biForm binding)) -> Just (biName binding)
+                  | otherwise -> Just (specializedFunctionName (SpecRequest name resolvedTypeArgs))
+                Left _ -> Nothing
+        _ -> Nothing
+
+    childReferences =
+      case expr of
+        BackendVar {} -> Set.empty
+        BackendLit {} -> Set.empty
+        BackendLam _ name _ body ->
+          collectReferencedFunctionNamesInExpr base substitution (Set.insert name bound) body
+        BackendApp _ fun arg ->
+          collectReferencedFunctionNamesInExpr base substitution bound fun
+            `Set.union` collectReferencedFunctionNamesInExpr base substitution bound arg
+        BackendLet _ name bindingTy rhs body ->
+          collectLetRhsReferences bindingTy rhs
+            `Set.union` collectReferencedFunctionNamesInExpr base substitution (Set.insert name bound) body
+        BackendTyAbs _ name _ body ->
+          collectReferencedFunctionNamesInExpr base (Map.delete name substitution) bound body
+        BackendTyApp _ fun _ ->
+          collectReferencedFunctionNamesInExpr base substitution bound fun
+        BackendConstruct _ _ args ->
+          Set.unions (map (collectReferencedFunctionNamesInExpr base substitution bound) args)
+        BackendCase _ scrutinee alternatives ->
+          collectReferencedFunctionNamesInExpr base substitution bound scrutinee
+            `Set.union` Set.unions (map collectAlternativeReferences (NE.toList alternatives))
+        BackendRoll _ payload ->
+          collectReferencedFunctionNamesInExpr base substitution bound payload
+        BackendUnroll _ payload ->
+          collectReferencedFunctionNamesInExpr base substitution bound payload
+
+    collectLetRhsReferences bindingTy rhs =
+      case functionFormFromExpected bindingTy rhs of
+        form
+          | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+              collectReferencedFunctionNamesInForm base substitution bound form
+        _ ->
+          collectReferencedFunctionNamesInExpr base substitution bound rhs
+
+    collectAlternativeReferences alternative =
+      collectReferencedFunctionNamesInExpr
+        base
+        substitution
+        (Set.union (patternBinders (backendAltPattern alternative)) bound)
+        (backendAltBody alternative)
+
+    patternBinders =
+      \case
+        BackendDefaultPattern -> Set.empty
+        BackendConstructorPattern _ binders -> Set.fromList binders
 
 collectEvidenceWrappersInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
 collectEvidenceWrappersInForm base substitution bound form =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -6,6 +6,7 @@ Description : Lower typed backend IR into real LLVM IR syntax
 -}
 module MLF.Backend.LLVM.Lower
   ( BackendLLVMError (..),
+    evidenceFunctionTypesCompatible,
     lowerBackendProgram,
     renderBackendLLVMError,
   )
@@ -1926,8 +1927,26 @@ runtimeCompatibleValueType left right =
   alphaEqBackendType left right
     || case (left, right) of
       (BTMu {}, BTMu {}) -> True
-      (BTArrow {}, BTArrow {}) -> True
-      (BTForall {}, BTForall {}) -> True
+      (BTArrow leftParam leftResult, BTArrow rightParam rightResult) ->
+        runtimeCompatibleValueType leftParam rightParam
+          && runtimeCompatibleValueType leftResult rightResult
+      (BTForall leftName leftBound leftBody, BTForall rightName rightBound rightBody) ->
+        runtimeCompatibleMaybeType leftBound rightBound
+          && runtimeCompatibleValueType
+            (substituteBackendType leftName (BTVar freshName) leftBody)
+            (substituteBackendType rightName (BTVar freshName) rightBody)
+        where
+          freshName =
+            freshNameLike
+              leftName
+              ( Set.unions
+                  [ backendTypeVariableNames leftBody,
+                    backendTypeVariableNames rightBody,
+                    maybe Set.empty backendTypeVariableNames leftBound,
+                    maybe Set.empty backendTypeVariableNames rightBound,
+                    Set.fromList [leftName, rightName]
+                  ]
+              )
       (BTBase leftBase, BTBase rightBase) -> leftBase == rightBase
       (BTCon leftCon leftArgs, BTCon rightCon rightArgs) ->
         leftCon == rightCon
@@ -1935,6 +1954,33 @@ runtimeCompatibleValueType left right =
           && and (zipWith runtimeCompatibleValueType (NE.toList leftArgs) (NE.toList rightArgs))
       (BTBottom, BTBottom) -> True
       _ -> False
+
+runtimeCompatibleMaybeType :: Maybe BackendType -> Maybe BackendType -> Bool
+runtimeCompatibleMaybeType Nothing Nothing =
+  True
+runtimeCompatibleMaybeType (Just left) (Just right) =
+  runtimeCompatibleValueType left right
+runtimeCompatibleMaybeType _ _ =
+  False
+
+backendTypeVariableNames :: BackendType -> Set String
+backendTypeVariableNames =
+  \case
+    BTVar name ->
+      Set.singleton name
+    BTArrow param result ->
+      backendTypeVariableNames param `Set.union` backendTypeVariableNames result
+    BTBase {} ->
+      Set.empty
+    BTCon _ args ->
+      Set.unions (map backendTypeVariableNames (NE.toList args))
+    BTForall name mbBound body ->
+      Set.insert name $
+        maybe Set.empty backendTypeVariableNames mbBound `Set.union` backendTypeVariableNames body
+    BTMu name body ->
+      Set.insert name (backendTypeVariableNames body)
+    BTBottom ->
+      Set.empty
 
 lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -116,7 +116,8 @@ data LocalFunction = LocalFunction
 
 data ExprEnv = ExprEnv
   { eeValues :: Map String LowerValue,
-    eeLocalFunctions :: Map String LocalFunction
+    eeLocalFunctions :: Map String LocalFunction,
+    eeActiveGlobalInlines :: Set String
   }
   deriving (Eq, Show)
 
@@ -1232,7 +1233,7 @@ lowerFunction env name private form = do
     Left (BackendLLVMUnsupportedExpression ("binding " ++ show name) "unspecialized polymorphic binding")
   returnTy <- lowerBackendType env ("return type of " ++ name) (ffReturnType form)
   params <- traverse lowerParam (ffParams form)
-  let initialExprEnv = initialFunctionEnv form params
+  let initialExprEnv = initialFunctionEnv name form params
   result <-
     evalStateT
       ( do
@@ -1270,6 +1271,7 @@ lowerFunctionParameterTypeM env context allowNestedEvidence paramName paramTy =
 lowerArgumentType :: ProgramEnv -> String -> Bool -> String -> BackendType -> Either BackendLLVMError LLVMType
 lowerArgumentType env context allowNestedEvidence paramName paramTy
   | isEvidenceArgument allowNestedEvidence paramName paramTy = Right LLVMPtr
+  | isFirstOrderFunctionPointerType paramTy = Right LLVMPtr
   | otherwise = lowerBackendType env context paramTy
 
 isEvidenceArgument :: Bool -> String -> BackendType -> Bool
@@ -1432,15 +1434,16 @@ initialFunctionState =
       fsCompletedBlocks = []
     }
 
-initialFunctionEnv :: FunctionForm -> [LLVMParameter] -> ExprEnv
-initialFunctionEnv form params =
+initialFunctionEnv :: String -> FunctionForm -> [LLVMParameter] -> ExprEnv
+initialFunctionEnv name form params =
   ExprEnv
     { eeValues =
         Map.fromList
           [ (paramName, LowerValue paramTy (llvmParameterType param) (LLVMLocal (llvmParameterType param) paramName))
           | ((paramName, paramTy), param) <- zip (ffParams form) params
           ],
-      eeLocalFunctions = Map.empty
+      eeLocalFunctions = Map.empty,
+      eeActiveGlobalInlines = Set.singleton name
     }
 
 liftEither :: BackendLLVMError -> LowerM a
@@ -1758,6 +1761,8 @@ lowerExprForArgument :: ProgramEnv -> ExprEnv -> String -> Bool -> (String, Back
 lowerExprForArgument env exprEnv context allowNestedEvidence (paramName, paramTy) arg
   | isEvidenceArgument allowNestedEvidence paramName paramTy =
       lowerEvidenceArgument env exprEnv context paramTy arg
+  | isFirstOrderFunctionPointerType paramTy =
+      lowerFunctionArgument env exprEnv context paramTy arg
   | otherwise =
       lowerExpr env exprEnv context arg
 
@@ -2004,7 +2009,11 @@ lowerGlobalCall env exprEnv context name typeArgs args =
         liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
       if shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args
         then do
-          bodyEnv <- bindCallArguments env exprEnv exprEnv context False name form args
+          let bodyEnv0 =
+                exprEnv
+                  { eeActiveGlobalInlines = Set.insert (biName binding) (eeActiveGlobalInlines exprEnv)
+                  }
+          bodyEnv <- bindCallArguments env exprEnv bodyEnv0 context False name form args
           lowerExpr env bodyEnv context (ffBody form)
         else do
           callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
@@ -2027,7 +2036,7 @@ lowerGlobalCall env exprEnv context name typeArgs args =
 
 shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
 shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =
-  requiresInlineCall form
+  (requiresInlineCall form && Set.notMember (biName binding) (eeActiveGlobalInlines exprEnv))
     || missingPolymorphicSpecialization env binding resolvedTypeArgs
     || any (evidenceArgumentRequiresInline env exprEnv) (zip (ffParams form) args)
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -148,7 +148,7 @@ lowerBackendProgram program = do
   functions <-
     concat
       <$> sequence
-        [ traverse (lowerMonomorphicBinding env) (filter (null . ffTypeBinders . biForm) reachable),
+        [ traverse (lowerMonomorphicBinding env) (filter shouldLowerReachableBinding reachable),
           traverse (lowerSpecialization env) specializations,
           traverse (lowerEvidenceWrapper env) evidenceWrappers
         ]
@@ -162,6 +162,13 @@ lowerBackendProgram program = do
         llvmModuleDeclarations = runtimeDeclarations base,
         llvmModuleFunctions = functions
       }
+
+shouldLowerReachableBinding :: BindingInfo -> Bool
+shouldLowerReachableBinding binding =
+  null (ffTypeBinders form)
+    && (biExportedAsMain binding || not (requiresInlineCall form))
+  where
+    form = biForm binding
 
 runtimeAndName :: String
 runtimeAndName =
@@ -311,7 +318,7 @@ isAliasExpr =
     BackendVar {} -> True
     BackendTyApp _ fun _ -> isAliasExpr fun
     BackendApp _ fun arg -> isAliasExpr fun && isAliasArgument arg
-    BackendLet _ _ _ rhs body -> isAliasLetRhs rhs && isAliasExpr body
+    BackendLet _ _ _ rhs body -> isTransparentAliasLetRhs rhs && isAliasExpr body
     _ -> False
 
 isAliasLetRhs :: BackendExpr -> Bool
@@ -329,8 +336,18 @@ isAliasArgument =
     BackendVar ty _ -> isFunctionLikeBackendType ty
     BackendTyApp ty fun _ -> isFunctionLikeBackendType ty && isAliasArgument fun
     BackendApp ty fun arg -> isFunctionLikeBackendType ty && isAliasExpr fun && isAliasArgument arg
-    BackendLet ty _ _ rhs body -> isFunctionLikeBackendType ty && isAliasLetRhs rhs && isAliasArgument body
+    BackendLet ty _ _ rhs body -> isFunctionLikeBackendType ty && isTransparentAliasLetRhs rhs && isAliasArgument body
     _ -> False
+
+isTransparentAliasLetRhs :: BackendExpr -> Bool
+isTransparentAliasLetRhs rhs =
+  isAliasLetRhs rhs || hasTopLevelTypeAbs rhs
+
+hasTopLevelTypeAbs :: BackendExpr -> Bool
+hasTopLevelTypeAbs expr =
+  not (null typeBinders)
+  where
+    (typeBinders, _) = collectTypeAbs expr
 
 collectForallsType :: BackendType -> ([(String, Maybe BackendType)], BackendType)
 collectForallsType =
@@ -980,6 +997,16 @@ isFunctionLikeBackendType =
     BTArrow {} -> True
     _ -> False
 
+requiresInlineCall :: FunctionForm -> Bool
+requiresInlineCall form =
+  any (uncurry (isInlineOnlyFunctionParameter False)) (ffParams form)
+
+hasTypeBinders :: BackendType -> Bool
+hasTypeBinders =
+  \case
+    BTForall {} -> True
+    _ -> False
+
 initialFunctionState :: FunctionState
 initialFunctionState =
   FunctionState
@@ -1368,18 +1395,16 @@ runtimeCompatibleValueType left right =
 
 lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do
+  let allowNestedEvidence = isEvidenceName name
   form <- instantiateFunctionFormM context (lfForm localFunction) typeArgs args
-  callArgs <- zipWithM (lowerExprForArgument env callEnv context False) (ffParams form) args
-  bindFunctionArguments env context False name form callArgs
-  let bodyEnv = extendExprEnvWithArguments (lfCapturedEnv localFunction) form callArgs
+  bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form args
   lowerExpr env bodyEnv context (ffBody form)
 
 lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do
   form <- instantiateFunctionFormM context form0 typeArgs args
-  callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
-  bindFunctionArguments env context False "lambda" form callArgs
-  lowerExpr env (extendExprEnvWithArguments exprEnv form callArgs) context (ffBody form)
+  bodyEnv <- bindCallArguments env exprEnv exprEnv context False "lambda" form args
+  lowerExpr env bodyEnv context (ffBody form)
 
 lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> String -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerGlobalCall env exprEnv context name typeArgs args =
@@ -1388,12 +1413,17 @@ lowerGlobalCall env exprEnv context name typeArgs args =
       (resolvedTypeArgs, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
       unless (length args == length (ffParams form)) $
         liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-      callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
-      bindFunctionArguments env context False name form callArgs
-      resultTy <- lowerBackendTypeM env context (ffReturnType form)
-      functionName <- globalFunctionName env context binding resolvedTypeArgs
-      result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-      pure (LowerValue (ffReturnType form) resultTy result)
+      if shouldInlineGlobalCall env binding resolvedTypeArgs form
+        then do
+          bodyEnv <- bindCallArguments env exprEnv exprEnv context False name form args
+          lowerExpr env bodyEnv context (ffBody form)
+        else do
+          callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
+          bindFunctionArguments env context False name form callArgs
+          resultTy <- lowerBackendTypeM env context (ffReturnType form)
+          functionName <- globalFunctionName env context binding resolvedTypeArgs
+          result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+          pure (LowerValue (ffReturnType form) resultTy result)
     Nothing
       | name == runtimeAndName -> do
           unless (length args == 2) $
@@ -1405,6 +1435,15 @@ lowerGlobalCall env exprEnv context name typeArgs args =
           pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result)
     Nothing ->
       liftEither (BackendLLVMUnknownFunction name)
+
+shouldInlineGlobalCall :: ProgramEnv -> BindingInfo -> [BackendType] -> FunctionForm -> Bool
+shouldInlineGlobalCall env binding resolvedTypeArgs form =
+  requiresInlineCall form || missingPolymorphicSpecialization env binding resolvedTypeArgs
+
+missingPolymorphicSpecialization :: ProgramEnv -> BindingInfo -> [BackendType] -> Bool
+missingPolymorphicSpecialization env binding resolvedTypeArgs =
+  not (null (ffTypeBinders (biForm binding)))
+    && Map.notMember (specializationKey (SpecRequest (biName binding) resolvedTypeArgs)) (peSpecializations env)
 
 globalFunctionName :: ProgramEnv -> String -> BindingInfo -> [BackendType] -> LowerM String
 globalFunctionName env context binding typeArgs
@@ -1425,6 +1464,50 @@ bindFunctionArguments env context allowNestedEvidence name form args = do
   expectedTypes <- traverse (\(paramName, paramTy) -> lowerFunctionParameterTypeM env context allowNestedEvidence paramName paramTy) (ffParams form)
   zipWithM_ (requireLLVMType context name) expectedTypes args
 
+bindCallArguments ::
+  ProgramEnv ->
+  ExprEnv ->
+  ExprEnv ->
+  String ->
+  Bool ->
+  String ->
+  FunctionForm ->
+  [BackendExpr] ->
+  LowerM ExprEnv
+bindCallArguments env callEnv bodyEnv0 context allowNestedEvidence name form args = do
+  unless (length args == length (ffParams form)) $
+    liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
+  foldM bindOne bodyEnv0 (zip (ffParams form) args)
+  where
+    bindOne bodyEnv ((paramName, paramTy), arg)
+      | isInlineFunctionArgument allowNestedEvidence paramName paramTy = do
+          let argForm = functionFormFromExpected paramTy arg
+          pure
+            bodyEnv
+              { eeLocalFunctions =
+                  Map.insert
+                    paramName
+                    LocalFunction {lfForm = argForm, lfCapturedEnv = callEnv}
+                    (eeLocalFunctions bodyEnv)
+              }
+      | otherwise = do
+          value <- lowerExprForArgument env callEnv context allowNestedEvidence (paramName, paramTy) arg
+          pure bodyEnv {eeValues = Map.insert paramName value (eeValues bodyEnv)}
+
+isInlineFunctionArgument :: Bool -> String -> BackendType -> Bool
+isInlineFunctionArgument allowNestedEvidence paramName paramTy =
+  isInlineOnlyFunctionParameter allowNestedEvidence paramName paramTy
+
+isInlineOnlyFunctionParameter :: Bool -> String -> BackendType -> Bool
+isInlineOnlyFunctionParameter allowNestedEvidence paramName paramTy =
+  isFunctionLikeBackendType paramTy
+    && (evidenceNeedsInlining || firstOrderFunctionNeedsInlining)
+  where
+    evidenceLike = isEvidenceArgument allowNestedEvidence paramName paramTy
+    polymorphicFunction = hasTypeBinders paramTy
+    evidenceNeedsInlining = evidenceLike && polymorphicFunction
+    firstOrderFunctionNeedsInlining = not evidenceLike && not polymorphicFunction
+
 requireLLVMType :: String -> String -> LLVMType -> LowerValue -> LowerM ()
 requireLLVMType context name expected actual =
   unless (lvLLVMType actual == expected) $
@@ -1440,15 +1523,6 @@ requireLLVMType context name expected actual =
               ++ show (lvLLVMType actual)
           )
       )
-
-extendExprEnvWithArguments :: ExprEnv -> FunctionForm -> [LowerValue] -> ExprEnv
-extendExprEnvWithArguments exprEnv form args =
-  exprEnv
-    { eeValues =
-        Map.union
-          (Map.fromList [(name, value) | ((name, _), value) <- zip (ffParams form) args])
-          (eeValues exprEnv)
-    }
 
 instantiateFunctionFormM :: String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM FunctionForm
 instantiateFunctionFormM context form typeArgs args =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -306,6 +306,19 @@ functionFormFromExpected expectedTy expr =
             Just aliasForm -> aliasForm
             Nothing -> form
 
+substituteFunctionFormTypes :: Map String BackendType -> FunctionForm -> FunctionForm
+substituteFunctionFormTypes substitution0 form =
+  FunctionForm
+    { ffTypeBinders = [(name, fmap substituteTy mbBound) | (name, mbBound) <- ffTypeBinders form],
+      ffParams = [(name, substituteTy ty) | (name, ty) <- ffParams form],
+      ffBody = substituteExprTypes substitution (ffBody form),
+      ffReturnType = substituteTy (ffReturnType form)
+    }
+  where
+    binderNames = Set.fromList (map fst (ffTypeBinders form))
+    substitution = Map.withoutKeys substitution0 binderNames
+    substituteTy = substituteBackendTypes substitution
+
 completeAliasFunctionForm :: FunctionForm -> Maybe FunctionForm
 completeAliasFunctionForm form
   | not (isAliasExpr (ffBody form)) = Nothing
@@ -609,16 +622,23 @@ collectReferencedFunctionNames base reachable specializations evidenceWrappers =
         ++ map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . evidenceWrapperForm) evidenceWrappers
     )
 
+type LocalFunctionForms = Map String FunctionForm
+
 collectReferencedFunctionNamesInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> Set String
 collectReferencedFunctionNamesInForm base substitution bound form =
+  collectReferencedFunctionNamesInFormWithLocals base substitution Map.empty bound form
+
+collectReferencedFunctionNamesInFormWithLocals :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> FunctionForm -> Set String
+collectReferencedFunctionNamesInFormWithLocals base substitution localForms bound form =
   collectReferencedFunctionNamesInExpr
     base
     substitution
+    localForms
     (Set.union (Set.fromList (map fst (ffParams form))) bound)
     (ffBody form)
 
-collectReferencedFunctionNamesInExpr :: ProgramBase -> Map String BackendType -> Set String -> BackendExpr -> Set String
-collectReferencedFunctionNamesInExpr base substitution bound expr =
+collectReferencedFunctionNamesInExpr :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> BackendExpr -> Set String
+collectReferencedFunctionNamesInExpr base substitution localForms bound expr =
   referencedHere `Set.union` childReferences
   where
     referencedHere =
@@ -628,70 +648,120 @@ collectReferencedFunctionNamesInExpr base substitution bound expr =
               args' = map (substituteExprTypes substitution) args
            in case instantiateFunctionFormWithTypeArgs "referenced function argument" (callableForm callee) typeArgs' args' of
                 Right (_, form) ->
-                  Set.fromList
-                    [ functionName
-                    | ((_, paramTy), arg) <- zip (ffParams form) args',
-                      isFunctionLikeBackendType paramTy,
-                      Just functionName <- [referencedFunctionArgumentName arg]
-                    ]
+                  localCallReferences callee typeArgs' args'
+                    `Set.union` Set.fromList
+                      [ functionName
+                      | ((_, paramTy), arg) <- zip (ffParams form) args',
+                        isFunctionLikeBackendType paramTy,
+                        Just functionName <- [referencedFunctionArgumentName arg]
+                      ]
                 Left _ -> Set.empty
-        Nothing -> Set.empty
+        Nothing ->
+          localTypeApplicationReferences
 
     callableForm callee =
       case callee of
-        BackendVar calleeTy _ -> functionFormFromType calleeTy
+        BackendVar calleeTy name ->
+          case Map.lookup name localForms of
+            Just form -> form
+            Nothing -> functionFormFromType calleeTy
         _ -> functionFormFromExpr callee
 
     referencedFunctionArgumentName arg =
       case collectTyApps arg of
-        (BackendVar _ name, typeArgs)
-          | Set.notMember name bound,
-            Just binding <- Map.lookup name (pbBindings base) ->
-              case instantiateFunctionFormWithTypeArgs ("referenced function argument " ++ name) (biForm binding) typeArgs [] of
-                Right (resolvedTypeArgs, _)
-                  | null (ffTypeBinders (biForm binding)) -> Just (biName binding)
-                  | otherwise -> Just (specializedFunctionName (SpecRequest name resolvedTypeArgs))
-                Left _ -> Nothing
+        (BackendVar _ name, typeArgs) ->
+          referencedFunctionNameByName Set.empty name typeArgs
         _ -> Nothing
+
+    referencedFunctionNameByName seen name typeArgs
+      | Set.member name seen = Nothing
+      | Just form <- Map.lookup name localForms =
+          case instantiateFunctionFormWithTypeArgs ("referenced local function argument " ++ name) form typeArgs [] of
+            Right (_, instantiated) ->
+              case etaAliasTarget instantiated of
+                Just (targetName, targetTypeArgs) ->
+                  referencedFunctionNameByName (Set.insert name seen) targetName targetTypeArgs
+                Nothing -> Nothing
+            Left _ -> Nothing
+      | Set.notMember name bound,
+        Just binding <- Map.lookup name (pbBindings base) =
+          case instantiateFunctionFormWithTypeArgs ("referenced function argument " ++ name) (biForm binding) typeArgs [] of
+            Right (resolvedTypeArgs, _)
+              | null (ffTypeBinders (biForm binding)) -> Just (biName binding)
+              | otherwise -> Just (specializedFunctionName (SpecRequest name resolvedTypeArgs))
+            Left _ -> Nothing
+      | otherwise = Nothing
+
+    localCallReferences callee typeArgs args =
+      case callee of
+        BackendVar _ name
+          | Just form <- Map.lookup name localForms ->
+              collectInstantiatedLocalReferences name form typeArgs args
+        _ -> Set.empty
+
+    localTypeApplicationReferences =
+      case collectTyApps expr of
+        (BackendVar _ name, typeArgs)
+          | Just form <- Map.lookup name localForms ->
+              collectInstantiatedLocalReferences name form (map (substituteBackendTypes substitution) typeArgs) []
+        _ -> Set.empty
+
+    collectInstantiatedLocalReferences name form typeArgs args =
+      case instantiateFunctionFormWithTypeArgs ("referenced local function " ++ name) form typeArgs args of
+        Right (_, instantiated) ->
+          collectReferencedFunctionNamesInFormWithLocals base Map.empty localForms bound instantiated
+        Left _ -> Set.empty
 
     childReferences =
       case expr of
         BackendVar {} -> Set.empty
         BackendLit {} -> Set.empty
         BackendLam _ name _ body ->
-          collectReferencedFunctionNamesInExpr base substitution (Set.insert name bound) body
+          collectReferencedFunctionNamesInExpr base substitution localForms (Set.insert name bound) body
         BackendApp _ fun arg ->
-          collectReferencedFunctionNamesInExpr base substitution bound fun
-            `Set.union` collectReferencedFunctionNamesInExpr base substitution bound arg
+          collectReferencedFunctionNamesInExpr base substitution localForms bound fun
+            `Set.union` collectReferencedFunctionNamesInExpr base substitution localForms bound arg
         BackendLet _ name bindingTy rhs body ->
           collectLetRhsReferences bindingTy rhs
-            `Set.union` collectReferencedFunctionNamesInExpr base substitution (Set.insert name bound) body
+            `Set.union` collectReferencedFunctionNamesInExpr base substitution (collectLetLocalForms name bindingTy rhs) (Set.insert name bound) body
         BackendTyAbs _ name _ body ->
-          collectReferencedFunctionNamesInExpr base (Map.delete name substitution) bound body
+          collectReferencedFunctionNamesInExpr base (Map.delete name substitution) localForms bound body
         BackendTyApp _ fun _ ->
-          collectReferencedFunctionNamesInExpr base substitution bound fun
+          collectReferencedFunctionNamesInExpr base substitution localForms bound fun
         BackendConstruct _ _ args ->
-          Set.unions (map (collectReferencedFunctionNamesInExpr base substitution bound) args)
+          Set.unions (map (collectReferencedFunctionNamesInExpr base substitution localForms bound) args)
         BackendCase _ scrutinee alternatives ->
-          collectReferencedFunctionNamesInExpr base substitution bound scrutinee
+          collectReferencedFunctionNamesInExpr base substitution localForms bound scrutinee
             `Set.union` Set.unions (map collectAlternativeReferences (NE.toList alternatives))
         BackendRoll _ payload ->
-          collectReferencedFunctionNamesInExpr base substitution bound payload
+          collectReferencedFunctionNamesInExpr base substitution localForms bound payload
         BackendUnroll _ payload ->
-          collectReferencedFunctionNamesInExpr base substitution bound payload
+          collectReferencedFunctionNamesInExpr base substitution localForms bound payload
 
     collectLetRhsReferences bindingTy rhs =
       case functionFormFromExpected bindingTy rhs of
+        form0
+          | not (null (ffTypeBinders form0)) || not (null (ffParams form0)) ->
+              let form = substituteFunctionFormTypes substitution form0
+               in if null (ffTypeBinders form)
+                    then collectReferencedFunctionNamesInFormWithLocals base Map.empty localForms bound form
+                    else Set.empty
+        _ ->
+          collectReferencedFunctionNamesInExpr base substitution localForms bound rhs
+
+    collectLetLocalForms name bindingTy rhs =
+      case functionFormFromExpected bindingTy rhs of
         form
           | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
-              collectReferencedFunctionNamesInForm base substitution bound form
+              Map.insert name (substituteFunctionFormTypes substitution form) localForms
         _ ->
-          collectReferencedFunctionNamesInExpr base substitution bound rhs
+          Map.delete name localForms
 
     collectAlternativeReferences alternative =
       collectReferencedFunctionNamesInExpr
         base
         substitution
+        localForms
         (Set.union (patternBinders (backendAltPattern alternative)) bound)
         (backendAltBody alternative)
 
@@ -702,72 +772,109 @@ collectReferencedFunctionNamesInExpr base substitution bound expr =
 
 collectEvidenceWrappersInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
 collectEvidenceWrappersInForm base substitution bound form =
+  collectEvidenceWrappersInFormWithLocals base substitution Map.empty bound form
+
+collectEvidenceWrappersInFormWithLocals :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
+collectEvidenceWrappersInFormWithLocals base substitution localForms bound form =
   collectEvidenceWrappersInExpr
     base
     substitution
+    localForms
     (Set.union (Set.fromList (map fst (ffParams form))) bound)
     (ffBody form)
 
-collectEvidenceWrappersInExpr :: ProgramBase -> Map String BackendType -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
-collectEvidenceWrappersInExpr base substitution bound expr =
+collectEvidenceWrappersInExpr :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
+collectEvidenceWrappersInExpr base substitution localForms bound expr =
   wrappersHere ++ childWrappers
   where
     wrappersHere =
       case collectCall expr of
         Just (BackendVar _ name, typeArgs, args)
+          | Just form <- Map.lookup name localForms ->
+              let typeArgs' = map (substituteBackendTypes substitution) typeArgs
+                  args' = map (substituteExprTypes substitution) args
+               in collectInstantiatedLocalWrappers name form typeArgs' args'
           | Set.notMember name bound,
             Just binding <- Map.lookup name (pbBindings base) ->
               let typeArgs' = map (substituteBackendTypes substitution) typeArgs
                   args' = map (substituteExprTypes substitution) args
                in case instantiateFunctionFormWithTypeArgs ("evidence wrapper request " ++ name) (biForm binding) typeArgs' args' of
-                    Right (_, form) ->
-                      [ (paramTy, arg)
-                      | ((paramName, paramTy), arg) <- zip (ffParams form) args',
-                        isEvidenceArgument False paramName paramTy,
-                        not (isSimpleFunctionReference arg),
-                        evidenceWrapperArgumentClosed bound arg
-                      ]
+                    Right (_, form) -> evidenceArgumentWrappers form args'
                     Left _ -> []
-        _ -> []
+        _ -> localTypeApplicationWrappers
 
     childWrappers =
       case expr of
         BackendVar {} -> []
         BackendLit {} -> []
         BackendLam _ name _ body ->
-          collectEvidenceWrappersInExpr base substitution (Set.insert name bound) body
+          collectEvidenceWrappersInExpr base substitution localForms (Set.insert name bound) body
         BackendApp _ fun arg ->
-          collectEvidenceWrappersInExpr base substitution bound fun
-            ++ collectEvidenceWrappersInExpr base substitution bound arg
+          collectEvidenceWrappersInExpr base substitution localForms bound fun
+            ++ collectEvidenceWrappersInExpr base substitution localForms bound arg
         BackendLet _ name bindingTy rhs body ->
           collectLetRhsWrappers bindingTy rhs
-            ++ collectEvidenceWrappersInExpr base substitution (Set.insert name bound) body
+            ++ collectEvidenceWrappersInExpr base substitution (collectLetLocalForms name bindingTy rhs) (Set.insert name bound) body
         BackendTyAbs _ name _ body ->
-          collectEvidenceWrappersInExpr base (Map.delete name substitution) bound body
+          collectEvidenceWrappersInExpr base (Map.delete name substitution) localForms bound body
         BackendTyApp _ fun _ ->
-          collectEvidenceWrappersInExpr base substitution bound fun
+          collectEvidenceWrappersInExpr base substitution localForms bound fun
         BackendConstruct _ _ args ->
-          concatMap (collectEvidenceWrappersInExpr base substitution bound) args
+          concatMap (collectEvidenceWrappersInExpr base substitution localForms bound) args
         BackendCase _ scrutinee alternatives ->
-          collectEvidenceWrappersInExpr base substitution bound scrutinee
+          collectEvidenceWrappersInExpr base substitution localForms bound scrutinee
             ++ concatMap collectAlternativeWrappers (NE.toList alternatives)
         BackendRoll _ payload ->
-          collectEvidenceWrappersInExpr base substitution bound payload
+          collectEvidenceWrappersInExpr base substitution localForms bound payload
         BackendUnroll _ payload ->
-          collectEvidenceWrappersInExpr base substitution bound payload
+          collectEvidenceWrappersInExpr base substitution localForms bound payload
+
+    evidenceArgumentWrappers form args =
+      [ (paramTy, arg)
+      | ((paramName, paramTy), arg) <- zip (ffParams form) args,
+        isEvidenceArgument False paramName paramTy,
+        not (isSimpleFunctionReference arg),
+        evidenceWrapperArgumentClosed bound arg
+      ]
+
+    localTypeApplicationWrappers =
+      case collectTyApps expr of
+        (BackendVar _ name, typeArgs)
+          | Just form <- Map.lookup name localForms ->
+              collectInstantiatedLocalWrappers name form (map (substituteBackendTypes substitution) typeArgs) []
+        _ -> []
+
+    collectInstantiatedLocalWrappers name form typeArgs args =
+      case instantiateFunctionFormWithTypeArgs ("evidence wrapper request " ++ name) form typeArgs args of
+        Right (_, instantiated) ->
+          evidenceArgumentWrappers instantiated args
+            ++ collectEvidenceWrappersInFormWithLocals base Map.empty localForms bound instantiated
+        Left _ -> []
 
     collectLetRhsWrappers bindingTy rhs =
       case functionFormFromExpected bindingTy rhs of
+        form0
+          | not (null (ffTypeBinders form0)) || not (null (ffParams form0)) ->
+              let form = substituteFunctionFormTypes substitution form0
+               in if null (ffTypeBinders form)
+                    then collectEvidenceWrappersInFormWithLocals base Map.empty localForms bound form
+                    else []
+        _ ->
+          collectEvidenceWrappersInExpr base substitution localForms bound rhs
+
+    collectLetLocalForms name bindingTy rhs =
+      case functionFormFromExpected bindingTy rhs of
         form
           | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
-              collectEvidenceWrappersInForm base substitution bound form
+              Map.insert name (substituteFunctionFormTypes substitution form) localForms
         _ ->
-          collectEvidenceWrappersInExpr base substitution bound rhs
+          Map.delete name localForms
 
     collectAlternativeWrappers alternative =
       collectEvidenceWrappersInExpr
         base
         substitution
+        localForms
         (Set.union (patternBinders (backendAltPattern alternative)) bound)
         (backendAltBody alternative)
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1476,11 +1476,16 @@ bindLet env exprEnv context name rhs =
                   Map.insert
                     name
                     LocalFunction {lfForm = form, lfCapturedEnv = exprEnv}
-                    (eeLocalFunctions exprEnv)
+                    (eeLocalFunctions exprEnv),
+                eeValues = Map.delete name (eeValues exprEnv)
               }
     _ -> do
       value <- lowerExpr env exprEnv (context ++ ", let " ++ show name) rhs
-      pure exprEnv {eeValues = Map.insert name value (eeValues exprEnv)}
+      pure
+        exprEnv
+          { eeValues = Map.insert name value (eeValues exprEnv),
+            eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
+          }
 
 lowerVar :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> LowerM LowerValue
 lowerVar env exprEnv context ty name =
@@ -1940,11 +1945,16 @@ bindCallArguments env callEnv bodyEnv0 context allowNestedEvidence name form arg
                   Map.insert
                     paramName
                     LocalFunction {lfForm = argForm, lfCapturedEnv = callEnv}
-                    (eeLocalFunctions bodyEnv)
+                    (eeLocalFunctions bodyEnv),
+                eeValues = Map.delete paramName (eeValues bodyEnv)
               }
       | otherwise = do
           value <- lowerExprForArgument env callEnv context allowNestedEvidence (paramName, paramTy) arg
-          pure bodyEnv {eeValues = Map.insert paramName value (eeValues bodyEnv)}
+          pure
+            bodyEnv
+              { eeValues = Map.insert paramName value (eeValues bodyEnv),
+                eeLocalFunctions = Map.delete paramName (eeLocalFunctions bodyEnv)
+              }
 
 isInlineFunctionArgument :: Bool -> String -> BackendType -> Bool
 isInlineFunctionArgument allowNestedEvidence paramName paramTy =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -149,7 +149,7 @@ lowerBackendProgram program = do
     concat
       <$> sequence
         [ traverse (lowerMonomorphicBinding env) (filter shouldLowerReachableBinding reachable),
-          traverse (lowerSpecialization env) specializations,
+          traverse (lowerSpecialization env) (filter shouldLowerSpecialization specializations),
           traverse (lowerEvidenceWrapper env) evidenceWrappers
         ]
   mainBinding <- requireBinding base (backendProgramMain program)
@@ -169,6 +169,10 @@ shouldLowerReachableBinding binding =
     && (biExportedAsMain binding || not (requiresInlineCall form))
   where
     form = biForm binding
+
+shouldLowerSpecialization :: Specialization -> Bool
+shouldLowerSpecialization =
+  not . requiresInlineCall . spForm
 
 runtimeAndName :: String
 runtimeAndName =
@@ -980,7 +984,8 @@ lowerArgumentType env context allowNestedEvidence paramName paramTy
 
 isEvidenceArgument :: Bool -> String -> BackendType -> Bool
 isEvidenceArgument allowNestedEvidence paramName paramTy =
-  (allowNestedEvidence || isEvidenceName paramName) && isFunctionLikeBackendType paramTy
+  (isEvidenceName paramName || (allowNestedEvidence && isNestedEvidenceName paramName))
+    && isFunctionLikeBackendType paramTy
 
 isEvidenceParameter :: String -> BackendType -> Bool
 isEvidenceParameter =
@@ -989,6 +994,11 @@ isEvidenceParameter =
 isEvidenceName :: String -> Bool
 isEvidenceName =
   isPrefixOf "$evidence_"
+
+isNestedEvidenceName :: String -> Bool
+isNestedEvidenceName name =
+  "__mlfp_alias_arg" `isPrefixOf` name
+    || "__mlfp_evidence_arg" `isPrefixOf` name
 
 isFunctionLikeBackendType :: BackendType -> Bool
 isFunctionLikeBackendType =
@@ -1283,11 +1293,43 @@ lowerIndirectValueCall env exprEnv context name callee typeArgs args = do
   form <- instantiateFunctionFormM context (functionFormFromType (lvBackendType callee)) typeArgs args
   unless (length args == length (ffParams form)) $
     liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-  callArgs <- zipWithM (lowerExprForArgument env exprEnv context True) (ffParams form) args
-  bindFunctionArguments env context True name form callArgs
-  resultTy <- lowerBackendTypeM env context (ffReturnType form)
-  result <- emitAssign "call" resultTy (LLVMCallOperand (lvOperand callee) [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-  pure (LowerValue (ffReturnType form) resultTy result)
+  case indirectCalleeFunctionForm env callee of
+    Just calleeForm0 -> do
+      calleeForm <- instantiateFunctionFormM context calleeForm0 typeArgs args
+      if requiresInlineCall calleeForm
+        then do
+          bodyEnv <- bindCallArguments env exprEnv exprEnv context False name calleeForm args
+          lowerExpr env bodyEnv context (ffBody calleeForm)
+        else lowerIndirectPointerCall form
+    Nothing ->
+      lowerIndirectPointerCall form
+  where
+    lowerIndirectPointerCall form = do
+      callArgs <- zipWithM (lowerExprForIndirectArgument env exprEnv context) (ffParams form) args
+      bindIndirectFunctionArguments env context name form callArgs
+      resultTy <- lowerBackendTypeM env context (ffReturnType form)
+      result <- emitAssign "call" resultTy (LLVMCallOperand (lvOperand callee) [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+      pure (LowerValue (ffReturnType form) resultTy result)
+
+indirectCalleeFunctionForm :: ProgramEnv -> LowerValue -> Maybe FunctionForm
+indirectCalleeFunctionForm env callee =
+  case lvOperand callee of
+    LLVMGlobalRef _ functionName ->
+      lookupFunctionFormByName env functionName
+    _ ->
+      Nothing
+
+lookupFunctionFormByName :: ProgramEnv -> String -> Maybe FunctionForm
+lookupFunctionFormByName env functionName =
+  case Map.lookup functionName (pbBindings (peBase env)) of
+    Just binding -> Just (biForm binding)
+    Nothing ->
+      case [spForm specialization | specialization <- Map.elems (peSpecializations env), spFunctionName specialization == functionName] of
+        form : _ -> Just form
+        [] ->
+          case [evidenceWrapperForm wrapper | wrapper <- Map.elems (peEvidenceWrappers env), ewFunctionName wrapper == functionName] of
+            form : _ -> Just form
+            [] -> Nothing
 
 functionFormFromType :: BackendType -> FunctionForm
 functionFormFromType ty =
@@ -1308,6 +1350,27 @@ lowerExprForArgument env exprEnv context allowNestedEvidence (paramName, paramTy
       lowerEvidenceArgument env exprEnv context paramTy arg
   | otherwise =
       lowerExpr env exprEnv context arg
+
+lowerExprForIndirectArgument :: ProgramEnv -> ExprEnv -> String -> (String, BackendType) -> BackendExpr -> LowerM LowerValue
+lowerExprForIndirectArgument env exprEnv context (paramName, paramTy) arg
+  | isEvidenceArgument False paramName paramTy =
+      lowerEvidenceArgument env exprEnv context paramTy arg
+  | isFunctionLikeBackendType paramTy =
+      case Map.lookup (evidenceWrapperKey paramTy arg) (peEvidenceWrappers env) of
+        Just wrapper ->
+          pure (LowerValue paramTy LLVMPtr (LLVMGlobalRef LLVMPtr (ewFunctionName wrapper)))
+        Nothing ->
+          lowerFunctionArgument env exprEnv context paramTy arg
+  | otherwise =
+      lowerExpr env exprEnv context arg
+
+lowerFunctionArgument :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
+lowerFunctionArgument env exprEnv context expectedTy arg =
+  case collectTyApps arg of
+    (BackendVar _ name, typeArgs) ->
+      lowerFunctionReference env exprEnv context expectedTy name typeArgs
+    _ ->
+      liftEither (BackendLLVMUnsupportedExpression context "unsupported function argument")
 
 lowerEvidenceArgument :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
 lowerEvidenceArgument env exprEnv context expectedTy arg =
@@ -1413,7 +1476,7 @@ lowerGlobalCall env exprEnv context name typeArgs args =
       (resolvedTypeArgs, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
       unless (length args == length (ffParams form)) $
         liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-      if shouldInlineGlobalCall env binding resolvedTypeArgs form
+      if shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args
         then do
           bodyEnv <- bindCallArguments env exprEnv exprEnv context False name form args
           lowerExpr env bodyEnv context (ffBody form)
@@ -1436,14 +1499,32 @@ lowerGlobalCall env exprEnv context name typeArgs args =
     Nothing ->
       liftEither (BackendLLVMUnknownFunction name)
 
-shouldInlineGlobalCall :: ProgramEnv -> BindingInfo -> [BackendType] -> FunctionForm -> Bool
-shouldInlineGlobalCall env binding resolvedTypeArgs form =
-  requiresInlineCall form || missingPolymorphicSpecialization env binding resolvedTypeArgs
+shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
+shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =
+  requiresInlineCall form
+    || missingPolymorphicSpecialization env binding resolvedTypeArgs
+    || any (evidenceArgumentRequiresInline env exprEnv) (zip (ffParams form) args)
 
 missingPolymorphicSpecialization :: ProgramEnv -> BindingInfo -> [BackendType] -> Bool
 missingPolymorphicSpecialization env binding resolvedTypeArgs =
   not (null (ffTypeBinders (biForm binding)))
     && Map.notMember (specializationKey (SpecRequest (biName binding) resolvedTypeArgs)) (peSpecializations env)
+
+evidenceArgumentRequiresInline :: ProgramEnv -> ExprEnv -> ((String, BackendType), BackendExpr) -> Bool
+evidenceArgumentRequiresInline env exprEnv ((paramName, paramTy), arg) =
+  isEvidenceArgument False paramName paramTy && functionArgumentRequiresInline env exprEnv arg
+
+functionArgumentRequiresInline :: ProgramEnv -> ExprEnv -> BackendExpr -> Bool
+functionArgumentRequiresInline env exprEnv arg =
+  case collectTyApps arg of
+    (BackendVar _ name, typeArgs)
+      | Just localFunction <- Map.lookup name (eeLocalFunctions exprEnv) ->
+          requiresInlineCall (lfForm localFunction)
+      | Just binding <- Map.lookup name (pbBindings (peBase env)) ->
+          case instantiateFunctionFormWithTypeArgs "inline evidence argument" (biForm binding) typeArgs [] of
+            Right (_, form) -> requiresInlineCall form
+            Left _ -> False
+    _ -> False
 
 globalFunctionName :: ProgramEnv -> String -> BindingInfo -> [BackendType] -> LowerM String
 globalFunctionName env context binding typeArgs
@@ -1463,6 +1544,21 @@ bindFunctionArguments env context allowNestedEvidence name form args = do
     liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
   expectedTypes <- traverse (\(paramName, paramTy) -> lowerFunctionParameterTypeM env context allowNestedEvidence paramName paramTy) (ffParams form)
   zipWithM_ (requireLLVMType context name) expectedTypes args
+
+bindIndirectFunctionArguments :: ProgramEnv -> String -> String -> FunctionForm -> [LowerValue] -> LowerM ()
+bindIndirectFunctionArguments env context name form args = do
+  unless (length args == length (ffParams form)) $
+    liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
+  expectedTypes <- traverse (lowerIndirectFunctionParameterTypeM env context . snd) (ffParams form)
+  zipWithM_ (requireLLVMType context name) expectedTypes args
+
+lowerIndirectFunctionParameterTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
+lowerIndirectFunctionParameterTypeM env context paramTy
+  | isFunctionLikeBackendType paramTy = pure LLVMPtr
+  | otherwise =
+      case lowerBackendType env context paramTy of
+        Right llvmTy -> pure llvmTy
+        Left err -> liftEither err
 
 bindCallArguments ::
   ProgramEnv ->

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -624,18 +624,23 @@ collectReferencedFunctionNames base reachable specializations evidenceWrappers =
 
 type LocalFunctionForms = Map String FunctionForm
 
+shadowLocalFunctionForms :: Set String -> LocalFunctionForms -> LocalFunctionForms
+shadowLocalFunctionForms names forms =
+  Map.withoutKeys forms names
+
 collectReferencedFunctionNamesInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> Set String
 collectReferencedFunctionNamesInForm base substitution bound form =
   collectReferencedFunctionNamesInFormWithLocals base substitution Map.empty bound form
 
 collectReferencedFunctionNamesInFormWithLocals :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> FunctionForm -> Set String
 collectReferencedFunctionNamesInFormWithLocals base substitution localForms bound form =
-  collectReferencedFunctionNamesInExpr
-    base
-    substitution
-    localForms
-    (Set.union (Set.fromList (map fst (ffParams form))) bound)
-    (ffBody form)
+  let paramNames = Set.fromList (map fst (ffParams form))
+   in collectReferencedFunctionNamesInExpr
+        base
+        substitution
+        (shadowLocalFunctionForms paramNames localForms)
+        (Set.union paramNames bound)
+        (ffBody form)
 
 collectReferencedFunctionNamesInExpr :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> BackendExpr -> Set String
 collectReferencedFunctionNamesInExpr base substitution localForms bound expr =
@@ -717,7 +722,7 @@ collectReferencedFunctionNamesInExpr base substitution localForms bound expr =
         BackendVar {} -> Set.empty
         BackendLit {} -> Set.empty
         BackendLam _ name _ body ->
-          collectReferencedFunctionNamesInExpr base substitution localForms (Set.insert name bound) body
+          collectReferencedFunctionNamesInExpr base substitution (Map.delete name localForms) (Set.insert name bound) body
         BackendApp _ fun arg ->
           collectReferencedFunctionNamesInExpr base substitution localForms bound fun
             `Set.union` collectReferencedFunctionNamesInExpr base substitution localForms bound arg
@@ -758,11 +763,13 @@ collectReferencedFunctionNamesInExpr base substitution localForms bound expr =
           Map.delete name localForms
 
     collectAlternativeReferences alternative =
+      let binders = patternBinders (backendAltPattern alternative)
+       in
       collectReferencedFunctionNamesInExpr
         base
         substitution
-        localForms
-        (Set.union (patternBinders (backendAltPattern alternative)) bound)
+        (shadowLocalFunctionForms binders localForms)
+        (Set.union binders bound)
         (backendAltBody alternative)
 
     patternBinders =
@@ -776,12 +783,13 @@ collectEvidenceWrappersInForm base substitution bound form =
 
 collectEvidenceWrappersInFormWithLocals :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
 collectEvidenceWrappersInFormWithLocals base substitution localForms bound form =
-  collectEvidenceWrappersInExpr
-    base
-    substitution
-    localForms
-    (Set.union (Set.fromList (map fst (ffParams form))) bound)
-    (ffBody form)
+  let paramNames = Set.fromList (map fst (ffParams form))
+   in collectEvidenceWrappersInExpr
+        base
+        substitution
+        (shadowLocalFunctionForms paramNames localForms)
+        (Set.union paramNames bound)
+        (ffBody form)
 
 collectEvidenceWrappersInExpr :: ProgramBase -> Map String BackendType -> LocalFunctionForms -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
 collectEvidenceWrappersInExpr base substitution localForms bound expr =
@@ -808,7 +816,7 @@ collectEvidenceWrappersInExpr base substitution localForms bound expr =
         BackendVar {} -> []
         BackendLit {} -> []
         BackendLam _ name _ body ->
-          collectEvidenceWrappersInExpr base substitution localForms (Set.insert name bound) body
+          collectEvidenceWrappersInExpr base substitution (Map.delete name localForms) (Set.insert name bound) body
         BackendApp _ fun arg ->
           collectEvidenceWrappersInExpr base substitution localForms bound fun
             ++ collectEvidenceWrappersInExpr base substitution localForms bound arg
@@ -871,11 +879,13 @@ collectEvidenceWrappersInExpr base substitution localForms bound expr =
           Map.delete name localForms
 
     collectAlternativeWrappers alternative =
+      let binders = patternBinders (backendAltPattern alternative)
+       in
       collectEvidenceWrappersInExpr
         base
         substitution
-        localForms
-        (Set.union (patternBinders (backendAltPattern alternative)) bound)
+        (shadowLocalFunctionForms binders localForms)
+        (Set.union binders bound)
         (backendAltBody alternative)
 
     patternBinders =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1034,11 +1034,15 @@ isEvidenceArgument allowNestedEvidence paramName paramTy =
 
 isEvidenceParameter :: String -> BackendType -> Bool
 isEvidenceParameter =
-  isEvidenceArgument False
+  isEvidenceArgument True
 
 isEvidenceName :: String -> Bool
 isEvidenceName =
   isPrefixOf "$evidence_"
+
+isEvidenceCallableName :: String -> Bool
+isEvidenceCallableName name =
+  isEvidenceName name || isNestedEvidenceName name
 
 isNestedEvidenceName :: String -> Bool
 isNestedEvidenceName name =
@@ -1392,15 +1396,15 @@ lowerCall env exprEnv context expr =
     Just (headExpr, typeArgs, args) ->
       case headExpr of
         BackendVar _ name ->
-          case Map.lookup name (eeValues exprEnv) of
-            Just value
-              | isFunctionLikeBackendType (lvBackendType value) ->
-                  lowerIndirectValueCall env exprEnv context name value typeArgs args
-            _ ->
-              case Map.lookup name (eeLocalFunctions exprEnv) of
-                Just localFunction ->
-                  lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
-                Nothing ->
+          case Map.lookup name (eeLocalFunctions exprEnv) of
+            Just localFunction ->
+              lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
+            Nothing ->
+              case Map.lookup name (eeValues exprEnv) of
+                Just value
+                  | isFunctionLikeBackendType (lvBackendType value) ->
+                      lowerIndirectValueCall env exprEnv context name value typeArgs args
+                _ ->
                   lowerGlobalCall env exprEnv context name typeArgs args
         BackendLam {} ->
           lowerDirectFunctionCall env exprEnv context (functionFormFromExpr headExpr) typeArgs args
@@ -1417,7 +1421,7 @@ lowerCall env exprEnv context expr =
 
 lowerIndirectValueCall :: ProgramEnv -> ExprEnv -> String -> String -> LowerValue -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerIndirectValueCall env exprEnv context name callee typeArgs args = do
-  unless (isEvidenceName name) $
+  unless (isEvidenceCallableName name) $
     liftEither (BackendLLVMUnsupportedExpression context ("escaping function value " ++ show name))
   form <- instantiateFunctionFormM context (functionFormFromType (lvBackendType callee)) typeArgs args
   unless (length args == length (ffParams form)) $

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1519,12 +1519,67 @@ lowerEvidenceArgument env exprEnv context expectedTy arg =
 
 lowerFunctionReference :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendType] -> LowerM LowerValue
 lowerFunctionReference env exprEnv context expectedTy name typeArgs =
+  case Map.lookup name (eeLocalFunctions exprEnv) of
+    Just localFunction ->
+      lowerLocalFunctionReference env context expectedTy name localFunction typeArgs
+    Nothing ->
+      lowerNonLocalFunctionReference env exprEnv context expectedTy name typeArgs
+
+lowerLocalFunctionReference :: ProgramEnv -> String -> BackendType -> String -> LocalFunction -> [BackendType] -> LowerM LowerValue
+lowerLocalFunctionReference env context expectedTy name localFunction typeArgs = do
+  form <-
+    if null typeArgs
+      then pure (lfForm localFunction)
+      else instantiateFunctionFormM context (lfForm localFunction) typeArgs []
+  let actualTy = functionTypeFromFormWithBinders form
+  requireEvidenceFunctionType context name expectedTy actualTy
+  case etaAliasTarget form of
+    Just (targetName, targetTypeArgs) ->
+      lowerFunctionReference env (lfCapturedEnv localFunction) context expectedTy targetName targetTypeArgs
+    Nothing ->
+      liftEither (BackendLLVMUnsupportedExpression context ("unsupported function argument " ++ show name))
+
+etaAliasTarget :: FunctionForm -> Maybe (String, [BackendType])
+etaAliasTarget form =
+  case collectValueApps (ffBody form) of
+    (headExpr, args)
+      | mapMaybe backendVarExprName args == map fst (ffParams form),
+        length args == length (ffParams form) ->
+          case collectTyApps headExpr of
+            (BackendVar _ targetName, targetTypeArgs) ->
+              Just (targetName, eraseAliasBinderTypeArgs targetTypeArgs)
+            _ ->
+              Nothing
+    _ ->
+      Nothing
+  where
+    binderTypeArgs =
+      [BTVar name | (name, _) <- ffTypeBinders form]
+    eraseAliasBinderTypeArgs targetTypeArgs
+      | targetTypeArgs == binderTypeArgs = []
+      | otherwise = targetTypeArgs
+
+collectValueApps :: BackendExpr -> (BackendExpr, [BackendExpr])
+collectValueApps =
+  go []
+  where
+    go args =
+      \case
+        BackendApp _ fun arg -> go (arg : args) fun
+        expr -> (expr, args)
+
+backendVarExprName :: BackendExpr -> Maybe String
+backendVarExprName =
+  \case
+    BackendVar _ name -> Just name
+    _ -> Nothing
+
+lowerNonLocalFunctionReference :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendType] -> LowerM LowerValue
+lowerNonLocalFunctionReference env exprEnv context expectedTy name typeArgs =
   case Map.lookup name (eeValues exprEnv) of
     Just value
-      | isFunctionLikeBackendType (lvBackendType value) -> do
-          actualTy <- instantiateCallableTypeM context (lvBackendType value) typeArgs []
-          requireEvidenceFunctionType context name expectedTy actualTy
-          pure (LowerValue expectedTy LLVMPtr (lvOperand value))
+      | isFunctionLikeBackendType (lvBackendType value) ->
+          lowerValueFunctionReference context expectedTy name value typeArgs
     _ ->
       case Map.lookup name (pbBindings (peBase env)) of
         Just binding -> do
@@ -1536,6 +1591,15 @@ lowerFunctionReference env exprEnv context expectedTy name typeArgs =
         Nothing ->
           liftEither (BackendLLVMUnknownFunction name)
 
+lowerValueFunctionReference :: String -> BackendType -> String -> LowerValue -> [BackendType] -> LowerM LowerValue
+lowerValueFunctionReference context expectedTy name value typeArgs = do
+  actualTy <-
+    if null typeArgs
+      then pure (lvBackendType value)
+      else instantiateCallableTypeM context (lvBackendType value) typeArgs []
+  requireEvidenceFunctionType context name expectedTy actualTy
+  pure (LowerValue expectedTy LLVMPtr (lvOperand value))
+
 instantiateCallableTypeM :: String -> BackendType -> [BackendType] -> [BackendExpr] -> LowerM BackendType
 instantiateCallableTypeM context ty typeArgs args = do
   form <- instantiateFunctionFormM context (functionFormFromType ty) typeArgs args
@@ -1544,6 +1608,13 @@ instantiateCallableTypeM context ty typeArgs args = do
 functionTypeFromForm :: FunctionForm -> BackendType
 functionTypeFromForm form =
   foldr BTArrow (ffReturnType form) (map snd (ffParams form))
+
+functionTypeFromFormWithBinders :: FunctionForm -> BackendType
+functionTypeFromFormWithBinders form =
+  foldr
+    (\(name, mbBound) body -> BTForall name mbBound body)
+    (functionTypeFromForm form)
+    (ffTypeBinders form)
 
 requireEvidenceFunctionType :: String -> String -> BackendType -> BackendType -> LowerM ()
 requireEvidenceFunctionType context name expected actual =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1010,6 +1010,90 @@ isFunctionLikeBackendType =
 requiresInlineCall :: FunctionForm -> Bool
 requiresInlineCall form =
   any (uncurry (isInlineOnlyFunctionParameter False)) (ffParams form)
+    || containsInlineOnlyEvidenceParameterCall form
+
+containsInlineOnlyEvidenceParameterCall :: FunctionForm -> Bool
+containsInlineOnlyEvidenceParameterCall form =
+  go (evidenceParameterNames form) Set.empty (ffBody form)
+  where
+    go evidenceParams localFunctions expr =
+      callRequiresInline evidenceParams localFunctions expr
+        || case expr of
+          BackendVar {} -> False
+          BackendLit {} -> False
+          BackendLam _ name _ body ->
+            go evidenceParams (Set.delete name localFunctions) body
+          BackendApp _ fun arg ->
+            go evidenceParams localFunctions fun || go evidenceParams localFunctions arg
+          BackendLet _ name bindingTy rhs body ->
+            let rhsForm = functionFormFromExpected bindingTy rhs
+                rhsIsLocalFunction = not (null (ffTypeBinders rhsForm)) || not (null (ffParams rhsForm))
+                localFunctions' =
+                  if rhsIsLocalFunction
+                    then Set.insert name localFunctions
+                    else Set.delete name localFunctions
+             in go evidenceParams localFunctions rhs || go evidenceParams localFunctions' body
+          BackendTyAbs _ _ _ body ->
+            go evidenceParams localFunctions body
+          BackendTyApp _ fun _ ->
+            go evidenceParams localFunctions fun
+          BackendConstruct _ _ args ->
+            any (go evidenceParams localFunctions) args
+          BackendCase _ scrutinee alternatives ->
+            go evidenceParams localFunctions scrutinee
+              || any (goAlternative evidenceParams localFunctions) (NE.toList alternatives)
+          BackendRoll _ payload ->
+            go evidenceParams localFunctions payload
+          BackendUnroll _ payload ->
+            go evidenceParams localFunctions payload
+
+    goAlternative evidenceParams localFunctions (BackendAlternative pattern0 body) =
+      go evidenceParams (localFunctions `Set.difference` patternBinders pattern0) body
+
+    callRequiresInline evidenceParams localFunctions expr =
+      case collectCall expr of
+        Just (BackendVar calleeTy name, typeArgs, args)
+          | Set.member name evidenceParams ->
+              case instantiateFunctionFormWithTypeArgs "inline evidence parameter call" (functionFormFromType calleeTy) typeArgs args of
+                Right (_, callForm) ->
+                  any (uncurry (argumentRequiresInline localFunctions)) (zip (ffParams callForm) args)
+                Left _ ->
+                  False
+        _ ->
+          False
+
+    argumentRequiresInline localFunctions (_, paramTy) arg =
+      isFunctionLikeBackendType paramTy && functionExpressionRequiresInline localFunctions arg
+
+    functionExpressionRequiresInline localFunctions arg =
+      case collectTyApps arg of
+        (BackendVar _ name, _) ->
+          Set.member name localFunctions
+        _ ->
+          case arg of
+            BackendLam {} -> True
+            BackendTyAbs {} -> True
+            BackendLet _ name bindingTy rhs body ->
+              let rhsForm = functionFormFromExpected bindingTy rhs
+                  localFunctions' =
+                    if not (null (ffTypeBinders rhsForm)) || not (null (ffParams rhsForm))
+                      then Set.insert name localFunctions
+                      else Set.delete name localFunctions
+               in functionExpressionRequiresInline localFunctions' body
+            _ -> False
+
+    patternBinders =
+      \case
+        BackendDefaultPattern -> Set.empty
+        BackendConstructorPattern _ binders -> Set.fromList binders
+
+evidenceParameterNames :: FunctionForm -> Set String
+evidenceParameterNames form =
+  Set.fromList
+    [ name
+    | (name, ty) <- ffParams form,
+      isEvidenceArgument False name ty
+    ]
 
 hasTypeBinders :: BackendType -> Bool
 hasTypeBinders =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -587,8 +587,10 @@ collectEvidenceWrappers base reachable specializations =
   zipWith assignName [(0 :: Int) ..] uniqueRequests
   where
     requests =
-      concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . biForm) reachable
+      concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . biForm) monomorphicReachable
         ++ concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . spForm) specializations
+    monomorphicReachable =
+      filter (null . ffTypeBinders . biForm) reachable
     uniqueRequests =
       map snd (Map.toAscList (Map.fromList [(evidenceWrapperKey expected expr, (expected, expr)) | (expected, expr) <- requests]))
     assignName index0 (expected, expr) =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -597,7 +597,8 @@ collectEvidenceWrappersInExpr base substitution bound expr =
                       [ (paramTy, arg)
                       | ((paramName, paramTy), arg) <- zip (ffParams form) args',
                         isEvidenceArgument False paramName paramTy,
-                        not (isSimpleFunctionReference arg)
+                        not (isSimpleFunctionReference arg),
+                        evidenceWrapperArgumentClosed bound arg
                       ]
                     Left _ -> []
         _ -> []
@@ -657,6 +658,50 @@ isSimpleFunctionReference arg =
   case collectTyApps arg of
     (BackendVar {}, _) -> True
     _ -> False
+
+evidenceWrapperArgumentClosed :: Set String -> BackendExpr -> Bool
+evidenceWrapperArgumentClosed bound expr =
+  Set.null (freeTermVars expr `Set.intersection` bound)
+
+freeTermVars :: BackendExpr -> Set String
+freeTermVars =
+  go Set.empty
+  where
+    go bound =
+      \case
+        BackendVar _ name
+          | Set.member name bound -> Set.empty
+          | otherwise -> Set.singleton name
+        BackendLit {} ->
+          Set.empty
+        BackendLam _ name _ body ->
+          go (Set.insert name bound) body
+        BackendApp _ fun arg ->
+          Set.union (go bound fun) (go bound arg)
+        BackendLet _ name _ rhs body ->
+          Set.union (go bound rhs) (go (Set.insert name bound) body)
+        BackendTyAbs _ _ _ body ->
+          go bound body
+        BackendTyApp _ fun _ ->
+          go bound fun
+        BackendConstruct _ _ args ->
+          foldMap (go bound) args
+        BackendCase _ scrutinee alternatives ->
+          Set.union
+            (go bound scrutinee)
+            (foldMap (goAlternative bound) (NE.toList alternatives))
+        BackendRoll _ payload ->
+          go bound payload
+        BackendUnroll _ payload ->
+          go bound payload
+
+    goAlternative bound (BackendAlternative pattern0 body) =
+      go (Set.union (patternBinders pattern0) bound) body
+
+    patternBinders =
+      \case
+        BackendDefaultPattern -> Set.empty
+        BackendConstructorPattern _ binders -> Set.fromList binders
 
 collectSpecializationRequestsInForm :: ProgramBase -> Map String BackendType -> FunctionForm -> [SpecRequest]
 collectSpecializationRequestsInForm base substitution form =

--- a/src/MLF/Backend/LLVM/Ppr.hs
+++ b/src/MLF/Backend/LLVM/Ppr.hs
@@ -115,6 +115,14 @@ renderLLVMExpression resultTy expression =
         ++ "("
         ++ intercalate ", " (map renderLLVMArgument args)
         ++ ")"
+    LLVMCallOperand callee args ->
+      "call "
+        ++ renderLLVMType resultTy
+        ++ " "
+        ++ renderLLVMOperand callee
+        ++ "("
+        ++ intercalate ", " (map renderLLVMArgument args)
+        ++ ")"
     LLVMGetElementPtr elementTy base indexes ->
       "getelementptr "
         ++ renderLLVMType elementTy

--- a/src/MLF/Backend/LLVM/Syntax.hs
+++ b/src/MLF/Backend/LLVM/Syntax.hs
@@ -71,6 +71,7 @@ data LLVMInstruction
 
 data LLVMExpression
   = LLVMCall String [(LLVMType, LLVMOperand)]
+  | LLVMCallOperand LLVMOperand [(LLVMType, LLVMOperand)]
   | LLVMGetElementPtr LLVMType LLVMOperand [(LLVMType, LLVMOperand)]
   | LLVMLoad LLVMType LLVMOperand
   | LLVMPhi LLVMType [(LLVMOperand, String)]

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -462,10 +462,22 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
     backendBindingExpr helper `shouldSatisfy` containsFreshenedTypeAbsWithOuterBound
 
-  it "leaves type abstraction bounds unchanged under shadowing type binders" $ do
-    source <- readFile "src/MLF/Backend/Convert.hs"
+  it "renames shadowing type abstraction bounds that refer to outer binders" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveNestedTypeBoundScopeElabTy,
+                    checkedBindingTerm = recursiveNestedTypeBoundScopeTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
 
-    source `shouldSatisfy` isInfixOf "| name == old ->\n              ETyAbs name mbBound body"
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
 
   it "lifts recursive lets that shadow outer term binders" $ do
     checked0 <- requireChecked simpleFunctionProgram
@@ -1393,6 +1405,43 @@ recursiveTypeBoundScopeRhs =
             "a"
             (Just (dependentArrowElabBoundTy (Elab.TVar "a")))
             (Elab.EApp (Elab.EVar "loop") (Elab.EVar "n"))
+        )
+        (Elab.InstApp (dependentArrowElabTy (Elab.TVar "a")))
+    )
+
+recursiveNestedTypeBoundScopeElabTy :: Elab.ElabType
+recursiveNestedTypeBoundScopeElabTy =
+  Elab.TForall "a" Nothing intElabTy
+
+recursiveNestedTypeBoundScopeTerm :: Elab.ElabTerm
+recursiveNestedTypeBoundScopeTerm =
+  Elab.ETyAbs
+    "a"
+    Nothing
+    ( Elab.ELet
+        "loop"
+        (Elab.schemeFromType unaryIntElabTy)
+        recursiveNestedTypeBoundScopeRhs
+        (Elab.EApp (Elab.EVar "loop") (Elab.ELit (LInt 0)))
+    )
+
+recursiveNestedTypeBoundScopeRhs :: Elab.ElabTerm
+recursiveNestedTypeBoundScopeRhs =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ETyInst
+        ( Elab.ETyAbs
+            "a"
+            (Just (dependentArrowElabBoundTy (Elab.TVar "a")))
+            ( Elab.ETyInst
+                ( Elab.ETyAbs
+                    "a"
+                    (Just (dependentArrowElabBoundTy (Elab.TVar "a")))
+                    (Elab.EApp (Elab.EVar "loop") (Elab.EVar "n"))
+                )
+                (Elab.InstApp (dependentArrowElabTy (Elab.TVar "a")))
+            )
         )
         (Elab.InstApp (dependentArrowElabTy (Elab.TVar "a")))
     )

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -462,6 +462,46 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
     backendBindingExpr helper `shouldSatisfy` containsFreshenedTypeAbsWithOuterBound
 
+  it "leaves type abstraction bounds unchanged under shadowing type binders" $ do
+    source <- readFile "src/MLF/Backend/Convert.hs"
+
+    source `shouldSatisfy` isInfixOf "| name == old ->\n              ETyAbs name mbBound body"
+
+  it "lifts recursive lets that shadow outer term binders" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveShadowedLetElabTy,
+                    checkedBindingTerm = recursiveShadowedLetTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    backendBindingType helper `shouldBe` unaryIntBackendTy
+    backendBindingExpr helper `shouldSatisfy` containsBackendVar (backendBindingName helper)
+
+  it "preserves lexical type binder order when lifting recursive helper captures" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveLexicalTypeOrderElabTy,
+                    checkedBindingTerm = recursiveLexicalTypeOrderTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    backendBindingType helper `shouldBe` recursiveLexicalTypeOrderHelperBackendTy
+
   it "rejects recursive local functions that capture lexical values" $ do
     checked <- requireChecked recursiveLetCaptureProgram
 
@@ -1355,6 +1395,88 @@ recursiveTypeBoundScopeRhs =
             (Elab.EApp (Elab.EVar "loop") (Elab.EVar "n"))
         )
         (Elab.InstApp (dependentArrowElabTy (Elab.TVar "a")))
+    )
+
+recursiveShadowedLetElabTy :: Elab.ElabType
+recursiveShadowedLetElabTy =
+  intElabTy
+
+recursiveShadowedLetTerm :: Elab.ElabTerm
+recursiveShadowedLetTerm =
+  Elab.ELet
+    "f"
+    (Elab.schemeFromType unaryIntElabTy)
+    intIdentityElabTerm
+    ( Elab.ELet
+        "f"
+        (Elab.schemeFromType unaryIntElabTy)
+        ( Elab.ELam
+            "n"
+            intElabTy
+            (Elab.EApp (Elab.EVar "f") (Elab.EVar "n"))
+        )
+        (Elab.EApp (Elab.EVar "f") (Elab.ELit (LInt 0)))
+    )
+
+recursiveLexicalTypeOrderElabTy :: Elab.ElabType
+recursiveLexicalTypeOrderElabTy =
+  Elab.TForall
+    "z"
+    Nothing
+    ( Elab.TForall
+        "a"
+        Nothing
+        intElabTy
+    )
+
+recursiveLexicalTypeOrderTerm :: Elab.ElabTerm
+recursiveLexicalTypeOrderTerm =
+  Elab.ETyAbs
+    "z"
+    Nothing
+    ( Elab.ETyAbs
+        "a"
+        Nothing
+        ( Elab.ELet
+            "loop"
+            (Elab.schemeFromType unaryIntElabTy)
+            recursiveLexicalTypeOrderRhs
+            (Elab.EApp (Elab.EVar "loop") (Elab.ELit (LInt 0)))
+        )
+    )
+
+recursiveLexicalTypeOrderRhs :: Elab.ElabTerm
+recursiveLexicalTypeOrderRhs =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ELet
+        "captureA"
+        (Elab.schemeFromType intElabTy)
+        ( Elab.ETyInst
+            (Elab.ETyAbs "b" Nothing (Elab.ELit (LInt 0)))
+            (Elab.InstApp (Elab.TVar "a"))
+        )
+        ( Elab.ELet
+            "captureZ"
+            (Elab.schemeFromType intElabTy)
+            ( Elab.ETyInst
+                (Elab.ETyAbs "b" Nothing (Elab.ELit (LInt 0)))
+                (Elab.InstApp (Elab.TVar "z"))
+            )
+            (Elab.EApp (Elab.EVar "loop") (Elab.EVar "n"))
+        )
+    )
+
+recursiveLexicalTypeOrderHelperBackendTy :: BackendType
+recursiveLexicalTypeOrderHelperBackendTy =
+  BTForall
+    "z"
+    Nothing
+    ( BTForall
+        "a"
+        Nothing
+        unaryIntBackendTy
     )
 
 intIdentityElabTerm :: Elab.ElabTerm

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -444,11 +444,23 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
     backendBindingExpr helper `shouldSatisfy` containsBackendTyAppArgument (BTVar "a")
 
-  it "renames type abstraction bounds when recursive helper substitution freshens type binders" $ do
-    source <- readFile "src/MLF/Backend/Convert.hs"
+  it "keeps type abstraction bounds outside freshened binder scope" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveTypeBoundScopeElabTy,
+                    checkedBindingTerm = recursiveTypeBoundScopeTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
 
-    source `shouldSatisfy` isInfixOf "mbBound' = fmap (renameElabTypeVariable name name') mbBound"
-    source `shouldSatisfy` isInfixOf "in ETyAbs name' mbBound' (go body')"
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
+    backendBindingExpr helper `shouldSatisfy` containsFreshenedTypeAbsWithOuterBound
 
   it "rejects recursive local functions that capture lexical values" $ do
     checked <- requireChecked recursiveLetCaptureProgram
@@ -1047,6 +1059,26 @@ containsBackendTyAppArgument expected expr =
     BackendUnroll {backendUnrollPayload = body} -> containsBackendTyAppArgument expected body
     _ -> False
 
+containsFreshenedTypeAbsWithOuterBound :: BackendExpr -> Bool
+containsFreshenedTypeAbsWithOuterBound expr =
+  case expr of
+    BackendTyAbs {backendTyParamName = name, backendTyParamBound = Just (BTArrow (BTVar boundDom) (BTVar boundCod)), backendTyAbsBody = body} ->
+      (name /= "a" && boundDom == "a" && boundCod == "a") || containsFreshenedTypeAbsWithOuterBound body
+    BackendTyAbs {backendTyAbsBody = body} ->
+      containsFreshenedTypeAbsWithOuterBound body
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsFreshenedTypeAbsWithOuterBound scrutinee || any (containsFreshenedTypeAbsWithOuterBound . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsFreshenedTypeAbsWithOuterBound body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsFreshenedTypeAbsWithOuterBound fun || containsFreshenedTypeAbsWithOuterBound arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsFreshenedTypeAbsWithOuterBound rhs || containsFreshenedTypeAbsWithOuterBound body
+    BackendTyApp {backendTyFunction = fun} -> containsFreshenedTypeAbsWithOuterBound fun
+    BackendConstruct {backendConstructArgs = args} -> any containsFreshenedTypeAbsWithOuterBound args
+    BackendRoll {backendRollPayload = body} -> containsFreshenedTypeAbsWithOuterBound body
+    BackendUnroll {backendUnrollPayload = body} -> containsFreshenedTypeAbsWithOuterBound body
+    _ -> False
+
 containsBackendVar :: String -> BackendExpr -> Bool
 containsBackendVar expected expr =
   case expr of
@@ -1295,6 +1327,36 @@ recursiveTypeOnlyInstantiation =
     (Elab.ETyAbs "b" Nothing (Elab.ELit (LInt 0)))
     (Elab.InstApp (Elab.TVar "a"))
 
+recursiveTypeBoundScopeElabTy :: Elab.ElabType
+recursiveTypeBoundScopeElabTy =
+  Elab.TForall "a" Nothing intElabTy
+
+recursiveTypeBoundScopeTerm :: Elab.ElabTerm
+recursiveTypeBoundScopeTerm =
+  Elab.ETyAbs
+    "a"
+    Nothing
+    ( Elab.ELet
+        "loop"
+        (Elab.schemeFromType unaryIntElabTy)
+        recursiveTypeBoundScopeRhs
+        (Elab.EApp (Elab.EVar "loop") (Elab.ELit (LInt 0)))
+    )
+
+recursiveTypeBoundScopeRhs :: Elab.ElabTerm
+recursiveTypeBoundScopeRhs =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ETyInst
+        ( Elab.ETyAbs
+            "a"
+            (Just (dependentArrowElabBoundTy (Elab.TVar "a")))
+            (Elab.EApp (Elab.EVar "loop") (Elab.EVar "n"))
+        )
+        (Elab.InstApp (dependentArrowElabTy (Elab.TVar "a")))
+    )
+
 intIdentityElabTerm :: Elab.ElabTerm
 intIdentityElabTerm =
   Elab.ELam "m" intElabTy (Elab.EVar "m")
@@ -1346,6 +1408,10 @@ dependentBoundedWrapTerm =
 
 dependentArrowElabBoundTy :: Elab.ElabType -> Elab.BoundType
 dependentArrowElabBoundTy ty =
+  Elab.TArrow ty ty
+
+dependentArrowElabTy :: Elab.ElabType -> Elab.ElabType
+dependentArrowElabTy ty =
   Elab.TArrow ty ty
 
 polymorphicIdentityElabTy :: Elab.ElabType

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -259,6 +259,26 @@ spec = describe "MLF.Backend.Convert" $ do
 
     validateBackendProgram backend `shouldBe` Right ()
 
+  it "converts hidden Eq evidence for constrained helpers" $ do
+    checked <- requireChecked hiddenEqEvidenceProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+  it "converts constrained parameterized Eq evidence without ambiguous ADT recovery" $ do
+    checked <- requireChecked parameterizedEqEvidenceProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    map backendBindingName (backendBindings backend) `shouldSatisfy` any (isInfixOf "Eq__Option")
+
+  it "lifts recursive parameterized deriving Eq helpers with captured evidence" $ do
+    checked <- requireChecked recursiveListDerivingEqProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    map backendBindingName (backendBindings backend) `shouldSatisfy` any (isInfixOf "$letrec$")
+
   it "ignores stale constructor head type instantiations" $ do
     checked0 <- requireChecked constructorForallApplicationProgram
     let checked =
@@ -474,6 +494,80 @@ parameterizedConstructorProgram =
       "    | Some : a -> Option a;",
       "",
       "  def main : Option Int = Some 1;",
+      "}"
+    ]
+
+hiddenEqEvidenceProgram :: String
+hiddenEqEvidenceProgram =
+  unlines
+    [ "module Main export (Eq, Nat(..), eq, same, main) {",
+      "  class Eq a {",
+      "    eq : a -> a -> Bool;",
+      "  }",
+      "",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat",
+      "    deriving Eq;",
+      "",
+      "  def same : Eq a => a -> a -> Bool = \\x \\y eq x y;",
+      "  def main : Bool = same Zero Zero;",
+      "}"
+    ]
+
+parameterizedEqEvidenceProgram :: String
+parameterizedEqEvidenceProgram =
+  unlines
+    [ "module Main export (Eq, Nat(..), Option(..), eq, main) {",
+      "  class Eq a {",
+      "    eq : a -> a -> Bool;",
+      "  }",
+      "",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat",
+      "    deriving Eq;",
+      "",
+      "  data Option a =",
+      "      None : Option a",
+      "    | Some : a -> Option a;",
+      "",
+      "  instance Eq a => Eq (Option a) {",
+      "    eq = \\left \\right case left of {",
+      "      None -> case right of {",
+      "        None -> true;",
+      "        Some _ -> false",
+      "      };",
+      "      Some l -> case right of {",
+      "        None -> false;",
+      "        Some r -> eq l r",
+      "      }",
+      "    };",
+      "  }",
+      "",
+      "  def main : Bool = eq (Some (Some Zero)) (Some (Some Zero));",
+      "}"
+    ]
+
+recursiveListDerivingEqProgram :: String
+recursiveListDerivingEqProgram =
+  unlines
+    [ "module Main export (Eq, Nat(..), List(..), eq, main) {",
+      "  class Eq a {",
+      "    eq : a -> a -> Bool;",
+      "  }",
+      "",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat",
+      "    deriving Eq;",
+      "",
+      "  data List a =",
+      "      Nil : List a",
+      "    | Cons : a -> List a -> List a",
+      "    deriving Eq;",
+      "",
+      "  def main : Bool = eq (Cons Zero Nil) (Cons Zero Nil);",
       "}"
     ]
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -373,6 +373,41 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendVar (backendBindingName helper)
 
+  it "renames binders that would capture recursive helper evidence" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveCaptureAvoidingElabTy,
+                    checkedBindingTerm = recursiveCaptureAvoidingTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    length (filter (== "$evidence_E") (backendExprBinders (backendBindingExpr helper))) `shouldBe` 1
+
+  it "captures type variables used only by recursive RHS instantiations" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveTypeCaptureElabTy,
+                    checkedBindingTerm = recursiveTypeCaptureTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
+    backendBindingExpr helper `shouldSatisfy` containsBackendTyAppArgument (BTVar "a")
+
   it "rejects recursive local functions that capture lexical values" $ do
     checked <- requireChecked recursiveLetCaptureProgram
 
@@ -883,6 +918,12 @@ requireBinding name backend =
     Just binding -> pure binding
     Nothing -> expectationFailure ("missing backend binding " ++ show name) >> fail "missing binding"
 
+requireSingleLiftedHelper :: BackendProgram -> IO BackendBinding
+requireSingleLiftedHelper backend =
+  case filter (isInfixOf "$letrec$" . backendBindingName) (backendBindings backend) of
+    [helper] -> pure helper
+    helpers -> expectationFailure ("expected one lifted helper, got " ++ show (map backendBindingName helpers)) >> fail "helper mismatch"
+
 requireConstructor :: String -> BackendProgram -> IO BackendConstructor
 requireConstructor name backend =
   case find ((== name) . backendConstructorName) (backendConstructors backend) of
@@ -936,6 +977,24 @@ containsBackendTyApp expr =
     BackendUnroll {backendUnrollPayload = body} -> containsBackendTyApp body
     _ -> False
 
+containsBackendTyAppArgument :: BackendType -> BackendExpr -> Bool
+containsBackendTyAppArgument expected expr =
+  case expr of
+    BackendTyApp {backendTyArgument = ty, backendTyFunction = fun} ->
+      ty == expected || containsBackendTyAppArgument expected fun
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsBackendTyAppArgument expected scrutinee || any (containsBackendTyAppArgument expected . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsBackendTyAppArgument expected body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsBackendTyAppArgument expected fun || containsBackendTyAppArgument expected arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsBackendTyAppArgument expected rhs || containsBackendTyAppArgument expected body
+    BackendTyAbs {backendTyAbsBody = body} -> containsBackendTyAppArgument expected body
+    BackendConstruct {backendConstructArgs = args} -> any (containsBackendTyAppArgument expected) args
+    BackendRoll {backendRollPayload = body} -> containsBackendTyAppArgument expected body
+    BackendUnroll {backendUnrollPayload = body} -> containsBackendTyAppArgument expected body
+    _ -> False
+
 containsBackendVar :: String -> BackendExpr -> Bool
 containsBackendVar expected expr =
   case expr of
@@ -956,6 +1015,28 @@ containsBackendVar expected expr =
     BackendRoll {backendRollPayload = body} -> containsBackendVar expected body
     BackendUnroll {backendUnrollPayload = body} -> containsBackendVar expected body
     _ -> False
+
+backendExprBinders :: BackendExpr -> [String]
+backendExprBinders expr =
+  case expr of
+    BackendVar {} -> []
+    BackendLit {} -> []
+    BackendLam {backendParamName = name, backendBody = body} -> name : backendExprBinders body
+    BackendApp {backendFunction = fun, backendArgument = arg} -> backendExprBinders fun ++ backendExprBinders arg
+    BackendLet {backendLetName = name, backendLetRhs = rhs, backendLetBody = body} -> name : backendExprBinders rhs ++ backendExprBinders body
+    BackendTyAbs {backendTyAbsBody = body} -> backendExprBinders body
+    BackendTyApp {backendTyFunction = fun} -> backendExprBinders fun
+    BackendConstruct {backendConstructArgs = args} -> concatMap backendExprBinders args
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      backendExprBinders scrutinee ++ concatMap alternativeBinders (toList alternatives)
+    BackendRoll {backendRollPayload = body} -> backendExprBinders body
+    BackendUnroll {backendUnrollPayload = body} -> backendExprBinders body
+  where
+    alternativeBinders (BackendAlternative pattern0 body) =
+      patternBackendBinders pattern0 ++ backendExprBinders body
+
+    patternBackendBinders BackendDefaultPattern = []
+    patternBackendBinders (BackendConstructorPattern _ names) = names
 
 isBackendFunctionType :: BackendType -> Bool
 isBackendFunctionType ty =
@@ -1023,6 +1104,10 @@ boolTy :: BackendType
 boolTy =
   BTBase (BaseTy "Bool")
 
+unaryIntBackendTy :: BackendType
+unaryIntBackendTy =
+  BTArrow intTy intTy
+
 intElabTy :: Elab.ElabType
 intElabTy =
   Elab.TBase (BaseTy "Int")
@@ -1030,6 +1115,81 @@ intElabTy =
 boolElabTy :: Elab.ElabType
 boolElabTy =
   Elab.TBase (BaseTy "Bool")
+
+unaryIntElabTy :: Elab.ElabType
+unaryIntElabTy =
+  Elab.TArrow intElabTy intElabTy
+
+recursiveCaptureAvoidingElabTy :: Elab.ElabType
+recursiveCaptureAvoidingElabTy =
+  Elab.TArrow unaryIntElabTy intElabTy
+
+recursiveCaptureAvoidingTerm :: Elab.ElabTerm
+recursiveCaptureAvoidingTerm =
+  Elab.ELam
+    "$evidence_E"
+    unaryIntElabTy
+    ( Elab.ELet
+        "loop"
+        (Elab.schemeFromType unaryIntElabTy)
+        recursiveCaptureAvoidingRhs
+        (Elab.EApp (Elab.EVar "loop") (Elab.ELit (LInt 0)))
+    )
+
+recursiveCaptureAvoidingRhs :: Elab.ElabTerm
+recursiveCaptureAvoidingRhs =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ELet
+        "before"
+        (Elab.schemeFromType intElabTy)
+        (Elab.EApp (Elab.EVar "$evidence_E") (Elab.EVar "n"))
+        ( Elab.ELet
+            "$evidence_E"
+            (Elab.schemeFromType unaryIntElabTy)
+            intIdentityElabTerm
+            (Elab.EApp (Elab.EVar "loop") (Elab.EVar "before"))
+        )
+    )
+
+recursiveTypeCaptureElabTy :: Elab.ElabType
+recursiveTypeCaptureElabTy =
+  Elab.TForall "a" Nothing intElabTy
+
+recursiveTypeCaptureTerm :: Elab.ElabTerm
+recursiveTypeCaptureTerm =
+  Elab.ETyAbs
+    "a"
+    Nothing
+    ( Elab.ELet
+        "loop"
+        (Elab.schemeFromType unaryIntElabTy)
+        recursiveTypeCaptureRhs
+        (Elab.EApp (Elab.EVar "loop") (Elab.ELit (LInt 0)))
+    )
+
+recursiveTypeCaptureRhs :: Elab.ElabTerm
+recursiveTypeCaptureRhs =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ELet
+        "ignored"
+        (Elab.schemeFromType intElabTy)
+        recursiveTypeOnlyInstantiation
+        (Elab.EApp (Elab.EVar "loop") (Elab.EVar "n"))
+    )
+
+recursiveTypeOnlyInstantiation :: Elab.ElabTerm
+recursiveTypeOnlyInstantiation =
+  Elab.ETyInst
+    (Elab.ETyAbs "b" Nothing (Elab.ELit (LInt 0)))
+    (Elab.InstApp (Elab.TVar "a"))
+
+intIdentityElabTerm :: Elab.ElabTerm
+intIdentityElabTerm =
+  Elab.ELam "m" intElabTy (Elab.EVar "m")
 
 intElabBoundTy :: Elab.BoundType
 intElabBoundTy =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -444,6 +444,12 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingType helper `shouldBe` BTForall "a" Nothing unaryIntBackendTy
     backendBindingExpr helper `shouldSatisfy` containsBackendTyAppArgument (BTVar "a")
 
+  it "renames type abstraction bounds when recursive helper substitution freshens type binders" $ do
+    source <- readFile "src/MLF/Backend/Convert.hs"
+
+    source `shouldSatisfy` isInfixOf "mbBound' = fmap (renameElabTypeVariable name name') mbBound"
+    source `shouldSatisfy` isInfixOf "in ETyAbs name' mbBound' (go body')"
+
   it "rejects recursive local functions that capture lexical values" $ do
     checked <- requireChecked recursiveLetCaptureProgram
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -409,6 +409,23 @@ spec = describe "MLF.Backend.Convert" $ do
     helper <- requireSingleLiftedHelper backend
     length (filter (== "$evidence_E") (backendExprBinders (backendBindingExpr helper))) `shouldBe` 1
 
+  it "keeps renamed let binders out of their own right-hand sides" $ do
+    checked0 <- requireChecked simpleFunctionProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = recursiveLetRhsRenameElabTy,
+                    checkedBindingTerm = recursiveLetRhsRenameTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    backendBindingExpr helper `shouldNotSatisfy` containsSelfReferentialLetRhs
+
   it "captures type variables used only by recursive RHS instantiations" $ do
     checked0 <- requireChecked simpleFunctionProgram
     let checked =
@@ -1067,6 +1084,29 @@ backendExprBinders expr =
     patternBackendBinders BackendDefaultPattern = []
     patternBackendBinders (BackendConstructorPattern _ names) = names
 
+containsSelfReferentialLetRhs :: BackendExpr -> Bool
+containsSelfReferentialLetRhs expr =
+  case expr of
+    BackendVar {} -> False
+    BackendLit {} -> False
+    BackendLam {backendBody = body} -> containsSelfReferentialLetRhs body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsSelfReferentialLetRhs fun || containsSelfReferentialLetRhs arg
+    BackendLet {backendLetName = name, backendLetRhs = rhs, backendLetBody = body} ->
+      rhsIsSelfReference name rhs || containsSelfReferentialLetRhs rhs || containsSelfReferentialLetRhs body
+    BackendTyAbs {backendTyAbsBody = body} -> containsSelfReferentialLetRhs body
+    BackendTyApp {backendTyFunction = fun} -> containsSelfReferentialLetRhs fun
+    BackendConstruct {backendConstructArgs = args} -> any containsSelfReferentialLetRhs args
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsSelfReferentialLetRhs scrutinee || any (containsSelfReferentialLetRhs . backendAltBody) (toList alternatives)
+    BackendRoll {backendRollPayload = body} -> containsSelfReferentialLetRhs body
+    BackendUnroll {backendUnrollPayload = body} -> containsSelfReferentialLetRhs body
+  where
+    rhsIsSelfReference name rhs =
+      case rhs of
+        BackendVar {backendVarName = rhsName} -> rhsName == name
+        _ -> False
+
 isBackendFunctionType :: BackendType -> Bool
 isBackendFunctionType ty =
   case ty of
@@ -1178,6 +1218,39 @@ recursiveCaptureAvoidingRhs =
             "$evidence_E"
             (Elab.schemeFromType unaryIntElabTy)
             intIdentityElabTerm
+            (Elab.EApp (Elab.EVar "loop") (Elab.EVar "before"))
+        )
+    )
+
+recursiveLetRhsRenameElabTy :: Elab.ElabType
+recursiveLetRhsRenameElabTy =
+  Elab.TArrow unaryIntElabTy intElabTy
+
+recursiveLetRhsRenameTerm :: Elab.ElabTerm
+recursiveLetRhsRenameTerm =
+  Elab.ELam
+    "$evidence_E"
+    unaryIntElabTy
+    ( Elab.ELet
+        "loop"
+        (Elab.schemeFromType unaryIntElabTy)
+        recursiveLetRhsRenameRhs
+        (Elab.EApp (Elab.EVar "loop") (Elab.ELit (LInt 0)))
+    )
+
+recursiveLetRhsRenameRhs :: Elab.ElabTerm
+recursiveLetRhsRenameRhs =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ELet
+        "before"
+        (Elab.schemeFromType intElabTy)
+        (Elab.EApp (Elab.EVar "$evidence_E") (Elab.EVar "n"))
+        ( Elab.ELet
+            "$evidence_E"
+            (Elab.schemeFromType unaryIntElabTy)
+            (Elab.EVar "$evidence_E")
             (Elab.EApp (Elab.EVar "loop") (Elab.EVar "before"))
         )
     )

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -8,6 +8,7 @@ import MLF.Backend.Convert
 import MLF.Backend.IR
 import MLF.Constraint.Types.Graph (BaseTy (..))
 import qualified MLF.Elab.Types as Elab
+import MLF.Frontend.Program.Types (ConstructorInfo (..), DataInfo (..))
 import MLF.Frontend.Syntax (Lit (..), SrcTy (..), SrcType)
 import MLF.Program
 import System.Directory (createDirectoryIfMissing)
@@ -314,6 +315,24 @@ spec = describe "MLF.Backend.Convert" $ do
     backend <- requireRight (convertCheckedProgram checked)
 
     validateBackendProgram backend `shouldBe` Right ()
+
+  it "rejects mismatched vacuous recursive constructor fallback results during conversion" $ do
+    checked0 <- requireChecked vacuousRecursiveConstructorFallbackProgram
+    let checked =
+          withConstructorResult "Main__MkBox" (STMu "a" (STBase "Int")) $
+            mapMainBinding
+              ( \binding ->
+                  binding {checkedBindingType = Elab.TMu "b" boolElabTy}
+              )
+              checked0
+
+    case convertCheckedProgram checked of
+      Left (BackendUnsupportedCaseShape message) ->
+        message `shouldSatisfy` isInfixOf "constructor result type does not match expected result"
+      Left err ->
+        expectationFailure ("expected constructor shape rejection, got " ++ show err)
+      Right backend ->
+        expectationFailure ("expected constructor shape rejection, got backend:\n" ++ show backend)
 
   it "keeps same-name data declarations module-scoped during type lowering" $ do
     checked <- requireChecked duplicateDataNameProgram
@@ -672,6 +691,16 @@ duplicateDataNameProgram =
       "  def main : Bool = case A.make of {",
       "    A.A -> true",
       "  };",
+      "}"
+    ]
+
+vacuousRecursiveConstructorFallbackProgram :: String
+vacuousRecursiveConstructorFallbackProgram =
+  unlines
+    [ "module Main export (Box(..), main) {",
+      "  data Box = MkBox : Box;",
+      "",
+      "  def main : Box = MkBox;",
       "}"
     ]
 
@@ -1293,6 +1322,27 @@ mapMainBinding f checked =
     updateBinding binding
       | checkedBindingName binding == checkedProgramMain checked = f binding
       | otherwise = binding
+
+withConstructorResult :: String -> SrcType -> CheckedProgram -> CheckedProgram
+withConstructorResult runtimeName resultTy checked =
+  checked
+    { checkedProgramModules =
+        map updateModule (checkedProgramModules checked)
+    }
+  where
+    updateModule checkedModule =
+      checkedModule
+        { checkedModuleData = fmap updateDataInfo (checkedModuleData checkedModule)
+        }
+
+    updateDataInfo dataInfo =
+      dataInfo {dataConstructors = map updateConstructorInfo (dataConstructors dataInfo)}
+
+    updateConstructorInfo constructorInfo
+      | ctorRuntimeName constructorInfo == runtimeName =
+          constructorInfo {ctorResult = resultTy}
+      | otherwise =
+          constructorInfo
 
 mapBackendMainBinding :: (BackendBinding -> BackendBinding) -> BackendProgram -> BackendProgram
 mapBackendMainBinding f backend =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -177,6 +177,17 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendExpr (BackendUnroll boolTy (BackendVar recTy "boxed"))
       `shouldBe` Left (BackendUnrollResultMismatch boolTy intTy)
 
+  it "compares vacuous recursive wrappers by their bodies" $ do
+    validateBackendProgram vacuousRecursiveVariableMismatchProgram
+      `shouldBe` Left (BackendVariableTypeMismatch "x" vacuousRecursiveIntTy vacuousRecursiveBoolTy)
+
+    validateBackendProgram oneSidedVacuousRecursiveMismatchProgram
+      `shouldBe` Left (BackendVariableTypeMismatch "x" recursiveArrowIntTy vacuousRecursiveBoolTy)
+
+    validateBackendProgram vacuousRecursiveConstructorMismatchProgram
+      `shouldBe` Left
+        (BackendConstructorArgumentMismatch "VacuousMuBox" 0 vacuousRecursiveIntTy vacuousRecursiveBoolTy)
+
   it "accepts ADT construction and case analysis through constructor metadata" $ do
     validateBackendProgram (programWithMainExpr boxCaseExpr)
       `shouldBe` Right ()
@@ -467,6 +478,14 @@ captureCaseData =
       backendDataConstructors = [BackendConstructor "CaptureCase" [] [] captureCaseTemplateTy]
     }
 
+vacuousRecursiveBoxData :: BackendData
+vacuousRecursiveBoxData =
+  BackendData
+    { backendDataName = "VacuousMuBox",
+      backendDataParameters = [],
+      backendDataConstructors = [BackendConstructor "VacuousMuBox" [] [vacuousRecursiveIntTy] vacuousRecursiveBoxTy]
+    }
+
 boxCaseExpr :: BackendExpr
 boxCaseExpr =
   boxCaseExprWith
@@ -680,6 +699,38 @@ captureCaseProgram =
       binding "captureCaseArg" captureCaseScrutineeTy (BackendVar captureCaseScrutineeTy "captureCaseArg")
     ]
 
+vacuousRecursiveVariableMismatchProgram :: BackendProgram
+vacuousRecursiveVariableMismatchProgram =
+  programWithBindings
+    [ mainBinding
+        BackendLam
+          { backendExprType = BTArrow vacuousRecursiveIntTy vacuousRecursiveBoolTy,
+            backendParamName = "x",
+            backendParamType = vacuousRecursiveIntTy,
+            backendBody = BackendVar vacuousRecursiveBoolTy "x"
+          }
+    ]
+
+oneSidedVacuousRecursiveMismatchProgram :: BackendProgram
+oneSidedVacuousRecursiveMismatchProgram =
+  programWithBindings
+    [ mainBinding
+        BackendLam
+          { backendExprType = BTArrow recursiveArrowIntTy vacuousRecursiveBoolTy,
+            backendParamName = "x",
+            backendParamType = recursiveArrowIntTy,
+            backendBody = BackendVar vacuousRecursiveBoolTy "x"
+          }
+    ]
+
+vacuousRecursiveConstructorMismatchProgram :: BackendProgram
+vacuousRecursiveConstructorMismatchProgram =
+  programWithDataAndBindings
+    [vacuousRecursiveBoxData]
+    [ mainBinding (BackendConstruct vacuousRecursiveBoxTy "VacuousMuBox" [BackendVar vacuousRecursiveBoolTy "muBoolArg"]),
+      binding "muBoolArg" vacuousRecursiveBoolTy (BackendVar vacuousRecursiveBoolTy "muBoolArg")
+    ]
+
 optionCaseExpr :: BackendExpr
 optionCaseExpr =
   BackendCase
@@ -762,6 +813,10 @@ dependentActualBoundPackTy :: BackendType
 dependentActualBoundPackTy =
   BTBase (BaseTy "DependentActualBoundPack")
 
+vacuousRecursiveBoxTy :: BackendType
+vacuousRecursiveBoxTy =
+  BTBase (BaseTy "VacuousMuBox")
+
 listTy :: BackendType -> BackendType
 listTy ty =
   BTCon (BaseTy "List") (ty :| [])
@@ -793,6 +848,18 @@ captureMuActualTy =
 captureMuInstantiatedTy :: BackendType
 captureMuInstantiatedTy =
   BTMu "a" (BTVar "a1")
+
+vacuousRecursiveIntTy :: BackendType
+vacuousRecursiveIntTy =
+  BTMu "a" intTy
+
+vacuousRecursiveBoolTy :: BackendType
+vacuousRecursiveBoolTy =
+  BTMu "b" boolTy
+
+recursiveArrowIntTy :: BackendType
+recursiveArrowIntTy =
+  BTMu "self" (BTArrow (BTVar "self") intTy)
 
 captureCaseTemplateTy :: BackendType
 captureCaseTemplateTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -337,6 +337,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "ptr %\"__mlfp_evidence_arg0\""
     validateLLVMAssembly output
 
+  it "rejects higher-order evidence parameters with mismatched nested function shapes" $
+    Lower.evidenceFunctionTypesCompatible
+      (BTArrow (BTArrow unaryIntTy intTy) intTy)
+      (BTArrow (BTArrow unaryBoolTy intTy) intTy)
+      `shouldBe` False
+
+  it "accepts higher-order evidence parameters with matching nested function shapes" $
+    Lower.evidenceFunctionTypesCompatible
+      (BTArrow (BTArrow unaryIntTy intTy) intTy)
+      (BTArrow (BTArrow unaryIntTy intTy) intTy)
+      `shouldBe` True
+
   it "resolves inlined local function calls before captured values" $ do
     output <- requireRight (renderBackendProgramLLVM localFunctionCallShadowsValueProgram)
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -303,6 +303,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "emits inline-only callees passed through opaque evidence pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM inlineOnlyEvidenceCalleeProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"callee\"(ptr %\"f\")"
+    output `shouldSatisfy` isInfixOf "ptr @\"callee\""
+    validateLLVMAssembly output
+
   it "lowers nested evidence wrapper parameters as pointers" $ do
     output <- requireRight (renderBackendProgramLLVM nestedEvidenceWrapperParameterProgram)
 
@@ -510,6 +517,68 @@ localFunctionEvidenceMethodProgram =
       "  def use : C a => a -> a = \\x let f : a -> a = \\y y in apply f x;",
       "  def main : Int = use 1;",
       "}"
+    ]
+
+inlineOnlyEvidenceCalleeProgram :: BackendProgram
+inlineOnlyEvidenceCalleeProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "id",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "callee",
+          backendBindingType = BTArrow unaryIntTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow unaryIntTy intTy)
+              "f"
+              unaryIntTy
+              (BackendApp intTy (BackendVar unaryIntTy "f") (intLit 1)),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = BTArrow (BTArrow unaryIntTy intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow unaryIntTy intTy) intTy)
+              "$evidence_method"
+              (BTArrow unaryIntTy intTy)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow unaryIntTy intTy) "$evidence_method")
+                  (BackendVar unaryIntTy "id")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "caller",
+          backendBindingType = BTArrow (BTArrow (BTArrow unaryIntTy intTy) intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow (BTArrow unaryIntTy intTy) intTy) intTy)
+              "$evidence_C"
+              (BTArrow (BTArrow unaryIntTy intTy) intTy)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow (BTArrow unaryIntTy intTy) intTy) "$evidence_C")
+                  (BackendVar (BTArrow unaryIntTy intTy) "callee")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              (BackendVar (BTArrow (BTArrow (BTArrow unaryIntTy intTy) intTy) intTy) "caller")
+              (BackendVar (BTArrow (BTArrow unaryIntTy intTy) intTy) "$evidence_C"),
+          backendBindingExportedAsMain = True
+        }
     ]
 
 capturingEvidenceWrapperProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -287,6 +287,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "call i1 @\"RecursiveExistential__unwrapSome\""
     validateLLVMAssembly output
 
+  it "keeps ordinary function-valued method arguments out of evidence lowering" $ do
+    output <- requireRight =<< withTempProgram ordinaryFunctionEvidenceMethodProgram emitBackendFile
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
+    output `shouldNotSatisfy` isInfixOf "Unknown backend LLVM function"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   describe "ProgramSpec-to-LLVM parity matrix" $ do
     it "classifies every interpreter-success case exactly once" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
@@ -433,6 +441,24 @@ recursiveListProgram =
       "  };",
       "",
       "  def main : Bool = isNil (tailOrNil (RCons Zero RNil));",
+      "}"
+    ]
+
+ordinaryFunctionEvidenceMethodProgram :: String
+ordinaryFunctionEvidenceMethodProgram =
+  unlines
+    [ "module Main export (C, apply, idInt, use, main) {",
+      "  class C a {",
+      "    apply : (a -> a) -> a -> a;",
+      "  }",
+      "",
+      "  instance C Int {",
+      "    apply = \\f \\x f x;",
+      "  }",
+      "",
+      "  def idInt : Int -> Int = \\x x;",
+      "  def use : C a => (a -> a) -> a -> a = \\f \\x apply f x;",
+      "  def main : Int = use idInt 1;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -303,6 +303,10 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "rejects evidence wrappers that capture local term bindings" $ do
+    renderBackendProgramLLVM capturingEvidenceWrapperProgram
+      `shouldSatisfyLeft` isInfixOf "unsupported evidence function argument"
+
   describe "ProgramSpec-to-LLVM parity matrix" $ do
     it "classifies every interpreter-success case exactly once" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
@@ -485,6 +489,48 @@ localFunctionEvidenceMethodProgram =
       "  def use : C a => a -> a = \\x let f : a -> a = \\y y in apply f x;",
       "  def main : Int = use 1;",
       "}"
+    ]
+
+capturingEvidenceWrapperProgram :: BackendProgram
+capturingEvidenceWrapperProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = BTArrow unaryIntTy intTy,
+          backendBindingExpr =
+            BackendLam
+              { backendExprType = BTArrow unaryIntTy intTy,
+                backendParamName = "$evidence_apply",
+                backendParamType = unaryIntTy,
+                backendBody =
+                  BackendApp
+                    intTy
+                    (BackendVar unaryIntTy "$evidence_apply")
+                    (intLit 0)
+              },
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendLet
+              intTy
+              "x"
+              intTy
+              (intLit 1)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow unaryIntTy intTy) "$evidence_C")
+                  ( BackendLam
+                      unaryIntTy
+                      "y"
+                      intTy
+                      (BackendVar intTy "x")
+                  )
+              ),
+          backendBindingExportedAsMain = True
+        }
     ]
 
 stringProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -349,6 +349,13 @@ spec = describe "MLF.Backend.LLVM" $ do
       (BTArrow (BTArrow unaryIntTy intTy) intTy)
       `shouldBe` True
 
+  it "emits self-recursive higher-order calls instead of expanding them inline" $ do
+    output <- requireRight (renderBackendProgramLLVM selfRecursiveHigherOrderProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"loop\"(ptr %\"f\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "call i64 @\"loop\"(ptr %\"f\", i64 %\"x\")"
+    validateLLVMAssembly output
+
   it "resolves inlined local function calls before captured values" $ do
     output <- requireRight (renderBackendProgramLLVM localFunctionCallShadowsValueProgram)
 
@@ -567,6 +574,55 @@ localFunctionEvidenceMethodProgram =
       "  def use : C a => a -> a = \\x let f : a -> a = \\y y in apply f x;",
       "  def main : Int = use 1;",
       "}"
+    ]
+
+selfRecursiveHigherOrderProgram :: BackendProgram
+selfRecursiveHigherOrderProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "id",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "loop",
+          backendBindingType = BTArrow unaryIntTy unaryIntTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow unaryIntTy unaryIntTy)
+              "f"
+              unaryIntTy
+              ( BackendLam
+                  unaryIntTy
+                  "x"
+                  intTy
+                  ( BackendApp
+                      intTy
+                      ( BackendApp
+                          unaryIntTy
+                          (BackendVar (BTArrow unaryIntTy unaryIntTy) "loop")
+                          (BackendVar unaryIntTy "f")
+                      )
+                      (BackendVar intTy "x")
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              ( BackendApp
+                  unaryIntTy
+                  (BackendVar (BTArrow unaryIntTy unaryIntTy) "loop")
+                  (BackendVar unaryIntTy "id")
+              )
+              (intLit 1),
+          backendBindingExportedAsMain = True
+        }
     ]
 
 inlineOnlyEvidenceCalleeProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -295,6 +295,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "inlines opaque evidence helpers with local function-valued method arguments" $ do
+    output <- requireRight =<< withTempProgram localFunctionEvidenceMethodProgram emitBackendFile
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
+    output `shouldNotSatisfy` isInfixOf "Unknown backend LLVM function"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   describe "ProgramSpec-to-LLVM parity matrix" $ do
     it "classifies every interpreter-success case exactly once" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
@@ -459,6 +467,23 @@ ordinaryFunctionEvidenceMethodProgram =
       "  def idInt : Int -> Int = \\x x;",
       "  def use : C a => (a -> a) -> a -> a = \\f \\x apply f x;",
       "  def main : Int = use idInt 1;",
+      "}"
+    ]
+
+localFunctionEvidenceMethodProgram :: String
+localFunctionEvidenceMethodProgram =
+  unlines
+    [ "module Main export (C, apply, use, main) {",
+      "  class C a {",
+      "    apply : (a -> a) -> a -> a;",
+      "  }",
+      "",
+      "  instance C Int {",
+      "    apply = \\f \\x f x;",
+      "  }",
+      "",
+      "  def use : C a => a -> a = \\x let f : a -> a = \\y y in apply f x;",
+      "  def main : Int = use 1;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -317,6 +317,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "ptr @\"calleeWithEvidenceCall\""
     validateLLVMAssembly output
 
+  it "emits referenced inline-only callees passed through local aliases" $ do
+    output <- requireRight (renderBackendProgramLLVM aliasedInlineOnlyEvidenceCalleeProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"calleeWithEvidenceCall\"(ptr %\"$evidence_apply\")"
+    output `shouldSatisfy` isInfixOf "ptr @\"calleeWithEvidenceCall\""
+    validateLLVMAssembly output
+
   it "lowers nested evidence wrapper parameters as pointers" $ do
     output <- requireRight (renderBackendProgramLLVM nestedEvidenceWrapperParameterProgram)
 
@@ -351,6 +358,13 @@ spec = describe "MLF.Backend.LLVM" $ do
 
     output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_evidence_wrapper$"
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
+    validateLLVMAssembly output
+
+  it "collects local polymorphic evidence wrappers after type application" $ do
+    output <- requireRight (renderBackendProgramLLVM localPolymorphicEvidenceWrapperProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_evidence_wrapper$"
+    output `shouldNotSatisfy` isInfixOf "unsupported evidence function argument"
     validateLLVMAssembly output
 
   describe "ProgramSpec-to-LLVM parity matrix" $ do
@@ -691,6 +705,104 @@ inlineOnlyEvidenceParameterCallCalleeProgram =
         }
     ]
 
+aliasedInlineOnlyEvidenceCalleeProgram :: BackendProgram
+aliasedInlineOnlyEvidenceCalleeProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "id",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_apply",
+          backendBindingType = higherOrderEvidenceTy,
+          backendBindingExpr =
+            BackendLam
+              higherOrderEvidenceTy
+              "f"
+              unaryIntTy
+              ( BackendLam
+                  unaryIntTy
+                  "x"
+                  intTy
+                  (BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x"))
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "calleeWithEvidenceCall",
+          backendBindingType = BTArrow higherOrderEvidenceTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow higherOrderEvidenceTy intTy)
+              "$evidence_apply"
+              higherOrderEvidenceTy
+              ( BackendLet
+                  intTy
+                  "localId"
+                  unaryIntTy
+                  (BackendVar unaryIntTy "id")
+                  ( BackendApp
+                      intTy
+                      ( BackendApp
+                          unaryIntTy
+                          (BackendVar higherOrderEvidenceTy "$evidence_apply")
+                          (BackendVar unaryIntTy "localId")
+                      )
+                      (intLit 1)
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy)
+              "$evidence_method"
+              (BTArrow higherOrderEvidenceTy intTy)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow higherOrderEvidenceTy intTy) "$evidence_method")
+                  (BackendVar higherOrderEvidenceTy "$evidence_apply")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "caller",
+          backendBindingType = BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy)
+              "$evidence_C"
+              (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy)
+              ( BackendLet
+                  intTy
+                  "methodAlias"
+                  (BTArrow higherOrderEvidenceTy intTy)
+                  (BackendVar (BTArrow higherOrderEvidenceTy intTy) "calleeWithEvidenceCall")
+                  ( BackendApp
+                      intTy
+                      (BackendVar (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) "$evidence_C")
+                      (BackendVar (BTArrow higherOrderEvidenceTy intTy) "methodAlias")
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              (BackendVar (BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy) "caller")
+              (BackendVar (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) "$evidence_C"),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
 capturingEvidenceWrapperProgram :: BackendProgram
 capturingEvidenceWrapperProgram =
   programWithBindings
@@ -801,6 +913,33 @@ polymorphicEvidenceWrapperProgram =
               intTy
               (BackendVar polyEvidenceCallerTy "poly")
               intTy,
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+localPolymorphicEvidenceWrapperProgram :: BackendProgram
+localPolymorphicEvidenceWrapperProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = polyEvidenceConsumerTy,
+          backendBindingExpr = polyEvidenceConsumerExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendLet
+              intTy
+              "poly"
+              polyEvidenceCallerTy
+              polyEvidenceCallerExpr
+              ( BackendTyApp
+                  intTy
+                  (BackendVar polyEvidenceCallerTy "poly")
+                  intTy
+              ),
           backendBindingExportedAsMain = True
         }
     ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -310,6 +310,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "ptr @\"callee\""
     validateLLVMAssembly output
 
+  it "emits referenced callees that call opaque evidence parameters inline-only" $ do
+    output <- requireRight (renderBackendProgramLLVM inlineOnlyEvidenceParameterCallCalleeProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"calleeWithEvidenceCall\"(ptr %\"$evidence_apply\")"
+    output `shouldSatisfy` isInfixOf "ptr @\"calleeWithEvidenceCall\""
+    validateLLVMAssembly output
+
   it "lowers nested evidence wrapper parameters as pointers" $ do
     output <- requireRight (renderBackendProgramLLVM nestedEvidenceWrapperParameterProgram)
 
@@ -577,6 +584,98 @@ inlineOnlyEvidenceCalleeProgram =
               intTy
               (BackendVar (BTArrow (BTArrow (BTArrow unaryIntTy intTy) intTy) intTy) "caller")
               (BackendVar (BTArrow (BTArrow unaryIntTy intTy) intTy) "$evidence_C"),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+inlineOnlyEvidenceParameterCallCalleeProgram :: BackendProgram
+inlineOnlyEvidenceParameterCallCalleeProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "id",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_apply",
+          backendBindingType = higherOrderEvidenceTy,
+          backendBindingExpr =
+            BackendLam
+              higherOrderEvidenceTy
+              "f"
+              unaryIntTy
+              ( BackendLam
+                  unaryIntTy
+                  "x"
+                  intTy
+                  (BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x"))
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "calleeWithEvidenceCall",
+          backendBindingType = BTArrow higherOrderEvidenceTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow higherOrderEvidenceTy intTy)
+              "$evidence_apply"
+              higherOrderEvidenceTy
+              ( BackendLet
+                  intTy
+                  "localId"
+                  unaryIntTy
+                  (BackendVar unaryIntTy "id")
+                  ( BackendApp
+                      intTy
+                      ( BackendApp
+                          unaryIntTy
+                          (BackendVar higherOrderEvidenceTy "$evidence_apply")
+                          (BackendVar unaryIntTy "localId")
+                      )
+                      (intLit 1)
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy)
+              "$evidence_method"
+              (BTArrow higherOrderEvidenceTy intTy)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow higherOrderEvidenceTy intTy) "$evidence_method")
+                  (BackendVar higherOrderEvidenceTy "$evidence_apply")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "caller",
+          backendBindingType = BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy)
+              "$evidence_C"
+              (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) "$evidence_C")
+                  (BackendVar (BTArrow higherOrderEvidenceTy intTy) "calleeWithEvidenceCall")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              (BackendVar (BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy) "caller")
+              (BackendVar (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) "$evidence_C"),
           backendBindingExportedAsMain = True
         }
     ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -317,6 +317,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "unexpected type arguments"
     validateLLVMAssembly output
 
+  it "resolves local function references before captured values for indirect arguments" $ do
+    output <- requireRight (renderBackendProgramLLVM localFunctionReferenceShadowsValueProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"main\"()"
+    output `shouldNotSatisfy` isInfixOf "evidence function type mismatch"
+    validateLLVMAssembly output
+
   it "rejects evidence wrappers that capture local term bindings" $ do
     renderBackendProgramLLVM capturingEvidenceWrapperProgram
       `shouldSatisfyLeft` isInfixOf "unsupported evidence function argument"
@@ -645,6 +652,74 @@ localFunctionCallShadowsValueProgram =
               intTy
               (BackendVar (BTArrow unaryIntTy intTy) "outer")
               (BackendVar unaryIntTy "id"),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+localFunctionReferenceShadowsValueProgram :: BackendProgram
+localFunctionReferenceShadowsValueProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "idInt",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "idBool",
+          backendBindingType = unaryBoolTy,
+          backendBindingExpr = boolIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "callBool",
+          backendBindingType = BTArrow unaryBoolTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow unaryBoolTy intTy)
+              "f"
+              unaryBoolTy
+              (intLit 1),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "outer",
+          backendBindingType = BTArrow unaryIntTy (BTArrow (BTArrow unaryBoolTy intTy) intTy),
+          backendBindingExpr =
+            BackendLam
+              (BTArrow unaryIntTy (BTArrow (BTArrow unaryBoolTy intTy) intTy))
+              "$evidence_E"
+              unaryIntTy
+              ( BackendLam
+                  (BTArrow (BTArrow unaryBoolTy intTy) intTy)
+                  "$evidence_Call"
+                  (BTArrow unaryBoolTy intTy)
+                  ( BackendLet
+                      intTy
+                      "$evidence_E"
+                      unaryBoolTy
+                      (BackendVar unaryBoolTy "idBool")
+                      ( BackendApp
+                          intTy
+                          (BackendVar (BTArrow unaryBoolTy intTy) "$evidence_Call")
+                          (BackendVar unaryBoolTy "$evidence_E")
+                      )
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              ( BackendApp
+                  (BTArrow (BTArrow unaryBoolTy intTy) intTy)
+                  (BackendVar (BTArrow unaryIntTy (BTArrow (BTArrow unaryBoolTy intTy) intTy)) "outer")
+                  (BackendVar unaryIntTy "idInt")
+              )
+              (BackendVar (BTArrow unaryBoolTy intTy) "callBool"),
           backendBindingExportedAsMain = True
         }
     ]
@@ -1410,6 +1485,15 @@ intIdentityExpr =
       backendBody = BackendVar intTy "x"
     }
 
+boolIdentityExpr :: BackendExpr
+boolIdentityExpr =
+  BackendLam
+    { backendExprType = unaryBoolTy,
+      backendParamName = "x",
+      backendParamType = boolTy,
+      backendBody = BackendVar boolTy "x"
+    }
+
 fnBoxData :: BackendData
 fnBoxData =
   BackendData
@@ -1468,6 +1552,10 @@ stringTy :: BackendType
 stringTy =
   BTBase (BaseTy "String")
 
+boolTy :: BackendType
+boolTy =
+  BTBase (BaseTy "Bool")
+
 optionTy :: BackendType -> BackendType
 optionTy ty =
   BTCon (BaseTy "Option") (ty :| [])
@@ -1475,6 +1563,10 @@ optionTy ty =
 unaryIntTy :: BackendType
 unaryIntTy =
   BTArrow intTy intTy
+
+unaryBoolTy :: BackendType
+unaryBoolTy =
+  BTArrow boolTy boolTy
 
 binaryIntTy :: BackendType
 binaryIntTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -346,6 +346,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     renderBackendProgramLLVM capturingEvidenceWrapperProgram
       `shouldSatisfyLeft` isInfixOf "unsupported evidence function argument"
 
+  it "collects evidence wrappers only after polymorphic forms are specialized" $ do
+    output <- requireRight (renderBackendProgramLLVM polymorphicEvidenceWrapperProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_evidence_wrapper$"
+    output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
+    validateLLVMAssembly output
+
   describe "ProgramSpec-to-LLVM parity matrix" $ do
     it "classifies every interpreter-success case exactly once" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
@@ -770,6 +777,75 @@ nestedEvidenceWrapperParameterProgram =
           backendBindingExportedAsMain = True
         }
     ]
+
+polymorphicEvidenceWrapperProgram :: BackendProgram
+polymorphicEvidenceWrapperProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = polyEvidenceConsumerTy,
+          backendBindingExpr = polyEvidenceConsumerExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "poly",
+          backendBindingType = polyEvidenceCallerTy,
+          backendBindingExpr = polyEvidenceCallerExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendTyApp
+              intTy
+              (BackendVar polyEvidenceCallerTy "poly")
+              intTy,
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+polyEvidenceConsumerTy :: BackendType
+polyEvidenceConsumerTy =
+  BTForall "a" Nothing (BTArrow (BTArrow (BTVar "a") intTy) intTy)
+
+polyEvidenceConsumerExpr :: BackendExpr
+polyEvidenceConsumerExpr =
+  BackendTyAbs
+    polyEvidenceConsumerTy
+    "a"
+    Nothing
+    ( BackendLam
+        (BTArrow (BTArrow (BTVar "a") intTy) intTy)
+        "$evidence_apply"
+        (BTArrow (BTVar "a") intTy)
+        (intLit 0)
+    )
+
+polyEvidenceCallerTy :: BackendType
+polyEvidenceCallerTy =
+  BTForall "a" Nothing intTy
+
+polyEvidenceCallerExpr :: BackendExpr
+polyEvidenceCallerExpr =
+  BackendTyAbs
+    polyEvidenceCallerTy
+    "a"
+    Nothing
+    ( BackendApp
+        intTy
+        ( BackendTyApp
+            (BTArrow (BTArrow (BTVar "a") intTy) intTy)
+            (BackendVar polyEvidenceConsumerTy "$evidence_C")
+            (BTVar "a")
+        )
+        ( BackendLam
+            (BTArrow (BTVar "a") intTy)
+            "x"
+            (BTVar "a")
+            (intLit 0)
+        )
+    )
 
 localFunctionCallShadowsValueProgram :: BackendProgram
 localFunctionCallShadowsValueProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1312,16 +1312,9 @@ unsupportedLLVMParityCases :: [(String, String)]
 unsupportedLLVMParityCases =
   [ ("surface: runs first-class polymorphic top-level argument", "Unsupported backend LLVM type at parameter \"$poly#0\" of FirstClassPolymorphism__usePoly"),
     ("surface: runs first-class polymorphic local argument", "could not infer type arguments [\"a\"]"),
-    ("boundary: runs overloaded method dispatch with ordinary nullary constructors", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs overloaded method dispatch with nested ordinary constructors", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs overloaded method dispatch with lambda/application-inferred argument", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs overloaded method dispatch with let-polymorphism-inferred argument", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs overloaded method dispatch with explicit argument annotation", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs overloaded method dispatch on pattern-bound variable", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: constructor argument inferred as first-class polymorphic value should run", "escaping type abstraction"),
     ("boundary: local first-class polymorphic let through constructor boundary should run", "could not infer type arguments [\"a\"]"),
     ("boundary: pattern-bound first-class polymorphic variable should run", "could not infer type arguments [\"a\"]"),
-    ("boundary: partial overloaded method application should run after deferred resolution", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs higher-kinded data field over a concrete constructor head", "BackendUnsupportedSourceType"),
     ("boundary: runs nullary constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
     ("boundary: runs first-class nullary constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
@@ -1332,37 +1325,17 @@ unsupportedLLVMParityCases =
     ("boundary: runs aliased bulk-imported hidden-owner constructors in one case", "BackendUnsupportedSourceType"),
     ("boundary: runs value-exported GADT constructor when owner type is not exported", "BackendUnsupportedSourceType"),
     ("boundary: runs value-imported nonzero-index constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
-    ("boundary: runs constrained helper through hidden Eq evidence", "constructor result type does not match expected result"),
-    ("boundary: runs ground constrained helper alias with resolved evidence", "Unsupported backend LLVM type at parameter \"$evidence_Eq_eq#0\" of Main__sameBool"),
-    ("boundary: runs constrained helper after local lambda inference", "escaping function \"Main__Eq__Bool__eq\""),
     ("boundary: runs deferred method with method-level type variable constraint", "BackendTypeCheckFailed"),
     ("boundary: runs partial deferred method after method-local evidence is fixed by application", "BackendTypeCheckFailed"),
     ("boundary: runs deferred method when only a later forall binder is inferred", "BackendUnsupportedInstantiation InstElim"),
     ("boundary: runs constrained helper with method-local evidence fixed by call args", "BackendTypeCheckFailed"),
-    ("boundary: runs deferred class method with method-level Eq constraint", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs constrained helper through method-level evidence constraints", "constructor result type does not match expected result"),
-    ("boundary: runs explicit constrained parameterized Eq instance", "ambiguous backend data matches scrutinee type"),
-    ("boundary: runs parameterized deriving Eq for Option", "ambiguous backend data matches scrutinee type"),
-    ("boundary: runs parameterized deriving Eq for recursive List", "BackendUnsupportedRecursiveLet"),
-    ("boundary: runs qualified import with alias-only value and constructor access", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("boundary: runs aliased import with exposed method and qualified constructors", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("boundary: runs aliased import exposing a type without duplicate alias-head instance matches", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("boundary: deduplicates equivalent instances from mixed unqualified and aliased imports", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("boundary: deduplicates constrained imported instances from mixed unqualified and aliased imports", "escaping function \"Core__Eq__Bool__eq\""),
-    ("fixture: test/programs/recursive-adt/deriving-eq.mlfp", "Unsupported backend LLVM type at return type of DerivingEq__Eq__Nat__eq"),
-    ("fixture: test/programs/recursive-adt/recursive-tree-deriving.mlfp", "Unsupported backend LLVM type at return type of RecursiveTreeDeriving__Eq__Tree__eq"),
-    ("fixture: test/programs/recursive-adt/complex-recursive-program.mlfp", "Unsupported backend LLVM type at return type of ComplexRecursiveProgram__Eq__Nat__eq"),
-    ("fixture: test/programs/recursive-adt/module-integrated.mlfp", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("unified fixture: test/programs/unified/authoritative-overloaded-method.mlfp", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("unified fixture: test/programs/unified/first-class-polymorphism.mlfp", "Unsupported backend LLVM type at parameter \"$poly#0\" of FirstClassPolymorphism__usePoly"),
-    ("standalone: allows importing a module declared later in the file", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("standalone: does not decode typed non-data constructor fields through fallback ADT decoding", "escaping lambda"),
-    ("standalone: evaluates a recursive Nat equality example at representative depth", "Unsupported backend LLVM type at return type of Baseline__Eq__Nat__eq")
+    ("standalone: does not decode typed non-data constructor fields through fallback ADT decoding", "escaping lambda")
   ]
 
 expectedLLVMUnsupportedParityCount :: Int
 expectedLLVMUnsupportedParityCount =
-  48
+  21
 
 llvmUnsupportedParityCount :: Int
 llvmUnsupportedParityCount =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -303,6 +303,20 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "lowers nested evidence wrapper parameters as pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM nestedEvidenceWrapperParameterProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_evidence_wrapper$"
+    output `shouldSatisfy` isInfixOf "ptr %\"__mlfp_evidence_arg0\""
+    validateLLVMAssembly output
+
+  it "resolves inlined local function calls before captured values" $ do
+    output <- requireRight (renderBackendProgramLLVM localFunctionCallShadowsValueProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"main\"()"
+    output `shouldNotSatisfy` isInfixOf "unexpected type arguments"
+    validateLLVMAssembly output
+
   it "rejects evidence wrappers that capture local term bindings" $ do
     renderBackendProgramLLVM capturingEvidenceWrapperProgram
       `shouldSatisfyLeft` isInfixOf "unsupported evidence function argument"
@@ -529,6 +543,108 @@ capturingEvidenceWrapperProgram =
                       (BackendVar intTy "x")
                   )
               ),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+nestedEvidenceWrapperParameterProgram :: BackendProgram
+nestedEvidenceWrapperParameterProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = BTArrow higherOrderEvidenceTy intTy,
+          backendBindingExpr =
+            BackendLam
+              { backendExprType = BTArrow higherOrderEvidenceTy intTy,
+                backendParamName = "$evidence_apply",
+                backendParamType = higherOrderEvidenceTy,
+                backendBody =
+                  BackendApp
+                    intTy
+                    ( BackendApp
+                        unaryIntTy
+                        (BackendVar higherOrderEvidenceTy "$evidence_apply")
+                        intIdentityExpr
+                    )
+                    (intLit 1)
+              },
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              (BackendVar (BTArrow higherOrderEvidenceTy intTy) "$evidence_C")
+              ( BackendLam
+                  higherOrderEvidenceTy
+                  "f"
+                  unaryIntTy
+                  ( BackendLam
+                      unaryIntTy
+                      "x"
+                      intTy
+                      (BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x"))
+                  )
+              ),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+localFunctionCallShadowsValueProgram :: BackendProgram
+localFunctionCallShadowsValueProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "inner",
+          backendBindingType = polyIdTy,
+          backendBindingExpr = polyIdExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "id",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "callee",
+          backendBindingType = BTArrow polyIdTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow polyIdTy intTy)
+              "$evidence_E"
+              polyIdTy
+              ( BackendApp
+                  intTy
+                  (BackendTyApp unaryIntTy (BackendVar polyIdTy "$evidence_E") intTy)
+                  (intLit 7)
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "outer",
+          backendBindingType = BTArrow unaryIntTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow unaryIntTy intTy)
+              "$evidence_E"
+              unaryIntTy
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow polyIdTy intTy) "callee")
+                  (BackendVar polyIdTy "inner")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              (BackendVar (BTArrow unaryIntTy intTy) "outer")
+              (BackendVar unaryIntTy "id"),
           backendBindingExportedAsMain = True
         }
     ]
@@ -1363,6 +1479,10 @@ unaryIntTy =
 binaryIntTy :: BackendType
 binaryIntTy =
   BTArrow intTy unaryIntTy
+
+higherOrderEvidenceTy :: BackendType
+higherOrderEvidenceTy =
+  BTArrow unaryIntTy unaryIntTy
 
 fnBoxTy :: BackendType
 fnBoxTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -324,6 +324,12 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "ptr @\"calleeWithEvidenceCall\""
     validateLLVMAssembly output
 
+  it "does not collect shadowed local aliases as referenced callees" $ do
+    output <- requireRight (renderBackendProgramLLVM shadowedLocalAliasReferenceCollectorProgram)
+
+    output `shouldNotSatisfy` isInfixOf "define i64 @\"shadowedCalleeWithEvidenceCall\""
+    validateLLVMAssembly output
+
   it "lowers nested evidence wrapper parameters as pointers" $ do
     output <- requireRight (renderBackendProgramLLVM nestedEvidenceWrapperParameterProgram)
 
@@ -799,6 +805,123 @@ aliasedInlineOnlyEvidenceCalleeProgram =
               intTy
               (BackendVar (BTArrow (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) intTy) "caller")
               (BackendVar (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) "$evidence_C"),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+shadowedLocalAliasReferenceCollectorProgram :: BackendProgram
+shadowedLocalAliasReferenceCollectorProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "id",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr = intIdentityExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_apply",
+          backendBindingType = higherOrderEvidenceTy,
+          backendBindingExpr =
+            BackendLam
+              higherOrderEvidenceTy
+              "f"
+              unaryIntTy
+              ( BackendLam
+                  unaryIntTy
+                  "x"
+                  intTy
+                  (BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x"))
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "actualCalleeWithEvidenceCall",
+          backendBindingType = BTArrow higherOrderEvidenceTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow higherOrderEvidenceTy intTy)
+              "$evidence_apply"
+              higherOrderEvidenceTy
+              ( BackendLet
+                  intTy
+                  "localId"
+                  unaryIntTy
+                  (BackendVar unaryIntTy "id")
+                  ( BackendApp
+                      intTy
+                      ( BackendApp
+                          unaryIntTy
+                          (BackendVar higherOrderEvidenceTy "$evidence_apply")
+                          (BackendVar unaryIntTy "localId")
+                      )
+                      (intLit 1)
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "shadowedCalleeWithEvidenceCall",
+          backendBindingType = BTArrow higherOrderEvidenceTy intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow higherOrderEvidenceTy intTy)
+              "$evidence_apply"
+              higherOrderEvidenceTy
+              ( BackendLet
+                  intTy
+                  "localId"
+                  unaryIntTy
+                  (BackendVar unaryIntTy "id")
+                  ( BackendApp
+                      intTy
+                      ( BackendApp
+                          unaryIntTy
+                          (BackendVar higherOrderEvidenceTy "$evidence_apply")
+                          (BackendVar unaryIntTy "localId")
+                      )
+                      (intLit 1)
+                  )
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "$evidence_C",
+          backendBindingType = BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy,
+          backendBindingExpr =
+            BackendLam
+              (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy)
+              "$evidence_method"
+              (BTArrow higherOrderEvidenceTy intTy)
+              ( BackendApp
+                  intTy
+                  (BackendVar (BTArrow higherOrderEvidenceTy intTy) "$evidence_method")
+                  (BackendVar higherOrderEvidenceTy "$evidence_apply")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendLet
+              intTy
+              "$evidence_method"
+              (BTArrow higherOrderEvidenceTy intTy)
+              (BackendVar (BTArrow higherOrderEvidenceTy intTy) "shadowedCalleeWithEvidenceCall")
+              ( BackendApp
+                  intTy
+                  ( BackendLam
+                      (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy)
+                      "$evidence_method"
+                      (BTArrow higherOrderEvidenceTy intTy)
+                      ( BackendApp
+                          intTy
+                          (BackendVar (BTArrow (BTArrow higherOrderEvidenceTy intTy) intTy) "$evidence_C")
+                          (BackendVar (BTArrow higherOrderEvidenceTy intTy) "$evidence_method")
+                      )
+                  )
+                  (BackendVar (BTArrow higherOrderEvidenceTy intTy) "actualCalleeWithEvidenceCall")
+              ),
           backendBindingExportedAsMain = True
         }
     ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1325,17 +1325,13 @@ unsupportedLLVMParityCases =
     ("boundary: runs aliased bulk-imported hidden-owner constructors in one case", "BackendUnsupportedSourceType"),
     ("boundary: runs value-exported GADT constructor when owner type is not exported", "BackendUnsupportedSourceType"),
     ("boundary: runs value-imported nonzero-index constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
-    ("boundary: runs deferred method with method-level type variable constraint", "BackendTypeCheckFailed"),
-    ("boundary: runs partial deferred method after method-local evidence is fixed by application", "BackendTypeCheckFailed"),
-    ("boundary: runs deferred method when only a later forall binder is inferred", "BackendUnsupportedInstantiation InstElim"),
-    ("boundary: runs constrained helper with method-local evidence fixed by call args", "BackendTypeCheckFailed"),
     ("unified fixture: test/programs/unified/first-class-polymorphism.mlfp", "Unsupported backend LLVM type at parameter \"$poly#0\" of FirstClassPolymorphism__usePoly"),
     ("standalone: does not decode typed non-data constructor fields through fallback ADT decoding", "escaping lambda")
   ]
 
 expectedLLVMUnsupportedParityCount :: Int
 expectedLLVMUnsupportedParityCount =
-  21
+  17
 
 llvmUnsupportedParityCount :: Int
 llvmUnsupportedParityCount =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -338,6 +338,10 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "evidence function type mismatch"
     validateLLVMAssembly output
 
+  it "preserves inline function argument shadowing for bare references" $ do
+    renderBackendProgramLLVM inlineFunctionArgumentShadowsValueProgram
+      `shouldSatisfyLeft` isInfixOf "escaping function \"f\""
+
   it "rejects evidence wrappers that capture local term bindings" $ do
     renderBackendProgramLLVM capturingEvidenceWrapperProgram
       `shouldSatisfyLeft` isInfixOf "unsupported evidence function argument"
@@ -891,6 +895,62 @@ localFunctionReferenceShadowsValueProgram =
           backendBindingExportedAsMain = True
         }
     ]
+
+inlineFunctionArgumentShadowsValueProgram :: BackendProgram
+inlineFunctionArgumentShadowsValueProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "idInt",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr = intIdentityExpr,
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "callee",
+                      backendBindingType = BTArrow unaryIntTy fnBoxTy,
+                      backendBindingExpr =
+                        BackendLam
+                          (BTArrow unaryIntTy fnBoxTy)
+                          "f"
+                          unaryIntTy
+                          (BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"]),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "outer",
+                      backendBindingType = BTArrow unaryIntTy fnBoxTy,
+                      backendBindingExpr =
+                        BackendLam
+                          (BTArrow unaryIntTy fnBoxTy)
+                          "f"
+                          unaryIntTy
+                          ( BackendApp
+                              fnBoxTy
+                              (BackendVar (BTArrow unaryIntTy fnBoxTy) "callee")
+                              (BackendVar unaryIntTy "idInt")
+                          ),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = fnBoxTy,
+                      backendBindingExpr =
+                        BackendApp
+                          fnBoxTy
+                          (BackendVar (BTArrow unaryIntTy fnBoxTy) "outer")
+                          (BackendVar unaryIntTy "idInt"),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
 
 stringProgram :: BackendProgram
 stringProgram =

--- a/test/golden/backend-ir-adt-case.golden
+++ b/test/golden/backend-ir-adt-case.golden
@@ -18,10 +18,10 @@ backend-program
             construct Main__Zero : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
               args:
                 <none>
-        binding Main__Succ : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
+        binding Main__Succ : (mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
           exported-main: false
           expr:
-            lam $Succ_arg1 : mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
+            lam $Succ_arg1 : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result)) -> (mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
               body:
                 type-lam $a1 -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
                   body:
@@ -33,7 +33,7 @@ backend-program
                               function:
                                 var $Succ_k2 : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1)
                               argument:
-                                var $Succ_arg1 : mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result))
+                                var $Succ_arg1 : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
         binding Main__main : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
           exported-main: true
           expr:


### PR DESCRIPTION
Closes #71.

## Implementation Plan

---
issue_number: 71
pr_number: 81
branch: codex/issue-71
---

## Implementation Plan

1. Start implementation by reading the watcher-written issue plan, confirming branch `codex/issue-71`, PR #81, and a clean tracked worktree. Do not create another PR.

2. Reproduce the current issue-specific backend failures with focused commands before editing. At minimum run `cabal run mlf2 -- emit-backend test/programs/unified/authoritative-overloaded-method.mlfp` and representative recursive/deriving fixtures. The current inspected failure for the overloaded-method fixture is `Unsupported backend LLVM type at return type of Main__Eq__Nat__eq`, which points at function-valued instance evidence reaching LLVM as an unlowered arrow value.

3. Fix the backend path, scoped to resolved typeclass/instance/deriving evidence:
   - In `MLF.Backend.Convert` and/or `MLF.Backend.LLVM.Lower`, make function-valued instance methods and derived `Eq` methods reach LLVM as real function forms, including lifted recursive derived helpers shaped like `let self = helper in self`.
   - Preserve source data identity through backend case conversion for instance and derived method bodies so parameterized ADTs and alias-qualified/cross-module ADTs do not fall into ambiguous data matching.
   - Ensure hidden class-constraint evidence arguments lower as ordinary first-order function parameters/calls for constrained helpers, method-level constraints, schema instances, zero-method prerequisites, and imported instance evidence.
   - Keep unsupported boundaries intact: do not add first-class polymorphic value representation, higher-kinded constructor-owner support, or negative ProgramSpec runtime-success expectations.

4. Add or update regression coverage before relaxing parity expectations:
   - Add focused `BackendConvertSpec` coverage for derived recursive `Eq`, parameterized `Option` `Eq`, and cross-module/alias instance evidence, checking `convertCheckedProgram` plus `validateBackendProgram` and enough backend shape to lock the data identity/function-form behavior.
   - Update `BackendLLVMSpec` by removing only the issue-specific runtime-success rows from `unsupportedLLVMParityCases`, updating `expectedLLVMUnsupportedParityCount`, and keeping first-class-polymorphism, higher-kinded, and check-failure rows unsupported.
   - Consider adding one typeclass/deriving row to `llvmObjectCodeParityCases` as a smoke case if `llc` coverage stays cheap.

5. Update durable docs only if behavior or support status changes materially, likely `implementation_notes.md` and `CHANGELOG.md`. Do not use `Bugs.md` for pure guidance/status cleanup.

6. Validate in increasing scope: run the focused backend conversion/LLVM specs, direct `emit-backend` probes for the issue fixtures, `git diff --check`, then the required behavior-changing gate `cabal build all && cabal test`. If LLVM tools are unavailable, report the pending/blocked tool status explicitly.

7. Before publishing, inspect `git status --short` and relevant diffs, stage only issue-related source/test/doc files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, push `codex/issue-71`, and leave PR #81 ready for watcher handoff without resolving review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.