### PR TITLE
Implement #73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - Extended LLVM backend parity to higher-kinded constructor fields and
   hidden-owner value-constructor imports. Backend IR now preserves applied type
   variables, conversion recovers structural higher-kinded constructor terms as
-  explicit backend ADT nodes, and the temporary LLVM unsupported table no
-  longer lists the issue-owned rows.
+  explicit backend ADT nodes with module-scoped owner identity, and the temporary
+  LLVM unsupported table no longer lists the issue-owned rows. The `llc` smoke
+  subset now covers both hidden-owner and qualified-alias identity cases.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   explicit backend ADT nodes with module-scoped owner identity, and the temporary
   LLVM unsupported table no longer lists the issue-owned rows. The `llc` smoke
   subset now covers both hidden-owner and qualified-alias identity cases.
+- Tightened Backend IR structural ADT validation so field-carrying recursive
+  payloads must agree with constructor metadata before satisfying nominal
+  constructor and case boundaries.
 - Added LLVM lowering support for first-class polymorphic values at
   non-escaping runtime boundaries. Polymorphic arguments and immediate
   constructor fields are statically specialized/erased at call and case sites,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Changed
+- Extended LLVM backend parity to higher-kinded constructor fields and
+  hidden-owner value-constructor imports. Backend IR now preserves applied type
+  variables, conversion recovers structural higher-kinded constructor terms as
+  explicit backend ADT nodes, and the temporary LLVM unsupported table no
+  longer lists the issue-owned rows.
 - Extended the shared `ProgramSpec`-to-LLVM parity matrix from first-order
   coverage to the canonical interpreter-success surface. The backend LLVM spec
   now emits supported cases through the file backend path, validates generated

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,19 @@
+## 2026-04-29 - Higher-kinded and hidden-owner constructor LLVM parity
+
+- `MLF.Backend.IR` now preserves checked variable-headed type applications as
+  `BTVarApp` instead of rejecting all `STVarApp` fields at backend conversion.
+  Substitution, alpha equality, constructor matching, validation, and LLVM
+  lowering all understand applied type variables once they are resolved to
+  concrete backend data heads.
+- `MLF.Backend.Convert` now recovers backend constructor and case nodes from the
+  structural constructor terms produced for higher-kinded and hidden-owner ADTs.
+  Recovery is anchored to the constructor owner/result shape and the checked
+  constructor metadata, then normalizes structural recursive owner types back to
+  canonical backend data names.
+- LLVM parity now supports the issue-owned higher-kinded data-field rows and
+  hidden-owner value-constructor import rows. Typeclass/evidence and deriving
+  rows remain explicitly classified as separate unsupported backend work.
+
 ## 2026-04-28 - Shared Program-to-LLVM parity matrix
 
 - Extracted the `.mlfp` interpreter-success surface from `ProgramSpec` into

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -9,10 +9,14 @@
   structural constructor terms produced for higher-kinded and hidden-owner ADTs.
   Recovery is anchored to the constructor owner/result shape and the checked
   constructor metadata, then normalizes structural recursive owner types back to
-  canonical backend data names.
+  canonical backend data names. Unqualified structural owner binders are scoped
+  to the current module only; imported and qualified owners must match their
+  canonical module-qualified backend data names.
 - LLVM parity now supports the issue-owned higher-kinded data-field rows and
-  hidden-owner value-constructor import rows. Typeclass/evidence and deriving
-  rows remain explicitly classified as separate unsupported backend work.
+  hidden-owner value-constructor import rows, and the `llc` smoke subset includes
+  both hidden-owner and qualified-alias identity representatives. Typeclass/evidence
+  and deriving rows remain explicitly classified as separate unsupported backend
+  work.
 
 ## 2026-04-28 - Shared Program-to-LLVM parity matrix
 

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -44,7 +44,7 @@ import MLF.Elab.Types
     elabToBound,
     tyToElab,
   )
-import MLF.Frontend.Program.Elaborate (ElaborateScope, lowerType, mkElaborateScope)
+import MLF.Frontend.Program.Elaborate (ElaborateScope, elaborateScopeDataTypes, lowerType, mkElaborateScope)
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
     CheckedModule (..),
@@ -241,7 +241,8 @@ liftRecursiveLetsInTerm context lexicalLocals term =
           bodyLocals = Set.insert name lexicalLocals
       if termMentionsFreeVariable name rhs
         then do
-          bindingTy <- liftEitherConversion (convertElabType schemeTy)
+          bindingTy0 <- liftEitherConversion (convertElabType schemeTy)
+          let bindingTy = normalizeBackendTypeForContext context bindingTy0
           ensureLiftableRecursiveLet lexicalLocals name bindingTy rhs
           helperName <- freshLiftedRecursiveLetName context name
           rhs' <- liftRecursiveLetsInTerm context (Set.insert name lexicalLocals) rhs
@@ -457,20 +458,30 @@ checkedBindingCanonicalType context checkedModule binding = do
 checkedBindingCanonicalBackendType :: ConvertContext -> CheckedModule -> CheckedBinding -> ElabType -> Either BackendConversionError BackendType
 checkedBindingCanonicalBackendType context checkedModule binding fallbackTy =
   do
-    fallbackBackendTy <- convertElabType fallbackTy
-    let recoveredFallbackTy = recoverStructuralBackendType context fallbackBackendTy
+    fallbackBackendTy0 <- convertElabType fallbackTy
+    let fallbackBackendTy = canonicalizeStructuralMuNames moduleContext fallbackBackendTy0
+    let recoveredFallbackTy = recoverStructuralBackendType moduleContext fallbackBackendTy
     case convertLoweredSourceType scope (checkedBindingSourceType binding) of
-      Right sourceTy ->
-        let recoveredSourceTy = recoverStructuralBackendType context sourceTy
-       in if backendTypeNeedsStructuralRecovery context sourceTy
-              || backendTypeNeedsStructuralRecovery context recoveredSourceTy
-              || backendTypeNeedsStructuralRecovery context fallbackBackendTy
-              || backendTypeNeedsStructuralRecovery context recoveredFallbackTy
-              then Right recoveredSourceTy
-              else Right fallbackBackendTy
+      Right sourceTy0 ->
+        let sourceTy = canonicalizeStructuralMuNames moduleContext sourceTy0
+            recoveredSourceTy = recoverStructuralBackendType moduleContext sourceTy
+         in if backendTypeNeedsStructuralRecovery moduleContext sourceTy
+                || backendTypeNeedsStructuralRecovery moduleContext recoveredSourceTy
+                || backendTypeNeedsStructuralRecovery moduleContext fallbackBackendTy
+                || backendTypeNeedsStructuralRecovery moduleContext recoveredFallbackTy
+                then Right recoveredSourceTy
+                else Right fallbackBackendTy
       Left _ -> Right recoveredFallbackTy
   where
     scope = scopeForModule context (checkedModuleName checkedModule)
+    moduleContext = context {ccCurrentModuleName = Just (checkedModuleName checkedModule)}
+
+normalizeBackendTypeForContext :: ConvertContext -> BackendType -> BackendType
+normalizeBackendTypeForContext context ty =
+  let canonicalTy = canonicalizeStructuralMuNames context ty
+   in if backendTypeNeedsStructuralRecovery context canonicalTy
+        then recoverStructuralBackendType context canonicalTy
+        else canonicalTy
 
 scopeForModule :: ConvertContext -> String -> ElaborateScope
 scopeForModule context moduleName =
@@ -764,7 +775,7 @@ buildDataMeta scope info = do
           { dmInfo = info,
             dmBackend = rawData
           }
-      recoveryContext =
+      rawRecoveryContext =
         ConvertContext
           { ccModuleScopes = Map.empty,
             ccConstructors = Map.empty,
@@ -774,10 +785,18 @@ buildDataMeta scope info = do
             ccCurrentModuleName = Just (dataModule info),
             ccCurrentBindingName = ""
           }
+      canonicalConstructors =
+        map (canonicalizeBackendConstructorTypes rawRecoveryContext) rawConstructors
+      canonicalData =
+        rawData {backendDataConstructors = canonicalConstructors}
+      canonicalMeta =
+        rawMeta {dmBackend = canonicalData}
+      recoveryContext =
+        rawRecoveryContext {ccData = [canonicalMeta]}
       constructors =
         if any backendConstructorContainsVarApp rawConstructors
-          then map (recoverBackendConstructorTypes recoveryContext) rawConstructors
-          else rawConstructors
+          then map (recoverBackendConstructorTypes recoveryContext) canonicalConstructors
+          else canonicalConstructors
   Right
     DataMeta
       { dmInfo = info,
@@ -789,12 +808,30 @@ buildDataMeta scope info = do
             }
       }
 
+canonicalizeBackendConstructorTypes :: ConvertContext -> BackendConstructor -> BackendConstructor
+canonicalizeBackendConstructorTypes context constructor =
+  constructor
+    { backendConstructorForalls = map canonicalizeTypeBinder (backendConstructorForalls constructor),
+      backendConstructorFields = map canonicalizeTy (backendConstructorFields constructor),
+      backendConstructorResult = canonicalizeTy (backendConstructorResult constructor)
+    }
+  where
+    canonicalizeTy =
+      canonicalizeStructuralMuNames context
+
+    canonicalizeTypeBinder binder =
+      binder {backendTypeBinderBound = fmap canonicalizeTy (backendTypeBinderBound binder)}
+
 recoverBackendConstructorTypes :: ConvertContext -> BackendConstructor -> BackendConstructor
 recoverBackendConstructorTypes context constructor =
   constructor
-    { backendConstructorFields = map (recoverStructuralBackendType context) (backendConstructorFields constructor),
+    { backendConstructorForalls = map recoverTypeBinder (backendConstructorForalls constructor),
+      backendConstructorFields = map (recoverStructuralBackendType context) (backendConstructorFields constructor),
       backendConstructorResult = recoverStructuralBackendType context (backendConstructorResult constructor)
     }
+  where
+    recoverTypeBinder binder =
+      binder {backendTypeBinderBound = fmap (recoverStructuralBackendType context) (backendTypeBinderBound binder)}
 
 backendConstructorContainsVarApp :: BackendConstructor -> Bool
 backendConstructorContainsVarApp constructor =
@@ -1029,10 +1066,7 @@ convertSpecialTerm context env term resultTy =
 
 convertOrdinaryTerm :: ConvertContext -> Env -> ElabTerm -> BackendType -> Either BackendConversionError BackendExpr
 convertOrdinaryTerm context env term resultTy0 =
-  let resultTy =
-        if backendTypeNeedsStructuralRecovery context resultTy0
-          then recoverStructuralBackendType context resultTy0
-          else resultTy0
+  let resultTy = normalizeBackendTypeForContext context resultTy0
    in case term of
     EVar name ->
       Right
@@ -1050,7 +1084,7 @@ convertOrdinaryTerm context env term resultTy0 =
       paramBackendTy <-
         case resultTy of
           BTArrow dom _ -> Right dom
-          _ -> recoverStructuralBackendType context <$> convertElabType paramTy
+          _ -> normalizeBackendTypeForContext context <$> convertElabType paramTy
       let paramEnvTy =
             case backendTypeToElabType paramBackendTy of
               Just canonicalTy -> canonicalTy
@@ -1083,7 +1117,7 @@ convertOrdinaryTerm context env term resultTy0 =
       let schemeTy = schemeToType scheme
       when (termMentionsFreeVariable name rhs) $
         Left (BackendUnsupportedRecursiveLet name)
-      bindingTy <- recoverStructuralBackendType context <$> convertElabType schemeTy
+      bindingTy <- normalizeBackendTypeForContext context <$> convertElabType schemeTy
       rhsExpr <- convertTermExpected context env (Just bindingTy) rhs
       let bindingEnvTy =
             case backendTypeToElabType bindingTy of
@@ -1099,7 +1133,7 @@ convertOrdinaryTerm context env term resultTy0 =
             backendLetBody = bodyExpr
           }
     ETyAbs name mbBound body -> do
-      mbBackendBound <- traverse (convertElabType . tyToElab) mbBound
+      mbBackendBound <- traverse (fmap (normalizeBackendTypeForContext context) . convertElabType . tyToElab) mbBound
       let boundTy = maybe TBottom tyToElab mbBound
           bodyExpected =
             case resultTy of
@@ -1178,7 +1212,7 @@ convertTypeInstantiation context env resultTy inner inst =
           innerExpr <- convertTerm context env inner
           case backendExprType innerExpr of
             BTForall {} -> do
-              backendTyArg <- convertElabType tyArg
+              backendTyArg <- normalizeBackendTypeForContext context <$> convertElabType tyArg
               Right
                 BackendTyApp
                   { backendExprType = resultTy,
@@ -1268,7 +1302,7 @@ constructorApplicationTerm context term =
         Nothing -> structuralConstructorApplication headTerm args
   where
     directConstructorApplication headTerm args =
-      case constructorHead headTerm of
+      case constructorHead context headTerm of
         Just (constructorName, headTypeArgs) -> do
           constructorMeta <- Map.lookup constructorName (ccConstructors context)
           guardConstructorArity constructorMeta args
@@ -1435,11 +1469,11 @@ freeSourceTypeVars =
         STBottom ->
           Set.empty
 
-constructorHead :: ElabTerm -> Maybe (String, [BackendType])
-constructorHead term =
+constructorHead :: ConvertContext -> ElabTerm -> Maybe (String, [BackendType])
+constructorHead context term =
   case collectConstructorHeadTypes [] term of
     Just (name, typeArgs) ->
-      case traverse convertElabType typeArgs of
+      case traverse (fmap (normalizeBackendTypeForContext context) . convertElabType) typeArgs of
         Right backendTypeArgs -> Just (name, backendTypeArgs)
         Left _ -> Nothing
     Nothing -> Nothing
@@ -1541,10 +1575,7 @@ caseScrutineeInfo context env scrutineeTerm =
       Just info -> Right info
       Nothing -> do
         scrutineeTy0 <- inferBackendType env scrutineeTerm
-        let scrutineeTy =
-              if backendTypeNeedsStructuralRecovery context scrutineeTy0
-                then recoverStructuralBackendType context scrutineeTy0
-                else scrutineeTy0
+        let scrutineeTy = normalizeBackendTypeForContext context scrutineeTy0
         Right
           ( scrutineeTy,
             scrutineeDataHint context scrutineeTerm
@@ -1572,7 +1603,15 @@ dataMetaByBackendName context name =
 dataMetaByStructuralName :: ConvertContext -> String -> Maybe DataMeta
 dataMetaByStructuralName context name =
   dataMetaByBackendName context name
+    <|> dataMetaByCurrentScopeStructuralName context name
     <|> dataMetaByCurrentModuleStructuralName context name
+
+dataMetaByCurrentScopeStructuralName :: ConvertContext -> String -> Maybe DataMeta
+dataMetaByCurrentScopeStructuralName context name = do
+  moduleName <- ccCurrentModuleName context
+  scope <- Map.lookup moduleName (ccModuleScopes context)
+  info <- Map.lookup name (elaborateScopeDataTypes scope)
+  dataMetaBySymbol context (dataInfoSymbol info)
 
 dataMetaByCurrentModuleStructuralName :: ConvertContext -> String -> Maybe DataMeta
 dataMetaByCurrentModuleStructuralName context name =
@@ -1589,6 +1628,37 @@ dataMetaByCurrentModuleStructuralName context name =
         [dataMeta] -> Just dataMeta
         _ -> Nothing
 
+dataMetaBySymbol :: ConvertContext -> SymbolIdentity -> Maybe DataMeta
+dataMetaBySymbol context symbol =
+  find ((== symbol) . dataInfoSymbol . dmInfo) (ccData context)
+
+canonicalizeStructuralMuNames :: ConvertContext -> BackendType -> BackendType
+canonicalizeStructuralMuNames context =
+  go
+  where
+    go ty =
+      case ty of
+        BTVar {} -> ty
+        BTArrow dom cod -> BTArrow (go dom) (go cod)
+        BTBase {} -> ty
+        BTCon name args -> BTCon name (fmap go args)
+        BTVarApp name args -> BTVarApp name (fmap go args)
+        BTForall name mb body -> BTForall name (fmap go mb) (go body)
+        BTMu name body ->
+          let (name', body') = canonicalizeStructuralMuBinder context name body
+           in BTMu name' (go body')
+        BTBottom -> BTBottom
+
+canonicalizeStructuralMuBinder :: ConvertContext -> String -> BackendType -> (String, BackendType)
+canonicalizeStructuralMuBinder context name body =
+  case structuralRecursiveDataMeta context name of
+    Just dataMeta ->
+      let canonicalName = "$" ++ backendDataName (dmBackend dataMeta) ++ "_self"
+       in if name == canonicalName
+            then (name, body)
+            else (canonicalName, substituteBackendType name (BTVar canonicalName) body)
+    Nothing -> (name, body)
+
 recoverStructuralBackendType :: ConvertContext -> BackendType -> BackendType
 recoverStructuralBackendType context =
   go Set.empty
@@ -1601,12 +1671,16 @@ recoverStructuralBackendType context =
         BTCon name args -> BTCon name (fmap (go seen) args)
         BTVarApp name args -> BTVarApp name (fmap (go seen) args)
         BTForall name mb body -> BTForall name (fmap (go seen) mb) (go seen body)
-        BTMu name body
-          | Set.member name seen -> ty
-          | Just dataMeta <- structuralRecursiveDataMeta context name,
-            Just args <- structuralBackendDataArguments (go (Set.insert name seen)) dataMeta body ->
-              backendDataType (backendDataName (dmBackend dataMeta)) args
-          | otherwise -> BTMu name (go (Set.insert name seen) body)
+        BTMu name body ->
+          let (name', body') = canonicalizeStructuralMuBinder context name body
+              seen' = Set.insert name' (Set.insert name seen)
+           in if Set.member name seen || Set.member name' seen
+                then BTMu name' (canonicalizeStructuralMuNames context body')
+                else case structuralRecursiveDataMeta context name' of
+                  Just dataMeta
+                    | Just args <- structuralBackendDataArguments (go seen') dataMeta body' ->
+                        backendDataType (backendDataName (dmBackend dataMeta)) args
+                  _ -> BTMu name' (go seen' body')
         BTBottom -> BTBottom
 
 backendDataType :: String -> [BackendType] -> BackendType

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2123,19 +2123,19 @@ constructorApplicationTerm context term =
     structuralConstructorApplication headTerm args =
       case filter (`constructorArityMatches` args) (Map.elems (ccConstructors context)) of
         [] -> Right Nothing
-        candidates ->
-          let strippedHead = stripTypeInsts headTerm
-              matches = filter (\candidate -> structuralConstructorHeadMatches context candidate strippedHead) candidates
-           in case matches of
-                [constructorMeta] -> Right (Just (ConstructorApplication constructorMeta [] args))
-                [] -> Right Nothing
-                _ ->
-                    Left
-                      ( BackendUnsupportedCaseShape
-                          ( "ambiguous structural constructor matches: "
-                              ++ show (map (backendConstructorName . cmBackend) matches)
-                          )
-                      )
+        candidates -> do
+          (strippedHead, headTypeArgs) <- structuralConstructorHeadTypeArgs context headTerm
+          let matches = filter (\candidate -> structuralConstructorHeadMatches context candidate strippedHead) candidates
+          case matches of
+            [constructorMeta] -> Right (Just (ConstructorApplication constructorMeta headTypeArgs args))
+            [] -> Right Nothing
+            _ ->
+              Left
+                ( BackendUnsupportedCaseShape
+                    ( "ambiguous structural constructor matches: "
+                        ++ show (map (backendConstructorName . cmBackend) matches)
+                    )
+                )
 
     constructorArityMatches constructorMeta args =
       length args == length (backendConstructorFields (cmBackend constructorMeta))
@@ -2359,6 +2359,23 @@ stripTypeInsts =
   \case
     ETyInst inner _ -> stripTypeInsts inner
     other -> other
+
+structuralConstructorHeadTypeArgs :: ConvertContext -> ElabTerm -> Either BackendConversionError (ElabTerm, [BackendType])
+structuralConstructorHeadTypeArgs context =
+  go []
+  where
+    go typeArgs =
+      \case
+        ETyInst inner inst
+          | Just ty <- appLikeInstantiationType inst -> do
+              backendTy <- convertTypeArg ty
+              go (backendTy : typeArgs) inner
+          | otherwise ->
+              go typeArgs inner
+        other -> Right (other, typeArgs)
+
+    convertTypeArg ty =
+      normalizeBackendTypeForContext context <$> convertElabType ty
 
 convertCaseApplication ::
   ConvertContext ->

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1277,7 +1277,7 @@ convertConstructorApplication context env term resultTy =
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           fields = map (substituteBackendTypes completedSubstitution) rawFields
           substitutedResultTy = recoverStructuralBackendType ownerContext (substituteBackendTypes completedSubstitution constructorResultTy)
-      unless (alphaEqBackendType substitutedResultTy effectiveResultTy) $
+      unless (constructorResultTypesMatch ownerContext typeBounds substitutedResultTy effectiveResultTy) $
         Left
           ( BackendUnsupportedCaseShape
               ( "constructor result type does not match expected result for `"
@@ -1286,7 +1286,7 @@ convertConstructorApplication context env term resultTy =
               )
           )
       argExprs <- zipWithM (convertTermExpected context env . Just) fields args
-      mapM_ (checkConstructorArgumentType constructor) (zip [0 :: Int ..] (zip fields argExprs))
+      mapM_ (checkConstructorArgumentType ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs))
       Right
         ( Just
             BackendConstruct
@@ -1303,7 +1303,7 @@ convertConstructorApplication context env term resultTy =
           inferredSubstitution <-
             matchBackendTypeParameters typeBounds dataParameters parameters Map.empty constructorResultTy effectiveResultTy
           if explicitSubstitutionAgreesWithInferred ownerContext typeBounds explicitSubstitution inferredSubstitution
-            then Just inferredSubstitution
+            then Just (Map.union explicitSubstitution inferredSubstitution)
             else Nothing
 
     explicitSubstitutionAgreesWithInferred ownerContext typeBounds explicitSubstitution inferredSubstitution =
@@ -1312,7 +1312,11 @@ convertConstructorApplication context env term resultTy =
         explicitArgumentAgrees (name, explicitTy) =
           case Map.lookup name inferredSubstitution of
             Just (BTVar inferredName)
-              | inferredName == name -> True
+              | inferredName == name ->
+                  Map.notMember inferredName typeBounds
+                    || alphaEqBackendType
+                      (resolveTypeBoundDependencies explicitTy)
+                      (resolveTypeBoundDependencies (BTVar inferredName))
             Just inferredTy ->
               alphaEqBackendType (resolveTypeBoundDependencies explicitTy) (resolveTypeBoundDependencies inferredTy)
             Nothing -> False
@@ -1321,8 +1325,8 @@ convertConstructorApplication context env term resultTy =
           recoverStructuralBackendType ownerContext
             . substituteBackendTypes (completeBackendParameterSubstitution typeBounds Map.empty)
 
-    checkConstructorArgumentType constructor (index, (expectedTy, argExpr)) =
-      unless (alphaEqBackendType (backendExprType argExpr) expectedTy) $
+    checkConstructorArgumentType ownerContext typeBounds constructor (index, (expectedTy, argExpr)) =
+      unless (constructorBoundaryTypesMatch ownerContext typeBounds (backendExprType argExpr) expectedTy) $
         Left
           ( BackendUnsupportedCaseShape
               ( "constructor argument "
@@ -1332,6 +1336,49 @@ convertConstructorApplication context env term resultTy =
                   ++ "`"
               )
           )
+
+    constructorBoundaryTypesMatch ownerContext typeBounds left right =
+      alphaEqBackendType left right
+        || alphaEqBackendType (normalizeConstructorBoundaryType ownerContext typeBounds left) (normalizeConstructorBoundaryType ownerContext typeBounds right)
+
+    constructorResultTypesMatch ownerContext typeBounds left right =
+      constructorBoundaryTypesMatch ownerContext typeBounds left right
+        || resultTypePlaceholderMatches
+          typeBounds
+          (normalizeConstructorBoundaryType ownerContext typeBounds left)
+          (normalizeConstructorBoundaryType ownerContext typeBounds right)
+
+    normalizeConstructorBoundaryType ownerContext typeBounds =
+      recoverStructuralBackendType ownerContext
+        . substituteBackendTypes (completeBackendParameterSubstitution typeBounds Map.empty)
+
+    resultTypePlaceholderMatches typeBounds actual expected =
+      case (actual, expected) of
+        (_, BTVar name)
+          | Map.notMember name typeBounds -> True
+        (BTArrow actualDom actualCod, BTArrow expectedDom expectedCod) ->
+          resultTypePlaceholderMatches typeBounds actualDom expectedDom
+            && resultTypePlaceholderMatches typeBounds actualCod expectedCod
+        (BTCon actualCon actualArgs, BTCon expectedCon expectedArgs)
+          | actualCon == expectedCon,
+            length actualArgs == length expectedArgs ->
+              and (zipWith (resultTypePlaceholderMatches typeBounds) (NE.toList actualArgs) (NE.toList expectedArgs))
+        (BTVarApp actualName actualArgs, BTVarApp expectedName expectedArgs)
+          | actualName == expectedName,
+            length actualArgs == length expectedArgs ->
+              and (zipWith (resultTypePlaceholderMatches typeBounds) (NE.toList actualArgs) (NE.toList expectedArgs))
+        (BTForall actualName actualBound actualBody, BTForall expectedName expectedBound expectedBody) ->
+          resultTypePlaceholderBoundMatches typeBounds actualBound expectedBound
+            && resultTypePlaceholderMatches
+              (Map.insert expectedName Nothing (Map.insert actualName Nothing typeBounds))
+              actualBody
+              expectedBody
+        _ -> alphaEqBackendType actual expected
+
+    resultTypePlaceholderBoundMatches _ Nothing Nothing = True
+    resultTypePlaceholderBoundMatches typeBounds (Just actual) (Just expected) =
+      resultTypePlaceholderMatches typeBounds actual expected
+    resultTypePlaceholderBoundMatches _ _ _ = False
 
 constructorApplicationTerm :: ConvertContext -> ElabTerm -> Either BackendConversionError (Maybe ConstructorApplication)
 constructorApplicationTerm context term =
@@ -2130,7 +2177,9 @@ matchBackendTypeParameters typeBounds dataParameterOrder parameterBounds =
             then Just (Map.insert name actual substitution)
             else Nothing
         Just previous
-          | alphaEqBackendType previous actual && backendParameterBoundMatches name previous substitution -> Just substitution
+          | explicitParameterSubstitutionMatches previous actual
+              && backendParameterBoundMatches name previous substitution ->
+              Just substitution
         _ -> Nothing
 
     firstJust =
@@ -2157,6 +2206,10 @@ matchBackendTypeParameters typeBounds dataParameterOrder parameterBounds =
                in typeBoundDependenciesMatch actual expectedBound || actualTypeVariableBoundMatches actual expectedBound
         _ ->
           True
+
+    explicitParameterSubstitutionMatches previous actual =
+      alphaEqBackendType previous actual
+        || typeBoundDependenciesMatch previous actual
 
     typeBoundDependenciesMatch actual expectedBound =
       alphaEqBackendType

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1931,6 +1931,7 @@ convertConstructorApplication context env term resultTy =
       initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
       resultSubstitution <-
         case constructorResultSubstitution
+          context
           ownerContext
           typeBounds
           dataParameters
@@ -1960,8 +1961,8 @@ convertConstructorApplication context env term resultTy =
               Just nominalTy -> nominalTy
               Nothing -> recoverStructuralBackendType ownerContext substitutedResultTy0
       unless
-        ( constructorResultTypesMatch ownerContext typeBounds substitutedResultTy effectiveResultTy
-            || constructorBoundaryTypesMatch ownerContext typeBounds substitutedResultTy0 effectiveResultTy
+        ( constructorResultTypesMatch context ownerContext typeBounds substitutedResultTy effectiveResultTy
+            || constructorBoundaryTypesMatch context ownerContext typeBounds substitutedResultTy0 effectiveResultTy
         )
         $
         Left
@@ -1972,7 +1973,7 @@ convertConstructorApplication context env term resultTy =
               )
           )
       argExprs <- zipWithM (convertTermExpected context env . Just) fields args
-      mapM_ (checkConstructorArgumentType ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs))
+      mapM_ (checkConstructorArgumentType context ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs))
       Right
         ( Just
             BackendConstruct
@@ -1983,16 +1984,33 @@ convertConstructorApplication context env term resultTy =
         )
     Nothing -> Right Nothing
   where
-    constructorResultSubstitution ownerContext typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy =
-      matchBackendTypeParameters typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy
+    constructorResultSubstitution globalContext ownerContext typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy =
+      matchConstructorResult constructorResultTy effectiveResultTy normalizedExplicitSubstitution
         <|> do
           inferredSubstitution <-
-            matchBackendTypeParameters typeBounds dataParameters parameters Map.empty constructorResultTy effectiveResultTy
-          if explicitSubstitutionAgreesWithInferred ownerContext typeBounds explicitSubstitution inferredSubstitution
-            then Just (Map.union explicitSubstitution inferredSubstitution)
+            matchConstructorResult constructorResultTy effectiveResultTy Map.empty
+          if explicitSubstitutionAgreesWithInferred globalContext ownerContext typeBounds explicitSubstitution inferredSubstitution
+            then Just (Map.union normalizedExplicitSubstitution inferredSubstitution)
             else Nothing
+      where
+        normalizeResultType =
+          normalizeConstructorBoundaryType ownerContext typeBounds
+            . normalizeConstructorBoundaryType globalContext typeBounds
 
-    explicitSubstitutionAgreesWithInferred ownerContext typeBounds explicitSubstitution inferredSubstitution =
+        normalizedExplicitSubstitution =
+          Map.map normalizeResultType explicitSubstitution
+
+        matchConstructorResult expected actual substitution =
+          matchBackendTypeParameters typeBounds dataParameters parameters substitution expected actual
+            <|> matchBackendTypeParameters
+              typeBounds
+              dataParameters
+              parameters
+              substitution
+              (normalizeResultType expected)
+              (normalizeResultType actual)
+
+    explicitSubstitutionAgreesWithInferred globalContext ownerContext typeBounds explicitSubstitution inferredSubstitution =
       all explicitArgumentAgrees (Map.toList explicitSubstitution)
       where
         explicitArgumentAgrees (name, explicitTy) =
@@ -2003,10 +2021,11 @@ convertConstructorApplication context env term resultTy =
 
         resolveTypeBoundDependencies =
           recoverStructuralBackendType ownerContext
+            . recoverStructuralBackendType globalContext
             . substituteBackendTypes (completeBackendParameterSubstitution typeBounds Map.empty)
 
-    checkConstructorArgumentType ownerContext typeBounds constructor (index, (expectedTy, argExpr)) =
-      unless (constructorBoundaryTypesMatch ownerContext typeBounds (backendExprType argExpr) expectedTy) $
+    checkConstructorArgumentType globalContext ownerContext typeBounds constructor (index, (expectedTy, argExpr)) =
+      unless (constructorBoundaryTypesMatch globalContext ownerContext typeBounds (backendExprType argExpr) expectedTy) $
         Left
           ( BackendUnsupportedCaseShape
               ( "constructor argument "
@@ -2017,20 +2036,40 @@ convertConstructorApplication context env term resultTy =
               )
           )
 
-    constructorBoundaryTypesMatch ownerContext typeBounds left right =
+    constructorBoundaryTypesMatch globalContext ownerContext typeBounds left right =
       alphaEqBackendType left right
-        || alphaEqBackendType (normalizeConstructorBoundaryType ownerContext typeBounds left) (normalizeConstructorBoundaryType ownerContext typeBounds right)
+        || normalizedTypesMatch (normalizeBoundaryType globalContext ownerContext typeBounds left) (normalizeBoundaryType globalContext ownerContext typeBounds right)
+      where
+        normalizedTypesMatch leftTy rightTy =
+          alphaEqBackendType leftTy rightTy
+            || maybe False (const True) (matchBackendTypeParameters typeBounds [] Map.empty Map.empty leftTy rightTy)
+            || maybe False (const True) (matchBackendTypeParameters typeBounds [] Map.empty Map.empty rightTy leftTy)
 
-    constructorResultTypesMatch ownerContext typeBounds left right =
-      constructorBoundaryTypesMatch ownerContext typeBounds left right
+    constructorResultTypesMatch globalContext ownerContext typeBounds left right =
+      constructorBoundaryTypesMatch globalContext ownerContext typeBounds left right
         || resultTypePlaceholderMatches
           typeBounds
-          (normalizeConstructorBoundaryType ownerContext typeBounds left)
-          (normalizeConstructorBoundaryType ownerContext typeBounds right)
+          (normalizeBoundaryType globalContext ownerContext typeBounds left)
+          (normalizeBoundaryType globalContext ownerContext typeBounds right)
+
+    normalizeBoundaryType globalContext ownerContext typeBounds =
+      normalizeConstructorBoundaryType ownerContext typeBounds
+        . normalizeConstructorBoundaryType globalContext typeBounds
 
     normalizeConstructorBoundaryType ownerContext typeBounds =
-      recoverStructuralBackendType ownerContext
+      nominalizeStructuralRecursiveHead ownerContext
+        . recoverStructuralBackendType ownerContext
         . substituteBackendTypes (completeBackendParameterSubstitution typeBounds Map.empty)
+
+    nominalizeStructuralRecursiveHead ownerContext ty =
+      case ty of
+        BTMu name _
+          | Just dataMeta <- structuralRecursiveDataMeta ownerContext name ->
+              case structuralMuAsDataType (backendDataParameters (dmBackend dataMeta)) name of
+                Just nominalTy -> nominalTy
+                Nothing -> ty
+        _ ->
+          ty
 
     resultTypePlaceholderMatches typeBounds actual expected =
       case (actual, expected) of

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1251,10 +1251,20 @@ convertConstructorApplication context env term resultTy =
           constructorResultTy = recoverStructuralBackendType ownerContext (backendConstructorResult constructor)
       typeBounds <- backendTypeBoundsFromEnv env
       initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
-      let resultSubstitution =
-            case matchBackendTypeParameters typeBounds dataParameters parameters initialSubstitution constructorResultTy effectiveResultTy of
-              Just substitution -> substitution
-              Nothing -> initialSubstitution
+      resultSubstitution <-
+        case firstJust
+          [ matchBackendTypeParameters typeBounds dataParameters parameters initialSubstitution constructorResultTy effectiveResultTy,
+            matchBackendTypeParameters typeBounds dataParameters parameters Map.empty constructorResultTy effectiveResultTy
+          ] of
+          Just substitution -> Right substitution
+          Nothing ->
+            Left
+              ( BackendUnsupportedCaseShape
+                  ( "constructor result type does not match expected result for `"
+                      ++ backendConstructorName constructor
+                      ++ "`"
+                  )
+              )
       substitution <-
         foldM
           (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
@@ -1263,7 +1273,7 @@ convertConstructorApplication context env term resultTy =
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           fields = map (substituteBackendTypes completedSubstitution) rawFields
           substitutedResultTy = recoverStructuralBackendType ownerContext (substituteBackendTypes completedSubstitution constructorResultTy)
-      unless (alphaEqBackendType substitutedResultTy effectiveResultTy || sameBackendDataHead substitutedResultTy effectiveResultTy) $
+      unless (alphaEqBackendType substitutedResultTy effectiveResultTy) $
         Left
           ( BackendUnsupportedCaseShape
               ( "constructor result type does not match expected result for `"
@@ -1281,19 +1291,14 @@ convertConstructorApplication context env term resultTy =
               }
         )
     Nothing -> Right Nothing
-
-sameBackendDataHead :: BackendType -> BackendType -> Bool
-sameBackendDataHead left right =
-  case (backendTypeDataHeadName left, backendTypeDataHeadName right) of
-    (Just leftName, Just rightName) -> leftName == rightName
-    _ -> False
-
-backendTypeDataHeadName :: BackendType -> Maybe String
-backendTypeDataHeadName =
-  \case
-    BTBase (BaseTy name) -> Just name
-    BTCon (BaseTy name) _ -> Just name
-    _ -> Nothing
+  where
+    firstJust =
+      \case
+        [] -> Nothing
+        candidate : rest ->
+          case candidate of
+            Just value -> Just value
+            Nothing -> firstJust rest
 
 constructorApplicationTerm :: ConvertContext -> ElabTerm -> Either BackendConversionError (Maybe ConstructorApplication)
 constructorApplicationTerm context term =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -22,7 +22,7 @@ where
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, forM, unless, when, zipWithM)
 import Control.Monad.State.Strict (StateT (StateT), get, modify, runStateT)
