### PR TITLE
Implement #72

### DIFF
--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2209,13 +2209,20 @@ inferStaticFunctionTypeArgs context expectedTy form =
     sourceTy = foldr BTArrow (ffReturnType form) (map snd (ffParams form))
 
 lowerDirectStaticFunctionArgument :: ExprEnv -> String -> String -> BackendType -> BackendExpr -> LowerM LocalFunction
-lowerDirectStaticFunctionArgument callEnv context paramName expectedTy arg =
+lowerDirectStaticFunctionArgument callEnv context paramName expectedTy arg = do
+  let form = functionFormFromExpected expectedTy arg
+  when (null (ffTypeBinders form) && null (ffParams form)) $
+    liftEither
+      ( BackendLLVMUnsupportedExpression
+          context
+          ("unsupported static function argument " ++ show paramName)
+      )
   requireStaticFunctionType
     context
     paramName
     expectedTy
     ( LocalFunction
-        { lfForm = functionFormFromExpected expectedTy arg,
+        { lfForm = form,
           lfCapturedEnv = callEnv
         }
     )

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -180,6 +180,10 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
     validateLLVMAssembly output
 
+  it "rejects unsupported static function arguments instead of erasing them" $ do
+    renderBackendProgramLLVM staticPartialApplicationArgumentProgram
+      `shouldSatisfyLeft` isInfixOf "unsupported static function argument \"f\""
+
   it "collects specializations for type-applied global static aliases" $ do
     output <-
       withTempProgram typeAppliedGlobalStaticAliasProgram $ \path ->
@@ -2305,6 +2309,40 @@ partialApplicationProgram =
               { backendExprType = unaryIntTy,
                 backendFunction = BackendVar binaryIntTy "add",
                 backendArgument = intLit 1
+              },
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+staticPartialApplicationArgumentProgram :: BackendProgram
+staticPartialApplicationArgumentProgram =
+  programWithBindings
+    [ addBinding,
+      BackendBinding
+        { backendBindingName = "use",
+          backendBindingType = BTArrow unaryIntTy intTy,
+          backendBindingExpr =
+            BackendLam
+              { backendExprType = BTArrow unaryIntTy intTy,
+                backendParamName = "f",
+                backendParamType = unaryIntTy,
+                backendBody = intLit 0
+              },
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              { backendExprType = intTy,
+                backendFunction = BackendVar (BTArrow unaryIntTy intTy) "use",
+                backendArgument =
+                  BackendApp
+                    { backendExprType = unaryIntTy,
+                      backendFunction = BackendVar binaryIntTy "add",
+                      backendArgument = intLit 1
+                    }
               },
           backendBindingExportedAsMain = True
         }


### PR DESCRIPTION
Closes #72.

## Implementation Plan

---
issue_number: 72
pr_number: 84
branch: codex/issue-72-2
---

## Implementation Plan

1. Start from the existing clean PR branch `codex/issue-72-2` for PR #84. Re-check `git status --short --branch` before editing, and keep the write set scoped to the LLVM lowerer and its focused regression spec unless inspection shows a directly related need.

2. Add a focused regression in `test/BackendLLVMSpec.hs` for the reviewer finding: a backend program with `add : Int -> Int -> Int`, `use : (Int -> Int) -> Int = \f -> 0`, and `main = use (add 1)`. Assert LLVM lowering fails instead of emitting `0`; use a stable fragment such as `unsupported static function argument` once the production diagnostic is added.

3. Fix the root cause in `src/MLF/Backend/LLVM/Lower.hs` at `lowerDirectStaticFunctionArgument`. After computing the `FunctionForm` from `functionFormFromExpected expectedTy arg`, accept only real static function forms: forms with at least one type binder or value parameter, including direct lambdas/type abstractions and existing alias-expanded forms. If the computed form has no binders and no parameters, reject with `BackendLLVMUnsupportedExpression context ("unsupported static function argument " ++ show paramName)` before constructing a `LocalFunction`. This prevents arbitrary function-producing expressions such as partial applications from being erased as zero-argument local functions.

4. Preserve the existing successful first-class polymorphism paths. Do not broaden partial-application support, do not change `unsupportedLLVMParityCases` or `expectedLLVMUnsupportedParityCount` unless a focused test proves a classification genuinely changed, and keep the existing `first-class-polymorphism.mlfp` LLVM assembly/object coverage green.

5. Validate incrementally: first run the new focused Hspec example, then `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.LLVM"'`. Before reporting completion, run the full gate `cabal build all && cabal test` unless blocked by environment/tooling.

6. Publish only after validation: run `gh auth status` and `gh auth setup-git`, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as the prepared `codex-watcher` identity, and push `codex/issue-72-2` to update existing PR #84. Do not create a new PR and do not touch watcher-owned state files.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.