### PR TITLE
Implement #72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Changed
+- Added LLVM lowering support for first-class polymorphic values at
+  non-escaping runtime boundaries. Polymorphic arguments and immediate
+  constructor fields are statically specialized/erased at call and case sites,
+  while escaping closures and partial applications remain fail-closed.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -591,12 +591,10 @@ collectSpecializationRequestsWithBound base substitution bound expr =
             (BackendVar _ name, typeArgs)
               | Set.notMember name bound,
                 Just binding <- Map.lookup name (pbBindings base),
-                not (null (ffTypeBinders (biForm binding))),
-                null (ffParams (biForm binding)) ->
+                not (null (ffTypeBinders (biForm binding))) ->
                   let typeArgs' = map (substituteBackendTypes substitution) typeArgs
                    in case instantiateFunctionFormWithTypeArgs ("specialization request " ++ name) (biForm binding) typeArgs' [] of
-                        Right (resolvedTypeArgs, form)
-                          | null (ffParams form) -> [SpecRequest name resolvedTypeArgs]
+                        Right (resolvedTypeArgs, _) -> [SpecRequest name resolvedTypeArgs]
                         _ -> []
             (fun, typeArgs) ->
               collectAdministrativeTypeAppRequests fun typeArgs
@@ -1580,7 +1578,8 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
 
     bindImmediateAlternativePattern (BackendAlternative pattern0 body) =
       case pattern0 of
-        BackendDefaultPattern ->
+        BackendDefaultPattern -> do
+          zipWithM_ evaluateUnusedField fieldTys args
           pure exprEnv
         BackendConstructorPattern name binders -> do
           unless (name == constructorName) $
@@ -1611,6 +1610,17 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
             else pure acc
       | otherwise = do
           liftEither (BackendLLVMUnsupportedType ("field " ++ show binder ++ " at " ++ context) fieldTy)
+
+    evaluateUnusedField fieldTy arg
+      | backendTypeRequiresStaticSpecialization fieldTy = do
+          _ <- lowerStaticFunctionArgument env exprEnv context "_" fieldTy arg
+          pure ()
+      | backendTypeHasRuntimeRepresentation env fieldTy = do
+          value <- lowerExpr env exprEnv context arg
+          expectedTy <- lowerBackendTypeM env context fieldTy
+          requireLLVMType context constructorName expectedTy value
+      | otherwise =
+          liftEither (BackendLLVMUnsupportedType ("field at " ++ context) fieldTy)
 
 constructorFieldTypesForScrutinee :: ProgramEnv -> String -> ConstructorRuntime -> BackendType -> LowerM [BackendType]
 constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -329,7 +329,7 @@ backendTypeRequiresStaticSpecialization :: BackendType -> Bool
 backendTypeRequiresStaticSpecialization =
   \case
     BTVar {} -> False
-    BTArrow {} -> False
+    BTArrow {} -> True
     BTBase {} -> False
     BTCon {} -> False
     BTForall {} -> True
@@ -1597,16 +1597,18 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
             (zip3 binders fieldTys args)
 
     bindUsedField usedBinders acc (binder, fieldTy, arg)
-      | Set.notMember binder usedBinders =
-          pure acc
       | backendTypeRequiresStaticSpecialization fieldTy = do
           localFunction <- lowerStaticFunctionArgument env exprEnv context binder fieldTy arg
-          pure acc {eeLocalFunctions = Map.insert binder localFunction (eeLocalFunctions acc)}
+          if Set.member binder usedBinders
+            then pure acc {eeLocalFunctions = Map.insert binder localFunction (eeLocalFunctions acc)}
+            else pure acc
       | backendTypeHasRuntimeRepresentation env fieldTy = do
           value <- lowerExpr env exprEnv context arg
           expectedTy <- lowerBackendTypeM env context fieldTy
           requireLLVMType context constructorName expectedTy value
-          pure acc {eeValues = Map.insert binder value (eeValues acc)}
+          if Set.member binder usedBinders
+            then pure acc {eeValues = Map.insert binder value (eeValues acc)}
+            else pure acc
       | otherwise = do
           liftEither (BackendLLVMUnsupportedType ("field " ++ show binder ++ " at " ++ context) fieldTy)
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -115,7 +115,8 @@ data FunctionState = FunctionState
     fsNextBlock :: Int,
     fsCurrentLabel :: String,
     fsCurrentInstructions :: [LLVMInstruction],
-    fsCompletedBlocks :: [LLVMBasicBlock]
+    fsCompletedBlocks :: [LLVMBasicBlock],
+    fsStaticGlobalStack :: [String]
   }
   deriving (Eq, Show)
 
@@ -138,7 +139,7 @@ lowerBackendProgram program = do
     (++)
       <$> traverse
         (lowerMonomorphicBinding env)
-        (filter (shouldEmitMonomorphicFunction env . biForm) (filter (null . ffTypeBinders . biForm) reachable))
+        (filter (shouldEmitReachableBinding env (backendProgramMain program)) (filter (null . ffTypeBinders . biForm) reachable))
       <*> traverse
         (lowerSpecialization env)
         (filter (shouldEmitMonomorphicFunction env . spForm) specializations)
@@ -307,6 +308,10 @@ functionFormHasRuntimeCallingConvention env form =
 shouldEmitMonomorphicFunction :: ProgramEnv -> FunctionForm -> Bool
 shouldEmitMonomorphicFunction env form =
   not (functionFormNeedsStaticArguments env form)
+
+shouldEmitReachableBinding :: ProgramEnv -> String -> BindingInfo -> Bool
+shouldEmitReachableBinding env mainName binding =
+  biName binding == mainName || shouldEmitMonomorphicFunction env (biForm binding)
 
 functionFormNeedsStaticArguments :: ProgramEnv -> FunctionForm -> Bool
 functionFormNeedsStaticArguments env form =
@@ -822,7 +827,8 @@ initialFunctionState =
       fsNextBlock = 0,
       fsCurrentLabel = "entry",
       fsCurrentInstructions = [],
-      fsCompletedBlocks = []
+      fsCompletedBlocks = [],
+      fsStaticGlobalStack = []
     }
 
 initialFunctionEnv :: FunctionForm -> [LLVMParameter] -> ExprEnv