-import Data.List (find, intercalate, nub, sort, stripPrefix)
+import Data.List (find, intercalate, nub, stripPrefix)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -1928,31 +1928,29 @@ convertConstructorApplication context env term resultTy =
           effectiveResultTy = constructorExpectedResultType context ownerContext constructorMeta resultTy
           constructorResultTy = canonicalizeStructuralMuNames ownerContext (backendConstructorResult constructor)
       typeBounds <- backendTypeBoundsFromEnv env
-      initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
-      resultSubstitution <-
-        case constructorResultSubstitution
-          context
-          ownerContext
-          typeBounds
-          dataParameters
-          parameters
-          initialSubstitution
-          constructorResultTy
-          effectiveResultTy of
-          Just substitution -> Right substitution
-          Nothing ->
-            Left
-              ( BackendUnsupportedCaseShape
-                  ( "constructor result type does not match expected result for `"
-                      ++ backendConstructorName constructor
-                      ++ "`"
-                  )
-              )
+      initialSubstitutions <- constructorTypeApplicationSubstitutions env constructorMeta headTypeArgs
       substitution <-
-        foldM
-          (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
-          resultSubstitution
-          (zip rawFields args)
+        firstRightOr
+          (constructorResultMismatch constructor)
+          [ do
+              resultSubstitution <-
+                case constructorResultSubstitution
+                  context
+                  ownerContext
+                  typeBounds
+                  dataParameters
+                  parameters
+                  initialSubstitution
+                  constructorResultTy
+                  effectiveResultTy of
+                  Just substitution -> Right substitution
+                  Nothing -> Left (constructorResultMismatch constructor)
+              foldM
+                (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
+                resultSubstitution
+                (zip rawFields args)
+            | initialSubstitution <- initialSubstitutions
+          ]
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           fields = map (substituteBackendTypes completedSubstitution) rawFields
           substitutedResultTy0 = substituteBackendTypes completedSubstitution constructorResultTy
@@ -1984,6 +1982,13 @@ convertConstructorApplication context env term resultTy =
         )
     Nothing -> Right Nothing
   where
+    constructorResultMismatch constructor =
+      BackendUnsupportedCaseShape
+        ( "constructor result type does not match expected result for `"
+            ++ backendConstructorName constructor
+            ++ "`"
+        )
+
     constructorResultSubstitution globalContext ownerContext typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy =
       matchConstructorResult constructorResultTy effectiveResultTy normalizedExplicitSubstitution
         <|> do
@@ -2264,14 +2269,14 @@ constructorTypeParameterBoundsFor dataDecl constructor =
            | binder <- backendConstructorForalls constructor
          ]
 
-constructorTypeApplicationSubstitution ::
+constructorTypeApplicationSubstitutions ::
+  Env ->
   ConstructorMeta ->
   [BackendType] ->
-  Either BackendConversionError (Map String BackendType)
-constructorTypeApplicationSubstitution constructorMeta typeArgs =
-  if length typeArgs <= length typeApplicationNames
-    then Right (Map.fromList (zip typeApplicationNames typeArgs))
-    else
+  Either BackendConversionError [Map String BackendType]
+constructorTypeApplicationSubstitutions env constructorMeta typeArgs =
+  case usableTypeApplicationNames of
+    [] ->
       Left
         ( BackendUnsupportedCaseShape
             ( "constructor type application arity mismatch for `"
@@ -2279,42 +2284,58 @@ constructorTypeApplicationSubstitution constructorMeta typeArgs =
                 ++ "`"
             )
         )
+    names : otherNames ->
+      Right (nub (map (`substitutionFor` typeArgs) (names : otherNames)))
   where
-    typeApplicationNames = constructorTypeApplicationParameterNames constructorMeta
+    usableTypeApplicationNames =
+      filter ((>= length typeArgs) . length) typeApplicationNameOrders
+
+    typeApplicationNameOrders =
+      nub
+        ( constructorTypeApplicationParameterNames constructorMeta
+            : checkedConstructorTypeApplicationParameterNames env constructorMeta
+        )
+
+    substitutionFor names args =
+      Map.fromList (zip names args)
+
+checkedConstructorTypeApplicationParameterNames :: Env -> ConstructorMeta -> [[String]]
+checkedConstructorTypeApplicationParameterNames env constructorMeta =
+  case Map.lookup (backendConstructorName (cmBackend constructorMeta)) (termEnv env) of
+    Just constructorTy
+      | Right backendTy <- convertElabType constructorTy,
+        let (binders, _) = splitBackendForalls backendTy,
+        let names = map (\(BackendTypeAbsBinder name _) -> name) binders,
+        all (`Map.member` parameters) names ->
+          [names]
+    _ ->
+      []
+  where
+    parameters = constructorTypeParameters constructorMeta
+
+firstRightOr :: e -> [Either e a] -> Either e a
+firstRightOr fallback =
+  go Nothing
+  where
+    go firstErr =
+      \case
+        [] ->
+          maybe (Left fallback) Left firstErr
+        Right value : _ ->
+          Right value
+        Left err : rest ->
+          go (firstErr <|> Just err) rest
 
 constructorTypeApplicationParameterNames :: ConstructorMeta -> [String]
 constructorTypeApplicationParameterNames constructorMeta =
-  sort (Set.toList (freeSourceTypeVars (ctorType (cmInfo constructorMeta))))
+  [ name
+    | name <- constructorDataParameters constructorMeta,
+      Set.member name resultVariables
+  ]
     ++ map backendTypeBinderName (backendConstructorForalls (cmBackend constructorMeta))
-
-freeSourceTypeVars :: SrcType -> Set.Set String
-freeSourceTypeVars =
-  go Set.empty
   where
-    go bound =
-      \case
-        STVar name
-          | Set.member name bound -> Set.empty
-          | otherwise -> Set.singleton name
-        STArrow dom cod ->
-          go bound dom `Set.union` go bound cod
-        STBase {} ->
-          Set.empty
-        STCon _ args ->
-          foldMap (go bound) args
-        STVarApp name args ->
-          let headVars =
-                if Set.member name bound
-                  then Set.empty
-                  else Set.singleton name
-           in headVars `Set.union` foldMap (go bound) args
-        STForall name mb body ->
-          maybe Set.empty (go bound . unSrcBound) mb
-            `Set.union` go (Set.insert name bound) body
-        STMu name body ->
-          go (Set.insert name bound) body
-        STBottom ->
-          Set.empty
+    resultVariables =
+      freeBackendTypeVars (backendConstructorResult (cmBackend constructorMeta))
 
 constructorHead :: ConvertContext -> ElabTerm -> Maybe (String, [BackendType])
 constructorHead context term =
@@ -2658,12 +2679,16 @@ constructorApplicationResultType context env term =
           parameters = constructorTypeParameters constructorMeta
           constructorResultTy = canonicalizeStructuralMuNames ownerContext (backendConstructorResult constructor)
       typeBounds <- backendTypeBoundsFromEnv env
-      initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
+      initialSubstitutions <- constructorTypeApplicationSubstitutions env constructorMeta headTypeArgs
       substitution <-