@@ -1106,8 +1112,9 @@ lowerGlobalCall env exprEnv context name typeArgs args =
           result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
           pure (LowerValue (ffReturnType form) resultTy result)
         else do
-          bodyEnv <- bindFunctionCallArguments env exprEnv emptyExprEnv context name form args
-          lowerExpr env bodyEnv context (ffBody form)
+          withStaticGlobalInlining context name $ do
+            bodyEnv <- bindFunctionCallArguments env exprEnv emptyExprEnv context name form args
+            lowerExpr env bodyEnv context (ffBody form)
     Nothing
       | name == runtimeAndName -> do
           unless (length args == 2) $
@@ -1143,6 +1150,16 @@ lowerRuntimeCallArguments env callEnv context name form args = do
       value <- lowerExpr env callEnv context arg
       requireLLVMType context name expectedTy value
       pure value
+
+withStaticGlobalInlining :: String -> String -> LowerM a -> LowerM a
+withStaticGlobalInlining context name action = do
+  stack <- gets fsStaticGlobalStack
+  when (name `elem` stack) $
+    liftEither (BackendLLVMUnsupportedExpression context ("recursive static global " ++ show name))
+  modify (\state -> state {fsStaticGlobalStack = name : stack})
+  result <- action
+  modify (\state -> state {fsStaticGlobalStack = stack})
+  pure result
 
 bindFunctionCallArguments :: ProgramEnv -> ExprEnv -> ExprEnv -> String -> String -> FunctionForm -> [BackendExpr] -> LowerM ExprEnv
 bindFunctionCallArguments env callEnv bodyEnv0 context name form args = do

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -136,8 +136,12 @@ lowerBackendProgram program = do
           }
   functions <-
     (++)
-      <$> traverse (lowerMonomorphicBinding env) (filter (null . ffTypeBinders . biForm) reachable)
-      <*> traverse (lowerSpecialization env) specializations
+      <$> traverse
+        (lowerMonomorphicBinding env)
+        (filter (shouldEmitMonomorphicFunction env . biForm) (filter (null . ffTypeBinders . biForm) reachable))
+      <*> traverse
+        (lowerSpecialization env)
+        (filter (shouldEmitMonomorphicFunction env . spForm) specializations)
   mainBinding <- requireBinding base (backendProgramMain program)
   when (not (null (ffTypeBinders (biForm mainBinding)))) $
     Left (BackendLLVMUnsupportedExpression "program main" "polymorphic main binding")
@@ -287,6 +291,52 @@ collectForallsType =
       let (binders, core) = collectForallsType body
        in ((name, mbBound) : binders, core)
     ty -> ([], ty)
+
+functionFormType :: FunctionForm -> BackendType
+functionFormType form =
+  foldr
+    (\(name, mbBound) body -> BTForall name mbBound body)
+    (foldr (\(_, paramTy) body -> BTArrow paramTy body) (ffReturnType form) (ffParams form))
+    (ffTypeBinders form)
+
+functionFormHasRuntimeCallingConvention :: ProgramEnv -> FunctionForm -> Bool
+functionFormHasRuntimeCallingConvention env form =
+  null (ffTypeBinders form)
+    && all (backendTypeHasRuntimeRepresentation env) (ffReturnType form : map snd (ffParams form))
+
+shouldEmitMonomorphicFunction :: ProgramEnv -> FunctionForm -> Bool
+shouldEmitMonomorphicFunction env form =
+  not (functionFormNeedsStaticArguments env form)
+
+functionFormNeedsStaticArguments :: ProgramEnv -> FunctionForm -> Bool
+functionFormNeedsStaticArguments env form =
+  null (ffTypeBinders form)
+    && backendTypeHasRuntimeRepresentation env (ffReturnType form)
+    && any backendTypeRequiresStaticSpecialization (map snd (ffParams form))
+
+backendTypeHasRuntimeRepresentation :: ProgramEnv -> BackendType -> Bool
+backendTypeHasRuntimeRepresentation env ty =
+  case lowerBackendType env "runtime representation check" ty of
+    Right _ -> True
+    Left _ -> False
+
+backendTypeRequiresStaticSpecialization :: BackendType -> Bool
+backendTypeRequiresStaticSpecialization =
+  \case
+    BTVar {} -> False
+    BTArrow {} -> False
+    BTBase {} -> False
+    BTCon {} -> False
+    BTForall {} -> True
+    BTMu {} -> False
+    BTBottom -> False
+
+emptyExprEnv :: ExprEnv
+emptyExprEnv =
+  ExprEnv
+    { eeValues = Map.empty,
+      eeLocalFunctions = Map.empty
+    }
 
 collectArrowsType :: BackendType -> ([BackendType], BackendType)
 collectArrowsType =
@@ -1032,17 +1082,14 @@ lowerCall env exprEnv context expr =
 lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do
   form <- instantiateFunctionFormM context (lfForm localFunction) typeArgs args
-  callArgs <- traverse (lowerExpr env callEnv context) args
-  bindFunctionArguments env context name form callArgs
-  let bodyEnv = extendExprEnvWithArguments (lfCapturedEnv localFunction) form callArgs
+  bodyEnv <- bindFunctionCallArguments env callEnv (lfCapturedEnv localFunction) context name form args
   lowerExpr env bodyEnv context (ffBody form)
 
 lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do
   form <- instantiateFunctionFormM context form0 typeArgs args
-  callArgs <- traverse (lowerExpr env exprEnv context) args
-  bindFunctionArguments env context "lambda" form callArgs
-  lowerExpr env (extendExprEnvWithArguments exprEnv form callArgs) context (ffBody form)
+  bodyEnv <- bindFunctionCallArguments env exprEnv exprEnv context "lambda" form args
+  lowerExpr env bodyEnv context (ffBody form)
 
 lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> String -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerGlobalCall env exprEnv context name typeArgs args =
@@ -1051,12 +1098,16 @@ lowerGlobalCall env exprEnv context name typeArgs args =
       (resolvedTypeArgs, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
       unless (length args == length (ffParams form)) $
         liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-      callArgs <- traverse (lowerExpr env exprEnv context) args
-      bindFunctionArguments env context name form callArgs
-      resultTy <- lowerBackendTypeM env context (ffReturnType form)
-      functionName <- globalFunctionName env context binding resolvedTypeArgs
-      result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-      pure (LowerValue (ffReturnType form) resultTy result)
+      if functionFormHasRuntimeCallingConvention env form
+        then do
+          callArgs <- lowerRuntimeCallArguments env exprEnv context name form args
+          resultTy <- lowerBackendTypeM env context (ffReturnType form)
+          functionName <- globalFunctionName env context binding resolvedTypeArgs
+          result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+          pure (LowerValue (ffReturnType form) resultTy result)
+        else do
+          bodyEnv <- bindFunctionCallArguments env exprEnv emptyExprEnv context name form args
+          lowerExpr env bodyEnv context (ffBody form)
     Nothing
       | name == runtimeAndName -> do
           unless (length args == 2) $
@@ -1081,12 +1132,94 @@ globalFunctionName env context binding typeArgs
   where
     request = SpecRequest (biName binding) typeArgs
 
-bindFunctionArguments :: ProgramEnv -> String -> String -> FunctionForm -> [LowerValue] -> LowerM ()
-bindFunctionArguments env context name form args = do
+lowerRuntimeCallArguments :: ProgramEnv -> ExprEnv -> String -> String -> FunctionForm -> [BackendExpr] -> LowerM [LowerValue]
+lowerRuntimeCallArguments env callEnv context name form args = do
   unless (length args == length (ffParams form)) $
     liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
-  expectedTypes <- traverse (lowerBackendTypeM env context . snd) (ffParams form)
-  zipWithM_ (requireLLVMType context name) expectedTypes args
+  zipWithM lowerOne (ffParams form) args
+  where
+    lowerOne (_, paramTy) arg = do
+      expectedTy <- lowerBackendTypeM env context paramTy
+      value <- lowerExpr env callEnv context arg
+      requireLLVMType context name expectedTy value
+      pure value
+
+bindFunctionCallArguments :: ProgramEnv -> ExprEnv -> ExprEnv -> String -> String -> FunctionForm -> [BackendExpr] -> LowerM ExprEnv
+bindFunctionCallArguments env callEnv bodyEnv0 context name form args = do
+  unless (length args == length (ffParams form)) $
+    liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
+  foldM bindOne bodyEnv0 (zip (ffParams form) args)
+  where
+    bindOne bodyEnv ((paramName, paramTy), arg)
+      | backendTypeRequiresStaticSpecialization paramTy = do
+          localFunction <- lowerStaticFunctionArgument env callEnv context paramName paramTy arg
+          pure
+            bodyEnv
+              { eeLocalFunctions = Map.insert paramName localFunction (eeLocalFunctions bodyEnv)
+              }
+      | backendTypeHasRuntimeRepresentation env paramTy = do
+          expectedTy <- lowerBackendTypeM env context paramTy
+          value <- lowerExpr env callEnv context arg
+          requireLLVMType context name expectedTy value
+          pure
+            bodyEnv
+              { eeValues = Map.insert paramName value (eeValues bodyEnv)
+              }
+      | otherwise = do
+          _ <- lowerExpr env callEnv context arg
+          liftEither (BackendLLVMUnsupportedType ("parameter " ++ show paramName ++ " at " ++ context) paramTy)
+
+lowerStaticFunctionArgument :: ProgramEnv -> ExprEnv -> String -> String -> BackendType -> BackendExpr -> LowerM LocalFunction
+lowerStaticFunctionArgument env callEnv context paramName expectedTy arg =
+  case arg of
+    BackendVar _ name ->
+      case Map.lookup name (eeLocalFunctions callEnv) of
+        Just localFunction ->
+          requireStaticFunctionType context paramName expectedTy localFunction
+        Nothing ->
+          case Map.lookup name (pbBindings (peBase env)) of
+            Just binding ->
+              requireStaticFunctionType
+                context
+                paramName
+                expectedTy
+                ( LocalFunction
+                    { lfForm = biForm binding,
+                      lfCapturedEnv = emptyExprEnv
+                    }
+                )
+            Nothing ->
+              lowerDirectStaticFunctionArgument callEnv context paramName expectedTy arg
+    _ ->
+      lowerDirectStaticFunctionArgument callEnv context paramName expectedTy arg
+
+lowerDirectStaticFunctionArgument :: ExprEnv -> String -> String -> BackendType -> BackendExpr -> LowerM LocalFunction
+lowerDirectStaticFunctionArgument callEnv context paramName expectedTy arg =
+  requireStaticFunctionType
+    context
+    paramName
+    expectedTy
+    ( LocalFunction
+        { lfForm = functionFormFromExpected expectedTy arg,
+          lfCapturedEnv = callEnv
+        }
+    )
+
+requireStaticFunctionType :: String -> String -> BackendType -> LocalFunction -> LowerM LocalFunction
+requireStaticFunctionType context paramName expectedTy localFunction = do
+  unless (alphaEqBackendType expectedTy (functionFormType (lfForm localFunction))) $
+    liftEither
+      ( BackendLLVMUnsupportedExpression
+          context
+          ( "static argument "
+              ++ show paramName
+              ++ " has type "
+              ++ show (functionFormType (lfForm localFunction))
+              ++ ", expected "
+              ++ show expectedTy
+          )
+      )
+  pure localFunction
 
 requireLLVMType :: String -> String -> LLVMType -> LowerValue -> LowerM ()
 requireLLVMType context name expected actual =
@@ -1103,15 +1236,6 @@ requireLLVMType context name expected actual =
               ++ show (lvLLVMType actual)
           )
       )
-
-extendExprEnvWithArguments :: ExprEnv -> FunctionForm -> [LowerValue] -> ExprEnv
-extendExprEnvWithArguments exprEnv form args =
-  exprEnv
-    { eeValues =
-        Map.union
-          (Map.fromList [(name, value) | ((name, _), value) <- zip (ffParams form) args])
-          (eeValues exprEnv)
-    }
 
 instantiateFunctionFormM :: String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM FunctionForm
 instantiateFunctionFormM context form typeArgs args =