-        foldM
-          (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
-          initialSubstitution
-          (zip fields args)
+        firstRightOr
+          (BackendUnsupportedCaseShape ("constructor arguments do not match type applications for `" ++ backendConstructorName constructor ++ "`"))
+          [ foldM
+              (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
+              initialSubstitution
+              (zip fields args)
+            | initialSubstitution <- initialSubstitutions
+          ]
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           resultTy0 = substituteBackendTypes completedSubstitution constructorResultTy
           resultTy =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1997,12 +1997,6 @@ convertConstructorApplication context env term resultTy =
       where
         explicitArgumentAgrees (name, explicitTy) =
           case Map.lookup name inferredSubstitution of
-            Just (BTVar inferredName)
-              | inferredName == name ->
-                  Map.notMember inferredName typeBounds
-                    || alphaEqBackendType
-                      (resolveTypeBoundDependencies explicitTy)
-                      (resolveTypeBoundDependencies (BTVar inferredName))
             Just inferredTy ->
               alphaEqBackendType (resolveTypeBoundDependencies explicitTy) (resolveTypeBoundDependencies inferredTy)
             Nothing -> False
@@ -2610,6 +2604,10 @@ structuralBackendHandlerFields =
                 BTArrow fieldTy rest -> go (fields ++ [fieldTy]) rest
                 _ -> Nothing
 
+structuralMuPayloadTypes :: BackendType -> Maybe [BackendType]
+structuralMuPayloadTypes body =
+  concat <$> structuralBackendHandlerFields body
+
 constructorApplicationResultType :: ConvertContext -> Env -> ElabTerm -> Either BackendConversionError (Maybe (BackendType, Maybe DataMeta))
 constructorApplicationResultType context env term =
   constructorApplicationTerm context term >>= \case
@@ -2966,21 +2964,26 @@ matchBackendTypeParameters typeBounds dataParameterOrder parameterBounds =
                 (zip expectedArgs actualArgs)
         _ -> Nothing
 
-    matchStructuralMuExpected leftEnv rightEnv substitution muName _body actualTy =
-      ( structuralMuAsDataType dataParameterOrder muName
+    matchStructuralMuExpected leftEnv rightEnv substitution muName body actualTy =
+      ( structuralMuAsDataTypeForBody muName body
           >>= \expectedTy -> go leftEnv rightEnv substitution expectedTy actualTy
       )
-        <|> ( structuralMuAsActualDataType muName actualTy
+        <|> ( structuralMuPayloadTypes body
+                *> structuralMuAsActualDataType muName actualTy
                 >>= \expectedTy -> go leftEnv rightEnv substitution expectedTy actualTy
             )
 
-    matchStructuralMuActual leftEnv rightEnv substitution expectedTy muName _body =
-      ( structuralMuAsDataType dataParameterOrder muName
+    matchStructuralMuActual leftEnv rightEnv substitution expectedTy muName body =
+      ( structuralMuAsDataTypeForBody muName body
           >>= \actualTy -> go leftEnv rightEnv substitution expectedTy actualTy
       )
-        <|> ( structuralMuAsActualDataType muName expectedTy
+        <|> ( structuralMuPayloadTypes body
+                *> structuralMuAsActualDataType muName expectedTy
                 >>= \actualTy -> go leftEnv rightEnv substitution expectedTy actualTy
             )
+
+    structuralMuAsDataTypeForBody muName body =
+      structuralMuPayloadTypes body *> structuralMuAsDataType dataParameterOrder muName
 
     sameTypeVar leftEnv rightEnv expectedName actualName =
       case (Map.lookup expectedName leftEnv, Map.lookup actualName rightEnv) of

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1252,10 +1252,14 @@ convertConstructorApplication context env term resultTy =
       typeBounds <- backendTypeBoundsFromEnv env
       initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
       resultSubstitution <-
-        case firstJust
-          [ matchBackendTypeParameters typeBounds dataParameters parameters initialSubstitution constructorResultTy effectiveResultTy,
-            matchBackendTypeParameters typeBounds dataParameters parameters Map.empty constructorResultTy effectiveResultTy
-          ] of
+        case constructorResultSubstitution
+          ownerContext
+          typeBounds
+          dataParameters
+          parameters
+          initialSubstitution
+          constructorResultTy
+          effectiveResultTy of
           Just substitution -> Right substitution
           Nothing ->
             Left
@@ -1282,6 +1286,7 @@ convertConstructorApplication context env term resultTy =
               )
           )
       argExprs <- zipWithM (convertTermExpected context env . Just) fields args
+      mapM_ (checkConstructorArgumentType constructor) (zip [0 :: Int ..] (zip fields argExprs))
       Right
         ( Just
             BackendConstruct
@@ -1292,13 +1297,41 @@ convertConstructorApplication context env term resultTy =
         )
     Nothing -> Right Nothing
   where
-    firstJust =
-      \case
-        [] -> Nothing
-        candidate : rest ->
-          case candidate of
-            Just value -> Just value
-            Nothing -> firstJust rest
+    constructorResultSubstitution ownerContext typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy =
+      matchBackendTypeParameters typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy
+        <|> do
+          inferredSubstitution <-
+            matchBackendTypeParameters typeBounds dataParameters parameters Map.empty constructorResultTy effectiveResultTy
+          if explicitSubstitutionAgreesWithInferred ownerContext typeBounds explicitSubstitution inferredSubstitution
+            then Just inferredSubstitution
+            else Nothing
+
+    explicitSubstitutionAgreesWithInferred ownerContext typeBounds explicitSubstitution inferredSubstitution =
+      all explicitArgumentAgrees (Map.toList explicitSubstitution)
+      where
+        explicitArgumentAgrees (name, explicitTy) =
+          case Map.lookup name inferredSubstitution of
+            Just (BTVar inferredName)
+              | inferredName == name -> True
+            Just inferredTy ->
+              alphaEqBackendType (resolveTypeBoundDependencies explicitTy) (resolveTypeBoundDependencies inferredTy)
+            Nothing -> False
+
+        resolveTypeBoundDependencies =
+          recoverStructuralBackendType ownerContext
+            . substituteBackendTypes (completeBackendParameterSubstitution typeBounds Map.empty)
+
+    checkConstructorArgumentType constructor (index, (expectedTy, argExpr)) =
+      unless (alphaEqBackendType (backendExprType argExpr) expectedTy) $
+        Left
+          ( BackendUnsupportedCaseShape
+              ( "constructor argument "
+                  ++ show index
+                  ++ " type does not match expected field for `"
+                  ++ backendConstructorName constructor
+                  ++ "`"
+              )
+          )
 
 constructorApplicationTerm :: ConvertContext -> ElabTerm -> Either BackendConversionError (Maybe ConstructorApplication)
 constructorApplicationTerm context term =
@@ -1442,7 +1475,16 @@ constructorTypeApplicationSubstitution ::
   [BackendType] ->
   Either BackendConversionError (Map String BackendType)
 constructorTypeApplicationSubstitution constructorMeta typeArgs =
-  Right (Map.fromList (zip typeApplicationNames typeArgs))
+  if length typeArgs <= length typeApplicationNames
+    then Right (Map.fromList (zip typeApplicationNames typeArgs))
+    else
+      Left
+        ( BackendUnsupportedCaseShape
+            ( "constructor type application arity mismatch for `"
+                ++ backendConstructorName (cmBackend constructorMeta)
+                ++ "`"
+            )
+        )
   where
     typeApplicationNames = constructorTypeApplicationParameterNames constructorMeta
 

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -523,11 +523,12 @@ sourceBoundToElabBound (SrcBound boundTy) =
 
 constructorBindingResultMatches :: BackendType -> ConstructorMeta -> Bool
 constructorBindingResultMatches bindingTy constructorMeta =
-  case matchBackendTypeParameters Map.empty parameters Map.empty (backendConstructorResult constructor) resultTy of
+  case matchBackendTypeParameters Map.empty dataParameters parameters Map.empty (backendConstructorResult constructor) resultTy of
     Just _ -> True
     Nothing -> False
   where
     constructor = cmBackend constructorMeta
+    dataParameters = constructorDataParameters constructorMeta
     parameters = constructorTypeParameters constructorMeta
     (_, bodyTy) = splitBackendForalls bindingTy
     (_, resultTy) = splitBackendArrows bodyTy
@@ -1243,6 +1244,7 @@ convertConstructorApplication context env term resultTy =
     Just (ConstructorApplication constructorMeta headTypeArgs args) -> do
       let constructor = cmBackend constructorMeta
           ownerContext = contextForDataMeta context (cmData constructorMeta)
+          dataParameters = constructorDataParameters constructorMeta
           parameters = constructorTypeParameters constructorMeta
           rawFields = backendConstructorFields constructor
           effectiveResultTy = recoverStructuralBackendType ownerContext (recoverStructuralBackendType context resultTy)
@@ -1250,12 +1252,12 @@ convertConstructorApplication context env term resultTy =
       typeBounds <- backendTypeBoundsFromEnv env
       initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
       let resultSubstitution =
-            case matchBackendTypeParameters typeBounds parameters initialSubstitution constructorResultTy effectiveResultTy of
+            case matchBackendTypeParameters typeBounds dataParameters parameters initialSubstitution constructorResultTy effectiveResultTy of
               Just substitution -> substitution
               Nothing -> initialSubstitution
       substitution <-
         foldM
-          (matchConstructorApplicationArgument context env typeBounds parameters)
+          (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
           resultSubstitution
           (zip rawFields args)
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
@@ -1417,6 +1419,10 @@ selectedHandlerCallMatches selectedHandler argNames body =
 constructorTypeParameters :: ConstructorMeta -> BackendParameterBounds
 constructorTypeParameters constructorMeta =
   constructorTypeParameterBoundsFor (dmBackend (cmData constructorMeta)) (cmBackend constructorMeta)
+
+constructorDataParameters :: ConstructorMeta -> [String]
+constructorDataParameters =
+  backendDataParameters . dmBackend . cmData
 
 constructorTypeParameterBoundsFor :: BackendData -> BackendConstructor -> BackendParameterBounds
 constructorTypeParameterBoundsFor dataDecl constructor =
@@ -1698,14 +1704,10 @@ structuralRecursiveDataName name = do
   let withoutPrefix = dropWhile (== '$') name
   stripSuffix "_self" withoutPrefix
 
-structuralMuAsDataType :: BackendParameterBounds -> String -> BackendType -> Maybe BackendType
-structuralMuAsDataType parameterBounds muName body = do
+structuralMuAsDataType :: [String] -> String -> Maybe BackendType
+structuralMuAsDataType dataParameterOrder muName = do
   structuralName <- structuralRecursiveDataName muName
-  let parameterArgs =
-        [ BTVar name
-          | name <- freeBackendTypeVarsInOrder body,
-            Map.member name parameterBounds
-        ]
+  let parameterArgs = map BTVar dataParameterOrder
   Just $
     case parameterArgs of
       [] -> BTBase (BaseTy structuralName)
@@ -1726,35 +1728,6 @@ structuralMuNameMatches actualName muName =
     Just structuralName -> actualName == structuralName
     Nothing -> False
 
-freeBackendTypeVarsInOrder :: BackendType -> [String]
-freeBackendTypeVarsInOrder =
-  go Set.empty []
-  where
-    go bound seen ty =
-      case ty of
-        BTVar name ->
-          addName bound seen name
-        BTArrow dom cod ->
-          go bound (go bound seen dom) cod
-        BTBase {} ->
-          seen
-        BTCon _ args ->
-          foldl (go bound) seen (NE.toList args)
-        BTVarApp name args ->
-          foldl (go bound) (addName bound seen name) (NE.toList args)
-        BTForall name mb body ->
-          let seen' = maybe seen (go bound seen) mb
-           in go (Set.insert name bound) seen' body
-        BTMu name body ->
-          go (Set.insert name bound) seen body
-        BTBottom ->
-          seen
-
-    addName bound seen name
-      | Set.member name bound = seen
-      | name `elem` seen = seen
-      | otherwise = seen ++ [name]
-
 stripSuffix :: String -> String -> Maybe String
 stripSuffix suffix value =
   reverse <$> stripPrefix (reverse suffix) (reverse value)
@@ -1763,27 +1736,29 @@ structuralBackendDataArguments :: (BackendType -> BackendType) -> DataMeta -> Ba
 structuralBackendDataArguments recoverFieldTy dataMeta body = do
   handlerFields <- structuralBackendHandlerFields body
   let dataDecl = dmBackend dataMeta
+      dataParameters = backendDataParameters dataDecl
       constructors = backendDataConstructors dataDecl
       parameterBounds =
-        Map.fromList [(name, Nothing) | name <- backendDataParameters dataDecl]
+        Map.fromList [(name, Nothing) | name <- dataParameters]
   if length handlerFields == length constructors
     then do
       substitution <-
         foldM
-          (matchConstructorFields parameterBounds)
+          (matchConstructorFields dataParameters parameterBounds)
           Map.empty
           (zip constructors handlerFields)
       let completedSubstitution = completeBackendParameterSubstitution parameterBounds substitution
-      Just [Map.findWithDefault (BTVar name) name completedSubstitution | name <- backendDataParameters dataDecl]
+      Just [Map.findWithDefault (BTVar name) name completedSubstitution | name <- dataParameters]
     else Nothing
   where
-    matchConstructorFields parameterBounds substitution (constructor, fields) =
+    matchConstructorFields dataParameters parameterBounds substitution (constructor, fields) =
       if length fields == length (backendConstructorFields constructor)
         then
           foldM
             ( \substitutionAcc (expectedTy, actualTy) ->
                 matchBackendTypeParameters
                   Map.empty
+                  dataParameters
                   (constructorParameterBounds parameterBounds constructor)
                   substitutionAcc
                   expectedTy
@@ -1835,12 +1810,13 @@ constructorApplicationResultType context env term =
       let constructor = cmBackend constructorMeta
           ownerContext = contextForDataMeta context (cmData constructorMeta)
           fields = backendConstructorFields constructor
+          dataParameters = constructorDataParameters constructorMeta
           parameters = constructorTypeParameters constructorMeta
       typeBounds <- backendTypeBoundsFromEnv env
       initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
       substitution <-
         foldM
-          (matchConstructorApplicationArgument context env typeBounds parameters)
+          (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
           initialSubstitution
           (zip fields args)
       let resultTy =
@@ -1855,18 +1831,19 @@ matchConstructorApplicationArgument ::
   ConvertContext ->
   Env ->
   BackendTypeBounds ->
+  [String] ->
   BackendParameterBounds ->
   Map String BackendType ->
   (BackendType, ElabTerm) ->
   Either BackendConversionError (Map String BackendType)
-matchConstructorApplicationArgument context env typeBounds parameters substitution (expectedTy, arg) =
+matchConstructorApplicationArgument context env typeBounds dataParameters parameters substitution (expectedTy, arg) =
   -- This is only a best-effort way to recover constructor type parameters.
   -- Expected-type conversion of the argument remains authoritative because it
   -- can canonicalize nested constructor applications before validation.
   case inferBackendType env arg of
     Right actualTy0 ->
       let actualTy = recoverStructuralBackendType context actualTy0
-       in case matchBackendTypeParameters typeBounds parameters substitution expectedTy actualTy of
+       in case matchBackendTypeParameters typeBounds dataParameters parameters substitution expectedTy actualTy of
             Just substitution' -> Right substitution'
             Nothing -> Right substitution
     Left _ -> Right substitution
@@ -1886,7 +1863,14 @@ dataMatchesScrutinee :: BackendTypeBounds -> BackendType -> DataMeta -> Bool
 dataMatchesScrutinee typeBounds scrutineeTy dataMeta =
   any
     ( \constructor ->
-        case matchBackendTypeParameters typeBounds (constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor) Map.empty (backendConstructorResult constructor) scrutineeTy of
+        case
+          matchBackendTypeParameters
+            typeBounds
+            (backendDataParameters (dmBackend dataMeta))
+            (constructorTypeParameterBoundsFor (dmBackend dataMeta) constructor)
+            Map.empty
+            (backendConstructorResult constructor)
+            scrutineeTy of
           Just _ -> True
           Nothing -> False
     )
@@ -1987,12 +1971,13 @@ zipWithMCase f constructors handlers =
 
 matchBackendTypeParameters ::
   BackendTypeBounds ->
+  [String] ->
   BackendParameterBounds ->
   Map String BackendType ->
   BackendType ->
   BackendType ->
   Maybe (Map String BackendType)
-matchBackendTypeParameters typeBounds parameterBounds =
+matchBackendTypeParameters typeBounds dataParameterOrder parameterBounds =
   go Map.empty Map.empty
   where
     go leftEnv rightEnv substitution expected actual =
@@ -2069,17 +2054,17 @@ matchBackendTypeParameters typeBounds parameterBounds =
                 (zip expectedArgs actualArgs)
         _ -> Nothing
 
-    matchStructuralMuExpected leftEnv rightEnv substitution muName body actualTy =
+    matchStructuralMuExpected leftEnv rightEnv substitution muName _body actualTy =
       firstJust
-        [ structuralMuAsDataType parameterBounds muName body
+        [ structuralMuAsDataType dataParameterOrder muName
             >>= \expectedTy -> go leftEnv rightEnv substitution expectedTy actualTy,
           structuralMuAsActualDataType muName actualTy
             >>= \expectedTy -> go leftEnv rightEnv substitution expectedTy actualTy
         ]
 
-    matchStructuralMuActual leftEnv rightEnv substitution expectedTy muName body =
+    matchStructuralMuActual leftEnv rightEnv substitution expectedTy muName _body =
       firstJust
-        [ structuralMuAsDataType parameterBounds muName body
+        [ structuralMuAsDataType dataParameterOrder muName
             >>= \actualTy -> go leftEnv rightEnv substitution expectedTy actualTy,
           structuralMuAsActualDataType muName expectedTy
             >>= \actualTy -> go leftEnv rightEnv substitution expectedTy actualTy

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 {- |
 Module      : MLF.Backend.Convert
@@ -18,9 +19,10 @@ module MLF.Backend.Convert
   )
 where
 
+import Control.Applicative ((<|>))
 import Control.Monad (foldM, forM, unless, when, zipWithM)
 import Control.Monad.State.Strict (StateT (StateT), get, modify, runStateT)
-import Data.List (find, intercalate, sort)
+import Data.List (find, intercalate, sort, stripPrefix)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -32,11 +34,14 @@ import MLF.Elab.Inst (schemeToType)
 import MLF.Elab.TypeCheck (Env (..), typeCheckWithEnv)
 import MLF.Elab.Types
   ( ElabTerm (..),
+    ElabScheme,
     ElabType,
     BoundType,
     Instantiation (..),
+    pattern Forall,
     Ty (..),
     TypeCheckError,
+    elabToBound,
     tyToElab,
   )
 import MLF.Frontend.Program.Elaborate (ElaborateScope, lowerType, mkElaborateScope)
@@ -82,6 +87,8 @@ data DataMeta = DataMeta
   { dmInfo :: DataInfo,
     dmBackend :: BackendData
   }
+
+data ConstructorApplication = ConstructorApplication ConstructorMeta [BackendType] [ElabTerm]
 
 type BackendParameterBounds = Map String (Maybe BackendType)
 
@@ -161,7 +168,7 @@ convertCheckedBinding :: ConvertContext -> Env -> CheckedModule -> CheckedBindin
 convertCheckedBinding context env checkedModule binding = do
   let bindingContext = context {ccCurrentBindingName = checkedBindingName binding}
   canonicalElabTy <- checkedBindingCanonicalType context checkedModule binding
-  bindingTy <- convertElabType canonicalElabTy
+  bindingTy <- checkedBindingCanonicalBackendType context checkedModule binding canonicalElabTy
   (expr, liftedBindings) <-
     case Map.lookup (checkedBindingName binding) (ccConstructors context) of
       Just constructorMeta
@@ -343,6 +350,8 @@ isFirstOrderValueType bound =
       True
     BTCon _ args ->
       all (isFirstOrderValueType bound) args
+    BTVarApp name args ->
+      Set.member name bound && all (isFirstOrderValueType bound) args
     BTForall {} ->
       False
     BTMu {} ->
@@ -424,14 +433,39 @@ renameFreeTermVariable needle replacement =
 
 checkedBindingCanonicalType :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError ElabType
 checkedBindingCanonicalType context checkedModule binding = do
-  let checkedTy = checkedBindingType binding
+  let checkedTy = normalizeBuiltinElabType (checkedBindingType binding)
       scope = scopeForModule context (checkedModuleName checkedModule)
   checkedBackendTy <- convertElabType checkedTy
-  canonicalTy <- sourceTypeToElabType (lowerType scope (checkedBindingSourceType binding))
-  canonicalBackendTy <- convertElabType canonicalTy
-  if alphaEqBackendType checkedBackendTy canonicalBackendTy
-    then Right canonicalTy
-    else Right checkedTy
+  case sourceTypeToElabType (lowerType scope (checkedBindingSourceType binding)) of
+    Right canonicalTy -> do
+      let canonicalTy' = normalizeBuiltinElabType canonicalTy
+      canonicalBackendTy <- convertElabType canonicalTy'
+      if alphaEqBackendType checkedBackendTy canonicalBackendTy
+        then Right canonicalTy'
+        else
+          case (checkedBackendTy, canonicalBackendTy) of
+            (BTVar {}, BTVar {}) -> Right checkedTy
+            (BTVar {}, _) -> Right canonicalTy'
+            _ -> Right checkedTy
+    Left _ -> Right checkedTy
+
+checkedBindingCanonicalBackendType :: ConvertContext -> CheckedModule -> CheckedBinding -> ElabType -> Either BackendConversionError BackendType
+checkedBindingCanonicalBackendType context checkedModule binding fallbackTy =
+  do
+    fallbackBackendTy <- convertElabType fallbackTy
+    let recoveredFallbackTy = recoverStructuralBackendType context fallbackBackendTy
+    case convertLoweredSourceType scope (checkedBindingSourceType binding) of
+      Right sourceTy ->
+        let recoveredSourceTy = recoverStructuralBackendType context sourceTy
+       in if backendTypeNeedsStructuralRecovery context sourceTy
+              || backendTypeNeedsStructuralRecovery context recoveredSourceTy
+              || backendTypeNeedsStructuralRecovery context fallbackBackendTy
+              || backendTypeNeedsStructuralRecovery context recoveredFallbackTy
+              then Right recoveredSourceTy
+              else Right fallbackBackendTy
+      Left _ -> Right recoveredFallbackTy
+  where
+    scope = scopeForModule context (checkedModuleName checkedModule)
 
 scopeForModule :: ConvertContext -> String -> ElaborateScope
 scopeForModule context moduleName =
@@ -712,7 +746,31 @@ qualifiedDataName info =
 
 buildDataMeta :: ElaborateScope -> DataInfo -> Either BackendConversionError DataMeta
 buildDataMeta scope info = do
-  constructors <- mapM (convertConstructorInfo scope) (dataConstructors info)
+  rawConstructors <- mapM (convertConstructorInfo scope) (dataConstructors info)
+  let rawData =
+        BackendData
+          { backendDataName = qualifiedDataName info,
+            backendDataParameters = dataParams info,
+            backendDataConstructors = rawConstructors
+          }
+      rawMeta =
+        DataMeta
+          { dmInfo = info,
+            dmBackend = rawData
+          }
+      recoveryContext =
+        ConvertContext
+          { ccModuleScopes = Map.empty,
+            ccConstructors = Map.empty,
+            ccBindingData = Map.empty,
+            ccData = [rawMeta],
+            ccGlobalTerms = Set.empty,
+            ccCurrentBindingName = ""
+          }
+      constructors =
+        if any backendConstructorContainsVarApp rawConstructors
+          then map (recoverBackendConstructorTypes recoveryContext) rawConstructors
+          else rawConstructors
   Right
     DataMeta
       { dmInfo = info,
@@ -723,6 +781,49 @@ buildDataMeta scope info = do
               backendDataConstructors = constructors
             }
       }
+
+recoverBackendConstructorTypes :: ConvertContext -> BackendConstructor -> BackendConstructor
+recoverBackendConstructorTypes context constructor =
+  constructor
+    { backendConstructorFields = map (recoverStructuralBackendType context) (backendConstructorFields constructor),
+      backendConstructorResult = recoverStructuralBackendType context (backendConstructorResult constructor)
+    }
+
+backendConstructorContainsVarApp :: BackendConstructor -> Bool
+backendConstructorContainsVarApp constructor =
+  any backendTypeContainsVarApp (backendConstructorFields constructor)
+    || backendTypeContainsVarApp (backendConstructorResult constructor)
+    || any (maybe False backendTypeContainsVarApp . backendTypeBinderBound) (backendConstructorForalls constructor)
+
+backendTypeContainsVarApp :: BackendType -> Bool
+backendTypeContainsVarApp =
+  \case
+    BTVar {} -> False
+    BTArrow dom cod -> backendTypeContainsVarApp dom || backendTypeContainsVarApp cod
+    BTBase {} -> False
+    BTCon _ args -> any backendTypeContainsVarApp args
+    BTVarApp {} -> True
+    BTForall _ mb body -> maybe False backendTypeContainsVarApp mb || backendTypeContainsVarApp body
+    BTMu _ body -> backendTypeContainsVarApp body
+    BTBottom -> False
+
+backendTypeNeedsStructuralRecovery :: ConvertContext -> BackendType -> Bool
+backendTypeNeedsStructuralRecovery context =
+  \case
+    BTVar {} -> False
+    BTArrow dom cod -> backendTypeNeedsStructuralRecovery context dom || backendTypeNeedsStructuralRecovery context cod
+    BTBase {} -> False
+    BTCon _ args -> any (backendTypeNeedsStructuralRecovery context) args
+    BTVarApp {} -> True
+    BTForall _ mb body -> maybe False (backendTypeNeedsStructuralRecovery context) mb || backendTypeNeedsStructuralRecovery context body
+    BTMu name body ->
+      maybe False dataMetaNeedsStructuralRecovery (structuralRecursiveDataMeta context name)
+        || backendTypeNeedsStructuralRecovery context body
+    BTBottom -> False
+
+dataMetaNeedsStructuralRecovery :: DataMeta -> Bool
+dataMetaNeedsStructuralRecovery dataMeta =
+  any backendConstructorContainsVarApp (backendDataConstructors (dmBackend dataMeta))
 
 constructorMetasForData :: DataMeta -> [ConstructorMeta]
 constructorMetasForData dataMeta =
@@ -770,9 +871,9 @@ convertSourceType =
   \case
     STVar name -> Right (BTVar name)
     STArrow dom cod -> BTArrow <$> convertSourceType dom <*> convertSourceType cod
-    STBase name -> Right (BTBase (BaseTy name))
-    STCon name args -> BTCon (BaseTy name) <$> traverse convertSourceType args
-    ty@STVarApp {} -> Left (BackendUnsupportedSourceType ty)
+    STBase name -> Right (BTBase (backendBaseTy name))
+    STCon name args -> BTCon (backendBaseTy name) <$> traverse convertSourceType args
+    STVarApp name args -> BTVarApp name <$> traverse convertSourceType args
     STForall name mb body ->
       BTForall name
         <$> traverse (convertSourceType . unSrcBound) mb
@@ -785,14 +886,103 @@ convertElabType =
   \case
     TVar name -> Right (BTVar name)
     TArrow dom cod -> BTArrow <$> convertElabType dom <*> convertElabType cod
-    TCon name args -> BTCon name <$> traverse convertElabType args
-    TBase name -> Right (BTBase name)
+    TCon (BaseTy name) args -> BTCon (backendBaseTy name) <$> traverse convertElabType args
+    TBase (BaseTy name) -> Right (BTBase (backendBaseTy name))
     TForall name mb body ->
       BTForall name
         <$> traverse (convertElabType . tyToElab) mb
         <*> convertElabType body
     TMu name body -> BTMu name <$> convertElabType body
     TBottom -> Right BTBottom
+
+backendBaseTy :: String -> BaseTy
+backendBaseTy name =
+  BaseTy $
+    case stripPrefix "<builtin>." name of
+      Just builtinName
+        | builtinName `Set.member` backendBuiltinTypeNames -> builtinName
+      _ -> name
+
+backendBuiltinTypeNames :: Set.Set String
+backendBuiltinTypeNames =
+  Set.fromList ["Bool", "Int", "String"]
+
+normalizeBuiltinElabType :: Ty v -> Ty v
+normalizeBuiltinElabType =
+  \case
+    TVar name -> TVar name
+    TArrow dom cod -> TArrow (normalizeBuiltinElabType dom) (normalizeBuiltinElabType cod)
+    TCon (BaseTy name) args -> TCon (backendBaseTy name) (fmap normalizeBuiltinElabType args)
+    TBase (BaseTy name) -> TBase (backendBaseTy name)
+    TForall name mb body ->
+      TForall name (fmap normalizeBuiltinElabType mb) (normalizeBuiltinElabType body)
+    TMu name body -> TMu name (normalizeBuiltinElabType body)
+    TBottom -> TBottom
+
+normalizeBuiltinElabScheme :: ElabScheme -> ElabScheme
+normalizeBuiltinElabScheme (Forall binders body) =
+  Forall
+    [(name, fmap normalizeBuiltinElabType mbBound) | (name, mbBound) <- binders]
+    (normalizeBuiltinElabType body)
+
+normalizeBuiltinInstantiation :: Instantiation -> Instantiation
+normalizeBuiltinInstantiation =
+  \case
+    InstId -> InstId
+    InstApp ty -> InstApp (normalizeBuiltinElabType ty)
+    InstBot ty -> InstBot (normalizeBuiltinElabType ty)
+    InstIntro -> InstIntro
+    InstElim -> InstElim
+    InstAbstr name -> InstAbstr name
+    InstUnder name inst -> InstUnder name (normalizeBuiltinInstantiation inst)
+    InstInside inst -> InstInside (normalizeBuiltinInstantiation inst)
+    InstSeq left right -> InstSeq (normalizeBuiltinInstantiation left) (normalizeBuiltinInstantiation right)
+
+normalizeBuiltinElabTerm :: ElabTerm -> ElabTerm
+normalizeBuiltinElabTerm =
+  \case
+    EVar name -> EVar name
+    ELit lit -> ELit lit
+    ELam name ty body -> ELam name (normalizeBuiltinElabType ty) (normalizeBuiltinElabTerm body)
+    EApp fun arg -> EApp (normalizeBuiltinElabTerm fun) (normalizeBuiltinElabTerm arg)
+    ELet name scheme rhs body ->
+      ELet
+        name
+        (normalizeBuiltinElabScheme scheme)
+        (normalizeBuiltinElabTerm rhs)
+        (normalizeBuiltinElabTerm body)
+    ETyAbs name mbBound body ->
+      ETyAbs name (fmap normalizeBuiltinElabType mbBound) (normalizeBuiltinElabTerm body)
+    ETyInst inner inst ->
+      ETyInst (normalizeBuiltinElabTerm inner) (normalizeBuiltinInstantiation inst)
+    ERoll ty body -> ERoll (normalizeBuiltinElabType ty) (normalizeBuiltinElabTerm body)
+    EUnroll body -> EUnroll (normalizeBuiltinElabTerm body)
+
+normalizeBuiltinEnv :: Env -> Env
+normalizeBuiltinEnv env =
+  Env
+    { termEnv = Map.map normalizeBuiltinElabType (termEnv env),
+      typeEnv = Map.map normalizeBuiltinElabType (typeEnv env)
+    }
+
+backendTypeToElabType :: BackendType -> Maybe ElabType
+backendTypeToElabType =
+  \case
+    BTVar name -> Just (TVar name)
+    BTArrow dom cod -> TArrow <$> backendTypeToElabType dom <*> backendTypeToElabType cod
+    BTBase name -> Just (TBase name)
+    BTCon name args -> TCon name <$> traverse backendTypeToElabType args
+    BTVarApp {} -> Nothing
+    BTForall name mb body ->
+      TForall name
+        <$> traverse backendTypeToBoundType mb
+        <*> backendTypeToElabType body
+    BTMu name body -> TMu name <$> backendTypeToElabType body
+    BTBottom -> Just TBottom
+
+backendTypeToBoundType :: BackendType -> Maybe BoundType
+backendTypeToBoundType ty =
+  backendTypeToElabType ty >>= either (const Nothing) Just . elabToBound
 
 convertTerm :: ConvertContext -> Env -> ElabTerm -> Either BackendConversionError BackendExpr
 convertTerm context env =
@@ -827,8 +1017,12 @@ convertSpecialTerm context env term resultTy =
         convertConstructorApplication context env term resultTy
 
 convertOrdinaryTerm :: ConvertContext -> Env -> ElabTerm -> BackendType -> Either BackendConversionError BackendExpr
-convertOrdinaryTerm context env term resultTy =
-  case term of
+convertOrdinaryTerm context env term resultTy0 =
+  let resultTy =
+        if backendTypeNeedsStructuralRecovery context resultTy0
+          then recoverStructuralBackendType context resultTy0
+          else resultTy0
+   in case term of
     EVar name ->
       Right
         BackendVar
@@ -842,12 +1036,19 @@ convertOrdinaryTerm context env term resultTy =
             backendLit = lit
           }
     ELam name paramTy body -> do
-      paramBackendTy <- convertElabType paramTy
+      paramBackendTy <-
+        case resultTy of
+          BTArrow dom _ -> Right dom
+          _ -> convertElabType paramTy
+      let paramEnvTy =
+            case backendTypeToElabType paramBackendTy of
+              Just canonicalTy -> canonicalTy
+              Nothing -> paramTy
       let bodyExpected =
             case resultTy of
               BTArrow _ cod -> Just cod
               _ -> Nothing
-      bodyExpr <- convertTermExpected context (extendTermEnv name paramTy env) bodyExpected body
+      bodyExpr <- convertTermExpected context (extendTermEnv name paramEnvTy env) bodyExpected body
       Right
         BackendLam
           { backendExprType = resultTy,
@@ -989,46 +1190,143 @@ convertConstructorApplication ::
   BackendType ->
   Either BackendConversionError (Maybe BackendExpr)
 convertConstructorApplication context env term resultTy =
+  case constructorApplicationTerm context term of
+    Just (ConstructorApplication constructorMeta headTypeArgs args) -> do
+      let constructor = cmBackend constructorMeta
+          parameters = constructorTypeParameters constructorMeta
+          rawFields = backendConstructorFields constructor
+          effectiveResultTy = recoverStructuralBackendType context resultTy
+          constructorResultTy = recoverStructuralBackendType context (backendConstructorResult constructor)
+      typeBounds <- backendTypeBoundsFromEnv env
+      initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
+      let mbResultSubstitution =
+            matchBackendTypeParameters typeBounds parameters initialSubstitution constructorResultTy effectiveResultTy
+      substitution <-
+        foldM
+          (matchConstructorApplicationArgument context env typeBounds parameters)
+          (maybe initialSubstitution id mbResultSubstitution)
+          (zip rawFields args)
+      let completedSubstitution = completeBackendParameterSubstitution parameters substitution
+          fields = map (substituteBackendTypes completedSubstitution) rawFields
+          constructResultTy =
+            case mbResultSubstitution of
+              Just _ -> effectiveResultTy
+              Nothing -> substituteBackendTypes completedSubstitution (backendConstructorResult constructor)
+      argExprs <- zipWithM (convertTermExpected context env . Just) fields args
+      Right
+        ( Just
+            BackendConstruct
+              { backendExprType = constructResultTy,
+                backendConstructName = backendConstructorName constructor,
+                backendConstructArgs = argExprs
+              }
+        )
+    Nothing -> Right Nothing
+
+constructorApplicationTerm :: ConvertContext -> ElabTerm -> Maybe ConstructorApplication
+constructorApplicationTerm context term =
   case collectApps term of
     (headTerm, args) ->
+      directConstructorApplication headTerm args
+        <|> structuralConstructorApplication headTerm args
+  where
+    directConstructorApplication headTerm args =
       case constructorHead headTerm of
-        Just (constructorName, headTypeArgs) ->
-          case Map.lookup constructorName (ccConstructors context) of
-            Just constructorMeta -> do
-              let constructor = cmBackend constructorMeta
-                  parameters = constructorTypeParameters constructorMeta
-                  rawFields = backendConstructorFields constructor
-              if length args == length rawFields
-                then do
-                  typeBounds <- backendTypeBoundsFromEnv env
-                  initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
-                  resultSubstitution <-
-                    case matchBackendTypeParameters typeBounds parameters initialSubstitution (backendConstructorResult constructor) resultTy of
-                      Just substitution -> Right substitution
-                      Nothing ->
-                        Left
-                          ( BackendUnsupportedCaseShape
-                              ("constructor result type does not match expected result for `" ++ backendConstructorName constructor ++ "`")
-                          )
-                  substitution <-
-                    foldM
-                      (matchConstructorApplicationArgument env typeBounds parameters)
-                      resultSubstitution
-                      (zip rawFields args)
-                  let completedSubstitution = completeBackendParameterSubstitution parameters substitution
-                      fields = map (substituteBackendTypes completedSubstitution) rawFields
-                  argExprs <- zipWithM (convertTermExpected context env . Just) fields args
-                  Right
-                    ( Just
-                        BackendConstruct
-                          { backendExprType = resultTy,
-                            backendConstructName = backendConstructorName constructor,
-                            backendConstructArgs = argExprs
-                          }
-                    )
-                else Right Nothing
-            Nothing -> Right Nothing
-        Nothing -> Right Nothing
+        Just (constructorName, headTypeArgs) -> do
+          constructorMeta <- Map.lookup constructorName (ccConstructors context)
+          guardConstructorArity constructorMeta args
+          Just (ConstructorApplication constructorMeta headTypeArgs args)
+        Nothing -> Nothing
+
+    structuralConstructorApplication headTerm args =
+      case filter (`constructorArityMatches` args) (Map.elems (ccConstructors context)) of
+        [] -> Nothing
+        candidates ->
+          let strippedHead = stripTypeInsts headTerm
+              matches = filter (`structuralConstructorHeadMatches` strippedHead) candidates
+           in case matches of
+                constructorMeta : _ -> Just (ConstructorApplication constructorMeta [] args)
+                [] -> Nothing
+
+    constructorArityMatches constructorMeta args =
+      length args == length (backendConstructorFields (cmBackend constructorMeta))
+
+    guardConstructorArity constructorMeta args =
+      if constructorArityMatches constructorMeta args
+        then Just ()
+        else Nothing
+
+structuralConstructorHeadMatches :: ConstructorMeta -> ElabTerm -> Bool
+structuralConstructorHeadMatches constructorMeta headTerm =
+  case collectStructuralLams fieldArity headTerm of
+    Just (argNames, ERoll resultTy rolledBody)
+      | structuralConstructorResultMatches constructorMeta resultTy ->
+          case collectStructuralLams ownerArity (stripLeadingTypeAbs rolledBody) of
+            Just (handlerNames, selectedBody) ->
+              case drop constructorIndex handlerNames of
+                selectedHandler : _ ->
+                  selectedHandlerCallMatches selectedHandler argNames selectedBody
+                [] -> False
+            Nothing -> False
+    _ -> False
+  where
+    constructor = cmBackend constructorMeta
+    fieldArity = length (backendConstructorFields constructor)
+    ownerArity = length (backendDataConstructors (dmBackend (cmData constructorMeta)))
+    constructorIndex = ctorIndex (cmInfo constructorMeta)
+
+structuralConstructorResultMatches :: ConstructorMeta -> ElabType -> Bool
+structuralConstructorResultMatches constructorMeta resultTy =
+  case convertElabType resultTy >>= backendTypeStructuralDataName of
+    Right resultDataName -> constructorDataNameMatches constructorMeta resultDataName
+    Left _ -> False
+
+constructorDataNameMatches :: ConstructorMeta -> String -> Bool
+constructorDataNameMatches constructorMeta resultDataName =
+  resultDataName == backendDataName (dmBackend dataMeta)
+    || resultDataName == symbolDefiningName (dataInfoSymbol (dmInfo dataMeta))
+  where
+    dataMeta = cmData constructorMeta
+
+backendTypeStructuralDataName :: BackendType -> Either BackendConversionError String
+backendTypeStructuralDataName =
+  \case
+    BTBase (BaseTy name) -> Right name
+    BTCon (BaseTy name) _ -> Right name
+    BTMu name _ ->
+      case structuralRecursiveDataName name of
+        Just resultDataName -> Right resultDataName
+        Nothing -> Left (BackendUnsupportedCaseShape ("unsupported structural constructor result type " ++ show name))
+    ty -> Left (BackendUnsupportedCaseShape ("unsupported constructor result type " ++ show ty))
+
+collectStructuralLams :: Int -> ElabTerm -> Maybe ([String], ElabTerm)
+collectStructuralLams expectedCount =
+  go [] expectedCount
+  where
+    go names remaining term
+      | remaining <= 0 = Just (names, term)
+      | otherwise =
+          case term of
+            ELam name _ body -> go (names ++ [name]) (remaining - 1) body
+            _ -> Nothing
+
+stripLeadingTypeAbs :: ElabTerm -> ElabTerm
+stripLeadingTypeAbs =
+  \case
+    ETyAbs _ _ body -> stripLeadingTypeAbs body
+    term -> term
+
+selectedHandlerCallMatches :: String -> [String] -> ElabTerm -> Bool
+selectedHandlerCallMatches selectedHandler argNames body =
+  case collectApps body of
+    (EVar handlerName, args) ->
+      handlerName == selectedHandler && map selectedArgName args == map Just argNames
+    _ -> False
+  where
+    selectedArgName =
+      \case
+        EVar name -> Just name
+        _ -> Nothing
 
 constructorTypeParameters :: ConstructorMeta -> BackendParameterBounds
 constructorTypeParameters constructorMeta =
@@ -1190,8 +1488,16 @@ caseScrutineeInfo context env scrutineeTerm =
     >>= \case
       Just info -> Right info
       Nothing -> do
-        scrutineeTy <- inferBackendType env scrutineeTerm
-        Right (scrutineeTy, scrutineeDataHint context scrutineeTerm)
+        scrutineeTy0 <- inferBackendType env scrutineeTerm
+        let scrutineeTy =
+              if backendTypeNeedsStructuralRecovery context scrutineeTy0
+                then recoverStructuralBackendType context scrutineeTy0
+                else scrutineeTy0
+        Right
+          ( scrutineeTy,
+            scrutineeDataHint context scrutineeTerm
+              <|> backendTypeDataMeta context scrutineeTy
+          )
 
 scrutineeDataHint :: ConvertContext -> ElabTerm -> Maybe DataMeta
 scrutineeDataHint context term =
@@ -1199,51 +1505,237 @@ scrutineeDataHint context term =
     EVar name -> Map.lookup name (ccBindingData context)
     _ -> Nothing
 
+backendTypeDataMeta :: ConvertContext -> BackendType -> Maybe DataMeta
+backendTypeDataMeta context ty =
+  case ty of
+    BTBase (BaseTy name) -> dataMetaByBackendName context name
+    BTCon (BaseTy name) _ -> dataMetaByBackendName context name
+    BTMu name _ -> structuralRecursiveDataMeta context name
+    _ -> Nothing
+
+dataMetaByBackendName :: ConvertContext -> String -> Maybe DataMeta
+dataMetaByBackendName context name =
+  find ((== name) . backendDataName . dmBackend) (ccData context)
+
+dataMetaByStructuralName :: ConvertContext -> String -> Maybe DataMeta
+dataMetaByStructuralName context name =
+  dataMetaByBackendName context name
+    <|> case [dataMeta | dataMeta <- ccData context, symbolDefiningName (dataInfoSymbol (dmInfo dataMeta)) == name] of
+      [dataMeta] -> Just dataMeta
+      _ -> Nothing
+
+recoverStructuralBackendType :: ConvertContext -> BackendType -> BackendType
+recoverStructuralBackendType context =
+  go Set.empty
+  where
+    go seen ty =
+      case ty of
+        BTVar {} -> ty
+        BTArrow dom cod -> BTArrow (go seen dom) (go seen cod)
+        BTBase {} -> ty
+        BTCon name args -> BTCon name (fmap (go seen) args)
+        BTVarApp name args -> BTVarApp name (fmap (go seen) args)
+        BTForall name mb body -> BTForall name (fmap (go seen) mb) (go seen body)
+        BTMu name body
+          | Set.member name seen -> ty
+          | Just dataMeta <- structuralRecursiveDataMeta context name,
+            Just args <- structuralBackendDataArguments (go (Set.insert name seen)) dataMeta body ->
+              backendDataType (backendDataName (dmBackend dataMeta)) args
+          | otherwise -> BTMu name (go (Set.insert name seen) body)
+        BTBottom -> BTBottom
+
+backendDataType :: String -> [BackendType] -> BackendType
+backendDataType name args =
+  case args of
+    [] -> BTBase (BaseTy name)
+    arg : rest -> BTCon (BaseTy name) (arg :| rest)
+
+structuralRecursiveDataMeta :: ConvertContext -> String -> Maybe DataMeta
+structuralRecursiveDataMeta context name =
+  structuralRecursiveDataName name >>= dataMetaByStructuralName context
+
+structuralRecursiveDataName :: String -> Maybe String
+structuralRecursiveDataName name = do
+  let withoutPrefix = dropWhile (== '$') name
+  stripSuffix "_self" withoutPrefix
+
+structuralMuAsDataType :: BackendParameterBounds -> String -> BackendType -> Maybe BackendType
+structuralMuAsDataType parameterBounds muName body = do
+  structuralName <- structuralRecursiveDataName muName
+  let parameterArgs =
+        [ BTVar name
+          | name <- freeBackendTypeVarsInOrder body,
+            Map.member name parameterBounds
+        ]
+  Just $
+    case parameterArgs of
+      [] -> BTBase (BaseTy structuralName)
+      arg : rest -> BTCon (BaseTy structuralName) (arg :| rest)
+
+structuralMuAsActualDataType :: String -> BackendType -> Maybe BackendType
+structuralMuAsActualDataType muName actual =
+  case actual of
+    BTBase (BaseTy actualName)
+      | structuralMuNameMatches actualName muName -> Just actual
+    BTCon (BaseTy actualName) _
+      | structuralMuNameMatches actualName muName -> Just actual
+    _ -> Nothing
+
+structuralMuNameMatches :: String -> String -> Bool
+structuralMuNameMatches actualName muName =
+  case structuralRecursiveDataName muName of
+    Just structuralName ->
+      actualName == structuralName
+        || unqualifiedName actualName == structuralName
+        || actualName == unqualifiedName structuralName
+        || unqualifiedName actualName == unqualifiedName structuralName
+    Nothing -> False
+
+unqualifiedName :: String -> String
+unqualifiedName =
+  reverse . takeWhile (/= '.') . reverse
+
+freeBackendTypeVarsInOrder :: BackendType -> [String]
+freeBackendTypeVarsInOrder =
+  go Set.empty []
+  where
+    go bound seen ty =
+      case ty of
+        BTVar name ->
+          addName bound seen name
+        BTArrow dom cod ->
+          go bound (go bound seen dom) cod
+        BTBase {} ->
+          seen
+        BTCon _ args ->
+          foldl (go bound) seen (NE.toList args)
+        BTVarApp name args ->
+          foldl (go bound) (addName bound seen name) (NE.toList args)
+        BTForall name mb body ->
+          let seen' = maybe seen (go bound seen) mb
+           in go (Set.insert name bound) seen' body
+        BTMu name body ->
+          go (Set.insert name bound) seen body
+        BTBottom ->
+          seen
+
+    addName bound seen name
+      | Set.member name bound = seen
+      | name `elem` seen = seen
+      | otherwise = seen ++ [name]
+
+stripSuffix :: String -> String -> Maybe String
+stripSuffix suffix value =
+  reverse <$> stripPrefix (reverse suffix) (reverse value)
+
+structuralBackendDataArguments :: (BackendType -> BackendType) -> DataMeta -> BackendType -> Maybe [BackendType]
+structuralBackendDataArguments recoverFieldTy dataMeta body = do
+  handlerFields <- structuralBackendHandlerFields body
+  let dataDecl = dmBackend dataMeta
+      constructors = backendDataConstructors dataDecl
+      parameterBounds =
+        Map.fromList [(name, Nothing) | name <- backendDataParameters dataDecl]
+  if length handlerFields == length constructors
+    then do
+      substitution <-
+        foldM
+          (matchConstructorFields parameterBounds)
+          Map.empty
+          (zip constructors handlerFields)
+      let completedSubstitution = completeBackendParameterSubstitution parameterBounds substitution
+      Just [Map.findWithDefault (BTVar name) name completedSubstitution | name <- backendDataParameters dataDecl]
+    else Nothing
+  where
+    matchConstructorFields parameterBounds substitution (constructor, fields) =
+      if length fields == length (backendConstructorFields constructor)
+        then
+          foldM
+            ( \substitutionAcc (expectedTy, actualTy) ->
+                matchBackendTypeParameters
+                  Map.empty
+                  (constructorParameterBounds parameterBounds constructor)
+                  substitutionAcc
+                  expectedTy
+                  (recoverFieldTy actualTy)
+            )
+            substitution
+            (zip (backendConstructorFields constructor) fields)
+        else Nothing
+
+    constructorParameterBounds parameterBounds constructor =
+      parameterBounds
+        `Map.union` Map.fromList
+          [ (backendTypeBinderName binder, backendTypeBinderBound binder)
+            | binder <- backendConstructorForalls constructor
+          ]
+
+structuralBackendHandlerFields :: BackendType -> Maybe [[BackendType]]
+structuralBackendHandlerFields =
+  \case
+    BTForall resultName _ handlerTy -> collectHandlers resultName handlerTy
+    _ -> Nothing
+  where
+    collectHandlers resultName =
+      go []
+      where
+        go handlers ty
+          | alphaEqBackendType ty (BTVar resultName) = Just handlers
+          | otherwise =
+              case ty of
+                BTArrow handlerTy rest -> do
+                  fields <- collectHandlerFields resultName handlerTy
+                  go (handlers ++ [fields]) rest
+                _ -> Nothing
+
+    collectHandlerFields resultName =
+      go []
+      where
+        go fields ty
+          | alphaEqBackendType ty (BTVar resultName) = Just fields
+          | otherwise =
+              case ty of
+                BTArrow fieldTy rest -> go (fields ++ [fieldTy]) rest
+                _ -> Nothing
+
 constructorApplicationResultType :: ConvertContext -> Env -> ElabTerm -> Either BackendConversionError (Maybe (BackendType, Maybe DataMeta))
 constructorApplicationResultType context env term =
-  case collectApps term of
-    (headTerm, args) ->
-      case constructorHead headTerm of
-        Just (constructorName, headTypeArgs) ->
-          case Map.lookup constructorName (ccConstructors context) of
-            Just constructorMeta
-              | length args == length fields -> do
-                  typeBounds <- backendTypeBoundsFromEnv env
-                  initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
-                  substitution <-
-                    foldM
-                      (matchConstructorApplicationArgument env typeBounds parameters)
-                      initialSubstitution
-                      (zip fields args)
-                  let resultTy =
-                        substituteBackendTypes
-                          (completeBackendParameterSubstitution parameters substitution)
-                          (backendConstructorResult constructor)
-                  Right (Just (resultTy, Just (cmData constructorMeta)))
-              | otherwise -> Right Nothing
-              where
-                constructor = cmBackend constructorMeta
-                fields = backendConstructorFields constructor
-                parameters = constructorTypeParameters constructorMeta
-            Nothing -> Right Nothing
-        Nothing -> Right Nothing
+  case constructorApplicationTerm context term of
+    Just (ConstructorApplication constructorMeta headTypeArgs args) -> do
+      let constructor = cmBackend constructorMeta
+          fields = backendConstructorFields constructor
+          parameters = constructorTypeParameters constructorMeta
+      typeBounds <- backendTypeBoundsFromEnv env
+      initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
+      substitution <-
+        foldM
+          (matchConstructorApplicationArgument context env typeBounds parameters)
+          initialSubstitution
+          (zip fields args)
+      let resultTy =
+            substituteBackendTypes
+              (completeBackendParameterSubstitution parameters substitution)
+              (backendConstructorResult constructor)
+      Right (Just (resultTy, Just (cmData constructorMeta)))
+    Nothing -> Right Nothing
 
 matchConstructorApplicationArgument ::
+  ConvertContext ->
   Env ->
   BackendTypeBounds ->
   BackendParameterBounds ->
   Map String BackendType ->
   (BackendType, ElabTerm) ->
   Either BackendConversionError (Map String BackendType)
-matchConstructorApplicationArgument env typeBounds parameters substitution (expectedTy, arg) =
+matchConstructorApplicationArgument context env typeBounds parameters substitution (expectedTy, arg) =
   -- This is only a best-effort way to recover constructor type parameters.
   -- Expected-type conversion of the argument remains authoritative because it
   -- can canonicalize nested constructor applications before validation.
   case inferBackendType env arg of
-    Right actualTy ->
-      case matchBackendTypeParameters typeBounds parameters substitution expectedTy actualTy of
-        Just substitution' -> Right substitution'
-        Nothing -> Right substitution
+    Right actualTy0 ->
+      let actualTy = recoverStructuralBackendType context actualTy0
+       in case matchBackendTypeParameters typeBounds parameters substitution expectedTy actualTy of
+            Just substitution' -> Right substitution'
+            Nothing -> Right substitution
     Left _ -> Right substitution
 
 requireCaseData :: ConvertContext -> BackendTypeBounds -> BackendType -> Either BackendConversionError DataMeta
@@ -1329,17 +1821,17 @@ collectApps =
 
 inferBackendType :: Env -> ElabTerm -> Either BackendConversionError BackendType
 inferBackendType env term =
-  case typeCheckWithEnv env term of
+  case typeCheckWithEnv (normalizeBuiltinEnv env) (normalizeBuiltinElabTerm term) of
     Right ty -> convertElabType ty
     Left err -> Left (BackendTypeCheckFailed term err)
 
 extendTermEnv :: String -> ElabType -> Env -> Env
 extendTermEnv name ty env =
-  env {termEnv = Map.insert name ty (termEnv env)}
+  env {termEnv = Map.insert name (normalizeBuiltinElabType ty) (termEnv env)}
 
 extendTypeEnv :: String -> ElabType -> Env -> Env
 extendTypeEnv name ty env =
-  env {typeEnv = Map.insert name ty (typeEnv env)}
+  env {typeEnv = Map.insert name (normalizeBuiltinElabType ty) (typeEnv env)}
 
 backendTypeBoundsFromEnv :: Env -> Either BackendConversionError BackendTypeBounds
 backendTypeBoundsFromEnv env =
@@ -1396,6 +1888,16 @@ matchBackendTypeParameters typeBounds parameterBounds =
                     )
                     substitution
                     (zip (NE.toList expectedArgs) (NE.toList actualArgs))
+            (BTMu expectedName expectedBody, actualTy@(BTBase {})) ->
+              matchStructuralMuExpected leftEnv rightEnv substitution expectedName expectedBody actualTy
+            (BTMu expectedName expectedBody, actualTy@(BTCon {})) ->
+              matchStructuralMuExpected leftEnv rightEnv substitution expectedName expectedBody actualTy
+            (expectedTy@(BTBase {}), BTMu actualName actualBody) ->
+              matchStructuralMuActual leftEnv rightEnv substitution expectedTy actualName actualBody
+            (expectedTy@(BTCon {}), BTMu actualName actualBody) ->
+              matchStructuralMuActual leftEnv rightEnv substitution expectedTy actualName actualBody
+            (BTVarApp expectedName expectedArgs, _) ->
+              matchBackendTypeApplication leftEnv rightEnv substitution expectedName (NE.toList expectedArgs) actual
             (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) -> do
               substitution' <-
                 case (expectedBound, actualBound) of
@@ -1420,6 +1922,36 @@ matchBackendTypeParameters typeBounds parameterBounds =
             _ ->
               Nothing
 
+    matchBackendTypeApplication leftEnv rightEnv substitution name expectedArgs actual =
+      case decomposeBackendTypeHead actual of
+        Just (actualHead, actualArgs)
+          | length expectedArgs == length actualArgs -> do
+              substitution' <-
+                if Map.member name parameterBounds && Map.notMember name leftEnv
+                  then insertParameterSubstitution name actualHead substitution
+                  else go leftEnv rightEnv substitution (BTVar name) actualHead
+              foldM
+                (\substitutionAcc (expectedArg, actualArg) -> go leftEnv rightEnv substitutionAcc expectedArg actualArg)
+                substitution'
+                (zip expectedArgs actualArgs)
+        _ -> Nothing
+
+    matchStructuralMuExpected leftEnv rightEnv substitution muName body actualTy =
+      firstJust
+        [ structuralMuAsDataType parameterBounds muName body
+            >>= \expectedTy -> go leftEnv rightEnv substitution expectedTy actualTy,
+          structuralMuAsActualDataType muName actualTy
+            >>= \expectedTy -> go leftEnv rightEnv substitution expectedTy actualTy
+        ]
+
+    matchStructuralMuActual leftEnv rightEnv substitution expectedTy muName body =
+      firstJust
+        [ structuralMuAsDataType parameterBounds muName body
+            >>= \actualTy -> go leftEnv rightEnv substitution expectedTy actualTy,
+          structuralMuAsActualDataType muName expectedTy
+            >>= \actualTy -> go leftEnv rightEnv substitution expectedTy actualTy
+        ]
+
     sameTypeVar leftEnv rightEnv expectedName actualName =
       case (Map.lookup expectedName leftEnv, Map.lookup actualName rightEnv) of
         (Just expectedActual, Just actualExpected) -> expectedActual == actualName && actualExpected == expectedName
@@ -1435,6 +1967,14 @@ matchBackendTypeParameters typeBounds parameterBounds =
         Just previous
           | alphaEqBackendType previous actual && backendParameterBoundMatches name previous substitution -> Just substitution
         _ -> Nothing
+
+    firstJust =
+      \case
+        [] -> Nothing
+        candidate : rest ->
+          case candidate of
+            Just value -> Just value
+            Nothing -> firstJust rest
 
     backendParameterBoundMatches name actual substitution =
       case Map.lookup name parameterBounds of
@@ -1474,6 +2014,15 @@ matchBackendTypeParameters typeBounds parameterBounds =
 
     resolvedTypeBounds =
       completeBackendParameterSubstitution typeBounds Map.empty
+
+decomposeBackendTypeHead :: BackendType -> Maybe (BackendType, [BackendType])
+decomposeBackendTypeHead ty =
+  case ty of
+    BTVar name -> Just (BTVar name, [])
+    BTBase name -> Just (BTBase name, [])
+    BTCon name args -> Just (BTBase name, NE.toList args)
+    BTVarApp name args -> Just (BTVar name, NE.toList args)
+    _ -> Nothing
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map String BackendType -> Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -74,6 +74,7 @@ data ConvertContext = ConvertContext
     ccBindingData :: Map String DataMeta,
     ccData :: [DataMeta],
     ccGlobalTerms :: Set.Set String,
+    ccCurrentModuleName :: Maybe String,
     ccCurrentBindingName :: String
   }
 
@@ -166,7 +167,11 @@ convertCheckedModule context env checkedModule = do
 
 convertCheckedBinding :: ConvertContext -> Env -> CheckedModule -> CheckedBinding -> Either BackendConversionError [BackendBinding]
 convertCheckedBinding context env checkedModule binding = do
-  let bindingContext = context {ccCurrentBindingName = checkedBindingName binding}
+  let bindingContext =
+        context
+          { ccCurrentModuleName = Just (checkedModuleName checkedModule),
+            ccCurrentBindingName = checkedBindingName binding
+          }
   canonicalElabTy <- checkedBindingCanonicalType context checkedModule binding
   bindingTy <- checkedBindingCanonicalBackendType context checkedModule binding canonicalElabTy
   (expr, liftedBindings) <-
@@ -606,6 +611,7 @@ buildConvertContext checked = do
         ccBindingData = bindingData,
         ccData = dataMetas,
         ccGlobalTerms = checkedProgramGlobalTerms checked,
+        ccCurrentModuleName = Nothing,
         ccCurrentBindingName = ""
       }
 
@@ -765,6 +771,7 @@ buildDataMeta scope info = do
             ccBindingData = Map.empty,
             ccData = [rawMeta],
             ccGlobalTerms = Set.empty,
+            ccCurrentModuleName = Just (dataModule info),
             ccCurrentBindingName = ""
           }
       constructors =
@@ -824,6 +831,10 @@ backendTypeNeedsStructuralRecovery context =
 dataMetaNeedsStructuralRecovery :: DataMeta -> Bool
 dataMetaNeedsStructuralRecovery dataMeta =
   any backendConstructorContainsVarApp (backendDataConstructors (dmBackend dataMeta))
+
+contextForDataMeta :: ConvertContext -> DataMeta -> ConvertContext
+contextForDataMeta context dataMeta =
+  context {ccCurrentModuleName = Just (dataModule (dmInfo dataMeta))}
 
 constructorMetasForData :: DataMeta -> [ConstructorMeta]
 constructorMetasForData dataMeta =
@@ -1039,7 +1050,7 @@ convertOrdinaryTerm context env term resultTy0 =
       paramBackendTy <-
         case resultTy of
           BTArrow dom _ -> Right dom
-          _ -> convertElabType paramTy
+          _ -> recoverStructuralBackendType context <$> convertElabType paramTy
       let paramEnvTy =
             case backendTypeToElabType paramBackendTy of
               Just canonicalTy -> canonicalTy
@@ -1072,9 +1083,13 @@ convertOrdinaryTerm context env term resultTy0 =
       let schemeTy = schemeToType scheme
       when (termMentionsFreeVariable name rhs) $
         Left (BackendUnsupportedRecursiveLet name)
-      bindingTy <- convertElabType schemeTy
+      bindingTy <- recoverStructuralBackendType context <$> convertElabType schemeTy
       rhsExpr <- convertTermExpected context env (Just bindingTy) rhs
-      bodyExpr <- convertTermExpected context (extendTermEnv name schemeTy env) (Just resultTy) body
+      let bindingEnvTy =
+            case backendTypeToElabType bindingTy of
+              Just canonicalTy -> canonicalTy
+              Nothing -> schemeTy
+      bodyExpr <- convertTermExpected context (extendTermEnv name bindingEnvTy env) (Just resultTy) body
       Right
         BackendLet
           { backendExprType = resultTy,
@@ -1190,45 +1205,67 @@ convertConstructorApplication ::
   BackendType ->
   Either BackendConversionError (Maybe BackendExpr)
 convertConstructorApplication context env term resultTy =
-  case constructorApplicationTerm context term of
+  constructorApplicationTerm context term >>= \case
     Just (ConstructorApplication constructorMeta headTypeArgs args) -> do
       let constructor = cmBackend constructorMeta
+          ownerContext = contextForDataMeta context (cmData constructorMeta)
           parameters = constructorTypeParameters constructorMeta
           rawFields = backendConstructorFields constructor
-          effectiveResultTy = recoverStructuralBackendType context resultTy
-          constructorResultTy = recoverStructuralBackendType context (backendConstructorResult constructor)
+          effectiveResultTy = recoverStructuralBackendType ownerContext (recoverStructuralBackendType context resultTy)
+          constructorResultTy = recoverStructuralBackendType ownerContext (backendConstructorResult constructor)
       typeBounds <- backendTypeBoundsFromEnv env
       initialSubstitution <- constructorTypeApplicationSubstitution constructorMeta headTypeArgs
-      let mbResultSubstitution =
-            matchBackendTypeParameters typeBounds parameters initialSubstitution constructorResultTy effectiveResultTy
+      let resultSubstitution =
+            case matchBackendTypeParameters typeBounds parameters initialSubstitution constructorResultTy effectiveResultTy of
+              Just substitution -> substitution
+              Nothing -> initialSubstitution
       substitution <-
         foldM
           (matchConstructorApplicationArgument context env typeBounds parameters)
-          (maybe initialSubstitution id mbResultSubstitution)
+          resultSubstitution
           (zip rawFields args)
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           fields = map (substituteBackendTypes completedSubstitution) rawFields
-          constructResultTy =
-            case mbResultSubstitution of
-              Just _ -> effectiveResultTy
-              Nothing -> substituteBackendTypes completedSubstitution (backendConstructorResult constructor)
+          substitutedResultTy = recoverStructuralBackendType ownerContext (substituteBackendTypes completedSubstitution constructorResultTy)
+      unless (alphaEqBackendType substitutedResultTy effectiveResultTy || sameBackendDataHead substitutedResultTy effectiveResultTy) $
+        Left
+          ( BackendUnsupportedCaseShape
+              ( "constructor result type does not match expected result for `"
+                  ++ backendConstructorName constructor
+                  ++ "`"
+              )
+          )
       argExprs <- zipWithM (convertTermExpected context env . Just) fields args
       Right
         ( Just
             BackendConstruct
-              { backendExprType = constructResultTy,
+              { backendExprType = effectiveResultTy,
                 backendConstructName = backendConstructorName constructor,
                 backendConstructArgs = argExprs
               }
         )
     Nothing -> Right Nothing
 
-constructorApplicationTerm :: ConvertContext -> ElabTerm -> Maybe ConstructorApplication
+sameBackendDataHead :: BackendType -> BackendType -> Bool
+sameBackendDataHead left right =
+  case (backendTypeDataHeadName left, backendTypeDataHeadName right) of
+    (Just leftName, Just rightName) -> leftName == rightName
+    _ -> False
+
+backendTypeDataHeadName :: BackendType -> Maybe String
+backendTypeDataHeadName =
+  \case
+    BTBase (BaseTy name) -> Just name
+    BTCon (BaseTy name) _ -> Just name
+    _ -> Nothing
+
+constructorApplicationTerm :: ConvertContext -> ElabTerm -> Either BackendConversionError (Maybe ConstructorApplication)
 constructorApplicationTerm context term =
   case collectApps term of
     (headTerm, args) ->
-      directConstructorApplication headTerm args
-        <|> structuralConstructorApplication headTerm args
+      case directConstructorApplication headTerm args of
+        Just application -> Right (Just application)
+        Nothing -> structuralConstructorApplication headTerm args
   where
     directConstructorApplication headTerm args =
       case constructorHead headTerm of
@@ -1240,13 +1277,20 @@ constructorApplicationTerm context term =
 
     structuralConstructorApplication headTerm args =
       case filter (`constructorArityMatches` args) (Map.elems (ccConstructors context)) of
-        [] -> Nothing
+        [] -> Right Nothing
         candidates ->
           let strippedHead = stripTypeInsts headTerm
-              matches = filter (`structuralConstructorHeadMatches` strippedHead) candidates
+              matches = filter (\candidate -> structuralConstructorHeadMatches context candidate strippedHead) candidates
            in case matches of
-                constructorMeta : _ -> Just (ConstructorApplication constructorMeta [] args)
-                [] -> Nothing
+                [constructorMeta] -> Right (Just (ConstructorApplication constructorMeta [] args))
+                [] -> Right Nothing
+                _ ->
+                  Left
+                    ( BackendUnsupportedCaseShape
+                        ( "ambiguous structural constructor matches: "
+                            ++ show (map (backendConstructorName . cmBackend) matches)
+                        )
+                    )
 
     constructorArityMatches constructorMeta args =
       length args == length (backendConstructorFields (cmBackend constructorMeta))
@@ -1256,11 +1300,11 @@ constructorApplicationTerm context term =
         then Just ()
         else Nothing
 
-structuralConstructorHeadMatches :: ConstructorMeta -> ElabTerm -> Bool
-structuralConstructorHeadMatches constructorMeta headTerm =
+structuralConstructorHeadMatches :: ConvertContext -> ConstructorMeta -> ElabTerm -> Bool
+structuralConstructorHeadMatches context constructorMeta headTerm =
   case collectStructuralLams fieldArity headTerm of
     Just (argNames, ERoll resultTy rolledBody)
-      | structuralConstructorResultMatches constructorMeta resultTy ->
+      | structuralConstructorResultMatches context constructorMeta resultTy ->
           case collectStructuralLams ownerArity (stripLeadingTypeAbs rolledBody) of
             Just (handlerNames, selectedBody) ->
               case drop constructorIndex handlerNames of
@@ -1275,18 +1319,26 @@ structuralConstructorHeadMatches constructorMeta headTerm =
     ownerArity = length (backendDataConstructors (dmBackend (cmData constructorMeta)))
     constructorIndex = ctorIndex (cmInfo constructorMeta)
 
-structuralConstructorResultMatches :: ConstructorMeta -> ElabType -> Bool
-structuralConstructorResultMatches constructorMeta resultTy =
+structuralConstructorResultMatches :: ConvertContext -> ConstructorMeta -> ElabType -> Bool
+structuralConstructorResultMatches context constructorMeta resultTy =
   case convertElabType resultTy >>= backendTypeStructuralDataName of
-    Right resultDataName -> constructorDataNameMatches constructorMeta resultDataName
+    Right resultDataName -> constructorDataNameMatches context constructorMeta resultDataName
     Left _ -> False
 
-constructorDataNameMatches :: ConstructorMeta -> String -> Bool
-constructorDataNameMatches constructorMeta resultDataName =
+constructorDataNameMatches :: ConvertContext -> ConstructorMeta -> String -> Bool
+constructorDataNameMatches context constructorMeta resultDataName =
   resultDataName == backendDataName (dmBackend dataMeta)
-    || resultDataName == symbolDefiningName (dataInfoSymbol (dmInfo dataMeta))
+    || localUnqualifiedDataNameMatches context dataMeta resultDataName
   where
     dataMeta = cmData constructorMeta
+
+localUnqualifiedDataNameMatches :: ConvertContext -> DataMeta -> String -> Bool
+localUnqualifiedDataNameMatches context dataMeta resultDataName =
+  case ccCurrentModuleName context of
+    Just moduleName ->
+      dataModule (dmInfo dataMeta) == moduleName
+        && resultDataName == symbolDefiningName (dataInfoSymbol (dmInfo dataMeta))
+    Nothing -> False
 
 backendTypeStructuralDataName :: BackendType -> Either BackendConversionError String
 backendTypeStructuralDataName =
@@ -1520,9 +1572,22 @@ dataMetaByBackendName context name =
 dataMetaByStructuralName :: ConvertContext -> String -> Maybe DataMeta
 dataMetaByStructuralName context name =
   dataMetaByBackendName context name
-    <|> case [dataMeta | dataMeta <- ccData context, symbolDefiningName (dataInfoSymbol (dmInfo dataMeta)) == name] of
-      [dataMeta] -> Just dataMeta
-      _ -> Nothing
+    <|> dataMetaByCurrentModuleStructuralName context name
+
+dataMetaByCurrentModuleStructuralName :: ConvertContext -> String -> Maybe DataMeta
+dataMetaByCurrentModuleStructuralName context name =
+  case ccCurrentModuleName context of
+    Nothing -> Nothing
+    Just moduleName ->
+      case
+        [ dataMeta
+          | dataMeta <- ccData context,
+            dataModule (dmInfo dataMeta) == moduleName,
+            symbolDefiningName (dataInfoSymbol (dmInfo dataMeta)) == name
+        ]
+      of
+        [dataMeta] -> Just dataMeta
+        _ -> Nothing
 
 recoverStructuralBackendType :: ConvertContext -> BackendType -> BackendType
 recoverStructuralBackendType context =
@@ -1584,16 +1649,8 @@ structuralMuAsActualDataType muName actual =
 structuralMuNameMatches :: String -> String -> Bool
 structuralMuNameMatches actualName muName =
   case structuralRecursiveDataName muName of
-    Just structuralName ->
-      actualName == structuralName
-        || unqualifiedName actualName == structuralName
-        || actualName == unqualifiedName structuralName
-        || unqualifiedName actualName == unqualifiedName structuralName
+    Just structuralName -> actualName == structuralName
     Nothing -> False
-
-unqualifiedName :: String -> String
-unqualifiedName =
-  reverse . takeWhile (/= '.') . reverse
 
 freeBackendTypeVarsInOrder :: BackendType -> [String]
 freeBackendTypeVarsInOrder =
@@ -1699,9 +1756,10 @@ structuralBackendHandlerFields =
 
 constructorApplicationResultType :: ConvertContext -> Env -> ElabTerm -> Either BackendConversionError (Maybe (BackendType, Maybe DataMeta))
 constructorApplicationResultType context env term =
-  case constructorApplicationTerm context term of
+  constructorApplicationTerm context term >>= \case
     Just (ConstructorApplication constructorMeta headTypeArgs args) -> do
       let constructor = cmBackend constructorMeta
+          ownerContext = contextForDataMeta context (cmData constructorMeta)
           fields = backendConstructorFields constructor
           parameters = constructorTypeParameters constructorMeta
       typeBounds <- backendTypeBoundsFromEnv env
@@ -1712,9 +1770,10 @@ constructorApplicationResultType context env term =
           initialSubstitution
           (zip fields args)
       let resultTy =
-            substituteBackendTypes
-              (completeBackendParameterSubstitution parameters substitution)
-              (backendConstructorResult constructor)
+            recoverStructuralBackendType ownerContext $
+              substituteBackendTypes
+                (completeBackendParameterSubstitution parameters substitution)
+                (backendConstructorResult constructor)
       Right (Just (resultTy, Just (cmData constructorMeta)))
     Nothing -> Right Nothing
 

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -668,12 +668,16 @@ validateBackendVariable (Just context0) name actualTy =
 
 backendTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
 backendTypeMatches mbContext expectedTy actualTy =
-  backendVariableTypeMatches typeBounds expectedTy actualTy
+  backendTypeMatchesWith True typeBounds expectedTy actualTy
   where
     typeBounds = maybe Map.empty bvcTypeBounds mbContext
 
 backendVariableTypeMatches :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
 backendVariableTypeMatches typeBounds expectedTy actualTy =
+  backendTypeMatchesWith False typeBounds expectedTy actualTy
+
+backendTypeMatchesWith :: Bool -> Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
+backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds expectedTy actualTy =
   go Set.empty expectedTy actualTy
   where
     go bound expected actual =
@@ -685,11 +689,14 @@ backendVariableTypeMatches typeBounds expectedTy actualTy =
             go bound expectedDom actualDom && go bound expectedCod actualCod
           (BTBase expectedBase, BTBase actualBase) ->
             expectedBase == actualBase
+          (BTVar expectedName, BTVar actualName)
+            | unconstrainedTypeVariable bound expectedName && unconstrainedTypeVariable bound actualName ->
+                True
           (BTVar expectedName, _)
-            | freeTypeVariable bound expectedName ->
+            | allowFreeTypeVariableInstantiation && unconstrainedTypeVariable bound expectedName ->
                 True
           (_, BTVar actualName)
-            | freeTypeVariable bound actualName ->
+            | allowFreeTypeVariableInstantiation && unconstrainedTypeVariable bound actualName ->
                 True
           (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
             expectedCon == actualCon
@@ -734,8 +741,12 @@ backendVariableTypeMatches typeBounds expectedTy actualTy =
     maybeBoundMatches _ _ _ =
       False
 
-    freeTypeVariable bound name =
-      Set.notMember name bound && Map.notMember name typeBounds
+    unconstrainedTypeVariable bound name =
+      Set.notMember name bound
+        && case Map.lookup name typeBounds of
+          Nothing -> True
+          Just Nothing -> True
+          Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
 
     typeVariableBoundMatches bound ty otherTy =
       case ty of

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -360,7 +360,7 @@ structuralMuMatchesData (BaseTy dataName) args muName body =
         | null args -> True
         | null payloadTypes -> all isBareTypeVariable args
         | otherwise -> zipAllWith alphaEqBackendType args payloadTypes
-      Nothing -> null args
+      Nothing -> False
 
 isBareTypeVariable :: BackendType -> Bool
 isBareTypeVariable =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -57,6 +57,7 @@ module MLF.Backend.IR
 where
 
 import Control.Monad (foldM, unless)
+import Data.Char (isDigit)
 import Data.List (sort)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
@@ -249,8 +250,13 @@ data BackendConstructorInfo = BackendConstructorInfo
   }
 
 data TypeVariableInstantiation
-  = RejectFreeTypeVariableInstantiation
-  | AllowContextFreeTypeVariableInstantiation
+  = RejectFreeTypeVariableInstantiation FreshenedTypeVariableAliases
+  | AllowStructuralPayloadInstantiation
+  deriving (Eq, Show)
+
+data FreshenedTypeVariableAliases
+  = RejectFreshenedTypeVariableAliases
+  | AllowFreshenedTypeVariableAliases
   deriving (Eq, Show)
 
 type BackendParameterBounds = Map.Map String (Maybe BackendType)
@@ -686,23 +692,39 @@ validateBackendVariable (Just context0) name actualTy =
     Nothing ->
       Left (BackendUnknownVariable name)
     Just expectedTy ->
-      unless (backendVariableTypeMatches context0 expectedTy actualTy) $
+      unless (backendVariableTypeMatches context0 name expectedTy actualTy) $
         Left (BackendVariableTypeMismatch name expectedTy actualTy)
 
 backendApplicationTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
 backendApplicationTypeMatches mbContext expectedTy actualTy =
-  backendTypeMatchesWith AllowContextFreeTypeVariableInstantiation typeBounds dataDecls expectedTy actualTy
+  backendTypeMatchesWith AllowStructuralPayloadInstantiation typeBounds dataDecls expectedTy actualTy
   where
     typeBounds = maybe Map.empty bvcTypeBounds mbContext
     dataDecls = bvcData <$> mbContext
 
-backendVariableTypeMatches :: BackendValidationContext -> BackendType -> BackendType -> Bool
-backendVariableTypeMatches context0 expectedTy actualTy =
-  backendTypeMatchesWith RejectFreeTypeVariableInstantiation (bvcTypeBounds context0) (Just (bvcData context0)) expectedTy actualTy
+backendVariableTypeMatches :: BackendValidationContext -> String -> BackendType -> BackendType -> Bool
+backendVariableTypeMatches context0 name expectedTy actualTy =
+  backendTypeMatchesWith
+    (RejectFreeTypeVariableInstantiation (freshenedAliasesForVariable name))
+    (bvcTypeBounds context0)
+    (Just (bvcData context0))
+    expectedTy
+    actualTy
 
 backendVariableTypeMatchesWithBounds :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
 backendVariableTypeMatchesWithBounds typeBounds expectedTy actualTy =
-  backendTypeMatchesWith RejectFreeTypeVariableInstantiation typeBounds Nothing expectedTy actualTy
+  backendTypeMatchesWith
+    (RejectFreeTypeVariableInstantiation RejectFreshenedTypeVariableAliases)
+    typeBounds
+    Nothing
+    expectedTy
+    actualTy
+
+freshenedAliasesForVariable :: String -> FreshenedTypeVariableAliases
+freshenedAliasesForVariable ('$' : _) =
+  AllowFreshenedTypeVariableAliases
+freshenedAliasesForVariable _ =
+  RejectFreshenedTypeVariableAliases
 
 backendTypeMatchesWith ::
   TypeVariableInstantiation ->
@@ -728,13 +750,7 @@ backendTypeMatchesWith typeVariableInstantiation typeBounds mbDataDecls expected
           (BTMu expectedName expectedBody, BTBase actualBase) ->
             structuralMuMatchesKnownData actualBase [] expectedName expectedBody
           (BTVar expectedName, BTVar actualName)
-            | typeVariablePairMayMatch bound expectedName actualName ->
-                True
-          (BTVar expectedName, _)
-            | typeVariableMayInstantiate bound expectedName ->
-                True
-          (_, BTVar actualName)
-            | typeVariableMayInstantiate bound actualName ->
+            | freshenedTypeVariablesMayMatch bound expectedName actualName ->
                 True
           (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
             expectedCon == actualCon
@@ -784,36 +800,31 @@ backendTypeMatchesWith typeVariableInstantiation typeBounds mbDataDecls expected
     maybeBoundMatches _ _ _ =
       False
 
-    typeVariableMayInstantiate bound name =
-      Set.notMember name bound
-        && case typeVariableInstantiation of
-          RejectFreeTypeVariableInstantiation ->
-            False
-          AllowContextFreeTypeVariableInstantiation ->
-            contextTypeVariableMayInstantiate name
-
-    contextTypeVariableMayInstantiate name =
-      case Map.lookup name typeBounds of
-        Just Nothing -> True
-        Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
-        Nothing -> False
-
-    typeVariablePairMayMatch bound expectedName actualName =
-      Set.notMember expectedName bound
-        && Set.notMember actualName bound
-        && case typeVariableInstantiation of
-          RejectFreeTypeVariableInstantiation ->
-            freeTypeVariableMayInstantiate expectedName
-              && freeTypeVariableMayInstantiate actualName
-          AllowContextFreeTypeVariableInstantiation ->
-            contextTypeVariableMayInstantiate expectedName
-              && contextTypeVariableMayInstantiate actualName
-
     freeTypeVariableMayInstantiate name =
       case Map.lookup name typeBounds of
         Nothing -> True
         Just Nothing -> True
         Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
+
+    -- Conversion may alpha-freshen generated case/evidence binders while their
+    -- lexical variable names stay fixed. Keep that escape hatch scoped to
+    -- generated variables; user-facing variables still require exact names.
+    freshenedTypeVariablesMayMatch bound expectedName actualName =
+      case typeVariableInstantiation of
+        RejectFreeTypeVariableInstantiation AllowFreshenedTypeVariableAliases ->
+          Set.notMember expectedName bound
+            && Set.notMember actualName bound
+            && freshenedNameVariant expectedName actualName
+        _ ->
+          False
+
+    freshenedNameVariant leftName rightName =
+      leftName /= rightName
+        && (isFreshenedFrom leftName rightName || isFreshenedFrom rightName leftName)
+
+    isFreshenedFrom baseName candidateName =
+      let (digits, prefix) = span isDigit (reverse candidateName)
+       in not (null digits) && reverse prefix == baseName
 
     typeVariableBoundMatches bound ty otherTy =
       case ty of
@@ -844,9 +855,9 @@ backendTypeMatchesWith typeVariableInstantiation typeBounds mbDataDecls expected
     -- strictly.
     structuralMuPayloadMayInstantiate expectedName expectedBody actualName actualBody =
       case typeVariableInstantiation of
-        RejectFreeTypeVariableInstantiation ->
+        RejectFreeTypeVariableInstantiation {} ->
           False
-        AllowContextFreeTypeVariableInstantiation ->
+        AllowStructuralPayloadInstantiation ->
           case (structuralMuDataName expectedName, structuralMuDataName actualName) of
             (Just expectedDataName, Just actualDataName)
               | expectedDataName == actualDataName ->

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -248,6 +248,11 @@ data BackendConstructorInfo = BackendConstructorInfo
     bciConstructor :: BackendConstructor
   }
 
+data TypeVariableInstantiation
+  = RejectFreeTypeVariableInstantiation
+  | AllowContextFreeTypeVariableInstantiation
+  deriving (Eq, Show)
+
 type BackendParameterBounds = Map.Map String (Maybe BackendType)
 
 literalBackendType :: Lit -> BackendType
@@ -686,47 +691,27 @@ validateBackendVariable (Just context0) name actualTy =
 
 backendApplicationTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
 backendApplicationTypeMatches mbContext expectedTy actualTy =
-  not (topLevelFreeTypeVariableWildcard expectedTy actualTy)
-    && backendTypeMatchesWith True typeBounds dataDecls expectedTy actualTy
+  backendTypeMatchesWith AllowContextFreeTypeVariableInstantiation typeBounds dataDecls expectedTy actualTy
   where
     typeBounds = maybe Map.empty bvcTypeBounds mbContext
     dataDecls = bvcData <$> mbContext
 
-    topLevelFreeTypeVariableWildcard expected actual =
-      case (expected, actual) of
-        (BTVar name, BTVar otherName) ->
-          name /= otherName
-            && applicationTypeVariableIsUnconstrained name
-            && applicationTypeVariableIsUnconstrained otherName
-        (BTVar name, _) ->
-          applicationTypeVariableIsUnconstrained name
-        (_, BTVar name) ->
-          applicationTypeVariableIsUnconstrained name
-        _ ->
-          False
-
-    applicationTypeVariableIsUnconstrained name =
-      case Map.lookup name typeBounds of
-        Nothing -> True
-        Just Nothing -> True
-        Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
-
 backendVariableTypeMatches :: BackendValidationContext -> BackendType -> BackendType -> Bool
 backendVariableTypeMatches context0 expectedTy actualTy =
-  backendTypeMatchesWith False (bvcTypeBounds context0) (Just (bvcData context0)) expectedTy actualTy
+  backendTypeMatchesWith RejectFreeTypeVariableInstantiation (bvcTypeBounds context0) (Just (bvcData context0)) expectedTy actualTy
 
 backendVariableTypeMatchesWithBounds :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
 backendVariableTypeMatchesWithBounds typeBounds expectedTy actualTy =
-  backendTypeMatchesWith False typeBounds Nothing expectedTy actualTy
+  backendTypeMatchesWith RejectFreeTypeVariableInstantiation typeBounds Nothing expectedTy actualTy
 
 backendTypeMatchesWith ::
-  Bool ->
+  TypeVariableInstantiation ->
   Map.Map String (Maybe BackendType) ->
   Maybe (Map.Map String BackendData) ->
   BackendType ->
   BackendType ->
   Bool
-backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds mbDataDecls expectedTy actualTy =
+backendTypeMatchesWith typeVariableInstantiation typeBounds mbDataDecls expectedTy actualTy =
   go Set.empty expectedTy actualTy
   where
     go bound expected actual =
@@ -743,13 +728,13 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds mbDataDecls
           (BTMu expectedName expectedBody, BTBase actualBase) ->
             structuralMuMatchesKnownData actualBase [] expectedName expectedBody
           (BTVar expectedName, BTVar actualName)
-            | unconstrainedTypeVariable bound expectedName && unconstrainedTypeVariable bound actualName ->
+            | typeVariablePairMayMatch bound expectedName actualName ->
                 True
           (BTVar expectedName, _)
-            | allowFreeTypeVariableInstantiation && unconstrainedTypeVariable bound expectedName ->
+            | typeVariableMayInstantiate bound expectedName ->
                 True
           (_, BTVar actualName)
-            | allowFreeTypeVariableInstantiation && unconstrainedTypeVariable bound actualName ->
+            | typeVariableMayInstantiate bound actualName ->
                 True
           (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
             expectedCon == actualCon
@@ -768,18 +753,19 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds mbDataDecls
                      actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
                   in go (Set.insert freshName bound) expectedBody' actualBody'
           (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
-            case (isVacuousRecursiveBinder expectedName expectedBody, isVacuousRecursiveBinder actualName actualBody) of
-              (True, True) ->
-                go bound expectedBody actualBody
-              (True, False) ->
-                recursiveBodyCompatible actualName actualBody expectedBody || go bound expectedBody actual
-              (False, True) ->
-                recursiveBodyCompatible expectedName expectedBody actualBody || go bound expected actualBody
-              (False, False) ->
-                let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
-                    expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
-                    actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
-                 in go (Set.insert freshName bound) expectedBody' actualBody'
+            structuralMuPayloadMayInstantiate expectedName expectedBody actualName actualBody
+              || case (isVacuousRecursiveBinder expectedName expectedBody, isVacuousRecursiveBinder actualName actualBody) of
+                (True, True) ->
+                  go bound expectedBody actualBody
+                (True, False) ->
+                  recursiveBodyCompatible actualName actualBody expectedBody || go bound expectedBody actual
+                (False, True) ->
+                  recursiveBodyCompatible expectedName expectedBody actualBody || go bound expected actualBody
+                (False, False) ->
+                  let freshName = freshBinderName expectedName actualName Nothing Nothing expectedBody actualBody
+                      expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                      actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                   in go (Set.insert freshName bound) expectedBody' actualBody'
           (BTMu expectedName expectedBody, _)
             | isVacuousRecursiveBinder expectedName expectedBody ->
                 go bound expectedBody actual
@@ -798,12 +784,36 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds mbDataDecls
     maybeBoundMatches _ _ _ =
       False
 
-    unconstrainedTypeVariable bound name =
+    typeVariableMayInstantiate bound name =
       Set.notMember name bound
-        && case Map.lookup name typeBounds of
-          Nothing -> True
-          Just Nothing -> True
-          Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
+        && case typeVariableInstantiation of
+          RejectFreeTypeVariableInstantiation ->
+            False
+          AllowContextFreeTypeVariableInstantiation ->
+            contextTypeVariableMayInstantiate name
+
+    contextTypeVariableMayInstantiate name =
+      case Map.lookup name typeBounds of
+        Just Nothing -> True
+        Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
+        Nothing -> False
+
+    typeVariablePairMayMatch bound expectedName actualName =
+      Set.notMember expectedName bound
+        && Set.notMember actualName bound
+        && case typeVariableInstantiation of
+          RejectFreeTypeVariableInstantiation ->
+            freeTypeVariableMayInstantiate expectedName
+              && freeTypeVariableMayInstantiate actualName
+          AllowContextFreeTypeVariableInstantiation ->
+            contextTypeVariableMayInstantiate expectedName
+              && contextTypeVariableMayInstantiate actualName
+
+    freeTypeVariableMayInstantiate name =
+      case Map.lookup name typeBounds of
+        Nothing -> True
+        Just Nothing -> True
+        Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
 
     typeVariableBoundMatches bound ty otherTy =
       case ty of
@@ -827,6 +837,113 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds mbDataDecls
                 structuralMuPayloadMatchesDataDecl typeBounds dataDecl substitution (BTMu muName body)
           _ ->
             False
+
+    -- Structural ADT payloads encode data parameters inside handler fields. Keep
+    -- that instantiation path local to matching structural encodings of the same
+    -- owner so ordinary recursive type matching still treats free variables
+    -- strictly.
+    structuralMuPayloadMayInstantiate expectedName expectedBody actualName actualBody =
+      case typeVariableInstantiation of
+        RejectFreeTypeVariableInstantiation ->
+          False
+        AllowContextFreeTypeVariableInstantiation ->
+          case (structuralMuDataName expectedName, structuralMuDataName actualName) of
+            (Just expectedDataName, Just actualDataName)
+              | expectedDataName == actualDataName ->
+                  let freshSelf =
+                        freshNameLike
+                          expectedName
+                          ( Set.unions
+                              [ Set.fromList [expectedName, actualName],
+                                Map.keysSet typeBounds,
+                                freeBackendTypeVars expectedBody,
+                                freeBackendTypeVars actualBody
+                              ]
+                          )
+                      expectedBody' = substituteBackendType expectedName (BTVar freshSelf) expectedBody
+                      actualBody' = substituteBackendType actualName (BTVar freshSelf) actualBody
+                   in case (structuralMuPayloadTypes expectedBody', structuralMuPayloadTypes actualBody') of
+                        (Just expectedPayloadTypes, Just actualPayloadTypes) ->
+                          structuralPayloadTypesMayInstantiate
+                            (Set.singleton freshSelf)
+                            expectedPayloadTypes
+                            actualPayloadTypes
+                        _ ->
+                          False
+            _ ->
+              False
+
+    structuralPayloadTypeMayInstantiate bound expected actual =
+      alphaEqBackendType expected actual
+        || case (expected, actual) of
+          (BTVar name, _)
+            | Set.notMember name bound && freeTypeVariableMayInstantiate name ->
+                True
+          (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
+            structuralPayloadTypeMayInstantiate bound expectedDom actualDom
+              && structuralPayloadTypeMayInstantiate bound expectedCod actualCod
+          (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
+            expectedCon == actualCon
+              && zipAllWith
+                (structuralPayloadTypeMayInstantiate bound)
+                (NE.toList expectedArgs)
+                (NE.toList actualArgs)
+          (BTVarApp expectedName expectedArgs, BTVarApp actualName actualArgs) ->
+            expectedName == actualName
+              && zipAllWith
+                (structuralPayloadTypeMayInstantiate bound)
+                (NE.toList expectedArgs)
+                (NE.toList actualArgs)
+          (BTForall expectedBinder expectedBound expectedForallBody, BTForall actualBinder actualBound actualForallBody) ->
+            structuralPayloadMaybeBoundMayInstantiate bound expectedBound actualBound
+              && let freshName =
+                       freshNameLike
+                         expectedBinder
+                         ( Set.unions
+                             [ Set.fromList [expectedBinder, actualBinder],
+                               Map.keysSet typeBounds,
+                               maybe Set.empty freeBackendTypeVars expectedBound,
+                               maybe Set.empty freeBackendTypeVars actualBound,
+                               freeBackendTypeVars expectedForallBody,
+                               freeBackendTypeVars actualForallBody
+                             ]
+                         )
+                     expectedForallBody' = substituteBackendType expectedBinder (BTVar freshName) expectedForallBody
+                     actualForallBody' = substituteBackendType actualBinder (BTVar freshName) actualForallBody
+                  in structuralPayloadTypeMayInstantiate (Set.insert freshName bound) expectedForallBody' actualForallBody'
+          (BTMu expectedMuName expectedMuBody, BTMu actualMuName actualMuBody) ->
+            let freshName =
+                  freshNameLike
+                    expectedMuName
+                    ( Set.unions
+                        [ Set.fromList [expectedMuName, actualMuName],
+                          Map.keysSet typeBounds,
+                          freeBackendTypeVars expectedMuBody,
+                          freeBackendTypeVars actualMuBody
+                        ]
+                    )
+                expectedMuBody' = substituteBackendType expectedMuName (BTVar freshName) expectedMuBody
+                actualMuBody' = substituteBackendType actualMuName (BTVar freshName) actualMuBody
+             in structuralPayloadTypeMayInstantiate (Set.insert freshName bound) expectedMuBody' actualMuBody'
+          _ ->
+            go bound expected actual
+
+    structuralPayloadTypesMayInstantiate bound expectedPayloadTypes actualPayloadTypes =
+      zipAllWith
+        (structuralPayloadTypeMayInstantiate bound)
+        expectedPayloadTypes
+        actualPayloadTypes
+        || zipAllWith
+          (structuralPayloadTypeMayInstantiate bound)
+          actualPayloadTypes
+          expectedPayloadTypes
+
+    structuralPayloadMaybeBoundMayInstantiate _ Nothing Nothing =
+      True
+    structuralPayloadMaybeBoundMayInstantiate bound (Just expectedBound) (Just actualBound) =
+      structuralPayloadTypeMayInstantiate bound expectedBound actualBound
+    structuralPayloadMaybeBoundMayInstantiate _ _ _ =
+      False
 
     freshBinderName leftName rightName leftBound rightBound leftBody rightBody =
       freshNameLike

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -415,9 +415,7 @@ freeBackendTypeVarsInOrder =
 structuralMuNameMatches :: String -> String -> Bool
 structuralMuNameMatches dataName muName =
   case structuralMuDataName muName of
-    Just structuralName ->
-      dataName == structuralName
-        || (isUnqualifiedName structuralName && unqualifiedName dataName == structuralName)
+    Just structuralName -> dataName == structuralName
     Nothing -> False
 
 structuralMuDataName :: String -> Maybe String
@@ -436,14 +434,6 @@ stripPrefixSimple _ [] =
 stripPrefixSimple (expected : expectedRest) (actual : actualRest)
   | expected == actual = stripPrefixSimple expectedRest actualRest
   | otherwise = Nothing
-
-isUnqualifiedName :: String -> Bool
-isUnqualifiedName =
-  notElem '.'
-
-unqualifiedName :: String -> String
-unqualifiedName =
-  reverse . takeWhile (/= '.') . reverse
 
 structuralMuPayloadTypes :: BackendType -> Maybe [BackendType]
 structuralMuPayloadTypes =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -1028,11 +1028,18 @@ validateBackendConstructorUse (Just context0) name resultTy args =
         substitution
         resultTy
         (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
-      _ <-
+      finalSubstitution <-
         foldM
           (validateBackendConstructorArgument (bvcTypeBounds context0) (Just (bvcData context0)) dataParameters parameters name)
           substitution
           (zip [0 ..] (zip fields args))
+      validateBackendConstructorResultSubstitution
+        (bvcTypeBounds context0)
+        (Just (bvcData context0))
+        constructorInfo
+        finalSubstitution
+        resultTy
+        (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
       pure ()
 
 validateBackendConstructorArgument ::
@@ -1317,6 +1324,25 @@ validateBackendConstructorStructuralPayload ::
 validateBackendConstructorStructuralPayload typeBounds constructorInfo substitution ty mismatchError =
   unless (backendConstructorStructuralPayloadMatches typeBounds constructorInfo substitution ty) $
     Left mismatchError
+
+validateBackendConstructorResultSubstitution ::
+  Map.Map String (Maybe BackendType) ->
+  Maybe (Map.Map String BackendData) ->
+  BackendConstructorInfo ->
+  Map.Map String BackendType ->
+  BackendType ->
+  BackendValidationError ->
+  Either BackendValidationError ()
+validateBackendConstructorResultSubstitution typeBounds mbDataDecls constructorInfo substitution resultTy mismatchError =
+  unless (backendStructuralDataBoundaryMatches typeBounds mbDataDecls substitutedResultTy resultTy) $
+    Left mismatchError
+  where
+    constructor =
+      bciConstructor constructorInfo
+    completedSubstitution =
+      completeBackendParameterSubstitution (constructorTypeParameterBounds constructorInfo) substitution
+    substitutedResultTy =
+      substituteBackendTypes completedSubstitution (backendConstructorResult constructor)
 
 backendConstructorStructuralPayloadMatches ::
   Map.Map String (Maybe BackendType) ->

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -235,13 +235,16 @@ data BackendValidationError
 
 data BackendValidationContext = BackendValidationContext
   { bvcGlobals :: Map.Map String BackendType,
+    bvcData :: Map.Map String BackendData,
     bvcConstructors :: Map.Map String BackendConstructorInfo,
     bvcLocals :: Map.Map String BackendType,
     bvcTypeBounds :: Map.Map String (Maybe BackendType)
   }
 
 data BackendConstructorInfo = BackendConstructorInfo
-  { bciDataParameters :: [String],
+  { bciDataName :: String,
+    bciDataParameters :: [String],
+    bciDataConstructors :: [BackendConstructor],
     bciConstructor :: BackendConstructor
   }
 
@@ -357,7 +360,7 @@ structuralMuMatchesData (BaseTy dataName) args muName body =
   structuralMuNameMatches dataName muName
     && case structuralMuPayloadTypes body of
       Just payloadTypes
-        | null args -> True
+        | null args -> null payloadTypes
         | null payloadTypes -> all isBareTypeVariable args
         | otherwise -> zipAllWith alphaEqBackendType args payloadTypes
       Nothing -> False
@@ -408,24 +411,32 @@ stripPrefixSimple (expected : expectedRest) (actual : actualRest)
   | otherwise = Nothing
 
 structuralMuPayloadTypes :: BackendType -> Maybe [BackendType]
-structuralMuPayloadTypes =
+structuralMuPayloadTypes body =
+  concat <$> structuralMuPayloadHandlers body
+
+structuralMuHandlerTypes :: BackendType -> Maybe (String, [BackendType])
+structuralMuHandlerTypes =
   \case
-    BTForall resultName _ handlerTy ->
-      concat <$> collectHandlers resultName handlerTy
+    BTForall resultName _ handlerTy -> do
+      handlers <- collectHandlerTypes resultName handlerTy
+      Just (resultName, handlers)
     _ -> Nothing
   where
-    collectHandlers resultName =
+    collectHandlerTypes resultName =
       go []
       where
         go handlers ty
           | alphaEqBackendType ty (BTVar resultName) = Just handlers
           | otherwise =
               case ty of
-                BTArrow handlerTy rest -> do
-                  fields <- collectHandlerFields resultName handlerTy
-                  go (handlers ++ [fields]) rest
+                BTArrow handlerTy rest -> go (handlers ++ [handlerTy]) rest
                 _ -> Nothing
 
+structuralMuPayloadHandlers :: BackendType -> Maybe [[BackendType]]
+structuralMuPayloadHandlers body = do
+  (resultName, handlers) <- structuralMuHandlerTypes body
+  traverse (collectHandlerFields resultName) handlers
+  where
     collectHandlerFields resultName =
       go []
       where
@@ -535,7 +546,13 @@ validateBackendProgram program = do
     bindings = concatMap backendModuleBindings modules0
     constructors = concatMap backendDataConstructors (concatMap backendModuleData modules0)
     constructorInfos =
-      [ (backendConstructorName constructor, BackendConstructorInfo (backendDataParameters dataDecl) constructor)
+      [ ( backendConstructorName constructor,
+          BackendConstructorInfo
+            (backendDataName dataDecl)
+            (backendDataParameters dataDecl)
+            (backendDataConstructors dataDecl)
+            constructor
+        )
         | dataDecl <- concatMap backendModuleData modules0,
           constructor <- backendDataConstructors dataDecl
       ]
@@ -544,6 +561,7 @@ validateBackendProgram program = do
         { bvcGlobals =
             Map.fromList [(backendBindingName binding, backendBindingType binding) | binding <- bindings]
               `Map.union` backendRuntimePrimitiveTypes,
+          bvcData = Map.fromList [(backendDataName dataDecl, dataDecl) | dataDecl <- concatMap backendModuleData modules0],
           bvcConstructors = Map.fromList constructorInfos,
           bvcLocals = Map.empty,
           bvcTypeBounds = Map.empty
@@ -663,21 +681,32 @@ validateBackendVariable (Just context0) name actualTy =
     Nothing ->
       Left (BackendUnknownVariable name)
     Just expectedTy ->
-      unless (backendVariableTypeMatches (bvcTypeBounds context0) expectedTy actualTy) $
+      unless (backendVariableTypeMatches context0 expectedTy actualTy) $
         Left (BackendVariableTypeMismatch name expectedTy actualTy)
 
 backendTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
 backendTypeMatches mbContext expectedTy actualTy =
-  backendTypeMatchesWith True typeBounds expectedTy actualTy
+  backendTypeMatchesWith True typeBounds dataDecls expectedTy actualTy
   where
     typeBounds = maybe Map.empty bvcTypeBounds mbContext
+    dataDecls = bvcData <$> mbContext
 
-backendVariableTypeMatches :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
-backendVariableTypeMatches typeBounds expectedTy actualTy =
-  backendTypeMatchesWith False typeBounds expectedTy actualTy
+backendVariableTypeMatches :: BackendValidationContext -> BackendType -> BackendType -> Bool
+backendVariableTypeMatches context0 expectedTy actualTy =
+  backendTypeMatchesWith False (bvcTypeBounds context0) (Just (bvcData context0)) expectedTy actualTy
 
-backendTypeMatchesWith :: Bool -> Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
-backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds expectedTy actualTy =
+backendVariableTypeMatchesWithBounds :: Map.Map String (Maybe BackendType) -> BackendType -> BackendType -> Bool
+backendVariableTypeMatchesWithBounds typeBounds expectedTy actualTy =
+  backendTypeMatchesWith False typeBounds Nothing expectedTy actualTy
+
+backendTypeMatchesWith ::
+  Bool ->
+  Map.Map String (Maybe BackendType) ->
+  Maybe (Map.Map String BackendData) ->
+  BackendType ->
+  BackendType ->
+  Bool
+backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds mbDataDecls expectedTy actualTy =
   go Set.empty expectedTy actualTy
   where
     go bound expected actual =
@@ -689,6 +718,10 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds expectedTy 
             go bound expectedDom actualDom && go bound expectedCod actualCod
           (BTBase expectedBase, BTBase actualBase) ->
             expectedBase == actualBase
+          (BTBase expectedBase, BTMu actualName actualBody) ->
+            structuralMuMatchesKnownData expectedBase [] actualName actualBody
+          (BTMu expectedName expectedBody, BTBase actualBase) ->
+            structuralMuMatchesKnownData actualBase [] expectedName expectedBody
           (BTVar expectedName, BTVar actualName)
             | unconstrainedTypeVariable bound expectedName && unconstrainedTypeVariable bound actualName ->
                 True
@@ -701,6 +734,10 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds expectedTy 
           (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
             expectedCon == actualCon
               && zipAllWith (go bound) (NE.toList expectedArgs) (NE.toList actualArgs)
+          (BTCon expectedCon expectedArgs, BTMu actualName actualBody) ->
+            structuralMuMatchesKnownData expectedCon (NE.toList expectedArgs) actualName actualBody
+          (BTMu expectedName expectedBody, BTCon actualCon actualArgs) ->
+            structuralMuMatchesKnownData actualCon (NE.toList actualArgs) expectedName expectedBody
           (BTVarApp expectedName expectedArgs, BTVarApp actualName actualArgs) ->
             expectedName == actualName
               && zipAllWith (go bound) (NE.toList expectedArgs) (NE.toList actualArgs)
@@ -760,6 +797,16 @@ backendTypeMatchesWith allowFreeTypeVariableInstantiation typeBounds expectedTy 
                   False
         _ ->
           False
+
+    structuralMuMatchesKnownData base@(BaseTy dataName) args muName body =
+      structuralMuMatchesData base args muName body
+        || case mbDataDecls >>= Map.lookup dataName of
+          Just dataDecl
+            | structuralMuNameMatches dataName muName,
+              Just substitution <- structuralDataArgumentSubstitution dataDecl args ->
+                structuralMuPayloadMatchesDataDecl typeBounds dataDecl substitution (BTMu muName body)
+          _ ->
+            False
 
     freshBinderName leftName rightName leftBound rightBound leftBody rightBody =
       freshNameLike
@@ -827,30 +874,42 @@ validateBackendConstructorUse (Just context0) name resultTy args =
         case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) dataParameters parameters Map.empty (backendConstructorResult constructor) resultTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
+      validateBackendConstructorStructuralPayload
+        (bvcTypeBounds context0)
+        constructorInfo
+        substitution
+        (backendConstructorResult constructor)
+        (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
+      validateBackendConstructorStructuralPayload
+        (bvcTypeBounds context0)
+        constructorInfo
+        substitution
+        resultTy
+        (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
       _ <-
         foldM
-          (validateBackendConstructorArgument (bvcTypeBounds context0) dataParameters parameters name)
+          (validateBackendConstructorArgument (bvcTypeBounds context0) (Just (bvcData context0)) dataParameters parameters name)
           substitution
           (zip [0 ..] (zip fields args))
       pure ()
 
 validateBackendConstructorArgument ::
   Map.Map String (Maybe BackendType) ->
+  Maybe (Map.Map String BackendData) ->
   [String] ->
   BackendParameterBounds ->
   String ->
   Map.Map String BackendType ->
   (Int, (BackendType, BackendExpr)) ->
   Either BackendValidationError (Map.Map String BackendType)
-validateBackendConstructorArgument typeBounds dataParameters parameters name substitution (index0, (expectedTy, arg)) =
+validateBackendConstructorArgument typeBounds mbDataDecls dataParameters parameters name substitution (index0, (expectedTy, arg)) =
   case matchBackendTypeParametersWithTypeBounds typeBounds dataParameters parameters substitution expectedTy (backendExprType arg) of
     Just substitution' ->
       pure substitution'
     Nothing ->
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           substitutedExpectedTy = substituteBackendTypes completedSubstitution expectedTy
-       in if backendTypeContainsVarApp expectedTy
-            && backendVariableTypeMatches typeBounds substitutedExpectedTy (backendExprType arg)
+       in if backendConstructorFieldTypeMatches substitutedExpectedTy
             then pure substitution
             else
               Left
@@ -860,6 +919,12 @@ validateBackendConstructorArgument typeBounds dataParameters parameters name sub
                     substitutedExpectedTy
                     (backendExprType arg)
                 )
+  where
+    backendConstructorFieldTypeMatches substitutedExpectedTy =
+      ( backendTypeContainsVarApp expectedTy
+          && backendVariableTypeMatchesWithBounds typeBounds substitutedExpectedTy (backendExprType arg)
+      )
+        || backendStructuralDataBoundaryMatches typeBounds mbDataDecls substitutedExpectedTy (backendExprType arg)
 
 backendTypeContainsVarApp :: BackendType -> Bool
 backendTypeContainsVarApp =
@@ -872,6 +937,125 @@ backendTypeContainsVarApp =
     BTForall _ mb body -> maybe False backendTypeContainsVarApp mb || backendTypeContainsVarApp body
     BTMu _ body -> backendTypeContainsVarApp body
     BTBottom -> False
+
+backendStructuralDataBoundaryMatches ::
+  Map.Map String (Maybe BackendType) ->
+  Maybe (Map.Map String BackendData) ->
+  BackendType ->
+  BackendType ->
+  Bool
+backendStructuralDataBoundaryMatches typeBounds mbDataDecls expectedTy actualTy =
+  go expectedTy actualTy
+  where
+    go expected actual =
+      alphaEqBackendType expected actual
+        || case (expected, actual) of
+          (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
+            go expectedDom actualDom && go expectedCod actualCod
+          (BTBase expectedBase, BTBase actualBase) ->
+            expectedBase == actualBase
+          (BTBase expectedBase, BTMu actualName actualBody) ->
+            structuralMuMatchesKnownData expectedBase [] actualName actualBody
+          (BTMu expectedName expectedBody, BTBase actualBase) ->
+            structuralMuMatchesKnownData actualBase [] expectedName expectedBody
+          (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
+            expectedCon == actualCon
+              && zipAllWith go (NE.toList expectedArgs) (NE.toList actualArgs)
+          (BTCon expectedCon expectedArgs, BTMu actualName actualBody) ->
+            structuralMuMatchesKnownData expectedCon (NE.toList expectedArgs) actualName actualBody
+          (BTMu expectedName expectedBody, BTCon actualCon actualArgs) ->
+            structuralMuMatchesKnownData actualCon (NE.toList actualArgs) expectedName expectedBody
+          (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
+            structuralMuBodiesMatchKnownData expectedName expectedBody actualName actualBody
+          (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) ->
+            maybeBoundaryMatches expectedBound actualBound
+              && let freshName = freshBinderName expectedName actualName expectedBound actualBound expectedBody actualBody
+                     expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                     actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                  in go expectedBody' actualBody'
+          (BTBottom, BTBottom) ->
+            True
+          _ ->
+            False
+
+    structuralMuBodiesMatchKnownData expectedName expectedBody actualName actualBody =
+      case
+        ( structuralMuDataName expectedName,
+          structuralMuDataName actualName,
+          structuralMuHandlerTypes expectedBody,
+          structuralMuHandlerTypes actualBody
+        )
+        of
+          ( Just expectedDataName,
+            Just actualDataName,
+            Just (expectedResultName, expectedHandlers),
+            Just (actualResultName, actualHandlers)
+            )
+              | expectedDataName == actualDataName,
+                Just dataDecl <- mbDataDecls >>= Map.lookup expectedDataName,
+                length expectedHandlers == length actualHandlers,
+                length expectedHandlers == length (backendDataConstructors dataDecl) ->
+                  let freshSelf =
+                        freshNameLike
+                          expectedName
+                          ( Set.unions
+                              [ Set.fromList [expectedName, actualName],
+                                freeBackendTypeVars expectedBody,
+                                freeBackendTypeVars actualBody
+                              ]
+                          )
+                      freshResult =
+                        freshNameLike
+                          expectedResultName
+                          ( Set.unions
+                              [ Set.fromList [expectedResultName, actualResultName, freshSelf],
+                                freeBackendTypeVars expectedBody,
+                                freeBackendTypeVars actualBody
+                              ]
+                          )
+                      normalizeHandler selfName resultName =
+                        substituteBackendTypes
+                          ( Map.fromList
+                              [ (selfName, BTVar freshSelf),
+                                (resultName, BTVar freshResult)
+                              ]
+                          )
+                   in zipAllWith
+                        go
+                        (map (normalizeHandler expectedName expectedResultName) expectedHandlers)
+                        (map (normalizeHandler actualName actualResultName) actualHandlers)
+          _ ->
+            False
+
+    maybeBoundaryMatches Nothing Nothing =
+      True
+    maybeBoundaryMatches (Just expectedBound) (Just actualBound) =
+      go expectedBound actualBound
+    maybeBoundaryMatches _ _ =
+      False
+
+    structuralMuMatchesKnownData base@(BaseTy dataName) args muName body =
+      structuralMuMatchesData base args muName body
+        || case mbDataDecls >>= Map.lookup dataName of
+          Just dataDecl
+            | structuralMuNameMatches dataName muName,
+              Just substitution <- structuralDataArgumentSubstitution dataDecl args ->
+                structuralMuPayloadMatchesDataDecl typeBounds dataDecl substitution (BTMu muName body)
+          _ ->
+            False
+
+    freshBinderName leftName rightName leftBound rightBound leftBody rightBody =
+      freshNameLike
+        leftName
+        ( Set.unions
+            [ Set.fromList [leftName, rightName],
+              Map.keysSet typeBounds,
+              maybe Set.empty freeBackendTypeVars leftBound,
+              maybe Set.empty freeBackendTypeVars rightBound,
+              freeBackendTypeVars leftBody,
+              freeBackendTypeVars rightBody
+            ]
+        )
 
 validateBackendAlternative :: Maybe BackendValidationContext -> BackendType -> BackendType -> BackendAlternative -> Either BackendValidationError ()
 validateBackendAlternative mbContext scrutineeTy resultTy alternative = do
@@ -900,6 +1084,18 @@ validateBackendPattern (Just context0) scrutineeTy (BackendConstructorPattern na
         case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) dataParameters parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
+      validateBackendConstructorStructuralPayload
+        (bvcTypeBounds context0)
+        constructorInfo
+        substitution
+        (backendConstructorResult constructor)
+        (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
+      validateBackendConstructorStructuralPayload
+        (bvcTypeBounds context0)
+        constructorInfo
+        substitution
+        scrutineeTy
+        (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
       let fresheningSubstitution = constructorPatternFresheningSubstitution context0 substitution constructor
           patternSubstitution = Map.union fresheningSubstitution substitution
           instantiatedFields = map (substituteBackendTypes patternSubstitution) fields
@@ -959,11 +1155,141 @@ constructorPatternTypeBounds substitution fresheningSubstitution constructor =
 
 constructorTypeParameterBounds :: BackendConstructorInfo -> BackendParameterBounds
 constructorTypeParameterBounds constructorInfo =
+  constructorTypeParameterBoundsForData (bciDataParameters constructorInfo) (bciConstructor constructorInfo)
+
+constructorTypeParameterBoundsForData :: [String] -> BackendConstructor -> BackendParameterBounds
+constructorTypeParameterBoundsForData dataParameters constructor =
   Map.fromList $
-    [(name, Nothing) | name <- bciDataParameters constructorInfo]
+    [(name, Nothing) | name <- dataParameters]
       ++ [ (backendTypeBinderName binder, backendTypeBinderBound binder)
-           | binder <- backendConstructorForalls (bciConstructor constructorInfo)
+           | binder <- backendConstructorForalls constructor
          ]
+
+validateBackendConstructorStructuralPayload ::
+  Map.Map String (Maybe BackendType) ->
+  BackendConstructorInfo ->
+  Map.Map String BackendType ->
+  BackendType ->
+  BackendValidationError ->
+  Either BackendValidationError ()
+validateBackendConstructorStructuralPayload typeBounds constructorInfo substitution ty mismatchError =
+  unless (backendConstructorStructuralPayloadMatches typeBounds constructorInfo substitution ty) $
+    Left mismatchError
+
+backendConstructorStructuralPayloadMatches ::
+  Map.Map String (Maybe BackendType) ->
+  BackendConstructorInfo ->
+  Map.Map String BackendType ->
+  BackendType ->
+  Bool
+backendConstructorStructuralPayloadMatches typeBounds constructorInfo substitution =
+  \case
+    BTMu muName body
+      | structuralMuNameMatches (bciDataName constructorInfo) muName ->
+          case structuralMuHandlerTypes body of
+            Just (resultName, handlers) ->
+              structuralPayloadHandlersMatchForData
+                typeBounds
+                (bciDataParameters constructorInfo)
+                (bciDataConstructors constructorInfo)
+                substitution
+                (BTMu muName body)
+                muName
+                resultName
+                handlers
+            Nothing ->
+              False
+    _ ->
+      True
+
+structuralMuPayloadMatchesDataDecl ::
+  Map.Map String (Maybe BackendType) ->
+  BackendData ->
+  Map.Map String BackendType ->
+  BackendType ->
+  Bool
+structuralMuPayloadMatchesDataDecl typeBounds dataDecl substitution =
+  \case
+    BTMu muName body
+      | structuralMuNameMatches (backendDataName dataDecl) muName ->
+          case structuralMuHandlerTypes body of
+            Just (resultName, handlers) ->
+              structuralPayloadHandlersMatchForData
+                typeBounds
+                (backendDataParameters dataDecl)
+                (backendDataConstructors dataDecl)
+                substitution
+                (BTMu muName body)
+                muName
+                resultName
+                handlers
+            Nothing ->
+              False
+    _ ->
+      True
+
+structuralDataArgumentSubstitution :: BackendData -> [BackendType] -> Maybe (Map.Map String BackendType)
+structuralDataArgumentSubstitution dataDecl args
+  | length dataParameters == length args =
+      Just (Map.fromList (zip dataParameters args))
+  | otherwise =
+      Nothing
+  where
+    dataParameters =
+      backendDataParameters dataDecl
+
+structuralPayloadHandlersMatchForData ::
+  Map.Map String (Maybe BackendType) ->
+  [String] ->
+  [BackendConstructor] ->
+  Map.Map String BackendType ->
+  BackendType ->
+  String ->
+  String ->
+  [BackendType] ->
+  Bool
+structuralPayloadHandlersMatchForData typeBounds dataParameters constructors substitution structuralTy muName resultName handlers =
+  length constructors == length handlers
+    && and (zipWith constructorHandlerMatches constructors handlers)
+  where
+    dataSubstitution =
+      Map.filterWithKey (\name _ -> name `elem` dataParameters) substitution
+    structuralTyWithData =
+      substituteBackendTypes dataSubstitution structuralTy
+    knownSubstitution =
+      Map.insert muName structuralTyWithData dataSubstitution
+    substituteKnownTypes =
+      substituteBackendTypes knownSubstitution
+    constructorHandlerMatches constructor handlerTy =
+      case
+        matchBackendTypeParametersWithTypeBounds
+          typeBounds
+          dataParameters
+          parameters
+          Map.empty
+          expectedHandlerTy
+          actualHandlerTy
+        of
+          Just _ -> True
+          Nothing -> False
+      where
+        expectedHandlerTy =
+          substituteKnownTypes (constructorStructuralHandlerType resultName constructor)
+        actualHandlerTy =
+          substituteKnownTypes handlerTy
+        parameters =
+          Map.map (fmap substituteKnownTypes) $
+            constructorTypeParameterBoundsForData dataParameters constructor
+
+constructorStructuralHandlerType :: String -> BackendConstructor -> BackendType
+constructorStructuralHandlerType resultName constructor =
+  foldr wrapForall handlerBody (backendConstructorForalls constructor)
+  where
+    handlerBody =
+      foldr BTArrow (BTVar resultName) (backendConstructorFields constructor)
+
+    wrapForall binder body =
+      BTForall (backendTypeBinderName binder) (backendTypeBinderBound binder) body
 
 validateCaseAlternative :: BackendType -> BackendAlternative -> Either BackendValidationError ()
 validateCaseAlternative resultTy alternative =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -976,9 +976,7 @@ matchBackendTypeParametersWithTypeBounds typeBounds dataParameterOrder parameter
           | Map.member name parameterBounds && Set.notMember name bound ->
               insertParameterSubstitution name actual substitution
         _ ->
-          if alphaEqBackendType expected actual
-            then Just substitution
-            else case (expected, actual) of
+          case (expected, actual) of
               (BTVar {}, _) ->
                 requireAlphaEq substitution expected actual
               (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
@@ -1070,7 +1068,9 @@ matchBackendTypeParametersWithTypeBounds typeBounds dataParameterOrder parameter
               (BTBottom, BTBottom) ->
                 Just substitution
               _ ->
-                Nothing
+                if alphaEqBackendType expected actual
+                  then Just substitution
+                  else Nothing
 
     matchMaybeBound _ substitution Nothing Nothing =
       Just substitution
@@ -1079,23 +1079,28 @@ matchBackendTypeParametersWithTypeBounds typeBounds dataParameterOrder parameter
     matchMaybeBound _ _ _ _ =
       Nothing
 
-    matchStructuralMuExpected bound substitution muName _body actualTy =
+    matchStructuralMuExpected bound substitution muName body actualTy =
       firstJust
-        [ structuralMuNominalTypeMatches actualTy muName _body >>= \() -> Just substitution,
-          structuralMuAsDataType dataParameterOrder muName
+        [ structuralMuNominalTypeMatches actualTy muName body >>= \() -> Just substitution,
+          structuralMuAsDataTypeForBody muName body
             >>= \expectedTy -> go bound substitution expectedTy actualTy,
-          structuralMuAsActualDataType muName actualTy
+          structuralMuPayloadTypes body
+            *> structuralMuAsActualDataType muName actualTy
             >>= \expectedTy -> go bound substitution expectedTy actualTy
         ]
 
-    matchStructuralMuActual bound substitution expectedTy muName _body =
+    matchStructuralMuActual bound substitution expectedTy muName body =
       firstJust
-        [ structuralMuNominalTypeMatches expectedTy muName _body >>= \() -> Just substitution,
-          structuralMuAsDataType dataParameterOrder muName
+        [ structuralMuNominalTypeMatches expectedTy muName body >>= \() -> Just substitution,
+          structuralMuAsDataTypeForBody muName body
             >>= \actualTy -> go bound substitution expectedTy actualTy,
-          structuralMuAsActualDataType muName expectedTy
+          structuralMuPayloadTypes body
+            *> structuralMuAsActualDataType muName expectedTy
             >>= \actualTy -> go bound substitution expectedTy actualTy
         ]
+
+    structuralMuAsDataTypeForBody muName body =
+      structuralMuPayloadTypes body *> structuralMuAsDataType dataParameterOrder muName
 
     structuralMuNominalTypeMatches nominalTy muName body =
       if nominalMatches

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -622,9 +622,9 @@ validateBackendExprWith mbContext expr =
       validateBackendExprWith mbContext arg
       case backendExprType fun of
         BTArrow expectedArg expectedResult -> do
-          unless (backendTypeMatches mbContext expectedArg (backendExprType arg)) $
+          unless (backendApplicationTypeMatches mbContext expectedArg (backendExprType arg)) $
             Left (BackendApplicationArgumentMismatch expectedArg (backendExprType arg))
-          unless (backendTypeMatches mbContext expectedResult resultTy) $
+          unless (backendApplicationTypeMatches mbContext expectedResult resultTy) $
             Left (BackendApplicationResultMismatch resultTy expectedResult)
         other ->
           Left (BackendApplicationExpectedFunction other)
@@ -684,12 +684,32 @@ validateBackendVariable (Just context0) name actualTy =
       unless (backendVariableTypeMatches context0 expectedTy actualTy) $
         Left (BackendVariableTypeMismatch name expectedTy actualTy)
 
-backendTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
-backendTypeMatches mbContext expectedTy actualTy =
-  backendTypeMatchesWith True typeBounds dataDecls expectedTy actualTy
+backendApplicationTypeMatches :: Maybe BackendValidationContext -> BackendType -> BackendType -> Bool
+backendApplicationTypeMatches mbContext expectedTy actualTy =
+  not (topLevelFreeTypeVariableWildcard expectedTy actualTy)
+    && backendTypeMatchesWith True typeBounds dataDecls expectedTy actualTy
   where
     typeBounds = maybe Map.empty bvcTypeBounds mbContext
     dataDecls = bvcData <$> mbContext
+
+    topLevelFreeTypeVariableWildcard expected actual =
+      case (expected, actual) of
+        (BTVar name, BTVar otherName) ->
+          name /= otherName
+            && applicationTypeVariableIsUnconstrained name
+            && applicationTypeVariableIsUnconstrained otherName
+        (BTVar name, _) ->
+          applicationTypeVariableIsUnconstrained name
+        (_, BTVar name) ->
+          applicationTypeVariableIsUnconstrained name
+        _ ->
+          False
+
+    applicationTypeVariableIsUnconstrained name =
+      case Map.lookup name typeBounds of
+        Nothing -> True
+        Just Nothing -> True
+        Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
 
 backendVariableTypeMatches :: BackendValidationContext -> BackendType -> BackendType -> Bool
 backendVariableTypeMatches context0 expectedTy actualTy =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -124,6 +124,7 @@ data BackendType
   | BTArrow BackendType BackendType
   | BTBase BaseTy
   | BTCon BaseTy (NonEmpty BackendType)
+  | BTVarApp String (NonEmpty BackendType)
   | BTForall String (Maybe BackendType) BackendType
   | BTMu String BackendType
   | BTBottom
@@ -267,6 +268,12 @@ freeBackendTypeVars =
           Set.empty
         BTCon _ args ->
           foldMap (go bound) args
+        BTVarApp name args ->
+          let headVars =
+                if Set.member name bound
+                  then Set.empty
+                  else Set.singleton name
+           in Set.union headVars (foldMap (go bound) args)
         BTForall name mbBound body ->
           let freeBound = maybe Set.empty (go bound) mbBound
               freeBody = go (Set.insert name bound) body
@@ -298,8 +305,19 @@ alphaEqBackendType =
           go leftEnv rightEnv leftDom rightDom && go leftEnv rightEnv leftCod rightCod
         (BTBase leftBase, BTBase rightBase) ->
           leftBase == rightBase
+        (BTBase leftBase, BTMu rightName rightBody) ->
+          structuralMuMatchesData leftBase [] rightName rightBody
+        (BTMu leftName leftBody, BTBase rightBase) ->
+          structuralMuMatchesData rightBase [] leftName leftBody
         (BTCon leftCon leftArgs, BTCon rightCon rightArgs) ->
           leftCon == rightCon && zipAllWith (go leftEnv rightEnv) (NE.toList leftArgs) (NE.toList rightArgs)
+        (BTCon leftCon leftArgs, BTMu rightName rightBody) ->
+          structuralMuMatchesData leftCon (NE.toList leftArgs) rightName rightBody
+        (BTMu leftName leftBody, BTCon rightCon rightArgs) ->
+          structuralMuMatchesData rightCon (NE.toList rightArgs) leftName leftBody
+        (BTVarApp leftName leftArgs, BTVarApp rightName rightArgs) ->
+          typeVarNamesMatch leftEnv rightEnv leftName rightName
+            && zipAllWith (go leftEnv rightEnv) (NE.toList leftArgs) (NE.toList rightArgs)
         (BTForall leftName leftBound leftBody, BTForall rightName rightBound rightBody) ->
           maybeAlphaEq leftEnv rightEnv leftBound rightBound
             && go
@@ -318,12 +336,138 @@ alphaEqBackendType =
         _ ->
           False
 
+    typeVarNamesMatch leftEnv rightEnv leftName rightName =
+      case (Map.lookup leftName leftEnv, Map.lookup rightName rightEnv) of
+        (Just expectedRight, Just expectedLeft) ->
+          expectedRight == rightName && expectedLeft == leftName
+        (Nothing, Nothing) ->
+          leftName == rightName
+        _ ->
+          False
+
     maybeAlphaEq _ _ Nothing Nothing =
       True
     maybeAlphaEq leftEnv rightEnv (Just leftTy) (Just rightTy) =
       go leftEnv rightEnv leftTy rightTy
     maybeAlphaEq _ _ _ _ =
       False
+
+structuralMuMatchesData :: BaseTy -> [BackendType] -> String -> BackendType -> Bool
+structuralMuMatchesData (BaseTy dataName) args muName body =
+  structuralMuNameMatches dataName muName
+    && case structuralMuPayloadTypes body of
+      Just payloadTypes
+        | null args -> True
+        | otherwise -> zipAllWith alphaEqBackendType args payloadTypes
+      Nothing -> null args
+
+structuralMuAsDataType :: BackendParameterBounds -> String -> BackendType -> Maybe BackendType
+structuralMuAsDataType parameterBounds muName body = do
+  dataName <- structuralMuDataName muName
+  let parameterArgs =
+        [ BTVar name
+          | name <- freeBackendTypeVarsInOrder body,
+            Map.member name parameterBounds
+        ]
+  Just $
+    case parameterArgs of
+      [] -> BTBase (BaseTy dataName)
+      arg : rest -> BTCon (BaseTy dataName) (arg NE.:| rest)
+
+structuralMuAsActualDataType :: String -> BackendType -> Maybe BackendType
+structuralMuAsActualDataType muName actual =
+  case actual of
+    BTBase (BaseTy actualName)
+      | structuralMuNameMatches actualName muName -> Just actual
+    BTCon (BaseTy actualName) _
+      | structuralMuNameMatches actualName muName -> Just actual
+    _ -> Nothing
+
+freeBackendTypeVarsInOrder :: BackendType -> [String]
+freeBackendTypeVarsInOrder =
+  go Set.empty []
+  where
+    go bound seen ty =
+      case ty of
+        BTVar name ->
+          addName bound seen name
+        BTArrow dom cod ->
+          go bound (go bound seen dom) cod
+        BTBase {} ->
+          seen
+        BTCon _ args ->
+          foldl (go bound) seen (NE.toList args)
+        BTVarApp name args ->
+          foldl (go bound) (addName bound seen name) (NE.toList args)
+        BTForall name mb body ->
+          let seen' = maybe seen (go bound seen) mb
+           in go (Set.insert name bound) seen' body
+        BTMu name body ->
+          go (Set.insert name bound) seen body
+        BTBottom ->
+          seen
+
+    addName bound seen name
+      | Set.member name bound = seen
+      | name `elem` seen = seen
+      | otherwise = seen ++ [name]
+
+structuralMuNameMatches :: String -> String -> Bool
+structuralMuNameMatches dataName muName =
+  case structuralMuDataName muName of
+    Just structuralName ->
+      dataName == structuralName || unqualifiedName dataName == structuralName
+    Nothing -> False
+
+structuralMuDataName :: String -> Maybe String
+structuralMuDataName name =
+  stripSuffixSimple "_self" (dropWhile (== '$') name)
+
+stripSuffixSimple :: String -> String -> Maybe String
+stripSuffixSimple suffix value =
+  reverse <$> stripPrefixSimple (reverse suffix) (reverse value)
+
+stripPrefixSimple :: String -> String -> Maybe String
+stripPrefixSimple [] value =
+  Just value
+stripPrefixSimple _ [] =
+  Nothing
+stripPrefixSimple (expected : expectedRest) (actual : actualRest)
+  | expected == actual = stripPrefixSimple expectedRest actualRest
+  | otherwise = Nothing
+
+unqualifiedName :: String -> String
+unqualifiedName =
+  reverse . takeWhile (/= '.') . reverse
+
+structuralMuPayloadTypes :: BackendType -> Maybe [BackendType]
+structuralMuPayloadTypes =
+  \case
+    BTForall resultName _ handlerTy ->
+      concat <$> collectHandlers resultName handlerTy
+    _ -> Nothing
+  where
+    collectHandlers resultName =
+      go []
+      where
+        go handlers ty
+          | alphaEqBackendType ty (BTVar resultName) = Just handlers
+          | otherwise =
+              case ty of
+                BTArrow handlerTy rest -> do
+                  fields <- collectHandlerFields resultName handlerTy
+                  go (handlers ++ [fields]) rest
+                _ -> Nothing
+
+    collectHandlerFields resultName =
+      go []
+      where
+        go fields ty
+          | alphaEqBackendType ty (BTVar resultName) = Just fields
+          | otherwise =
+              case ty of
+                BTArrow fieldTy rest -> go (fields ++ [fieldTy]) rest
+                _ -> Nothing
 
 -- | Capture-avoiding substitution for backend types. Forall binders scope over
 -- their body but not their optional bound, matching the frontend type syntax.
@@ -342,6 +486,11 @@ substituteBackendTypes replacements0 =
         BTArrow dom cod -> BTArrow (go replacements dom) (go replacements cod)
         BTBase {} -> ty
         BTCon con args -> BTCon con (fmap (go replacements) args)
+        BTVarApp name args ->
+          let args' = fmap (go replacements) args
+           in case Map.lookup name replacements >>= (`applyBackendTypeHead` NE.toList args') of
+                Just ty' -> ty'
+                Nothing -> BTVarApp name args'
         BTForall name mbBound body
           | Map.null bodyReplacements ->
               BTForall name (fmap (go replacements) mbBound) body
@@ -382,6 +531,23 @@ substituteBackendTypes replacements0 =
             bodyReplacements = Map.delete name replacements
             freeBodyReplacements = freeBackendTypeVarsIn bodyReplacements
         BTBottom -> BTBottom
+
+applyBackendTypeHead :: BackendType -> [BackendType] -> Maybe BackendType
+applyBackendTypeHead headTy args =
+  case headTy of
+    BTVar name -> Just (mkVarHead name args)
+    BTBase name -> Just (mkConHead name args)
+    BTCon name existingArgs -> Just (mkConHead name (NE.toList existingArgs ++ args))
+    BTVarApp name existingArgs -> Just (mkVarHead name (NE.toList existingArgs ++ args))
+    _ -> Nothing
+  where
+    mkVarHead name = \case
+      [] -> BTVar name
+      arg : rest -> BTVarApp name (arg NE.:| rest)
+
+    mkConHead name = \case
+      [] -> BTBase name
+      arg : rest -> BTCon name (arg NE.:| rest)
 
 unfoldBackendRecursiveType :: BackendType -> Maybe BackendType
 unfoldBackendRecursiveType ty =
@@ -548,6 +714,9 @@ backendVariableTypeMatches typeBounds expectedTy actualTy =
             expectedBase == actualBase
           (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs) ->
             expectedCon == actualCon
+              && zipAllWith (go bound) (NE.toList expectedArgs) (NE.toList actualArgs)
+          (BTVarApp expectedName expectedArgs, BTVarApp actualName actualArgs) ->
+            expectedName == actualName
               && zipAllWith (go bound) (NE.toList expectedArgs) (NE.toList actualArgs)
           (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) ->
             maybeBoundMatches bound expectedBound actualBound
@@ -789,67 +958,79 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
           | Map.member name parameterBounds && Set.notMember name bound ->
               insertParameterSubstitution name actual substitution
         _ ->
-          case (expected, actual) of
-            (BTVar {}, _) ->
-              requireAlphaEq substitution expected actual
-            (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
-              go bound substitution expectedDom actualDom
-                >>= \substitution' -> go bound substitution' expectedCod actualCod
-            (BTBase expectedBase, BTBase actualBase)
-              | expectedBase == actualBase ->
-                  Just substitution
-            (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs)
-              | expectedCon == actualCon ->
-                  foldM
-                    ( \(substitutionAcc, matched) (expectedArg, actualArg) ->
+          if alphaEqBackendType expected actual
+            then Just substitution
+            else case (expected, actual) of
+              (BTVar {}, _) ->
+                requireAlphaEq substitution expected actual
+              (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
+                go bound substitution expectedDom actualDom
+                  >>= \substitution' -> go bound substitution' expectedCod actualCod
+              (BTBase expectedBase, BTBase actualBase)
+                | expectedBase == actualBase ->
+                    Just substitution
+              (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs)
+                | expectedCon == actualCon ->
+                    foldM
+                      ( \(substitutionAcc, matched) (expectedArg, actualArg) ->
+                          if matched
+                            then fmap (\substitutionNext -> (substitutionNext, True)) (go bound substitutionAcc expectedArg actualArg)
+                            else Just (substitutionAcc, False)
+                      )
+                      (substitution, length expectedArgsList == length actualArgsList)
+                      (zip expectedArgsList actualArgsList)
+                      >>= \(substitution', matched) ->
                         if matched
-                          then fmap (\substitutionNext -> (substitutionNext, True)) (go bound substitutionAcc expectedArg actualArg)
-                          else Just (substitutionAcc, False)
-                    )
-                    (substitution, length expectedArgsList == length actualArgsList)
-                    (zip expectedArgsList actualArgsList)
-                    >>= \(substitution', matched) ->
-                      if matched
-                        then Just substitution'
-                        else Nothing
-              where
-                expectedArgsList = NE.toList expectedArgs
-                actualArgsList = NE.toList actualArgs
-            (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) -> do
-              substitution' <- matchMaybeBound bound substitution expectedBound actualBound
-              let used =
-                    Set.unions
-                      [ Set.fromList [expectedName, actualName],
-                        Map.keysSet substitution',
-                        freeBackendTypeVarsIn substitution',
-                        Map.keysSet parameterBounds,
-                        freeBackendTypeVars expectedBody,
-                        freeBackendTypeVars actualBody,
-                        maybe Set.empty freeBackendTypeVars expectedBound,
-                        maybe Set.empty freeBackendTypeVars actualBound
-                      ]
-                  freshName = freshNameLike expectedName used
-                  expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
-                  actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
-              go (Set.insert freshName bound) substitution' expectedBody' actualBody'
-            (BTMu expectedName expectedBody, BTMu actualName actualBody) -> do
-              let used =
-                    Set.unions
-                      [ Set.fromList [expectedName, actualName],
-                        Map.keysSet substitution,
-                        freeBackendTypeVarsIn substitution,
-                        Map.keysSet parameterBounds,
-                        freeBackendTypeVars expectedBody,
-                        freeBackendTypeVars actualBody
-                      ]
-                  freshName = freshNameLike expectedName used
-                  expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
-                  actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
-              go (Set.insert freshName bound) substitution expectedBody' actualBody'
-            (BTBottom, BTBottom) ->
-              Just substitution
-            _ ->
-              Nothing
+                          then Just substitution'
+                          else Nothing
+                where
+                  expectedArgsList = NE.toList expectedArgs
+                  actualArgsList = NE.toList actualArgs
+              (BTMu expectedName expectedBody, actualTy@(BTBase {})) ->
+                matchStructuralMuExpected bound substitution expectedName expectedBody actualTy
+              (BTMu expectedName expectedBody, actualTy@(BTCon {})) ->
+                matchStructuralMuExpected bound substitution expectedName expectedBody actualTy
+              (expectedTy@(BTBase {}), BTMu actualName actualBody) ->
+                matchStructuralMuActual bound substitution expectedTy actualName actualBody
+              (expectedTy@(BTCon {}), BTMu actualName actualBody) ->
+                matchStructuralMuActual bound substitution expectedTy actualName actualBody
+              (BTVarApp expectedName expectedArgs, _) ->
+                matchBackendTypeApplication bound substitution expectedName (NE.toList expectedArgs) actual
+              (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) -> do
+                substitution' <- matchMaybeBound bound substitution expectedBound actualBound
+                let used =
+                      Set.unions
+                        [ Set.fromList [expectedName, actualName],
+                          Map.keysSet substitution',
+                          freeBackendTypeVarsIn substitution',
+                          Map.keysSet parameterBounds,
+                          freeBackendTypeVars expectedBody,
+                          freeBackendTypeVars actualBody,
+                          maybe Set.empty freeBackendTypeVars expectedBound,
+                          maybe Set.empty freeBackendTypeVars actualBound
+                        ]
+                    freshName = freshNameLike expectedName used
+                    expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                    actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                go (Set.insert freshName bound) substitution' expectedBody' actualBody'
+              (BTMu expectedName expectedBody, BTMu actualName actualBody) -> do
+                let used =
+                      Set.unions
+                        [ Set.fromList [expectedName, actualName],
+                          Map.keysSet substitution,
+                          freeBackendTypeVarsIn substitution,
+                          Map.keysSet parameterBounds,
+                          freeBackendTypeVars expectedBody,
+                          freeBackendTypeVars actualBody
+                        ]
+                    freshName = freshNameLike expectedName used
+                    expectedBody' = substituteBackendType expectedName (BTVar freshName) expectedBody
+                    actualBody' = substituteBackendType actualName (BTVar freshName) actualBody
+                go (Set.insert freshName bound) substitution expectedBody' actualBody'
+              (BTBottom, BTBottom) ->
+                Just substitution
+              _ ->
+                Nothing
 
     matchMaybeBound _ substitution Nothing Nothing =
       Just substitution
@@ -858,9 +1039,47 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
     matchMaybeBound _ _ _ _ =
       Nothing
 
+    matchStructuralMuExpected bound substitution muName body actualTy =
+      firstJust
+        [ structuralMuAsDataType parameterBounds muName body
+            >>= \expectedTy -> go bound substitution expectedTy actualTy,
+          structuralMuAsActualDataType muName actualTy
+            >>= \expectedTy -> go bound substitution expectedTy actualTy
+        ]
+
+    matchStructuralMuActual bound substitution expectedTy muName body =
+      firstJust
+        [ structuralMuAsDataType parameterBounds muName body
+            >>= \actualTy -> go bound substitution expectedTy actualTy,
+          structuralMuAsActualDataType muName expectedTy
+            >>= \actualTy -> go bound substitution expectedTy actualTy
+        ]
+
+    matchBackendTypeApplication bound substitution name expectedArgs actual =
+      case decomposeBackendTypeHead actual of
+        Just (actualHead, actualArgs)
+          | length expectedArgs == length actualArgs -> do
+              substitution' <-
+                if Map.member name parameterBounds && Set.notMember name bound
+                  then insertParameterSubstitution name actualHead substitution
+                  else go bound substitution (BTVar name) actualHead
+              foldM
+                (\substitutionAcc (expectedArg, actualArg) -> go bound substitutionAcc expectedArg actualArg)
+                substitution'
+                (zip expectedArgs actualArgs)
+        _ -> Nothing
+
     requireAlphaEq substitution expected actual
       | alphaEqBackendType expected actual = Just substitution
       | otherwise = Nothing
+
+    firstJust =
+      \case
+        [] -> Nothing
+        candidate : rest ->
+          case candidate of
+            Just value -> Just value
+            Nothing -> firstJust rest
 
     insertParameterSubstitution name actual substitution =
       case Map.lookup name substitution of
@@ -908,6 +1127,15 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
 
     resolvedTypeBounds =
       completeBackendParameterSubstitution typeBounds Map.empty
+
+decomposeBackendTypeHead :: BackendType -> Maybe (BackendType, [BackendType])
+decomposeBackendTypeHead ty =
+  case ty of
+    BTVar name -> Just (BTVar name, [])
+    BTBase name -> Just (BTBase name, [])
+    BTCon name args -> Just (BTBase name, NE.toList args)
+    BTVarApp name args -> Just (BTVar name, NE.toList args)
+    _ -> Nothing
 
 completeBackendParameterSubstitution :: BackendParameterBounds -> Map.Map String BackendType -> Map.Map String BackendType
 completeBackendParameterSubstitution parameterBounds substitution0 =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -800,12 +800,6 @@ backendTypeMatchesWith typeVariableInstantiation typeBounds mbDataDecls expected
     maybeBoundMatches _ _ _ =
       False
 
-    freeTypeVariableMayInstantiate name =
-      case Map.lookup name typeBounds of
-        Nothing -> True
-        Just Nothing -> True
-        Just (Just boundTy) -> alphaEqBackendType boundTy BTBottom
-
     -- Conversion may alpha-freshen generated case/evidence binders while their
     -- lexical variable names stay fixed. Keep that escape hatch scoped to
     -- generated variables; user-facing variables still require exact names.
@@ -888,7 +882,7 @@ backendTypeMatchesWith typeVariableInstantiation typeBounds mbDataDecls expected
       alphaEqBackendType expected actual
         || case (expected, actual) of
           (BTVar name, _)
-            | Set.notMember name bound && freeTypeVariableMayInstantiate name ->
+            | Set.notMember name bound && Map.notMember name typeBounds ->
                 True
           (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
             structuralPayloadTypeMayInstantiate bound expectedDom actualDom

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -357,18 +357,21 @@ structuralMuMatchesData (BaseTy dataName) args muName body =
   structuralMuNameMatches dataName muName
     && case structuralMuPayloadTypes body of
       Just payloadTypes
-        | null args || null payloadTypes -> True
+        | null args -> True
+        | null payloadTypes -> all isBareTypeVariable args
         | otherwise -> zipAllWith alphaEqBackendType args payloadTypes
       Nothing -> null args
 
-structuralMuAsDataType :: BackendParameterBounds -> String -> BackendType -> Maybe BackendType
-structuralMuAsDataType parameterBounds muName body = do
+isBareTypeVariable :: BackendType -> Bool
+isBareTypeVariable =
+  \case
+    BTVar {} -> True
+    _ -> False
+
+structuralMuAsDataType :: [String] -> String -> Maybe BackendType
+structuralMuAsDataType dataParameterOrder muName = do
   dataName <- structuralMuDataName muName
-  let parameterArgs =
-        [ BTVar name
-          | name <- freeBackendTypeVarsInOrder body,
-            Map.member name parameterBounds
-        ]
+  let parameterArgs = map BTVar dataParameterOrder
   Just $
     case parameterArgs of
       [] -> BTBase (BaseTy dataName)
@@ -382,35 +385,6 @@ structuralMuAsActualDataType muName actual =
     BTCon (BaseTy actualName) _
       | structuralMuNameMatches actualName muName -> Just actual
     _ -> Nothing
-
-freeBackendTypeVarsInOrder :: BackendType -> [String]
-freeBackendTypeVarsInOrder =
-  go Set.empty []
-  where
-    go bound seen ty =
-      case ty of
-        BTVar name ->
-          addName bound seen name
-        BTArrow dom cod ->
-          go bound (go bound seen dom) cod
-        BTBase {} ->
-          seen
-        BTCon _ args ->
-          foldl (go bound) seen (NE.toList args)
-        BTVarApp name args ->
-          foldl (go bound) (addName bound seen name) (NE.toList args)
-        BTForall name mb body ->
-          let seen' = maybe seen (go bound seen) mb
-           in go (Set.insert name bound) seen' body
-        BTMu name body ->
-          go (Set.insert name bound) seen body
-        BTBottom ->
-          seen
-
-    addName bound seen name
-      | Set.member name bound = seen
-      | name `elem` seen = seen
-      | otherwise = seen ++ [name]
 
 structuralMuNameMatches :: String -> String -> Bool
 structuralMuNameMatches dataName muName =
@@ -806,30 +780,32 @@ validateBackendConstructorUse (Just context0) name resultTy args =
       Left (BackendUnknownConstructor name)
     Just constructorInfo -> do
       let constructor = bciConstructor constructorInfo
+          dataParameters = bciDataParameters constructorInfo
           parameters = constructorTypeParameterBounds constructorInfo
           fields = backendConstructorFields constructor
       unless (length fields == length args) $
         Left (BackendConstructorArityMismatch name (length fields) (length args))
       substitution <-
-        case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) parameters Map.empty (backendConstructorResult constructor) resultTy of
+        case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) dataParameters parameters Map.empty (backendConstructorResult constructor) resultTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendConstructorResultMismatch name (backendConstructorResult constructor) resultTy)
       _ <-
         foldM
-          (validateBackendConstructorArgument (bvcTypeBounds context0) parameters name)
+          (validateBackendConstructorArgument (bvcTypeBounds context0) dataParameters parameters name)
           substitution
           (zip [0 ..] (zip fields args))
       pure ()
 
 validateBackendConstructorArgument ::
   Map.Map String (Maybe BackendType) ->
+  [String] ->
   BackendParameterBounds ->
   String ->
   Map.Map String BackendType ->
   (Int, (BackendType, BackendExpr)) ->
   Either BackendValidationError (Map.Map String BackendType)
-validateBackendConstructorArgument typeBounds parameters name substitution (index0, (expectedTy, arg)) =
-  case matchBackendTypeParametersWithTypeBounds typeBounds parameters substitution expectedTy (backendExprType arg) of
+validateBackendConstructorArgument typeBounds dataParameters parameters name substitution (index0, (expectedTy, arg)) =
+  case matchBackendTypeParametersWithTypeBounds typeBounds dataParameters parameters substitution expectedTy (backendExprType arg) of
     Just substitution' ->
       pure substitution'
     Nothing ->
@@ -858,13 +834,14 @@ validateBackendPattern (Just context0) scrutineeTy (BackendConstructorPattern na
       Left (BackendUnknownConstructor name)
     Just constructorInfo -> do
       let constructor = bciConstructor constructorInfo
+          dataParameters = bciDataParameters constructorInfo
           parameters = constructorTypeParameterBounds constructorInfo
           fields = backendConstructorFields constructor
       requireUnique BackendDuplicatePatternBinding binders
       unless (length fields == length binders) $
         Left (BackendPatternArityMismatch name (length fields) (length binders))
       substitution <-
-        case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
+        case matchBackendTypeParametersWithTypeBounds (bvcTypeBounds context0) dataParameters parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
           Just substitution -> pure substitution
           Nothing -> Left (BackendCaseConstructorScrutineeMismatch name scrutineeTy (backendConstructorResult constructor))
       let fresheningSubstitution = constructorPatternFresheningSubstitution context0 substitution constructor
@@ -939,12 +916,13 @@ validateCaseAlternative resultTy alternative =
 
 matchBackendTypeParametersWithTypeBounds ::
   Map.Map String (Maybe BackendType) ->
+  [String] ->
   BackendParameterBounds ->
   Map.Map String BackendType ->
   BackendType ->
   BackendType ->
   Maybe (Map.Map String BackendType)
-matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
+matchBackendTypeParametersWithTypeBounds typeBounds dataParameterOrder parameterBounds =
   go Set.empty
   where
     go bound substitution expected actual =
@@ -1034,17 +1012,17 @@ matchBackendTypeParametersWithTypeBounds typeBounds parameterBounds =
     matchMaybeBound _ _ _ _ =
       Nothing
 
-    matchStructuralMuExpected bound substitution muName body actualTy =
+    matchStructuralMuExpected bound substitution muName _body actualTy =
       firstJust
-        [ structuralMuAsDataType parameterBounds muName body
+        [ structuralMuAsDataType dataParameterOrder muName
             >>= \expectedTy -> go bound substitution expectedTy actualTy,
           structuralMuAsActualDataType muName actualTy
             >>= \expectedTy -> go bound substitution expectedTy actualTy
         ]
 
-    matchStructuralMuActual bound substitution expectedTy muName body =
+    matchStructuralMuActual bound substitution expectedTy muName _body =
       firstJust
-        [ structuralMuAsDataType parameterBounds muName body
+        [ structuralMuAsDataType dataParameterOrder muName
             >>= \actualTy -> go bound substitution expectedTy actualTy,
           structuralMuAsActualDataType muName expectedTy
             >>= \actualTy -> go bound substitution expectedTy actualTy

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -357,7 +357,7 @@ structuralMuMatchesData (BaseTy dataName) args muName body =
   structuralMuNameMatches dataName muName
     && case structuralMuPayloadTypes body of
       Just payloadTypes
-        | null args -> True
+        | null args || null payloadTypes -> True
         | otherwise -> zipAllWith alphaEqBackendType args payloadTypes
       Nothing -> null args
 
@@ -416,7 +416,8 @@ structuralMuNameMatches :: String -> String -> Bool
 structuralMuNameMatches dataName muName =
   case structuralMuDataName muName of
     Just structuralName ->
-      dataName == structuralName || unqualifiedName dataName == structuralName
+      dataName == structuralName
+        || (isUnqualifiedName structuralName && unqualifiedName dataName == structuralName)
     Nothing -> False
 
 structuralMuDataName :: String -> Maybe String
@@ -435,6 +436,10 @@ stripPrefixSimple _ [] =
 stripPrefixSimple (expected : expectedRest) (actual : actualRest)
   | expected == actual = stripPrefixSimple expectedRest actualRest
   | otherwise = Nothing
+
+isUnqualifiedName :: String -> Bool
+isUnqualifiedName =
+  notElem '.'
 
 unqualifiedName :: String -> String
 unqualifiedName =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -187,7 +187,7 @@ buildProgramBase program = do
           { pbBindings = Map.fromList [(biName info, info) | info <- bindingInfos],
             pbBindingOrder = map biName bindingInfos,
             pbConstructors = Map.fromList [(backendConstructorName (crConstructor ctor), ctor) | ctor <- constructors],
-            pbDataNames = Set.fromList (concatMap dataNameAliases (map backendDataName dataDecls))
+            pbDataNames = Set.fromList (map backendDataName dataDecls)
           }
 
 bindingInfo :: BackendBinding -> BindingInfo
@@ -207,28 +207,6 @@ constructorRuntimes dataDecl =
       }
   | (tag, constructor) <- zip [0 ..] (backendDataConstructors dataDecl)
   ]
-
-dataNameAliases :: String -> [String]
-dataNameAliases name =
-  nub [name, suffixAfter '.' name, suffixAfterRuntimeModule name]
-
-suffixAfter :: Char -> String -> String
-suffixAfter needle value =
-  reverse (takeWhile (/= needle) (reverse value))
-
-suffixAfterRuntimeModule :: String -> String
-suffixAfterRuntimeModule value =
-  case splitRuntimeModule value of
-    Just suffix -> suffix
-    Nothing -> value
-
-splitRuntimeModule :: String -> Maybe String
-splitRuntimeModule value =
-  go value
-  where
-    go [] = Nothing
-    go ('_' : '_' : rest) = Just rest
-    go (_ : rest) = go rest
 
 functionFormFromExpr :: BackendExpr -> FunctionForm
 functionFormFromExpr expr =
@@ -419,6 +397,46 @@ freeBackendExprVars =
 
     freeAlternative bound (BackendAlternative pattern0 body) =
       go (Set.union (patternBinders pattern0) bound) body
+
+    patternBinders =
+      \case
+        BackendDefaultPattern ->
+          Set.empty
+        BackendConstructorPattern _ binders ->
+          Set.fromList binders
+
+backendExprVarTypesFor :: Set String -> BackendExpr -> Map String BackendType
+backendExprVarTypesFor targets =
+  go Set.empty
+  where
+    go shadowed =
+      \case
+        BackendVar ty name
+          | Set.member name targets && Set.notMember name shadowed -> Map.singleton name ty
+          | otherwise -> Map.empty
+        BackendLit {} ->
+          Map.empty
+        BackendLam _ name _ body ->
+          go (Set.insert name shadowed) body
+        BackendApp _ fun arg ->
+          go shadowed fun `Map.union` go shadowed arg
+        BackendLet _ name _ rhs body ->
+          go shadowed rhs `Map.union` go (Set.insert name shadowed) body
+        BackendTyAbs _ _ _ body ->
+          go shadowed body
+        BackendTyApp _ fun _ ->
+          go shadowed fun
+        BackendConstruct _ _ args ->
+          Map.unions (map (go shadowed) args)
+        BackendCase _ scrutinee alternatives ->
+          go shadowed scrutinee `Map.union` Map.unions (map (goAlternative shadowed) (NE.toList alternatives))
+        BackendRoll _ payload ->
+          go shadowed payload
+        BackendUnroll _ payload ->
+          go shadowed payload
+
+    goAlternative shadowed (BackendAlternative pattern0 body) =
+      go (Set.union shadowed (patternBinders pattern0)) body
 
     patternBinders =
       \case
@@ -1201,6 +1219,8 @@ matchTypeParams binderSet substitution expected actual =
                 (\subst (tyA, tyB) -> matchTypeParams binderSet subst tyA tyB)
                 substitution
                 (zip (NE.toList argsA) (NE.toList argsB))
+        (BTVarApp name args, _) ->
+          matchTypeParamApplication binderSet substitution name (NE.toList args) actual
         (BTBase baseA, BTBase baseB)
           | baseA == baseB -> Right substitution
         (BTForall nameA boundA bodyA, BTForall nameB boundB bodyB) -> do
@@ -1214,6 +1234,34 @@ matchTypeParams binderSet substitution expected actual =
           matchTypeParams binderSet substitution bodyA (substituteBackendType nameB (BTVar nameA) bodyB)
         (BTBottom, BTBottom) -> Right substitution
         _ -> Right substitution
+
+matchTypeParamApplication ::
+  Set String ->
+  Map String BackendType ->
+  String ->
+  [BackendType] ->
+  BackendType ->
+  Either BackendLLVMError (Map String BackendType)
+matchTypeParamApplication binderSet substitution name expectedArgs actual =
+  case decomposeBackendTypeHead actual of
+    Just (actualHead, actualArgs)
+      | length expectedArgs == length actualArgs -> do
+          substitution' <-
+            if Set.member name binderSet
+              then bindTypeParam name actualHead
+              else matchTypeParams binderSet substitution (BTVar name) actualHead
+          foldM
+            (\subst (expectedArg, actualArg) -> matchTypeParams binderSet subst expectedArg actualArg)
+            substitution'
+            (zip expectedArgs actualArgs)
+    _ -> Right substitution
+  where
+    bindTypeParam paramName actualHead =
+      case Map.lookup paramName substitution of
+        Nothing -> Right (Map.insert paramName actualHead substitution)
+        Just previous
+          | alphaEqBackendType previous actualHead -> Right substitution
+          | otherwise -> Left (BackendLLVMUnsupportedCall ("conflicting inferred type argument for " ++ paramName))
 
 collectCall :: BackendExpr -> Maybe (BackendExpr, [BackendType], [BackendExpr])
 collectCall expr =
@@ -1345,7 +1393,12 @@ lowerCase env exprEnv context resultTy scrutinee alternatives = do
               unless (length fieldTys == length binders) $
                 liftEither (BackendLLVMArityMismatch name (length fieldTys) (length binders))
               let usedBinders = freeBackendExprVars body
-              loadedFields <- mapMaybe id <$> traverse (loadUsedField usedBinders scrutineeValue) (zip3 [0 :: Int ..] binders fieldTys)
+                  bodyBinderTypes = backendExprVarTypesFor (Set.fromList binders) body
+                  effectiveFieldTys =
+                    [ Map.findWithDefault fieldTy binder bodyBinderTypes
+                      | (binder, fieldTy) <- zip binders fieldTys
+                    ]
+              loadedFields <- mapMaybe id <$> traverse (loadUsedField usedBinders scrutineeValue) (zip3 [0 :: Int ..] binders effectiveFieldTys)
               pure
                 exprEnv
                   { eeValues =
@@ -1369,15 +1422,19 @@ lowerCase env exprEnv context resultTy scrutinee alternatives = do
 
 constructorFieldTypesForScrutinee :: ProgramEnv -> String -> ConstructorRuntime -> BackendType -> LowerM [BackendType]
 constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =
-  case matchConstructorResult parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
-    Just substitution ->
-      pure (map (substituteBackendTypes substitution) (backendConstructorFields constructor))
+  case structuralConstructorFieldTypes constructorRuntime scrutineeTy of
+    Just fieldTys ->
+      pure fieldTys
     Nothing ->
-      liftEither
-        ( BackendLLVMUnsupportedExpression
-            context
-            ("could not match constructor result for " ++ backendConstructorName constructor)
-        )
+      case matchConstructorResult parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
+        Just substitution ->
+          pure (map (substituteBackendTypes substitution) (backendConstructorFields constructor))
+        Nothing ->
+          liftEither
+            ( BackendLLVMUnsupportedExpression
+                context
+                ("could not match constructor result for " ++ backendConstructorName constructor)
+            )
   where
     constructor = crConstructor constructorRuntime
     parameters =
@@ -1385,6 +1442,68 @@ constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =
         ( crDataParameters constructorRuntime
             ++ map backendTypeBinderName (backendConstructorForalls constructor)
         )
+
+structuralConstructorFieldTypes :: ConstructorRuntime -> BackendType -> Maybe [BackendType]
+structuralConstructorFieldTypes constructorRuntime scrutineeTy = do
+  (muName, body) <-
+    case scrutineeTy of
+      BTMu name muBody -> Just (name, muBody)
+      _ -> Nothing
+  dataName <- constructorResultDataName (backendConstructorResult constructor)
+  if structuralMuNameMatches dataName muName
+    then do
+      handlerFields <- structuralBackendHandlerFields body
+      fieldTys <- atMay handlerFields (fromInteger (crTag constructorRuntime))
+      if length fieldTys == length (backendConstructorFields constructor)
+        then Just (map (substituteBackendType muName scrutineeTy) fieldTys)
+        else Nothing
+    else Nothing
+  where
+    constructor = crConstructor constructorRuntime
+
+constructorResultDataName :: BackendType -> Maybe String
+constructorResultDataName =
+  \case
+    BTBase (BaseTy name) -> Just name
+    BTCon (BaseTy name) _ -> Just name
+    BTMu name _ -> structuralMuDataName name
+    _ -> Nothing
+
+structuralBackendHandlerFields :: BackendType -> Maybe [[BackendType]]
+structuralBackendHandlerFields =
+  \case
+    BTForall resultName _ handlerTy -> collectHandlers resultName handlerTy
+    _ -> Nothing
+  where
+    collectHandlers resultName =
+      go []
+      where
+        go handlers ty
+          | alphaEqBackendType ty (BTVar resultName) = Just handlers
+          | otherwise =
+              case ty of
+                BTArrow handlerTy rest -> do
+                  fields <- collectHandlerFields resultName handlerTy
+                  go (handlers ++ [fields]) rest
+                _ -> Nothing
+
+    collectHandlerFields resultName =
+      go []
+      where
+        go fields ty
+          | alphaEqBackendType ty (BTVar resultName) = Just fields
+          | otherwise =
+              case ty of
+                BTArrow fieldTy rest -> go (fields ++ [fieldTy]) rest
+                _ -> Nothing
+
+atMay :: [a] -> Int -> Maybe a
+atMay xs index0
+  | index0 < 0 = Nothing
+  | otherwise =
+      case drop index0 xs of
+        value : _ -> Just value
+        [] -> Nothing
 
 matchConstructorResult :: Set String -> Map String BackendType -> BackendType -> BackendType -> Maybe (Map String BackendType)
 matchConstructorResult parameters substitution expected actual =
@@ -1397,33 +1516,181 @@ matchConstructorResult parameters substitution expected actual =
               | alphaEqBackendType previous actual -> Just substitution
               | otherwise -> Nothing
     _ ->
-      case (expected, actual) of
-        (BTVar expectedName, BTVar actualName)
-          | expectedName == actualName -> Just substitution
-        (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
-          matchConstructorResult parameters substitution expectedDom actualDom
-            >>= \subst -> matchConstructorResult parameters subst expectedCod actualCod
-        (BTBase expectedBase, BTBase actualBase)
-          | expectedBase == actualBase -> Just substitution
-        (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs)
-          | expectedCon == actualCon && length expectedArgs == length actualArgs ->
-              foldM
-                (\subst (expectedArg, actualArg) -> matchConstructorResult parameters subst expectedArg actualArg)
-                substitution
-                (zip (NE.toList expectedArgs) (NE.toList actualArgs))
-        (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) -> do
-          subst <-
-            case (expectedBound, actualBound) of
-              (Nothing, Nothing) -> Just substitution
-              (Just expectedBoundTy, Just actualBoundTy) -> matchConstructorResult parameters substitution expectedBoundTy actualBoundTy
-              _ -> Nothing
-          matchConstructorResult parameters subst expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
-        (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
-          matchConstructorResult parameters substitution expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
-        (BTBottom, BTBottom) ->
-          Just substitution
-        _ ->
-          Nothing
+      if alphaEqBackendType expected actual
+        then Just substitution
+        else
+          ( case (expected, actual) of
+              (BTVar expectedName, BTVar actualName)
+                | expectedName == actualName -> Just substitution
+              (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
+                matchConstructorResult parameters substitution expectedDom actualDom
+                  >>= \subst -> matchConstructorResult parameters subst expectedCod actualCod
+              (BTBase expectedBase, BTBase actualBase)
+                | expectedBase == actualBase -> Just substitution
+              (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs)
+                | expectedCon == actualCon && length expectedArgs == length actualArgs ->
+                    foldM
+                      (\subst (expectedArg, actualArg) -> matchConstructorResult parameters subst expectedArg actualArg)
+                      substitution
+                      (zip (NE.toList expectedArgs) (NE.toList actualArgs))
+              (BTMu expectedName expectedBody, actualTy@(BTBase {})) ->
+                matchStructuralMuExpected expectedName expectedBody actualTy
+              (BTMu expectedName expectedBody, actualTy@(BTCon {})) ->
+                matchStructuralMuExpected expectedName expectedBody actualTy
+              (expectedTy@(BTBase {}), BTMu actualName actualBody) ->
+                matchStructuralMuActual expectedTy actualName actualBody
+              (expectedTy@(BTCon {}), BTMu actualName actualBody) ->
+                matchStructuralMuActual expectedTy actualName actualBody
+              (BTVarApp expectedName expectedArgs, _) ->
+                matchConstructorResultApplication parameters substitution expectedName (NE.toList expectedArgs) actual
+              (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) -> do
+                subst <-
+                  case (expectedBound, actualBound) of
+                    (Nothing, Nothing) -> Just substitution
+                    (Just expectedBoundTy, Just actualBoundTy) -> matchConstructorResult parameters substitution expectedBoundTy actualBoundTy
+                    _ -> Nothing
+                matchConstructorResult parameters subst expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
+              (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
+                matchConstructorResult parameters substitution expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
+              (BTBottom, BTBottom) ->
+                Just substitution
+              _ ->
+                Nothing
+          )
+  where
+    matchStructuralMuExpected muName body actualTy =
+      firstJust
+        [ structuralMuAsDataType parameters muName body
+            >>= \expectedTy -> matchConstructorResult parameters substitution expectedTy actualTy,
+          structuralMuAsActualDataType muName actualTy
+            >>= \expectedTy -> matchConstructorResult parameters substitution expectedTy actualTy
+        ]
+
+    matchStructuralMuActual expectedTy muName body =
+      firstJust
+        [ structuralMuAsDataType parameters muName body
+            >>= \actualTy -> matchConstructorResult parameters substitution expectedTy actualTy,
+          structuralMuAsActualDataType muName expectedTy
+            >>= \actualTy -> matchConstructorResult parameters substitution expectedTy actualTy
+        ]
+
+    firstJust =
+      \case
+        [] -> Nothing
+        candidate : rest ->
+          case candidate of
+            Just value -> Just value
+            Nothing -> firstJust rest
+
+structuralMuAsDataType :: Set String -> String -> BackendType -> Maybe BackendType
+structuralMuAsDataType parameters muName body = do
+  dataName <- structuralMuDataName muName
+  let parameterArgs =
+        [ BTVar name
+          | name <- freeBackendTypeVarsInOrder body,
+            Set.member name parameters
+        ]
+  Just $
+    case parameterArgs of
+      [] -> BTBase (BaseTy dataName)
+      arg : rest -> BTCon (BaseTy dataName) (arg NE.:| rest)
+
+structuralMuAsActualDataType :: String -> BackendType -> Maybe BackendType
+structuralMuAsActualDataType muName actual =
+  case actual of
+    BTBase (BaseTy actualName)
+      | structuralMuNameMatches actualName muName -> Just actual
+    BTCon (BaseTy actualName) _
+      | structuralMuNameMatches actualName muName -> Just actual
+    _ -> Nothing
+
+structuralMuNameMatches :: String -> String -> Bool
+structuralMuNameMatches dataName muName =
+  case structuralMuDataName muName of
+    Just muDataName ->
+      dataName == muDataName
+        || unqualifiedName dataName == muDataName
+        || dataName == unqualifiedName muDataName
+        || unqualifiedName dataName == unqualifiedName muDataName
+    Nothing -> False
+
+structuralMuDataName :: String -> Maybe String
+structuralMuDataName name =
+  stripSuffixSimple "_self" (dropWhile (== '$') name)
+
+unqualifiedName :: String -> String
+unqualifiedName =
+  reverse . takeWhile (/= '.') . reverse
+
+stripSuffixSimple :: String -> String -> Maybe String
+stripSuffixSimple suffix value =
+  reverse <$> stripPrefixSimple (reverse suffix) (reverse value)
+
+stripPrefixSimple :: String -> String -> Maybe String
+stripPrefixSimple [] value =
+  Just value
+stripPrefixSimple _ [] =
+  Nothing
+stripPrefixSimple (expected : expectedRest) (actual : actualRest)
+  | expected == actual = stripPrefixSimple expectedRest actualRest
+  | otherwise = Nothing
+
+freeBackendTypeVarsInOrder :: BackendType -> [String]
+freeBackendTypeVarsInOrder =
+  go Set.empty []
+  where
+    go bound seen ty =
+      case ty of
+        BTVar name ->
+          addName bound seen name
+        BTArrow dom cod ->
+          go bound (go bound seen dom) cod
+        BTBase {} ->
+          seen
+        BTCon _ args ->
+          foldl (go bound) seen (NE.toList args)
+        BTVarApp name args ->
+          foldl (go bound) (addName bound seen name) (NE.toList args)
+        BTForall name mb body ->
+          let seen' = maybe seen (go bound seen) mb
+           in go (Set.insert name bound) seen' body
+        BTMu name body ->
+          go (Set.insert name bound) seen body
+        BTBottom ->
+          seen
+
+    addName bound seen name
+      | Set.member name bound = seen
+      | name `elem` seen = seen
+      | otherwise = seen ++ [name]
+
+matchConstructorResultApplication ::
+  Set String ->
+  Map String BackendType ->
+  String ->
+  [BackendType] ->
+  BackendType ->
+  Maybe (Map String BackendType)
+matchConstructorResultApplication parameters substitution name expectedArgs actual =
+  case decomposeBackendTypeHead actual of
+    Just (actualHead, actualArgs)
+      | length expectedArgs == length actualArgs -> do
+          substitution' <-
+            if Set.member name parameters
+              then insertParameterSubstitution name actualHead substitution
+              else matchConstructorResult parameters substitution (BTVar name) actualHead
+          foldM
+            (\subst (expectedArg, actualArg) -> matchConstructorResult parameters subst expectedArg actualArg)
+            substitution'
+            (zip expectedArgs actualArgs)
+    _ -> Nothing
+  where
+    insertParameterSubstitution paramName actualHead substitution0 =
+      case Map.lookup paramName substitution0 of
+        Nothing -> Just (Map.insert paramName actualHead substitution0)
+        Just previous
+          | alphaEqBackendType previous actualHead -> Just substitution0
+          | otherwise -> Nothing
 
 lowerRollLike :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> String -> LowerM LowerValue
 lowerRollLike env exprEnv context resultTy payload nodeName = do
@@ -1453,9 +1720,19 @@ lowerBackendType env context ty =
       | otherwise -> Left (BackendLLVMUnsupportedType context ty)
     BTMu {} -> Right LLVMPtr
     BTVar {} -> Left (BackendLLVMUnsupportedType context ty)
+    BTVarApp {} -> Left (BackendLLVMUnsupportedType context ty)
     BTArrow {} -> Left (BackendLLVMUnsupportedType context ty)
     BTForall {} -> Left (BackendLLVMUnsupportedType context ty)
     BTBottom -> Left (BackendLLVMUnsupportedType context ty)
+
+decomposeBackendTypeHead :: BackendType -> Maybe (BackendType, [BackendType])
+decomposeBackendTypeHead ty =
+  case ty of
+    BTVar name -> Just (BTVar name, [])
+    BTBase name -> Just (BTBase name, [])
+    BTCon name args -> Just (BTBase name, NE.toList args)
+    BTVarApp name args -> Just (BTVar name, NE.toList args)
+    _ -> Nothing
 
 emitMalloc :: ProgramEnv -> String -> Int -> LowerM LLVMOperand
 emitMalloc env context size

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -6,6 +6,7 @@ Description : Lower typed backend IR into real LLVM IR syntax
 -}
 module MLF.Backend.LLVM.Lower
   ( BackendLLVMError (..),
+    inferTypeArgumentsForTest,
     lowerBackendProgram,
     renderBackendLLVMError,
   )
@@ -1249,19 +1250,38 @@ matchTypeParamApplication binderSet substitution name expectedArgs actual =
           substitution' <-
             if Set.member name binderSet
               then bindTypeParam name actualHead
-              else matchTypeParams binderSet substitution (BTVar name) actualHead
+              else matchRigidHead name actualHead
           foldM
             (\subst (expectedArg, actualArg) -> matchTypeParams binderSet subst expectedArg actualArg)
             substitution'
             (zip expectedArgs actualArgs)
-    _ -> Right substitution
+      | otherwise ->
+          Left (BackendLLVMUnsupportedCall ("type application arity mismatch during type argument inference for " ++ name))
+    _ ->
+      Left (BackendLLVMUnsupportedCall ("expected applied type while inferring type argument for " ++ name))
   where
+    matchRigidHead expectedName actualHead
+      | alphaEqBackendType (BTVar expectedName) actualHead = Right substitution
+      | otherwise =
+          Left
+            ( BackendLLVMUnsupportedCall
+                ( "rigid type application head mismatch during type argument inference: expected "
+                    ++ show (BTVar expectedName)
+                    ++ ", got "
+                    ++ show actualHead
+                )
+            )
+
     bindTypeParam paramName actualHead =
       case Map.lookup paramName substitution of
         Nothing -> Right (Map.insert paramName actualHead substitution)
         Just previous
           | alphaEqBackendType previous actualHead -> Right substitution
           | otherwise -> Left (BackendLLVMUnsupportedCall ("conflicting inferred type argument for " ++ paramName))
+
+inferTypeArgumentsForTest :: String -> [String] -> [(String, BackendType)] -> [BackendExpr] -> Either BackendLLVMError (Map String BackendType)
+inferTypeArgumentsForTest =
+  inferTypeArguments
 
 collectCall :: BackendExpr -> Maybe (BackendExpr, [BackendType], [BackendExpr])
 collectCall expr =
@@ -1607,22 +1627,12 @@ structuralMuAsActualDataType muName actual =
 structuralMuNameMatches :: String -> String -> Bool
 structuralMuNameMatches dataName muName =
   case structuralMuDataName muName of
-    Just muDataName ->
-      dataName == muDataName
-        || (isUnqualifiedName muDataName && unqualifiedName dataName == muDataName)
+    Just muDataName -> dataName == muDataName
     Nothing -> False
 
 structuralMuDataName :: String -> Maybe String
 structuralMuDataName name =
   stripSuffixSimple "_self" (dropWhile (== '$') name)
-
-isUnqualifiedName :: String -> Bool
-isUnqualifiedName =
-  notElem '.'
-
-unqualifiedName :: String -> String
-unqualifiedName =
-  reverse . takeWhile (/= '.') . reverse
 
 stripSuffixSimple :: String -> String -> Maybe String
 stripSuffixSimple suffix value =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1446,7 +1446,7 @@ constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =
     Just fieldTys ->
       pure fieldTys
     Nothing ->
-      case matchConstructorResult parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
+      case matchConstructorResult (crDataParameters constructorRuntime) parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
         Just substitution ->
           pure (map (substituteBackendTypes substitution) (backendConstructorFields constructor))
         Nothing ->
@@ -1525,8 +1525,8 @@ atMay xs index0
         value : _ -> Just value
         [] -> Nothing
 
-matchConstructorResult :: Set String -> Map String BackendType -> BackendType -> BackendType -> Maybe (Map String BackendType)
-matchConstructorResult parameters substitution expected actual =
+matchConstructorResult :: [String] -> Set String -> Map String BackendType -> BackendType -> BackendType -> Maybe (Map String BackendType)
+matchConstructorResult dataParameterOrder parameters substitution expected actual =
   case expected of
     BTVar name
       | Set.member name parameters ->
@@ -1543,14 +1543,14 @@ matchConstructorResult parameters substitution expected actual =
               (BTVar expectedName, BTVar actualName)
                 | expectedName == actualName -> Just substitution
               (BTArrow expectedDom expectedCod, BTArrow actualDom actualCod) ->
-                matchConstructorResult parameters substitution expectedDom actualDom
-                  >>= \subst -> matchConstructorResult parameters subst expectedCod actualCod
+                matchConstructorResult dataParameterOrder parameters substitution expectedDom actualDom
+                  >>= \subst -> matchConstructorResult dataParameterOrder parameters subst expectedCod actualCod
               (BTBase expectedBase, BTBase actualBase)
                 | expectedBase == actualBase -> Just substitution
               (BTCon expectedCon expectedArgs, BTCon actualCon actualArgs)
                 | expectedCon == actualCon && length expectedArgs == length actualArgs ->
                     foldM
-                      (\subst (expectedArg, actualArg) -> matchConstructorResult parameters subst expectedArg actualArg)
+                      (\subst (expectedArg, actualArg) -> matchConstructorResult dataParameterOrder parameters subst expectedArg actualArg)
                       substitution
                       (zip (NE.toList expectedArgs) (NE.toList actualArgs))
               (BTMu expectedName expectedBody, actualTy@(BTBase {})) ->
@@ -1562,36 +1562,36 @@ matchConstructorResult parameters substitution expected actual =
               (expectedTy@(BTCon {}), BTMu actualName actualBody) ->
                 matchStructuralMuActual expectedTy actualName actualBody
               (BTVarApp expectedName expectedArgs, _) ->
-                matchConstructorResultApplication parameters substitution expectedName (NE.toList expectedArgs) actual
+                matchConstructorResultApplication dataParameterOrder parameters substitution expectedName (NE.toList expectedArgs) actual
               (BTForall expectedName expectedBound expectedBody, BTForall actualName actualBound actualBody) -> do
                 subst <-
                   case (expectedBound, actualBound) of
                     (Nothing, Nothing) -> Just substitution
-                    (Just expectedBoundTy, Just actualBoundTy) -> matchConstructorResult parameters substitution expectedBoundTy actualBoundTy
+                    (Just expectedBoundTy, Just actualBoundTy) -> matchConstructorResult dataParameterOrder parameters substitution expectedBoundTy actualBoundTy
                     _ -> Nothing
-                matchConstructorResult parameters subst expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
+                matchConstructorResult dataParameterOrder parameters subst expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
               (BTMu expectedName expectedBody, BTMu actualName actualBody) ->
-                matchConstructorResult parameters substitution expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
+                matchConstructorResult dataParameterOrder parameters substitution expectedBody (substituteBackendType actualName (BTVar expectedName) actualBody)
               (BTBottom, BTBottom) ->
                 Just substitution
               _ ->
                 Nothing
           )
   where
-    matchStructuralMuExpected muName body actualTy =
+    matchStructuralMuExpected muName _body actualTy =
       firstJust
-        [ structuralMuAsDataType parameters muName body
-            >>= \expectedTy -> matchConstructorResult parameters substitution expectedTy actualTy,
+        [ structuralMuAsDataType dataParameterOrder muName
+            >>= \expectedTy -> matchConstructorResult dataParameterOrder parameters substitution expectedTy actualTy,
           structuralMuAsActualDataType muName actualTy
-            >>= \expectedTy -> matchConstructorResult parameters substitution expectedTy actualTy
+            >>= \expectedTy -> matchConstructorResult dataParameterOrder parameters substitution expectedTy actualTy
         ]
 
-    matchStructuralMuActual expectedTy muName body =
+    matchStructuralMuActual expectedTy muName _body =
       firstJust
-        [ structuralMuAsDataType parameters muName body
-            >>= \actualTy -> matchConstructorResult parameters substitution expectedTy actualTy,
+        [ structuralMuAsDataType dataParameterOrder muName
+            >>= \actualTy -> matchConstructorResult dataParameterOrder parameters substitution expectedTy actualTy,
           structuralMuAsActualDataType muName expectedTy
-            >>= \actualTy -> matchConstructorResult parameters substitution expectedTy actualTy
+            >>= \actualTy -> matchConstructorResult dataParameterOrder parameters substitution expectedTy actualTy
         ]
 
     firstJust =
@@ -1602,14 +1602,10 @@ matchConstructorResult parameters substitution expected actual =
             Just value -> Just value
             Nothing -> firstJust rest
 
-structuralMuAsDataType :: Set String -> String -> BackendType -> Maybe BackendType
-structuralMuAsDataType parameters muName body = do
+structuralMuAsDataType :: [String] -> String -> Maybe BackendType
+structuralMuAsDataType dataParameterOrder muName = do
   dataName <- structuralMuDataName muName
-  let parameterArgs =
-        [ BTVar name
-          | name <- freeBackendTypeVarsInOrder body,
-            Set.member name parameters
-        ]
+  let parameterArgs = map BTVar dataParameterOrder
   Just $
     case parameterArgs of
       [] -> BTBase (BaseTy dataName)
@@ -1647,52 +1643,24 @@ stripPrefixSimple (expected : expectedRest) (actual : actualRest)
   | expected == actual = stripPrefixSimple expectedRest actualRest
   | otherwise = Nothing
 
-freeBackendTypeVarsInOrder :: BackendType -> [String]
-freeBackendTypeVarsInOrder =
-  go Set.empty []
-  where
-    go bound seen ty =
-      case ty of
-        BTVar name ->
-          addName bound seen name
-        BTArrow dom cod ->
-          go bound (go bound seen dom) cod
-        BTBase {} ->
-          seen
-        BTCon _ args ->
-          foldl (go bound) seen (NE.toList args)
-        BTVarApp name args ->
-          foldl (go bound) (addName bound seen name) (NE.toList args)
-        BTForall name mb body ->
-          let seen' = maybe seen (go bound seen) mb
-           in go (Set.insert name bound) seen' body
-        BTMu name body ->
-          go (Set.insert name bound) seen body
-        BTBottom ->
-          seen
-
-    addName bound seen name
-      | Set.member name bound = seen
-      | name `elem` seen = seen
-      | otherwise = seen ++ [name]
-
 matchConstructorResultApplication ::
+  [String] ->
   Set String ->
   Map String BackendType ->
   String ->
   [BackendType] ->
   BackendType ->
   Maybe (Map String BackendType)
-matchConstructorResultApplication parameters substitution name expectedArgs actual =
+matchConstructorResultApplication dataParameterOrder parameters substitution name expectedArgs actual =
   case decomposeBackendTypeHead actual of
     Just (actualHead, actualArgs)
       | length expectedArgs == length actualArgs -> do
           substitution' <-
             if Set.member name parameters
               then insertParameterSubstitution name actualHead substitution
-              else matchConstructorResult parameters substitution (BTVar name) actualHead
+              else matchConstructorResult dataParameterOrder parameters substitution (BTVar name) actualHead
           foldM
-            (\subst (expectedArg, actualArg) -> matchConstructorResult parameters subst expectedArg actualArg)
+            (\subst (expectedArg, actualArg) -> matchConstructorResult dataParameterOrder parameters subst expectedArg actualArg)
             substitution'
             (zip expectedArgs actualArgs)
     _ -> Nothing

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2422,8 +2422,23 @@ inferTypeArguments context binderNames params args = do
   where
     binderSet = Set.fromList binderNames
 
+data TypeParamMatchStrictness
+  = AllowResidualTypeMismatch
+  | RejectResidualTypeMismatch
+  deriving (Eq, Show)
+
 matchTypeParams :: Set String -> Map String BackendType -> BackendType -> BackendType -> Either BackendLLVMError (Map String BackendType)
 matchTypeParams binderSet substitution expected actual =
+  matchTypeParamsWith AllowResidualTypeMismatch binderSet substitution expected actual
+
+matchTypeParamsWith ::
+  TypeParamMatchStrictness ->
+  Set String ->
+  Map String BackendType ->
+  BackendType ->
+  BackendType ->
+  Either BackendLLVMError (Map String BackendType)
+matchTypeParamsWith strictness binderSet substitution expected actual =
   case expected of
     BTVar name
       | Set.member name binderSet ->
@@ -2435,11 +2450,12 @@ matchTypeParams binderSet substitution expected actual =
     _ ->
       case (expected, actual) of
         (BTArrow leftA rightA, BTArrow leftB rightB) ->
-          matchTypeParams binderSet substitution leftA leftB >>= \subst -> matchTypeParams binderSet subst rightA rightB
+          matchTypeParamsWith strictness binderSet substitution leftA leftB >>= \subst ->
+            matchTypeParamsWith strictness binderSet subst rightA rightB
         (BTCon conA argsA, BTCon conB argsB)
           | conA == conB && length argsA == length argsB ->
               foldM
-                (\subst (tyA, tyB) -> matchTypeParams binderSet subst tyA tyB)
+                (\subst (tyA, tyB) -> matchTypeParamsWith strictness binderSet subst tyA tyB)
                 substitution
                 (zip (NE.toList argsA) (NE.toList argsB))
         (BTVarApp name args, _) ->
@@ -2450,13 +2466,26 @@ matchTypeParams binderSet substitution expected actual =
           substA <-
             case (boundA, boundB) of
               (Nothing, Nothing) -> Right substitution
-              (Just tyA, Just tyB) -> matchTypeParams binderSet substitution tyA tyB
+              (Just tyA, Just tyB) -> matchTypeParamsWith strictness binderSet substitution tyA tyB
               _ -> Left (BackendLLVMUnsupportedCall "mismatched forall bounds during type argument inference")
-          matchTypeParams binderSet substA bodyA (substituteBackendType nameB (BTVar nameA) bodyB)
+          matchTypeParamsWith strictness binderSet substA bodyA (substituteBackendType nameB (BTVar nameA) bodyB)
         (BTMu nameA bodyA, BTMu nameB bodyB) ->
-          matchTypeParams binderSet substitution bodyA (substituteBackendType nameB (BTVar nameA) bodyB)
+          matchTypeParamsWith strictness binderSet substitution bodyA (substituteBackendType nameB (BTVar nameA) bodyB)
         (BTBottom, BTBottom) -> Right substitution
-        _ -> Right substitution
+        _
+          | alphaEqBackendType expected actual ->
+              Right substitution
+          | strictness == RejectResidualTypeMismatch ->
+              Left
+                ( BackendLLVMUnsupportedCall
+                    ( "type application argument mismatch during type argument inference: expected "
+                        ++ show expected
+                        ++ ", got "
+                        ++ show actual
+                    )
+                )
+          | otherwise ->
+              Right substitution
 
 matchTypeParamApplication ::
   Set String ->
@@ -2474,7 +2503,7 @@ matchTypeParamApplication binderSet substitution name expectedArgs actual =
               then bindTypeParam name actualHead
               else matchRigidHead name actualHead
           foldM
-            (\subst (expectedArg, actualArg) -> matchTypeParams binderSet subst expectedArg actualArg)
+            (\subst (expectedArg, actualArg) -> matchTypeParamsWith RejectResidualTypeMismatch binderSet subst expectedArg actualArg)
             substitution'
             (zip expectedArgs actualArgs)
       | otherwise ->

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1609,14 +1609,16 @@ structuralMuNameMatches dataName muName =
   case structuralMuDataName muName of
     Just muDataName ->
       dataName == muDataName
-        || unqualifiedName dataName == muDataName
-        || dataName == unqualifiedName muDataName
-        || unqualifiedName dataName == unqualifiedName muDataName
+        || (isUnqualifiedName muDataName && unqualifiedName dataName == muDataName)
     Nothing -> False
 
 structuralMuDataName :: String -> Maybe String
 structuralMuDataName name =
   stripSuffixSimple "_self" (dropWhile (== '$') name)
+
+isUnqualifiedName :: String -> Bool
+isUnqualifiedName =
+  notElem '.'
 
 unqualifiedName :: String -> String
 unqualifiedName =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -279,7 +279,7 @@ spec = describe "MLF.Backend.Convert" $ do
 
     validateBackendProgram backend `shouldBe` Right ()
 
-  it "ignores stale constructor head type instantiations" $ do
+  it "rejects constructor head type instantiations with no matching constructor parameter" $ do
     checked0 <- requireChecked constructorForallApplicationProgram
     let checked =
           mapMainBinding
@@ -293,12 +293,39 @@ spec = describe "MLF.Backend.Convert" $ do
                   }
             )
             checked0
-    backend <- requireRight (convertCheckedProgram checked)
 
-    validateBackendProgram backend `shouldBe` Right ()
+    case convertCheckedProgram checked of
+      Left (BackendUnsupportedCaseShape message) ->
+        message `shouldSatisfy` isInfixOf "constructor type application arity mismatch"
+      Left err ->
+        expectationFailure ("expected constructor type application arity mismatch, got " ++ show err)
+      Right backend ->
+        expectationFailure ("expected constructor type application rejection, got " ++ show backend)
 
-    mainBinding <- requireBinding (backendProgramMain backend) backend
-    collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__Pack"]
+  it "rejects constructor head type instantiations that conflict with the expected result" $ do
+    checked0 <- requireChecked gadtResultConstructorProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingTerm =
+                      replaceConstructorHeadInstantiation
+                        "Main__Box"
+                        boolElabTy
+                        (checkedBindingTerm binding)
+                  }
+            )
+            checked0
+
+    case convertCheckedProgram checked of
+      Left (BackendUnsupportedCaseShape message) ->
+        message `shouldSatisfy` isInfixOf "constructor"
+      Left (BackendValidationFailed (BackendConstructorArgumentMismatch name _ _ _)) ->
+        name `shouldBe` "Main__Box"
+      Left err ->
+        expectationFailure ("expected constructor type application mismatch, got " ++ show err)
+      Right backend ->
+        expectationFailure ("expected constructor type application rejection, got " ++ show backend)
 
   it "matches repeated constructor parameters modulo alpha-equivalence" $ do
     checked0 <- requireChecked repeatedPolymorphicParameterProgram
@@ -514,6 +541,17 @@ parameterizedConstructorProgram =
       "    | Some : a -> Option a;",
       "",
       "  def main : Option Int = Some 1;",
+      "}"
+    ]
+
+gadtResultConstructorProgram :: String
+gadtResultConstructorProgram =
+  unlines
+    [ "module Main export (Box(..), main) {",
+      "  data Box a =",
+      "      Box : forall (b >= Int). b -> Box b;",
+      "",
+      "  def main : Box Int = Box 1;",
       "}"
     ]
 
@@ -1185,6 +1223,39 @@ addStaleConstructorHeadInstantiation target staleTy =
         (headTerm, args)
           | isTargetConstructorHead headTerm ->
               rebuildAppsElab (Elab.ETyInst headTerm (Elab.InstApp staleTy)) args
+        _ ->
+          case term of
+            Elab.ELam name ty body ->
+              Elab.ELam name ty (go body)
+            Elab.EApp fun arg ->
+              Elab.EApp (go fun) (go arg)
+            Elab.ELet name scheme rhs body ->
+              Elab.ELet name scheme (go rhs) (go body)
+            Elab.ETyAbs name mbBound body ->
+              Elab.ETyAbs name mbBound (go body)
+            Elab.ETyInst inner inst ->
+              Elab.ETyInst (go inner) inst
+            Elab.ERoll ty body ->
+              Elab.ERoll ty (go body)
+            Elab.EUnroll body ->
+              Elab.EUnroll (go body)
+            _ ->
+              term
+
+    isTargetConstructorHead headTerm =
+      case stripElabTypeInsts headTerm of
+        Elab.EVar name -> name == target
+        _ -> False
+
+replaceConstructorHeadInstantiation :: String -> Elab.ElabType -> Elab.ElabTerm -> Elab.ElabTerm
+replaceConstructorHeadInstantiation target replacementTy =
+  go
+  where
+    go term =
+      case collectAppsElab term of
+        (headTerm, args)
+          | isTargetConstructorHead headTerm ->
+              rebuildAppsElab (Elab.ETyInst (stripElabTypeInsts headTerm) (Elab.InstApp replacementTy)) args
         _ ->
           case term of
             Elab.ELam name ty body ->

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -355,6 +355,7 @@ spec = describe "MLF.Backend.Convert" $ do
 
     backend <- requireRight (convertCheckedProgram checked)
 
+    validateBackendProgram backend `shouldBe` Right ()
     mainBinding <- requireBinding (backendProgramMain backend) backend
     collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__T"]
     collectConstructNames (backendBindingExpr mainBinding) `shouldNotContain` ["Core__External"]

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -199,6 +199,28 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Core__NothingF"]
 
+  it "rejects stale structural constructor head type instantiations" $ do
+    checked0 <- requireChecked hiddenOwnerConstructorImportProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingTerm =
+                      addStructuralConstructorHeadInstantiation
+                        boolElabTy
+                        (checkedBindingTerm binding)
+                  }
+            )
+            checked0
+
+    case convertCheckedProgram checked of
+      Left (BackendUnsupportedCaseShape message) ->
+        message `shouldSatisfy` isInfixOf "constructor"
+      Left err ->
+        expectationFailure ("expected structural constructor type application mismatch, got " ++ show err)
+      Right backend ->
+        expectationFailure ("expected structural constructor type application rejection, got " ++ show backend)
+
   it "preserves constructor type applications when checking constructor fields" $ do
     checked <- requireChecked constructorForallApplicationProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -1993,6 +2015,33 @@ replaceConstructorHeadInstantiation target replacementTy =
       case stripElabTypeInsts headTerm of
         Elab.EVar name -> name == target
         _ -> False
+
+addStructuralConstructorHeadInstantiation :: Elab.ElabType -> Elab.ElabTerm -> Elab.ElabTerm
+addStructuralConstructorHeadInstantiation staleTy =
+  go
+  where
+    go term =
+      case collectAppsElab term of
+        (headTerm@Elab.ERoll {}, args) ->
+          rebuildAppsElab (Elab.ETyInst headTerm (Elab.InstApp staleTy)) args
+        _ ->
+          case term of
+            Elab.ELam name ty body ->
+              Elab.ELam name ty (go body)
+            Elab.EApp fun arg ->
+              Elab.EApp (go fun) (go arg)
+            Elab.ELet name scheme rhs body ->
+              Elab.ELet name scheme (go rhs) (go body)
+            Elab.ETyAbs name mbBound body ->
+              Elab.ETyAbs name mbBound (go body)
+            Elab.ETyInst inner inst ->
+              Elab.ETyInst (go inner) inst
+            Elab.ERoll ty body ->
+              Elab.ERoll ty (go body)
+            Elab.EUnroll body ->
+              Elab.EUnroll (go body)
+            _ ->
+              term
 
 stripElabTypeInsts :: Elab.ElabTerm -> Elab.ElabTerm
 stripElabTypeInsts term =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -327,6 +327,27 @@ spec = describe "MLF.Backend.Convert" $ do
       Right backend ->
         expectationFailure ("expected constructor type application rejection, got " ++ show backend)
 
+  it "rejects constructor head type instantiations that would fall back to same-named type variables" $ do
+    checked0 <- requireChecked parameterizedConstructorProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingSourceType = polymorphicOptionSourceTy,
+                    checkedBindingType = polymorphicOptionElabTy,
+                    checkedBindingTerm = staleSomeInPolymorphicOptionTerm
+                  }
+            )
+            checked0
+
+    case convertCheckedProgram checked of
+      Left (BackendUnsupportedCaseShape message) ->
+        message `shouldSatisfy` isInfixOf "constructor result type does not match expected result"
+      Left err ->
+        expectationFailure ("expected constructor result type mismatch, got " ++ show err)
+      Right backend ->
+        expectationFailure ("expected constructor type application rejection, got " ++ show backend)
+
   it "matches repeated constructor parameters modulo alpha-equivalence" $ do
     checked0 <- requireChecked repeatedPolymorphicParameterProgram
     let checked =
@@ -1074,6 +1095,37 @@ boolElabTy :: Elab.ElabType
 boolElabTy =
   Elab.TBase (BaseTy "Bool")
 
+polymorphicOptionSourceTy :: SrcType
+polymorphicOptionSourceTy =
+  STForall
+    "a"
+    Nothing
+    (STArrow (STVar "a") (STCon "Main.Option" (STVar "a" :| [])))
+
+polymorphicOptionElabTy :: Elab.ElabType
+polymorphicOptionElabTy =
+  Elab.TForall
+    "a"
+    Nothing
+    ( Elab.TArrow
+        (Elab.TVar "a")
+        (Elab.TCon (BaseTy "Main.Option") (Elab.TVar "a" :| []))
+    )
+
+staleSomeInPolymorphicOptionTerm :: Elab.ElabTerm
+staleSomeInPolymorphicOptionTerm =
+  Elab.ETyAbs
+    "a"
+    Nothing
+    ( Elab.ELam
+        "x"
+        (Elab.TVar "a")
+        ( Elab.EApp
+            (Elab.ETyInst (Elab.EVar "Main__Some") (Elab.InstApp boolElabTy))
+            (Elab.EVar "x")
+        )
+    )
+
 intElabBoundTy :: Elab.BoundType
 intElabBoundTy =
   Elab.TBase (BaseTy "Int")
@@ -1182,6 +1234,10 @@ unqualifiedStructuralTElabTy =
 
 mapMainBinding :: (CheckedBinding -> CheckedBinding) -> CheckedProgram -> CheckedProgram
 mapMainBinding f checked =
+  mapBinding (checkedProgramMain checked) f checked
+
+mapBinding :: String -> (CheckedBinding -> CheckedBinding) -> CheckedProgram -> CheckedProgram
+mapBinding target f checked =
   checked
     { checkedProgramModules =
         map updateModule (checkedProgramModules checked)
@@ -1194,7 +1250,7 @@ mapMainBinding f checked =
         }
 
     updateBinding binding
-      | checkedBindingName binding == checkedProgramMain checked = f binding
+      | checkedBindingName binding == target = f binding
       | otherwise = binding
 
 mapBackendMainBinding :: (BackendBinding -> BackendBinding) -> BackendProgram -> BackendProgram

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -208,6 +208,21 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__Pack"]
 
+  it "maps constructor type applications in backend data parameter order" $ do
+    checked0 <- requireChecked dataParameterOrderConstructorProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding {checkedBindingTerm = dataParameterOrderConstructorTerm}
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__Mk"]
+
   it "preserves bounded constructor foralls in backend metadata" $ do
     checked <- requireChecked boundedConstructorForallProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -861,6 +876,29 @@ constructorForallApplicationProgram =
       "  def main : Pack = Pack 1;",
       "}"
     ]
+
+dataParameterOrderConstructorProgram :: String
+dataParameterOrderConstructorProgram =
+  unlines
+    [ "module Main export (T(..), main) {",
+      "  data T z a =",
+      "      Mk : z -> a -> T z a;",
+      "",
+      "  def main : T Bool Int = Mk true 1;",
+      "}"
+    ]
+
+dataParameterOrderConstructorTerm :: Elab.ElabTerm
+dataParameterOrderConstructorTerm =
+  Elab.EApp
+    ( Elab.EApp
+        ( Elab.ETyInst
+            (Elab.ETyInst (Elab.EVar "Main__Mk") (Elab.InstApp boolElabTy))
+            (Elab.InstApp intElabTy)
+        )
+        (Elab.ELit (LBool True))
+    )
+    (Elab.ELit (LInt 1))
 
 boundedConstructorForallProgram :: String
 boundedConstructorForallProgram =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -340,6 +340,25 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendCase
 
+  it "scopes unqualified structural owner recovery to the current module" $ do
+    checked0 <- requireChecked sameNameUnqualifiedStructuralOwnerProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingSourceType = STBase "Main.T",
+                    checkedBindingType = Elab.TBase (BaseTy "Main.T"),
+                    checkedBindingTerm = unqualifiedStructuralNullaryConstructorTerm
+                  }
+            )
+            checked0
+
+    backend <- requireRight (convertCheckedProgram checked)
+
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__T"]
+    collectConstructNames (backendBindingExpr mainBinding) `shouldNotContain` ["Core__External"]
+
   it "treats stale app-like instantiations on non-forall terms as no-ops" $ do
     checked0 <- requireChecked simpleFunctionProgram
     let checked =
@@ -627,6 +646,24 @@ qualifiedAliasOrderingProgram =
       "  def main : Bool = case Z.make of {",
       "    Z.ZValue -> true",
       "  };",
+      "}"
+    ]
+
+sameNameUnqualifiedStructuralOwnerProgram :: String
+sameNameUnqualifiedStructuralOwnerProgram =
+  unlines
+    [ "module Core export (T(..)) {",
+      "  data T =",
+      "      External : T;",
+      "}",
+      "",
+      "module Main export (T(..), main) {",
+      "  import Core as C;",
+      "",
+      "  data T =",
+      "      T : T;",
+      "",
+      "  def main : T = T;",
       "}"
     ]
 
@@ -1083,6 +1120,26 @@ alphaEquivalentIdentityTerm =
     "b"
     Nothing
     (Elab.ELam "$poly_id_b" (Elab.TVar "b") (Elab.EVar "$poly_id_b"))
+
+unqualifiedStructuralNullaryConstructorTerm :: Elab.ElabTerm
+unqualifiedStructuralNullaryConstructorTerm =
+  Elab.ERoll
+    unqualifiedStructuralTElabTy
+    ( Elab.ETyAbs
+        "$T_result"
+        Nothing
+        (Elab.ELam "$T_handler" (Elab.TVar "$T_result") (Elab.EVar "$T_handler"))
+    )
+
+unqualifiedStructuralTElabTy :: Elab.ElabType
+unqualifiedStructuralTElabTy =
+  Elab.TMu
+    "$T_self"
+    ( Elab.TForall
+        "$T_result"
+        Nothing
+        (Elab.TArrow (Elab.TVar "$T_result") (Elab.TVar "$T_result"))
+    )
 
 mapMainBinding :: (CheckedBinding -> CheckedBinding) -> CheckedProgram -> CheckedProgram
 mapMainBinding f checked =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -178,6 +178,26 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Main__Some"]
 
+  it "recovers higher-kinded structural constructors as backend constructors" $ do
+    checked <- requireChecked higherKindedConstructorProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    let constructNames = collectConstructNames (backendBindingExpr mainBinding)
+    constructNames `shouldContain` ["Main__Wrap", "Main__Box"]
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendCase
+
+  it "recovers hidden-owner value-only constructor imports" $ do
+    checked <- requireChecked hiddenOwnerConstructorImportProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    collectConstructNames (backendBindingExpr mainBinding) `shouldContain` ["Core__NothingF"]
+
   it "preserves constructor type applications when checking constructor fields" $ do
     checked <- requireChecked constructorForallApplicationProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -372,9 +392,9 @@ spec = describe "MLF.Backend.Convert" $ do
       other ->
         expectationFailure ("expected nested recursive-let capture rejection, got " ++ show other)
 
-  it "reports unsupported source type applications instead of weakening them" $ do
+  it "converts source type applications into backend applied type variables" $ do
     convertSourceType unsupportedVariableHeadType
-      `shouldBe` Left (BackendUnsupportedSourceType unsupportedVariableHeadType)
+      `shouldBe` Right (BTVarApp "f" (intTy :| []))
 
 simpleFunctionProgram :: String
 simpleFunctionProgram =
@@ -474,6 +494,46 @@ parameterizedConstructorProgram =
       "    | Some : a -> Option a;",
       "",
       "  def main : Option Int = Some 1;",
+      "}"
+    ]
+
+higherKindedConstructorProgram :: String
+higherKindedConstructorProgram =
+  unlines
+    [ "module Main export (Box(..), Wrap(..), main) {",
+      "  data Box a =",
+      "      Box : a -> Box a;",
+      "",
+      "  data Wrap (f :: * -> *) a =",
+      "      Wrap : f a -> Wrap f a;",
+      "",
+      "  def main : Bool = case Wrap (Box false) of {",
+      "    Wrap box -> true",
+      "  };",
+      "}"
+    ]
+
+hiddenOwnerConstructorImportProgram :: String
+hiddenOwnerConstructorImportProgram =
+  unlines
+    [ "module Core export (Box(..), NothingF, accept) {",
+      "  data Box a =",
+      "      Box : a -> Box a;",
+      "",
+      "  data MaybeF (f :: * -> *) a =",
+      "      NothingF : MaybeF f a",
+      "    | JustF : f a -> MaybeF f a;",
+      "",
+      "  def accept : MaybeF Box Bool -> Bool = \\value case value of {",
+      "    NothingF -> true;",
+      "    JustF box -> true",
+      "  };",
+      "}",
+      "",
+      "module Main export (main) {",
+      "  import Core exposing (NothingF, accept);",
+      "  def id : forall a. a -> a = \\x x;",
+      "  def main : Bool = accept (id NothingF);",
       "}"
     ]
 
@@ -735,6 +795,7 @@ renderBackendIRType backendTy =
     BTArrow dom cod -> "(" ++ renderBackendIRType dom ++ " -> " ++ renderBackendIRType cod ++ ")"
     BTBase (BaseTy name) -> name
     BTCon (BaseTy name) args -> name ++ "<" ++ intercalate ", " (map renderBackendIRType (toList args)) ++ ">"
+    BTVarApp name args -> "$" ++ name ++ "<" ++ intercalate ", " (map renderBackendIRType (toList args)) ++ ">"
     BTForall name mbBound body -> "forall " ++ renderTypeBinder name mbBound ++ ". " ++ renderBackendIRType body
     BTMu name body -> "mu " ++ name ++ ". " ++ renderBackendIRType body
     BTBottom -> "bottom"

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -182,6 +182,9 @@ spec = describe "MLF.Backend.IR" $ do
     alphaEqBackendType (BTBase (BaseTy "Core.T")) (BTMu "$Core.T_self" BTBottom)
       `shouldBe` False
 
+    validateBackendProgram (programWithMainExpr malformedStructuralBoxConstructExpr)
+      `shouldBe` Left (BackendConstructorResultMismatch "Box" boxTy malformedStructuralBoxTy)
+
   it "preserves nominal arguments when structural recursive payloads omit them" $ do
     alphaEqBackendType
       (BTCon (BaseTy "Core.Phantom") (intTy :| []))
@@ -227,6 +230,9 @@ spec = describe "MLF.Backend.IR" $ do
 
     validateBackendProgram (programWithDataAndMainExpr [optionData] optionCaseExpr)
       `shouldBe` Right ()
+
+    validateBackendProgram (programWithDataAndMainExpr [optionData] someIntAsOptionVarExpr)
+      `shouldBe` Left (BackendConstructorArgumentMismatch "Some" 0 (BTVar "a") intTy)
 
     validateBackendProgram (programWithDataAndMainExpr [optionData] someBoolAsOptionIntExpr)
       `shouldBe` Left (BackendConstructorArgumentMismatch "Some" 0 intTy boolTy)
@@ -570,9 +576,21 @@ someIntExpr :: BackendExpr
 someIntExpr =
   BackendConstruct (optionTy intTy) "Some" [intLit 1]
 
+someIntAsOptionVarExpr :: BackendExpr
+someIntAsOptionVarExpr =
+  BackendConstruct (optionTy (BTVar "a")) "Some" [intLit 1]
+
 someBoolAsOptionIntExpr :: BackendExpr
 someBoolAsOptionIntExpr =
   BackendConstruct (optionTy intTy) "Some" [boolLit True]
+
+malformedStructuralBoxTy :: BackendType
+malformedStructuralBoxTy =
+  BTMu "$Box_self" BTBottom
+
+malformedStructuralBoxConstructExpr :: BackendExpr
+malformedStructuralBoxConstructExpr =
+  BackendConstruct malformedStructuralBoxTy "Box" [intLit 1]
 
 justFBoxBoolExpr :: BackendExpr
 justFBoxBoolExpr =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -178,6 +178,21 @@ spec = describe "MLF.Backend.IR" $ do
     alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$T_self" intTy)
       `shouldBe` False
 
+  it "preserves nominal arguments when structural recursive payloads omit them" $ do
+    alphaEqBackendType
+      (BTCon (BaseTy "Core.Phantom") (intTy :| []))
+      (BTMu "$Core.Phantom_self" (BTForall "r" Nothing (BTVar "r")))
+      `shouldBe` False
+
+    alphaEqBackendType
+      (BTCon (BaseTy "Core.Phantom") (BTVar "a" :| []))
+      (BTMu "$Core.Phantom_self" (BTForall "r" Nothing (BTVar "r")))
+      `shouldBe` True
+
+  it "recovers structural data arguments in declared parameter order" $ do
+    validateBackendProgram (programWithDataAndMainExpr [outOfOrderStructuralData] outOfOrderStructuralConstructExpr)
+      `shouldBe` Right ()
+
   it "rejects recursive roll and unroll type mismatches" $ do
     let recTy = BTMu "self" intTy
 
@@ -506,6 +521,20 @@ captureCaseData =
     { backendDataName = "CaptureCase",
       backendDataParameters = ["p"],
       backendDataConstructors = [BackendConstructor "CaptureCase" [] [] captureCaseTemplateTy]
+    }
+
+outOfOrderStructuralData :: BackendData
+outOfOrderStructuralData =
+  BackendData
+    { backendDataName = "OutOfOrder",
+      backendDataParameters = ["a", "b"],
+      backendDataConstructors =
+        [ BackendConstructor
+            "OutOfOrder"
+            []
+            [BTVar "b", BTVar "a"]
+            outOfOrderStructuralTy
+        ]
     }
 
 boxCaseExpr :: BackendExpr
@@ -864,3 +893,25 @@ captureCaseTemplateTy =
 captureCaseScrutineeTy :: BackendType
 captureCaseScrutineeTy =
   BTCon (BaseTy "CaptureCase") (BTVar "a1" :| [captureForallActualTy])
+
+outOfOrderStructuralConstructExpr :: BackendExpr
+outOfOrderStructuralConstructExpr =
+  BackendConstruct
+    (outOfOrderTy intTy boolTy)
+    "OutOfOrder"
+    [boolLit True, intLit 1]
+
+outOfOrderTy :: BackendType -> BackendType -> BackendType
+outOfOrderTy aTy bTy =
+  BTCon (BaseTy "OutOfOrder") (aTy :| [bTy])
+
+outOfOrderStructuralTy :: BackendType
+outOfOrderStructuralTy =
+  BTMu "$OutOfOrder_self" outOfOrderStructuralBody
+
+outOfOrderStructuralBody :: BackendType
+outOfOrderStructuralBody =
+  BTForall
+    "r"
+    Nothing
+    (BTArrow (BTArrow (BTVar "b") (BTArrow (BTVar "a") (BTVar "r"))) (BTVar "r"))

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -97,6 +97,7 @@ spec = describe "MLF.Backend.IR" $ do
         structuralBoxIntTy = BTMu "$Box_self" (singleFieldStructuralBody intTy)
         structuralBoxFreeTy = BTMu "$Box_self" (singleFieldStructuralBody (BTVar "a"))
         listIntToBoolTy = BTArrow listIntTy boolTy
+        structuralBoxIntToBoolTy = BTArrow structuralBoxIntTy boolTy
         listTyAbsAppExpr =
           BackendTyAbs
             (BTForall "a" Nothing (BTArrow (listTy (BTVar "a")) boolTy))
@@ -114,6 +115,23 @@ spec = describe "MLF.Backend.IR" $ do
             )
         listIntToBoolExpr =
           BackendLam listIntToBoolTy "ys" listIntTy (boolLit True)
+        structuralBoxTyAbsAppExpr =
+          BackendTyAbs
+            (BTForall "a" Nothing (BTArrow structuralBoxFreeTy boolTy))
+            "a"
+            Nothing
+            ( BackendLam
+                (BTArrow structuralBoxFreeTy boolTy)
+                "xs"
+                structuralBoxFreeTy
+                ( BackendApp
+                    boolTy
+                    (BackendVar structuralBoxIntToBoolTy "f")
+                    (BackendVar structuralBoxFreeTy "xs")
+                )
+            )
+        structuralBoxIntToBoolExpr =
+          BackendLam structuralBoxIntToBoolTy "box" structuralBoxIntTy (boolLit True)
 
     validateBackendExpr (BackendApp intTy (BackendVar (BTArrow listIntTy intTy) "f") (BackendVar listFreeTy "xs"))
       `shouldBe` Left (BackendApplicationArgumentMismatch listIntTy listFreeTy)
@@ -135,6 +153,9 @@ spec = describe "MLF.Backend.IR" $ do
 
     validateBackendProgram (programWithBindings [binding "f" listIntToBoolTy listIntToBoolExpr, mainBinding listTyAbsAppExpr])
       `shouldBe` Left (BackendApplicationArgumentMismatch listIntTy (listTy (BTVar "a")))
+
+    validateBackendProgram (programWithBindings [binding "f" structuralBoxIntToBoolTy structuralBoxIntToBoolExpr, mainBinding structuralBoxTyAbsAppExpr])
+      `shouldBe` Left (BackendApplicationArgumentMismatch structuralBoxIntTy structuralBoxFreeTy)
 
     validateBackendExpr (BackendApp boolTy (BackendVar (BTArrow structuralBoxFreeTy boolTy) "f") (BackendVar structuralBoxIntTy "box"))
       `shouldBe` Right ()

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -43,6 +43,28 @@ spec = describe "MLF.Backend.IR" $ do
       )
       `shouldBe` Left (BackendVariableTypeMismatch "helper" intTy (BTVar "a"))
 
+    validateBackendProgram
+      ( programWithMainExpr
+          ( BackendLam
+              (BTArrow (BTVar "a") (BTVar "b"))
+              "x"
+              (BTVar "a")
+              (BackendVar (BTVar "b") "x")
+          )
+      )
+      `shouldBe` Left (BackendVariableTypeMismatch "x" (BTVar "a") (BTVar "b"))
+
+    validateBackendProgram
+      ( programWithMainExpr
+          ( BackendLam
+              (BTArrow (BTVar "a") (BTVar "a1"))
+              "x"
+              (BTVar "a")
+              (BackendVar (BTVar "a1") "x")
+          )
+      )
+      `shouldBe` Left (BackendVariableTypeMismatch "x" (BTVar "a") (BTVar "a1"))
+
     validateBackendProgram (programWithMainExpr letIdentityExpr)
       `shouldBe` Right ()
 
@@ -74,6 +96,24 @@ spec = describe "MLF.Backend.IR" $ do
         forallFreeTy = BTForall "y" Nothing (BTArrow (BTVar "a") (BTVar "y"))
         structuralBoxIntTy = BTMu "$Box_self" (singleFieldStructuralBody intTy)
         structuralBoxFreeTy = BTMu "$Box_self" (singleFieldStructuralBody (BTVar "a"))
+        listIntToBoolTy = BTArrow listIntTy boolTy
+        listTyAbsAppExpr =
+          BackendTyAbs
+            (BTForall "a" Nothing (BTArrow (listTy (BTVar "a")) boolTy))
+            "a"
+            Nothing
+            ( BackendLam
+                (BTArrow (listTy (BTVar "a")) boolTy)
+                "xs"
+                (listTy (BTVar "a"))
+                ( BackendApp
+                    boolTy
+                    (BackendVar listIntToBoolTy "f")
+                    (BackendVar (listTy (BTVar "a")) "xs")
+                )
+            )
+        listIntToBoolExpr =
+          BackendLam listIntToBoolTy "ys" listIntTy (boolLit True)
 
     validateBackendExpr (BackendApp intTy (BackendVar (BTArrow listIntTy intTy) "f") (BackendVar listFreeTy "xs"))
       `shouldBe` Left (BackendApplicationArgumentMismatch listIntTy listFreeTy)
@@ -92,6 +132,9 @@ spec = describe "MLF.Backend.IR" $ do
 
     validateBackendExpr (BackendApp listIntTy (BackendVar (BTArrow intTy listFreeTy) "f") (intLit 1))
       `shouldBe` Left (BackendApplicationResultMismatch listIntTy listFreeTy)
+
+    validateBackendProgram (programWithBindings [binding "f" listIntToBoolTy listIntToBoolExpr, mainBinding listTyAbsAppExpr])
+      `shouldBe` Left (BackendApplicationArgumentMismatch listIntTy (listTy (BTVar "a")))
 
     validateBackendExpr (BackendApp boolTy (BackendVar (BTArrow structuralBoxFreeTy boolTy) "f") (BackendVar structuralBoxIntTy "box"))
       `shouldBe` Right ()

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -58,6 +58,12 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendExpr (BackendApp intTy intIdentityExpr (boolLit True))
       `shouldBe` Left (BackendApplicationArgumentMismatch intTy boolTy)
 
+    validateBackendExpr (BackendApp intTy intIdentityExpr (BackendVar (BTVar "a") "x"))
+      `shouldBe` Left (BackendApplicationArgumentMismatch intTy (BTVar "a"))
+
+    validateBackendExpr (BackendApp (BTVar "a") intIdentityExpr (intLit 1))
+      `shouldBe` Left (BackendApplicationResultMismatch (BTVar "a") intTy)
+
     validateBackendExpr (BackendLam boolTy "x" intTy (BackendVar intTy "x"))
       `shouldBe` Left (BackendLambdaTypeMismatch boolTy idTy)
 

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -305,6 +305,9 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithMainExpr mismatchedStructuralBoxConstructExpr)
       `shouldBe` Left (BackendConstructorResultMismatch "Box" boxTy mismatchedStructuralBoxTy)
 
+    validateBackendProgram mismatchedStructuralBoxCaseProgram
+      `shouldBe` Left (BackendCaseConstructorScrutineeMismatch "Box" mismatchedStructuralBoxTy boxTy)
+
   it "preserves nominal arguments when structural recursive payloads omit them" $ do
     alphaEqBackendType
       (BTCon (BaseTy "Core.Phantom") (intTy :| []))
@@ -727,6 +730,18 @@ mismatchedStructuralBoxTy =
 mismatchedStructuralBoxConstructExpr :: BackendExpr
 mismatchedStructuralBoxConstructExpr =
   BackendConstruct mismatchedStructuralBoxTy "Box" [intLit 1]
+
+mismatchedStructuralBoxCaseProgram :: BackendProgram
+mismatchedStructuralBoxCaseProgram =
+  programWithDataAndBindings
+    [boxData]
+    [ binding "badBox" mismatchedStructuralBoxTy (BackendVar mismatchedStructuralBoxTy "badBox"),
+      mainBinding
+        ( boxCaseExprWith
+            (BackendVar mismatchedStructuralBoxTy "badBox")
+            (BackendAlternative (BackendConstructorPattern "Box" ["n"]) (BackendVar intTy "n") :| [])
+        )
+    ]
 
 justFBoxBoolExpr :: BackendExpr
 justFBoxBoolExpr =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -193,6 +193,16 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithMainExpr malformedStructuralBoxConstructExpr)
       `shouldBe` Left (BackendConstructorResultMismatch "Box" boxTy malformedStructuralBoxTy)
 
+  it "checks structural constructor result payloads against metadata" $ do
+    alphaEqBackendType boxTy structuralBoxTy
+      `shouldBe` False
+
+    validateBackendProgram (programWithMainExpr structuralBoxConstructExpr)
+      `shouldBe` Right ()
+
+    validateBackendProgram (programWithMainExpr mismatchedStructuralBoxConstructExpr)
+      `shouldBe` Left (BackendConstructorResultMismatch "Box" boxTy mismatchedStructuralBoxTy)
+
   it "preserves nominal arguments when structural recursive payloads omit them" $ do
     alphaEqBackendType
       (BTCon (BaseTy "Core.Phantom") (intTy :| []))
@@ -600,6 +610,22 @@ malformedStructuralBoxConstructExpr :: BackendExpr
 malformedStructuralBoxConstructExpr =
   BackendConstruct malformedStructuralBoxTy "Box" [intLit 1]
 
+structuralBoxTy :: BackendType
+structuralBoxTy =
+  BTMu "$Box_self" (singleFieldStructuralBody intTy)
+
+structuralBoxConstructExpr :: BackendExpr
+structuralBoxConstructExpr =
+  BackendConstruct structuralBoxTy "Box" [intLit 1]
+
+mismatchedStructuralBoxTy :: BackendType
+mismatchedStructuralBoxTy =
+  BTMu "$Box_self" (singleFieldStructuralBody boolTy)
+
+mismatchedStructuralBoxConstructExpr :: BackendExpr
+mismatchedStructuralBoxConstructExpr =
+  BackendConstruct mismatchedStructuralBoxTy "Box" [intLit 1]
+
 justFBoxBoolExpr :: BackendExpr
 justFBoxBoolExpr =
   BackendConstruct (maybeFTy (BTBase (BaseTy "BoxF")) boolTy) "JustF" [BackendConstruct (boxFTy boolTy) "BoxF" [boolLit True]]
@@ -906,6 +932,10 @@ boolTy =
 nullaryStructuralBody :: BackendType
 nullaryStructuralBody =
   BTForall "r" Nothing (BTArrow (BTVar "r") (BTVar "r"))
+
+singleFieldStructuralBody :: BackendType -> BackendType
+singleFieldStructuralBody fieldTy =
+  BTForall "r" Nothing (BTArrow (BTArrow fieldTy (BTVar "r")) (BTVar "r"))
 
 boxTy :: BackendType
 boxTy =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -168,6 +168,16 @@ spec = describe "MLF.Backend.IR" $ do
       )
       `shouldBe` Right ()
 
+  it "keeps structural recursive owner names module-qualified" $ do
+    alphaEqBackendType (BTBase (BaseTy "Core.T")) (BTMu "$Core.T_self" intTy)
+      `shouldBe` True
+
+    alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$Core.T_self" intTy)
+      `shouldBe` False
+
+    alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$T_self" intTy)
+      `shouldBe` False
+
   it "rejects recursive roll and unroll type mismatches" $ do
     let recTy = BTMu "self" intTy
 

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -169,13 +169,17 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Right ()
 
   it "keeps structural recursive owner names module-qualified" $ do
-    alphaEqBackendType (BTBase (BaseTy "Core.T")) (BTMu "$Core.T_self" intTy)
+    alphaEqBackendType (BTBase (BaseTy "Core.T")) (BTMu "$Core.T_self" nullaryStructuralBody)
       `shouldBe` True
 
-    alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$Core.T_self" intTy)
+    alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$Core.T_self" nullaryStructuralBody)
       `shouldBe` False
 
-    alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$T_self" intTy)
+    alphaEqBackendType (BTBase (BaseTy "Other.T")) (BTMu "$T_self" nullaryStructuralBody)
+      `shouldBe` False
+
+  it "rejects non-structural recursive bodies as nominal data encodings" $ do
+    alphaEqBackendType (BTBase (BaseTy "Core.T")) (BTMu "$Core.T_self" BTBottom)
       `shouldBe` False
 
   it "preserves nominal arguments when structural recursive payloads omit them" $ do
@@ -821,6 +825,10 @@ intTy =
 boolTy :: BackendType
 boolTy =
   BTBase (BaseTy "Bool")
+
+nullaryStructuralBody :: BackendType
+nullaryStructuralBody =
+  BTForall "r" Nothing (BTArrow (BTVar "r") (BTVar "r"))
 
 boxTy :: BackendType
 boxTy =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -64,6 +64,38 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendExpr (BackendApp (BTVar "a") intIdentityExpr (intLit 1))
       `shouldBe` Left (BackendApplicationResultMismatch (BTVar "a") intTy)
 
+    let listIntTy = listTy intTy
+        listFreeTy = listTy (BTVar "a")
+        arrowIntBoolTy = BTArrow intTy boolTy
+        arrowFreeBoolTy = BTArrow (BTVar "a") boolTy
+        varAppIntTy = BTVarApp "f" (intTy :| [])
+        varAppFreeTy = BTVarApp "f" (BTVar "a" :| [])
+        forallIntTy = BTForall "x" Nothing (BTArrow intTy (BTVar "x"))
+        forallFreeTy = BTForall "y" Nothing (BTArrow (BTVar "a") (BTVar "y"))
+        structuralBoxIntTy = BTMu "$Box_self" (singleFieldStructuralBody intTy)
+        structuralBoxFreeTy = BTMu "$Box_self" (singleFieldStructuralBody (BTVar "a"))
+
+    validateBackendExpr (BackendApp intTy (BackendVar (BTArrow listIntTy intTy) "f") (BackendVar listFreeTy "xs"))
+      `shouldBe` Left (BackendApplicationArgumentMismatch listIntTy listFreeTy)
+
+    validateBackendExpr (BackendApp listFreeTy (BackendVar (BTArrow intTy listIntTy) "f") (intLit 1))
+      `shouldBe` Left (BackendApplicationResultMismatch listFreeTy listIntTy)
+
+    validateBackendExpr (BackendApp boolTy (BackendVar (BTArrow arrowIntBoolTy boolTy) "f") (BackendVar arrowFreeBoolTy "g"))
+      `shouldBe` Left (BackendApplicationArgumentMismatch arrowIntBoolTy arrowFreeBoolTy)
+
+    validateBackendExpr (BackendApp boolTy (BackendVar (BTArrow varAppIntTy boolTy) "f") (BackendVar varAppFreeTy "x"))
+      `shouldBe` Left (BackendApplicationArgumentMismatch varAppIntTy varAppFreeTy)
+
+    validateBackendExpr (BackendApp boolTy (BackendVar (BTArrow forallIntTy boolTy) "f") (BackendVar forallFreeTy "poly"))
+      `shouldBe` Left (BackendApplicationArgumentMismatch forallIntTy forallFreeTy)
+
+    validateBackendExpr (BackendApp listIntTy (BackendVar (BTArrow intTy listFreeTy) "f") (intLit 1))
+      `shouldBe` Left (BackendApplicationResultMismatch listIntTy listFreeTy)
+
+    validateBackendExpr (BackendApp boolTy (BackendVar (BTArrow structuralBoxFreeTy boolTy) "f") (BackendVar structuralBoxIntTy "box"))
+      `shouldBe` Right ()
+
     validateBackendExpr (BackendLam boolTy "x" intTy (BackendVar intTy "x"))
       `shouldBe` Left (BackendLambdaTypeMismatch boolTy idTy)
 

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -191,6 +191,18 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithDataAndMainExpr [optionData] someBoolAsOptionIntExpr)
       `shouldBe` Left (BackendConstructorArgumentMismatch "Some" 0 intTy boolTy)
 
+  it "substitutes applied type variables in constructor metadata" $ do
+    substituteBackendTypes
+      (Map.fromList [("f", BTBase (BaseTy "BoxF")), ("a", boolTy)])
+      (BTVarApp "f" (BTVar "a" :| []))
+      `shouldBe` boxFTy boolTy
+
+    validateBackendProgram (programWithDataAndMainExpr [boxFData, maybeFData] justFBoxBoolExpr)
+      `shouldBe` Right ()
+
+    validateBackendProgram (programWithDataAndMainExpr [boxFData, maybeFData] maybeFCaseExpr)
+      `shouldBe` Right ()
+
   it "uses constructor-level forall metadata when validating constructor fields" $ do
     validateBackendProgram (programWithDataAndMainExpr [packData] packIntExpr)
       `shouldBe` Right ()
@@ -379,6 +391,25 @@ optionData =
       backendDataConstructors = [BackendConstructor "Some" [] [BTVar "a"] (optionTy (BTVar "a"))]
     }
 
+boxFData :: BackendData
+boxFData =
+  BackendData
+    { backendDataName = "BoxF",
+      backendDataParameters = ["a"],
+      backendDataConstructors = [BackendConstructor "BoxF" [] [BTVar "a"] (boxFTy (BTVar "a"))]
+    }
+
+maybeFData :: BackendData
+maybeFData =
+  BackendData
+    { backendDataName = "MaybeF",
+      backendDataParameters = ["f", "a"],
+      backendDataConstructors =
+        [ BackendConstructor "NothingF" [] [] (maybeFTy (BTVar "f") (BTVar "a")),
+          BackendConstructor "JustF" [] [BTVarApp "f" (BTVar "a" :| [])] (maybeFTy (BTVar "f") (BTVar "a"))
+        ]
+    }
+
 packData :: BackendData
 packData =
   BackendData
@@ -480,6 +511,20 @@ someIntExpr =
 someBoolAsOptionIntExpr :: BackendExpr
 someBoolAsOptionIntExpr =
   BackendConstruct (optionTy intTy) "Some" [boolLit True]
+
+justFBoxBoolExpr :: BackendExpr
+justFBoxBoolExpr =
+  BackendConstruct (maybeFTy (BTBase (BaseTy "BoxF")) boolTy) "JustF" [BackendConstruct (boxFTy boolTy) "BoxF" [boolLit True]]
+
+maybeFCaseExpr :: BackendExpr
+maybeFCaseExpr =
+  BackendCase
+    { backendExprType = boolTy,
+      backendScrutinee = justFBoxBoolExpr,
+      backendAlternatives =
+        BackendAlternative (BackendConstructorPattern "NothingF" []) (boolLit False)
+          :| [BackendAlternative (BackendConstructorPattern "JustF" ["box"]) (boolLit True)]
+    }
 
 packIntExpr :: BackendExpr
 packIntExpr =
@@ -769,6 +814,14 @@ listTy ty =
 optionTy :: BackendType -> BackendType
 optionTy ty =
   BTCon (BaseTy "Option") (ty :| [])
+
+boxFTy :: BackendType -> BackendType
+boxFTy ty =
+  BTCon (BaseTy "BoxF") (ty :| [])
+
+maybeFTy :: BackendType -> BackendType -> BackendType
+maybeFTy fTy argTy =
+  BTCon (BaseTy "MaybeF") (fTy :| [argTy])
 
 pairTy :: BackendType -> BackendType -> BackendType
 pairTy left right =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -35,6 +35,14 @@ spec = describe "MLF.Backend.IR" $ do
       )
       `shouldBe` Left (BackendVariableTypeMismatch "helper" intTy boolTy)
 
+    validateBackendProgram
+      ( programWithBindings
+          [ binding "helper" intTy (intLit 1),
+            mainBinding (BackendVar (BTVar "a") "helper")
+          ]
+      )
+      `shouldBe` Left (BackendVariableTypeMismatch "helper" intTy (BTVar "a"))
+
     validateBackendProgram (programWithMainExpr letIdentityExpr)
       `shouldBe` Right ()
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1322,17 +1322,7 @@ unsupportedLLVMParityCases =
     ("boundary: local first-class polymorphic let through constructor boundary should run", "could not infer type arguments [\"a\"]"),
     ("boundary: pattern-bound first-class polymorphic variable should run", "could not infer type arguments [\"a\"]"),
     ("boundary: partial overloaded method application should run after deferred resolution", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs higher-kinded data field over a concrete constructor head", "BackendUnsupportedSourceType"),
-    ("boundary: runs nullary constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
-    ("boundary: runs first-class nullary constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
-    ("boundary: runs value-imported constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
-    ("boundary: runs value-exported constructor when owner type is not exported", "BackendUnsupportedSourceType"),
-    ("boundary: runs value-exported constructor from bulk import when owner type is not exported", "BackendUnsupportedSourceType"),
-    ("boundary: runs value-exported constructor from aliased bulk import when owner type is not exported", "BackendUnsupportedSourceType"),
-    ("boundary: runs aliased bulk-imported hidden-owner constructors in one case", "BackendUnsupportedSourceType"),
-    ("boundary: runs value-exported GADT constructor when owner type is not exported", "BackendUnsupportedSourceType"),
-    ("boundary: runs value-imported nonzero-index constructor from mixed higher-kinded data type", "BackendUnsupportedSourceType"),
-    ("boundary: runs constrained helper through hidden Eq evidence", "constructor result type does not match expected result"),
+    ("boundary: runs constrained helper through hidden Eq evidence", "BackendVariableTypeMismatch \"Main__Eq__Nat__eq\""),
     ("boundary: runs ground constrained helper alias with resolved evidence", "Unsupported backend LLVM type at parameter \"$evidence_Eq_eq#0\" of Main__sameBool"),
     ("boundary: runs constrained helper after local lambda inference", "escaping function \"Main__Eq__Bool__eq\""),
     ("boundary: runs deferred method with method-level type variable constraint", "BackendTypeCheckFailed"),
@@ -1340,9 +1330,9 @@ unsupportedLLVMParityCases =
     ("boundary: runs deferred method when only a later forall binder is inferred", "BackendUnsupportedInstantiation InstElim"),
     ("boundary: runs constrained helper with method-local evidence fixed by call args", "BackendTypeCheckFailed"),
     ("boundary: runs deferred class method with method-level Eq constraint", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs constrained helper through method-level evidence constraints", "constructor result type does not match expected result"),
-    ("boundary: runs explicit constrained parameterized Eq instance", "ambiguous backend data matches scrutinee type"),
-    ("boundary: runs parameterized deriving Eq for Option", "ambiguous backend data matches scrutinee type"),
+    ("boundary: runs constrained helper through method-level evidence constraints", "BackendApplicationResultMismatch"),
+    ("boundary: runs explicit constrained parameterized Eq instance", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
+    ("boundary: runs parameterized deriving Eq for Option", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs parameterized deriving Eq for recursive List", "BackendUnsupportedRecursiveLet"),
     ("boundary: runs qualified import with alias-only value and constructor access", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
     ("boundary: runs aliased import with exposed method and qualified constructors", "Unsupported backend LLVM type at return type of Core__Eq__Nat__eq"),
@@ -1362,7 +1352,7 @@ unsupportedLLVMParityCases =
 
 expectedLLVMUnsupportedParityCount :: Int
 expectedLLVMUnsupportedParityCount =
-  48
+  38
 
 llvmUnsupportedParityCount :: Int
 llvmUnsupportedParityCount =
@@ -1375,7 +1365,9 @@ llvmObjectCodeParityCases :: [String]
 llvmObjectCodeParityCases =
   [ "surface: runs lambda/application",
     "unified fixture: test/programs/unified/authoritative-case-analysis.mlfp",
-    "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp"
+    "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp",
+    "boundary: runs value-exported constructor when owner type is not exported",
+    "boundary: runs aliased bulk-imported hidden-owner constructors in one case"
   ]
 
 llvmObjectCodeParityCaseNames :: Set.Set String

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -153,6 +153,19 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "missing specialization"
     validateLLVMAssembly output
 
+  it "rejects rigid applied type heads during type-argument inference" $ do
+    case
+      Lower.inferTypeArgumentsForTest
+        "rigid application head"
+        ["a"]
+        [("value", BTVarApp "f" (BTVar "a" :| []))]
+        [BackendVar (BTVarApp "g" (intTy :| [])) "value"]
+      of
+        Left err ->
+          Lower.renderBackendLLVMError err `shouldSatisfy` isInfixOf "rigid type application head mismatch"
+        Right substitution ->
+          expectationFailure ("expected rigid head mismatch, got substitution: " ++ show substitution)
+
   it "lowers local function aliases without requiring closure conversion" $ do
     output <- requireRight (renderBackendProgramLLVM localFunctionAliasProgram)
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1322,7 +1322,7 @@ unsupportedLLVMParityCases =
     ("boundary: local first-class polymorphic let through constructor boundary should run", "could not infer type arguments [\"a\"]"),
     ("boundary: pattern-bound first-class polymorphic variable should run", "could not infer type arguments [\"a\"]"),
     ("boundary: partial overloaded method application should run after deferred resolution", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs constrained helper through hidden Eq evidence", "BackendVariableTypeMismatch \"Main__Eq__Nat__eq\""),
+    ("boundary: runs constrained helper through hidden Eq evidence", "constructor result type does not match expected result"),
     ("boundary: runs ground constrained helper alias with resolved evidence", "Unsupported backend LLVM type at parameter \"$evidence_Eq_eq#0\" of Main__sameBool"),
     ("boundary: runs constrained helper after local lambda inference", "escaping function \"Main__Eq__Bool__eq\""),
     ("boundary: runs deferred method with method-level type variable constraint", "BackendTypeCheckFailed"),
@@ -1330,7 +1330,7 @@ unsupportedLLVMParityCases =
     ("boundary: runs deferred method when only a later forall binder is inferred", "BackendUnsupportedInstantiation InstElim"),
     ("boundary: runs constrained helper with method-local evidence fixed by call args", "BackendTypeCheckFailed"),
     ("boundary: runs deferred class method with method-level Eq constraint", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
-    ("boundary: runs constrained helper through method-level evidence constraints", "BackendApplicationResultMismatch"),
+    ("boundary: runs constrained helper through method-level evidence constraints", "constructor result type does not match expected result"),
     ("boundary: runs explicit constrained parameterized Eq instance", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs parameterized deriving Eq for Option", "Unsupported backend LLVM type at return type of Main__Eq__Nat__eq"),
     ("boundary: runs parameterized deriving Eq for recursive List", "BackendUnsupportedRecursiveLet"),
@@ -1367,7 +1367,8 @@ llvmObjectCodeParityCases =
     "unified fixture: test/programs/unified/authoritative-case-analysis.mlfp",
     "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp",
     "boundary: runs value-exported constructor when owner type is not exported",
-    "boundary: runs aliased bulk-imported hidden-owner constructors in one case"
+    "boundary: runs aliased bulk-imported hidden-owner constructors in one case",
+    "boundary: runs exposed constructor with qualified alias type identity"
   ]
 
 llvmObjectCodeParityCaseNames :: Set.Set String

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -166,6 +166,19 @@ spec = describe "MLF.Backend.LLVM" $ do
         Right substitution ->
           expectationFailure ("expected rigid head mismatch, got substitution: " ++ show substitution)
 
+  it "rejects mismatched applied type arguments during type-argument inference" $ do
+    case
+      Lower.inferTypeArgumentsForTest
+        "applied argument mismatch"
+        ["f"]
+        [("value", BTVarApp "f" (intTy :| []))]
+        [BackendVar (BTCon (BaseTy "Box") (boolTy :| [])) "value"]
+      of
+        Left err ->
+          Lower.renderBackendLLVMError err `shouldSatisfy` isInfixOf "type application argument mismatch"
+        Right substitution ->
+          expectationFailure ("expected applied argument mismatch, got substitution: " ++ show substitution)
+
   it "statically lowers first-class polymorphic top-level arguments" $ do
     output <- requireRight =<< emitBackendFile "test/programs/unified/first-class-polymorphism.mlfp"
 

--- a/test/golden/backend-ir-adt-case.golden
+++ b/test/golden/backend-ir-adt-case.golden
@@ -18,22 +18,22 @@ backend-program
             construct Main__Zero : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
               args:
                 <none>
-        binding Main__Succ : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
+        binding Main__Succ : (mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
           exported-main: false
           expr:
-            lam $Succ_arg1 : mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
+            lam $Succ_arg1 : mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> (mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> forall $a1. ($a1 -> ((mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)))
               body:
-                type-lam $a1 -> forall $a1. ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
+                type-lam $a1 -> forall $a1. ($a1 -> ((mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
                   body:
-                    lam $Succ_k1 : $a1 -> ($a1 -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
+                    lam $Succ_k1 : $a1 -> ($a1 -> ((mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1))
                       body:
-                        lam $Succ_k2 : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> ((mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)
+                        lam $Succ_k2 : (mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> ((mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)
                           body:
                             app : $a1
                               function:
-                                var $Succ_k2 : (mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1)
+                                var $Succ_k2 : (mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1)
                               argument:
-                                var $Succ_arg1 : mu $Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Nat_self -> $$Nat_result) -> $$Nat_result))
+                                var $Succ_arg1 : mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result))
         binding Main__main : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
           exported-main: true
           expr:


### PR DESCRIPTION
Closes #73.

## Implementation Plan

---
issue_number: 73
pr_number: 83
branch: codex/issue-73
---

## Implementation Plan

1. Start each implementation turn by reading the watcher-written issue plan, confirming `git status --short --branch`, and verifying PR #83 still points at `codex/issue-73` against `master`/`origin/HEAD`. Do not create another PR.

2. Add a real backend representation for checked variable-headed type applications instead of treating every `STVarApp` as unsupported. Extend `MLF.Backend.IR.BackendType` with an applied type-variable form, then wire it through alpha equality, free-variable collection, substitution, validation, and pretty/debug expectations.

3. Update `MLF.Backend.Convert` so constructor metadata can carry and instantiate higher-kinded fields such as `f a`. Matching must bind the head parameter to the concrete checked type constructor and then match the applied arguments, rejecting conflicting substitutions instead of falling back to unqualified/string-only identity.

4. Update backend validation and LLVM lowering matchers so constructor construction/case analysis substitutes applied type variables before lowering. Unresolved applied type variables should still fail at the backend boundary; successfully checked and fully instantiated parity rows should lower to ordinary pointer ADT types.

5. Tighten cross-module ADT identity in the backend. Use canonical module-qualified backend data names and semantic owner metadata for hidden-owner constructors; avoid suffix/unqualified data-name acceptance that can mask same-name module collisions. Keep typeclass/deriving/evidence-related unsupported rows out of this issue.

6. Add focused tests before broadening parity: backend IR tests for applied type-variable substitution and constructor/case validation, backend conversion tests for higher-kinded constructor fields, hidden-owner value-only constructor imports, aliased bulk imports, and same-name qualified ADT identity, plus LLVM parity expectations for the issue-owned rows.

7. In `test/BackendLLVMSpec.hs`, remove the issue-owned `BackendUnsupportedSourceType` entries for the higher-kinded and hidden-owner constructor rows, adjust `expectedLLVMUnsupportedParityCount`, and add representative hidden-owner and qualified-alias cases to the `llc` object-code smoke list where the harness can run it.

8. Update `implementation_notes.md` and `CHANGELOG.md` with the backend parity progress and the remaining unsupported categories that belong to sibling issues.

9. Validate with focused slices first, then the full gate before handoff: `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.IR" --match "MLF.Backend.Convert" --match "MLF.Backend.LLVM/ProgramSpec-to-LLVM parity matrix"'`, followed by `cabal build all && cabal test`. If LLVM tools are unavailable locally, report which `llvm-as`/`llc` checks were pending.

10. Publish only the issue-related files: inspect `git status --short` and relevant diffs, stage the backend/test/docs changes, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, push `codex/issue-73`, and leave PR #83 ready for watcher/review handling.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.