@@ -1265,7 +1389,22 @@ lowerConstruct env exprEnv context resultTy name args =
       emitStore (lvLLVMType value) (lvOperand value) fieldPtr
 
 lowerCase :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> NonEmpty BackendAlternative -> LowerM LowerValue
-lowerCase env exprEnv context resultTy scrutinee alternatives = do
+lowerCase env exprEnv context resultTy scrutinee alternatives =
+  case scrutinee of
+    BackendConstruct scrutineeTy name args ->
+      case Map.lookup name (pbConstructors (peBase env)) of
+        Just constructorRuntime -> do
+          fieldTys <- constructorFieldTypesForScrutinee env context constructorRuntime scrutineeTy
+          if any backendTypeRequiresStaticSpecialization fieldTys
+            then lowerImmediateConstructCase env exprEnv context resultTy name args fieldTys alternatives
+            else lowerHeapCase env exprEnv context resultTy scrutinee alternatives
+        Nothing ->
+          lowerHeapCase env exprEnv context resultTy scrutinee alternatives
+    _ ->
+      lowerHeapCase env exprEnv context resultTy scrutinee alternatives
+
+lowerHeapCase :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> NonEmpty BackendAlternative -> LowerM LowerValue
+lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
   rejectNonTailDefaultAlternative
   resultLLVMType <- lowerBackendTypeM env context resultTy
   scrutineeValue <- lowerExpr env exprEnv context scrutinee
@@ -1366,6 +1505,93 @@ lowerCase env exprEnv context resultTy scrutinee alternatives = do
       fieldPtr <- emitGep "case.field.ptr" (lvOperand scrutineeValue) (8 * (index0 + 1))
       loaded <- emitAssign "case.field" llvmTy (LLVMLoad llvmTy fieldPtr)
       pure (LowerValue fieldTy llvmTy loaded)
+
+lowerImmediateConstructCase ::
+  ProgramEnv ->
+  ExprEnv ->
+  String ->
+  BackendType ->
+  String ->
+  [BackendExpr] ->
+  [BackendType] ->
+  NonEmpty BackendAlternative ->
+  LowerM LowerValue
+lowerImmediateConstructCase env exprEnv context resultTy constructorName args fieldTys alternatives = do
+  rejectNonTailDefaultAlternative
+  rejectDuplicateConstructorAlternatives
+  unless (length args == length fieldTys) $
+    liftEither (BackendLLVMArityMismatch constructorName (length fieldTys) (length args))
+  case selectedAlternative of
+    Just alternative -> do
+      exprEnv' <- bindImmediateAlternativePattern alternative
+      bodyValue <- lowerExpr env exprEnv' context (backendAltBody alternative)
+      expectedTy <- lowerBackendTypeM env context resultTy
+      unless (lvLLVMType bodyValue == expectedTy) $
+        liftEither (BackendLLVMInternalError ("immediate case alternative type mismatch at " ++ context))
+      pure bodyValue
+    Nothing ->
+      liftEither (BackendLLVMUnsupportedExpression context ("no matching immediate constructor alternative " ++ show constructorName))
+  where
+    alternativesList = NE.toList alternatives
+
+    selectedAlternative =
+      case [alternative | alternative@(BackendAlternative (BackendConstructorPattern name _) _) <- alternativesList, name == constructorName] of
+        alternative : _ -> Just alternative
+        [] ->
+          case [alternative | alternative@(BackendAlternative BackendDefaultPattern _) <- alternativesList] of
+            alternative : _ -> Just alternative
+            [] -> Nothing
+
+    rejectNonTailDefaultAlternative =
+      case break isDefaultAlternative alternativesList of
+        (_, []) -> pure ()
+        (_, [_]) -> pure ()
+        (_, _ : _ : _) ->
+          liftEither (BackendLLVMUnsupportedExpression context "default case alternative must be last")
+
+    isDefaultAlternative (BackendAlternative BackendDefaultPattern _) =
+      True
+    isDefaultAlternative _ =
+      False
+
+    rejectDuplicateConstructorAlternatives =
+      case firstDuplicate [name | BackendAlternative (BackendConstructorPattern name _) _ <- alternativesList] of
+        Just name ->
+          liftEither (BackendLLVMUnsupportedExpression context ("duplicate constructor case alternative " ++ show name))
+        Nothing ->
+          pure ()
+
+    bindImmediateAlternativePattern (BackendAlternative pattern0 body) =
+      case pattern0 of
+        BackendDefaultPattern ->
+          pure exprEnv
+        BackendConstructorPattern name binders -> do
+          unless (name == constructorName) $
+            liftEither
+              ( BackendLLVMUnsupportedExpression
+                  context
+                  ("selected immediate constructor mismatch " ++ show name ++ " for " ++ show constructorName)
+              )
+          unless (length binders == length fieldTys) $
+            liftEither (BackendLLVMArityMismatch name (length fieldTys) (length binders))
+          foldM
+            (bindUsedField (freeBackendExprVars body))
+            exprEnv
+            (zip3 binders fieldTys args)
+
+    bindUsedField usedBinders acc (binder, fieldTy, arg)
+      | Set.notMember binder usedBinders =
+          pure acc
+      | backendTypeRequiresStaticSpecialization fieldTy = do
+          localFunction <- lowerStaticFunctionArgument env exprEnv context binder fieldTy arg
+          pure acc {eeLocalFunctions = Map.insert binder localFunction (eeLocalFunctions acc)}
+      | backendTypeHasRuntimeRepresentation env fieldTy = do
+          value <- lowerExpr env exprEnv context arg
+          expectedTy <- lowerBackendTypeM env context fieldTy
+          requireLLVMType context constructorName expectedTy value
+          pure acc {eeValues = Map.insert binder value (eeValues acc)}
+      | otherwise = do
+          liftEither (BackendLLVMUnsupportedType ("field " ++ show binder ++ " at " ++ context) fieldTy)
 
 constructorFieldTypesForScrutinee :: ProgramEnv -> String -> ConstructorRuntime -> BackendType -> LowerM [BackendType]
 constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1545,7 +1545,7 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
         liftEither (BackendLLVMInternalError ("immediate case alternative type mismatch at " ++ context))
       pure bodyValue
     Nothing ->
-      liftEither (BackendLLVMUnsupportedExpression context ("no matching immediate constructor alternative " ++ show constructorName))
+      lowerUnmatchedImmediateCase
   where
     alternativesList = NE.toList alternatives
 
@@ -1575,6 +1575,15 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
           liftEither (BackendLLVMUnsupportedExpression context ("duplicate constructor case alternative " ++ show name))
         Nothing ->
           pure ()
+
+    lowerUnmatchedImmediateCase = do
+      zipWithM_ evaluateUnusedField fieldTys args
+      expectedTy <- lowerBackendTypeM env context resultTy
+      finishCurrentBlock LLVMUnreachable
+      continuationLabel <- freshBlock "case.unreachable.cont"
+      startBlock continuationLabel
+      operand <- dummyOperandAfterUnreachable context expectedTy
+      pure (LowerValue resultTy expectedTy operand)
 
     bindImmediateAlternativePattern (BackendAlternative pattern0 body) =
       case pattern0 of
@@ -1621,6 +1630,14 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
           requireLLVMType context constructorName expectedTy value
       | otherwise =
           liftEither (BackendLLVMUnsupportedType ("field at " ++ context) fieldTy)
+
+dummyOperandAfterUnreachable :: String -> LLVMType -> LowerM LLVMOperand
+dummyOperandAfterUnreachable _ (LLVMInt width) =
+  pure (LLVMIntLiteral width 0)
+dummyOperandAfterUnreachable _ LLVMPtr =
+  pure LLVMNull
+dummyOperandAfterUnreachable context ty =
+  liftEither (BackendLLVMInternalError ("cannot synthesize unreachable value of type " ++ show ty ++ " at " ++ context))
 
 constructorFieldTypesForScrutinee :: ProgramEnv -> String -> ConstructorRuntime -> BackendType -> LowerM [BackendType]
 constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -317,6 +317,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     renderBackendProgramLLVM strictImmediateDefaultProgram
       `shouldSatisfyLeft` isInfixOf "representation-changing roll"
 
+  it "lowers unmatched immediate constructor cases to unreachable" $ do
+    output <- requireRight (renderBackendProgramLLVM unmatchedImmediateConstructorProgram)
+
+    output `shouldSatisfy` isInfixOf "unreachable"
+    output `shouldNotSatisfy` isInfixOf "no matching immediate constructor alternative"
+    validateLLVMAssembly output
+
+  it "evaluates immediate constructor fields before unmatched alternatives" $ do
+    renderBackendProgramLLVM strictImmediateUnmatchedProgram
+      `shouldSatisfyLeft` isInfixOf "representation-changing roll"
+
   it "rejects duplicate constructor case alternatives before emitting switch" $ do
     renderBackendProgramLLVM duplicateConstructorCaseProgram
       `shouldSatisfyLeft` isInfixOf "duplicate constructor case tag"
@@ -1174,6 +1185,62 @@ strictImmediateDefaultProgram =
       backendProgramMain = "main"
     }
 
+unmatchedImmediateConstructorProgram :: BackendProgram
+unmatchedImmediateConstructorProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [immediateChoiceData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendCase
+                          intTy
+                          ( BackendConstruct
+                              immediateChoiceTy
+                              "WithStatic"
+                              [polyIdExpr, intLit 1]
+                          )
+                          (BackendAlternative (BackendConstructorPattern "Other" []) (intLit 0) :| []),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+strictImmediateUnmatchedProgram :: BackendProgram
+strictImmediateUnmatchedProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [immediateStrictChoiceData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendCase
+                          intTy
+                          ( BackendConstruct
+                              immediateStrictChoiceTy
+                              "WithStrictStatic"
+                              [polyIdExpr, BackendRoll recIntTy (intLit 1)]
+                          )
+                          (BackendAlternative (BackendConstructorPattern "StrictOther" []) (intLit 0) :| []),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
 duplicateConstructorCaseProgram :: BackendProgram
 duplicateConstructorCaseProgram =
   BackendProgram
@@ -1437,6 +1504,44 @@ strictBoxData =
         ]
     }
 
+immediateChoiceData :: BackendData
+immediateChoiceData =
+  BackendData
+    { backendDataName = "ImmediateChoice",
+      backendDataParameters = [],
+      backendDataConstructors =
+        [ BackendConstructor
+            "WithStatic"
+            []
+            [polyIdTy, intTy]
+            immediateChoiceTy,
+          BackendConstructor
+            "Other"
+            []
+            []
+            immediateChoiceTy
+        ]
+    }
+
+immediateStrictChoiceData :: BackendData
+immediateStrictChoiceData =
+  BackendData
+    { backendDataName = "ImmediateStrictChoice",
+      backendDataParameters = [],
+      backendDataConstructors =
+        [ BackendConstructor
+            "WithStrictStatic"
+            []
+            [polyIdTy, recIntTy]
+            immediateStrictChoiceTy,
+          BackendConstructor
+            "StrictOther"
+            []
+            []
+            immediateStrictChoiceTy
+        ]
+    }
+
 programWithMainExpr :: BackendType -> BackendExpr -> BackendProgram
 programWithMainExpr mainTy expr =
   programWithBindings
@@ -1504,6 +1609,14 @@ lazyFieldBoxTy =
 strictBoxTy :: BackendType
 strictBoxTy =
   BTBase (BaseTy "StrictBox")
+
+immediateChoiceTy :: BackendType
+immediateChoiceTy =
+  BTBase (BaseTy "ImmediateChoice")
+
+immediateStrictChoiceTy :: BackendType
+immediateStrictChoiceTy =
+  BTBase (BaseTy "ImmediateStrictChoice")
 
 aUnderscoreTy :: BackendType
 aUnderscoreTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -153,6 +153,32 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "missing specialization"
     validateLLVMAssembly output
 
+  it "statically lowers first-class polymorphic top-level arguments" $ do
+    output <- requireRight =<< emitBackendFile "test/programs/unified/first-class-polymorphism.mlfp"
+
+    output `shouldSatisfy` isInfixOf "define i1 @\"FirstClassPolymorphism__main\"()"
+    output `shouldNotSatisfy` isInfixOf "FirstClassPolymorphism__usePoly"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "statically lowers first-class polymorphic local arguments" $ do
+    output <-
+      withTempProgram localFirstClassPolymorphismProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define i1 @\"Main__main\"()"
+    output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
+    validateLLVMAssembly output
+
+  it "statically lowers immediate constructor fields carrying forall values" $ do
+    output <-
+      withTempProgram constructorFirstClassPolymorphismProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define i1 @\"Main__main\"()"
+    output `shouldNotSatisfy` isInfixOf "escaping type abstraction"
+    validateLLVMAssembly output
+
   it "lowers local function aliases without requiring closure conversion" $ do
     output <- requireRight (renderBackendProgramLLVM localFunctionAliasProgram)
 
@@ -433,6 +459,30 @@ recursiveListProgram =
       "  };",
       "",
       "  def main : Bool = isNil (tailOrNil (RCons Zero RNil));",
+      "}"
+    ]
+
+localFirstClassPolymorphismProgram :: String
+localFirstClassPolymorphismProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Bool =",
+      "    let usePoly : (forall a. a -> a) -> Bool =",
+      "      \\(poly : forall a. a -> a) let keepInt = poly 1 in poly true",
+      "    in let id : forall a. a -> a = \\x x in usePoly id;",
+      "}"
+    ]
+
+constructorFirstClassPolymorphismProgram :: String
+constructorFirstClassPolymorphismProgram =
+  unlines
+    [ "module Main export (PolyBox(..), main) {",
+      "  data PolyBox =",
+      "      PolyBox : (forall a. a -> a) -> PolyBox;",
+      "",
+      "  def main : Bool = case PolyBox (\\x x) of {",
+      "    PolyBox poly -> let keepInt = poly 1 in poly true",
+      "  };",
       "}"
     ]
 
@@ -1310,17 +1360,12 @@ llvmParityExpectations =
 
 unsupportedLLVMParityCases :: [(String, String)]
 unsupportedLLVMParityCases =
-  [ ("surface: runs first-class polymorphic top-level argument", "Unsupported backend LLVM type at parameter \"$poly#0\" of FirstClassPolymorphism__usePoly"),
-    ("surface: runs first-class polymorphic local argument", "could not infer type arguments [\"a\"]"),
-    ("boundary: runs overloaded method dispatch with ordinary nullary constructors", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
+  [ ("boundary: runs overloaded method dispatch with ordinary nullary constructors", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs overloaded method dispatch with nested ordinary constructors", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs overloaded method dispatch with lambda/application-inferred argument", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs overloaded method dispatch with let-polymorphism-inferred argument", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs overloaded method dispatch with explicit argument annotation", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs overloaded method dispatch on pattern-bound variable", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: constructor argument inferred as first-class polymorphic value should run", "escaping type abstraction"),
-    ("boundary: local first-class polymorphic let through constructor boundary should run", "could not infer type arguments [\"a\"]"),
-    ("boundary: pattern-bound first-class polymorphic variable should run", "could not infer type arguments [\"a\"]"),
     ("boundary: partial overloaded method application should run after deferred resolution", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs higher-kinded data field over a concrete constructor head", "BackendUnsupportedSourceType"),
     ("boundary: runs nullary constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
@@ -1354,7 +1399,6 @@ unsupportedLLVMParityCases =
     ("fixture: test/programs/recursive-adt/complex-recursive-program.mlfp", "Unsupported backend LLVM type at return type of ComplexRecursiveProgram__Eq__Nat__eq"),
     ("fixture: test/programs/recursive-adt/module-integrated.mlfp", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
     ("unified fixture: test/programs/unified/authoritative-overloaded-method.mlfp", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("unified fixture: test/programs/unified/first-class-polymorphism.mlfp", "Unsupported backend LLVM type at parameter \"$poly#0\" of FirstClassPolymorphism__usePoly"),
     ("standalone: allows importing a module declared later in the file", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
     ("standalone: does not decode typed non-data constructor fields through fallback ADT decoding", "escaping lambda"),
     ("standalone: evaluates a recursive Nat equality example at representative depth", "Unsupported backend LLVM type at return type of Baseline__Eq__Nat__eq")
@@ -1362,7 +1406,7 @@ unsupportedLLVMParityCases =
 
 expectedLLVMUnsupportedParityCount :: Int
 expectedLLVMUnsupportedParityCount =
-  48
+  42
 
 llvmUnsupportedParityCount :: Int
 llvmUnsupportedParityCount =
@@ -1375,7 +1419,8 @@ llvmObjectCodeParityCases :: [String]
 llvmObjectCodeParityCases =
   [ "surface: runs lambda/application",
     "unified fixture: test/programs/unified/authoritative-case-analysis.mlfp",
-    "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp"
+    "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp",
+    "unified fixture: test/programs/unified/first-class-polymorphism.mlfp"
   ]
 
 llvmObjectCodeParityCaseNames :: Set.Set String

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -180,6 +180,16 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
     validateLLVMAssembly output
 
+  it "collects specializations for type-applied global static aliases" $ do
+    output <-
+      withTempProgram typeAppliedGlobalStaticAliasProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
+    output `shouldSatisfy` isInfixOf "define private i64 @\"Main__id$t"
+    output `shouldNotSatisfy` isInfixOf "missing specialization"
+    validateLLVMAssembly output
+
   it "rejects static-argument entrypoints instead of eliding main" $ do
     renderBackendProgramLLVM staticArgumentMainProgram
       `shouldSatisfyLeft` isInfixOf "parameter \"poly\" of main"
@@ -301,6 +311,10 @@ spec = describe "MLF.Backend.LLVM" $ do
 
   it "evaluates unused immediate constructor fields before static erasure" $ do
     renderBackendProgramLLVM strictImmediateConstructFieldProgram
+      `shouldSatisfyLeft` isInfixOf "representation-changing roll"
+
+  it "evaluates immediate constructor fields before default alternatives" $ do
+    renderBackendProgramLLVM strictImmediateDefaultProgram
       `shouldSatisfyLeft` isInfixOf "representation-changing roll"
 
   it "rejects duplicate constructor case alternatives before emitting switch" $ do
@@ -501,6 +515,16 @@ firstClassFunctionArgumentProgram =
     [ "module Main export (main) {",
       "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
       "  def main : Int = use (\\(x : Int) x);",
+      "}"
+    ]
+
+typeAppliedGlobalStaticAliasProgram :: String
+typeAppliedGlobalStaticAliasProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def id : forall a. a -> a = \\x x;",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
+      "  def main : Int = use id;",
       "}"
     ]
 
@@ -1114,6 +1138,34 @@ strictImmediateConstructFieldProgram =
                               (intLit 0)
                               :| []
                           ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+strictImmediateDefaultProgram :: BackendProgram
+strictImmediateDefaultProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [strictBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendCase
+                          intTy
+                          ( BackendConstruct
+                              strictBoxTy
+                              "StrictBox"
+                              [polyIdExpr, BackendRoll recIntTy (intLit 1)]
+                          )
+                          (BackendAlternative BackendDefaultPattern (intLit 0) :| []),
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -170,6 +170,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
     validateLLVMAssembly output
 
+  it "rejects static-argument entrypoints instead of eliding main" $ do
+    renderBackendProgramLLVM staticArgumentMainProgram
+      `shouldSatisfyLeft` isInfixOf "parameter \"poly\" of main"
+
+  it "rejects recursive static global inlining instead of diverging" $ do
+    renderBackendProgramLLVM recursiveStaticGlobalProgram
+      `shouldSatisfyLeft` isInfixOf "recursive static global \"loop\""
+
   it "statically lowers immediate constructor fields carrying forall values" $ do
     output <-
       withTempProgram constructorFirstClassPolymorphismProgram $ \path ->
@@ -484,6 +492,41 @@ constructorFirstClassPolymorphismProgram =
       "    PolyBox poly -> let keepInt = poly 1 in poly true",
       "  };",
       "}"
+    ]
+
+staticArgumentMainProgram :: BackendProgram
+staticArgumentMainProgram =
+  programWithMainExpr staticPolyBoolTy $
+    BackendLam staticPolyBoolTy "poly" polyIdTy (boolLit True)
+
+recursiveStaticGlobalProgram :: BackendProgram
+recursiveStaticGlobalProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "loop",
+          backendBindingType = staticPolyBoolTy,
+          backendBindingExpr =
+            BackendLam
+              staticPolyBoolTy
+              "poly"
+              polyIdTy
+              ( BackendApp
+                  boolTy
+                  (BackendVar staticPolyBoolTy "loop")
+                  (BackendVar polyIdTy "poly")
+              ),
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = boolTy,
+          backendBindingExpr =
+            BackendApp
+              boolTy
+              (BackendVar staticPolyBoolTy "loop")
+              polyIdExpr,
+          backendBindingExportedAsMain = True
+        }
     ]
 
 stringProgram :: BackendProgram
@@ -1128,6 +1171,10 @@ polyIdExpr =
         (BackendVar (BTVar "a") "x")
     )
 
+staticPolyBoolTy :: BackendType
+staticPolyBoolTy =
+  BTArrow polyIdTy boolTy
+
 badPolyTy :: BackendType
 badPolyTy =
   BTForall "a" Nothing fnBoxTy
@@ -1297,9 +1344,17 @@ intLit :: Integer -> BackendExpr
 intLit value =
   BackendLit intTy (LInt value)
 
+boolLit :: Bool -> BackendExpr
+boolLit value =
+  BackendLit boolTy (LBool value)
+
 intTy :: BackendType
 intTy =
   BTBase (BaseTy "Int")
+
+boolTy :: BackendType
+boolTy =
+  BTBase (BaseTy "Bool")
 
 stringTy :: BackendType
 stringTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -170,6 +170,16 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
     validateLLVMAssembly output
 
+  it "statically lowers first-class function-typed arguments" $ do
+    output <-
+      withTempProgram firstClassFunctionArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
+    output `shouldNotSatisfy` isInfixOf "Main__use"
+    output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
+    validateLLVMAssembly output
+
   it "rejects static-argument entrypoints instead of eliding main" $ do
     renderBackendProgramLLVM staticArgumentMainProgram
       `shouldSatisfyLeft` isInfixOf "parameter \"poly\" of main"
@@ -288,6 +298,10 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"box\", i64 16"
     output `shouldNotSatisfy` isInfixOf "getelementptr i8, ptr %\"box\", i64 8"
     validateLLVMAssembly output
+
+  it "evaluates unused immediate constructor fields before static erasure" $ do
+    renderBackendProgramLLVM strictImmediateConstructFieldProgram
+      `shouldSatisfyLeft` isInfixOf "representation-changing roll"
 
   it "rejects duplicate constructor case alternatives before emitting switch" $ do
     renderBackendProgramLLVM duplicateConstructorCaseProgram
@@ -478,6 +492,15 @@ localFirstClassPolymorphismProgram =
       "    let usePoly : (forall a. a -> a) -> Bool =",
       "      \\(poly : forall a. a -> a) let keepInt = poly 1 in poly true",
       "    in let id : forall a. a -> a = \\x x in usePoly id;",
+      "}"
+    ]
+
+firstClassFunctionArgumentProgram :: String
+firstClassFunctionArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
+      "  def main : Int = use (\\(x : Int) x);",
       "}"
     ]
 
@@ -1067,6 +1090,38 @@ unusedPolymorphicPatternFieldProgram =
       backendProgramMain = "main"
     }
 
+strictImmediateConstructFieldProgram :: BackendProgram
+strictImmediateConstructFieldProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [strictBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendCase
+                          intTy
+                          ( BackendConstruct
+                              strictBoxTy
+                              "StrictBox"
+                              [polyIdExpr, BackendRoll recIntTy (intLit 1)]
+                          )
+                          ( BackendAlternative
+                              (BackendConstructorPattern "StrictBox" ["poly", "unused"])
+                              (intLit 0)
+                              :| []
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
 duplicateConstructorCaseProgram :: BackendProgram
 duplicateConstructorCaseProgram =
   BackendProgram
@@ -1316,6 +1371,20 @@ lazyFieldBoxData =
         ]
     }
 
+strictBoxData :: BackendData
+strictBoxData =
+  BackendData
+    { backendDataName = "StrictBox",
+      backendDataParameters = [],
+      backendDataConstructors =
+        [ BackendConstructor
+            "StrictBox"
+            []
+            [polyIdTy, recIntTy]
+            strictBoxTy
+        ]
+    }
+
 programWithMainExpr :: BackendType -> BackendExpr -> BackendProgram
 programWithMainExpr mainTy expr =
   programWithBindings
@@ -1380,6 +1449,10 @@ lazyFieldBoxTy :: BackendType
 lazyFieldBoxTy =
   BTBase (BaseTy "LazyFieldBox")
 
+strictBoxTy :: BackendType
+strictBoxTy =
+  BTBase (BaseTy "StrictBox")
+
 aUnderscoreTy :: BackendType
 aUnderscoreTy =
   BTBase (BaseTy "A_B")
@@ -1433,8 +1506,7 @@ unsupportedLLVMParityCases =
     ("boundary: runs value-exported GADT constructor when owner type is not exported", "BackendUnsupportedSourceType"),
     ("boundary: runs value-imported nonzero-index constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
     ("boundary: runs constrained helper through hidden Eq evidence", "constructor result type does not match expected result"),
-    ("boundary: runs ground constrained helper alias with resolved evidence", "Unsupported backend LLVM type at parameter \"$evidence_Eq_eq#0\" of Main__sameBool"),
-    ("boundary: runs constrained helper after local lambda inference", "escaping function \"Main__Eq__Bool__eq\""),
+    ("boundary: runs ground constrained helper alias with resolved evidence", "Unsupported backend LLVM type at return type of Main__alias"),
     ("boundary: runs deferred method with method-level type variable constraint", "BackendTypeCheckFailed"),
     ("boundary: runs partial deferred method after method-local evidence is fixed by application", "BackendTypeCheckFailed"),
     ("boundary: runs deferred method when only a later forall binder is inferred", "BackendUnsupportedInstantiation InstElim"),
@@ -1448,7 +1520,6 @@ unsupportedLLVMParityCases =
     ("boundary: runs aliased import with exposed method and qualified constructors", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
     ("boundary: runs aliased import exposing a type without duplicate alias-head instance matches", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
     ("boundary: deduplicates equivalent instances from mixed unqualified and aliased imports", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
-    ("boundary: deduplicates constrained imported instances from mixed unqualified and aliased imports", "escaping function \"Core__Eq__Bool__eq\""),
     ("fixture: test/programs/recursive-adt/deriving-eq.mlfp", "Unsupported backend LLVM type at return type of DerivingEq__Eq__Nat__eq"),
     ("fixture: test/programs/recursive-adt/recursive-tree-deriving.mlfp", "Unsupported backend LLVM type at return type of RecursiveTreeDeriving__Eq__Tree__eq"),
     ("fixture: test/programs/recursive-adt/complex-recursive-program.mlfp", "Unsupported backend LLVM type at return type of ComplexRecursiveProgram__Eq__Nat__eq"),
@@ -1461,7 +1532,7 @@ unsupportedLLVMParityCases =
 
 expectedLLVMUnsupportedParityCount :: Int
 expectedLLVMUnsupportedParityCount =
-  42
+  40
 
 llvmUnsupportedParityCount :: Int
 llvmUnsupportedParityCount =


### PR DESCRIPTION
Closes #72.

## Implementation Plan

---
issue_number: 72
pr_number: 82
branch: codex/issue-72
---

## Implementation Plan

1. Keep the change scoped to the backend LLVM lowering path. The converter already preserves the needed IR shapes (`BackendTyAbs`, `BackendTyApp`, `BackendConstruct`, `BackendCase`); current failures come from `MLF.Backend.LLVM.Lower` trying to lower `BTForall`/function values as runtime LLVM operands.

2. In `src/MLF/Backend/LLVM/Lower.hs`, add a static function/value binding path that reuses `ExprEnv.eeLocalFunctions` for first-class polymorphic or function-typed values. Implement helpers to classify runtime-lowerable types, turn global/local/direct lambda/type-abs/alias expressions into `LocalFunction`s, and bind call arguments as either LLVM operands or static functions. Keep partial applications and escaping lambdas unsupported unless they are immediately called through this static path.

3. Adjust call lowering so global functions with unlowerable parameters, such as `usePoly : (forall a. a -> a) -> Bool`, are statically inlined at call sites instead of emitted as LLVM functions with `BTForall` parameters. Keep ordinary first-order global calls as direct LLVM calls, and keep existing polymorphic specialization behavior for type-applied globals.

4. Add an immediate `case (Construct ...) of ...` lowering path. When the selected constructor alternative binds a used field, bind lowerable fields as LLVM values and `forall`/function fields as static functions. Leave the normal heap allocation path unchanged, so constructor fields carrying polymorphic or function values still fail closed when they escape instead of being immediately destructed.

5. Update `test/BackendLLVMSpec.hs` with focused regression coverage for top-level `usePoly id`, local `usePoly id`, immediate `PolyBox` cases with polymorphic fields, and unchanged rejection for escaping function fields/partial applications. Then remove the now-supported issue-owned entries from `unsupportedLLVMParityCases`, reduce `expectedLLVMUnsupportedParityCount` from 48 to 42, and add `unified fixture: test/programs/unified/first-class-polymorphism.mlfp` to `llvmObjectCodeParityCases` for `llc` smoke coverage.

6. Add a concise `CHANGELOG.md` Unreleased entry describing LLVM support for first-class polymorphism through static specialization/erasure at non-escaping runtime boundaries.

7. Validate with focused backend tests first, then the full gate before publish: `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.LLVM"'`, confirm the first-class-polymorphism fixture validates through LLVM assembly/object smoke coverage, then run `cabal build all && cabal test`.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.