### PR TITLE
Implement #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### Changed
+- Eliminated the final temporary LLVM unsupported classification from the
+  shared `ProgramSpec` runtime-success parity matrix. Stored first-order
+  function constructor fields now lower as function pointers, closed direct
+  function fields use private wrappers, captured closure fields still fail
+  closed, and the representative `llc` subset includes the formerly unsupported
+  typed constructor-field row.
 - Extended LLVM backend parity to higher-kinded constructor fields and
   hidden-owner value-constructor imports. Backend IR now preserves applied type
   variables, conversion recovers structural higher-kinded constructor terms as

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,19 @@
+## 2026-04-29 - Final ProgramSpec-to-LLVM parity closure
+
+- Removed the last temporary LLVM unsupported classification from the shared
+  `ProgramSpec` runtime-success parity matrix. Every
+  `programSpecToLLVMParityCases` row now expects LLVM emission and `llvm-as`
+  validation instead of accepting an unsupported backend diagnostic.
+- The LLVM lowerer now stores first-order function-valued constructor fields as
+  function pointers. Top-level function references are stored directly, closed
+  direct function expressions are lifted through private function wrappers, and
+  captured constructor-field functions still fail closed until closure
+  conversion exists.
+- Representative object-code coverage now includes the former unsupported
+  typed non-data constructor-field row, so the `llc -filetype=obj` smoke subset
+  exercises stored function-field lowering in addition to the existing first
+  order, ADT, import, and first-class-polymorphism representatives.
+
 ## 2026-04-29 - Higher-kinded and hidden-owner constructor LLVM parity
 
 - `MLF.Backend.IR` now preserves checked variable-headed type applications as

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -56,6 +56,7 @@ data ProgramEnv = ProgramEnv
   { peBase :: ProgramBase,
     peSpecializations :: Map String Specialization,
     peEvidenceWrappers :: Map String EvidenceWrapper,
+    peFunctionWrappers :: Map String FunctionWrapper,
     peStringGlobals :: Map String String
   }
 
@@ -102,6 +103,14 @@ data EvidenceWrapper = EvidenceWrapper
   }
   deriving (Eq, Show)
 
+data FunctionWrapper = FunctionWrapper
+  { fwKey :: String,
+    fwFunctionName :: String,
+    fwExpectedType :: BackendType,
+    fwExpr :: BackendExpr
+  }
+  deriving (Eq, Show)
+
 data LowerValue = LowerValue
   { lvBackendType :: BackendType,
     lvLLVMType :: LLVMType,
@@ -140,13 +149,15 @@ lowerBackendProgram program = do
   reachable <- reachableBindings base (backendProgramMain program)
   specializations <- collectRequiredSpecializations base reachable
   let evidenceWrappers = collectEvidenceWrappers base reachable specializations
-      referencedFunctionNames = collectReferencedFunctionNames base reachable specializations evidenceWrappers
-      stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations)
+      functionWrappers = collectFunctionWrappers base reachable specializations
+      referencedFunctionNames = collectReferencedFunctionNames base reachable specializations evidenceWrappers functionWrappers
+      stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations evidenceWrappers functionWrappers)
       env =
         ProgramEnv
           { peBase = base,
             peSpecializations = Map.fromList [(specializationKey (spRequest spec), spec) | spec <- specializations],
             peEvidenceWrappers = Map.fromList [(ewKey wrapper, wrapper) | wrapper <- evidenceWrappers],
+            peFunctionWrappers = Map.fromList [(fwKey wrapper, wrapper) | wrapper <- functionWrappers],
             peStringGlobals = stringGlobals
           }
   functions <-
@@ -154,7 +165,8 @@ lowerBackendProgram program = do
       <$> sequence
         [ traverse (lowerMonomorphicBinding env) (filter (shouldLowerReachableBinding referencedFunctionNames) reachable),
           traverse (lowerSpecialization env) (filter (shouldLowerSpecialization referencedFunctionNames) specializations),
-          traverse (lowerEvidenceWrapper env) evidenceWrappers
+          traverse (lowerEvidenceWrapper env) evidenceWrappers,
+          traverse (lowerFunctionWrapper env) functionWrappers
         ]
   mainBinding <- requireBinding base (backendProgramMain program)
   when (not (null (ffTypeBinders (biForm mainBinding)))) $
@@ -716,12 +728,32 @@ collectEvidenceWrappers base reachable specializations =
           ewExpr = expr
         }
 
-collectReferencedFunctionNames :: ProgramBase -> [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> Set String
-collectReferencedFunctionNames base reachable specializations evidenceWrappers =
+collectFunctionWrappers :: ProgramBase -> [BindingInfo] -> [Specialization] -> [FunctionWrapper]
+collectFunctionWrappers base reachable specializations =
+  zipWith assignName [(0 :: Int) ..] uniqueRequests
+  where
+    requests =
+      concatMap (collectFunctionWrappersInForm base Map.empty Set.empty . biForm) monomorphicReachable
+        ++ concatMap (collectFunctionWrappersInForm base Map.empty Set.empty . spForm) specializations
+    monomorphicReachable =
+      filter (null . ffTypeBinders . biForm) reachable
+    uniqueRequests =
+      map snd (Map.toAscList (Map.fromList [(functionWrapperKey expected expr, (expected, expr)) | (expected, expr) <- requests]))
+    assignName index0 (expected, expr) =
+      FunctionWrapper
+        { fwKey = functionWrapperKey expected expr,
+          fwFunctionName = "__mlfp_function_wrapper$" ++ show index0,
+          fwExpectedType = expected,
+          fwExpr = expr
+        }
+
+collectReferencedFunctionNames :: ProgramBase -> [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> Set String
+collectReferencedFunctionNames base reachable specializations evidenceWrappers functionWrappers =
   Set.unions
     ( map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . biForm) reachable
         ++ map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . spForm) specializations
         ++ map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . evidenceWrapperForm) evidenceWrappers
+        ++ map (collectReferencedFunctionNamesInForm base Map.empty Set.empty . functionWrapperForm) functionWrappers
     )
 
 type LocalFunctionForms = Map String FunctionForm
@@ -999,6 +1031,75 @@ evidenceWrapperKey :: BackendType -> BackendExpr -> String
 evidenceWrapperKey expected expr =
   backendTypeKey expected ++ "\0" ++ show expr
 
+collectFunctionWrappersInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
+collectFunctionWrappersInForm base substitution bound form =
+  collectFunctionWrappersInExpr
+    base
+    substitution
+    (Set.union (Set.fromList (map fst (ffParams form))) bound)
+    (ffBody form)
+
+collectFunctionWrappersInExpr :: ProgramBase -> Map String BackendType -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
+collectFunctionWrappersInExpr base substitution bound expr =
+  wrapperRequests ++ childRequests
+  where
+    wrapperRequests =
+      case expr of
+        BackendConstruct resultTy name args ->
+          case Map.lookup name (pbConstructors base) >>= \constructorRuntime -> constructorRuntimeFieldTypes constructorRuntime resultTy of
+            Just fieldTys ->
+              [ (fieldTy', arg')
+              | (fieldTy, arg) <- zip fieldTys args,
+                let fieldTy' = substituteBackendTypes substitution fieldTy,
+                let arg' = substituteExprTypes substitution arg,
+                isFirstOrderFunctionPointerType fieldTy',
+                not (isSimpleFunctionReference arg'),
+                evidenceWrapperArgumentClosed bound arg'
+              ]
+            Nothing -> []
+        _ -> []
+
+    childRequests =
+      case expr of
+        BackendVar {} ->
+          []
+        BackendLit {} ->
+          []
+        BackendLam _ name _ body ->
+          collectFunctionWrappersInExpr base substitution (Set.insert name bound) body
+        BackendApp _ fun arg ->
+          collectFunctionWrappersInExpr base substitution bound fun
+            ++ collectFunctionWrappersInExpr base substitution bound arg
+        BackendLet _ name _ rhs body ->
+          collectFunctionWrappersInExpr base substitution bound rhs
+            ++ collectFunctionWrappersInExpr base substitution (Set.insert name bound) body
+        BackendTyAbs _ name _ body ->
+          collectFunctionWrappersInExpr base (Map.delete name substitution) bound body
+        BackendTyApp _ fun _ ->
+          collectFunctionWrappersInExpr base substitution bound fun
+        BackendConstruct _ _ args ->
+          concatMap (collectFunctionWrappersInExpr base substitution bound) args
+        BackendCase _ scrutinee alternatives ->
+          collectFunctionWrappersInExpr base substitution bound scrutinee
+            ++ concatMap collectAlternativeWrappers (NE.toList alternatives)
+        BackendRoll _ payload ->
+          collectFunctionWrappersInExpr base substitution bound payload
+        BackendUnroll _ payload ->
+          collectFunctionWrappersInExpr base substitution bound payload
+
+    collectAlternativeWrappers alternative =
+      let binders = patternBinders (backendAltPattern alternative)
+       in collectFunctionWrappersInExpr base substitution (Set.union binders bound) (backendAltBody alternative)
+
+    patternBinders =
+      \case
+        BackendDefaultPattern -> Set.empty
+        BackendConstructorPattern _ binders -> Set.fromList binders
+
+functionWrapperKey :: BackendType -> BackendExpr -> String
+functionWrapperKey expected expr =
+  backendTypeKey expected ++ "\0" ++ show expr
+
 isSimpleFunctionReference :: BackendExpr -> Bool
 isSimpleFunctionReference arg =
   case collectTyApps arg of
@@ -1238,12 +1339,14 @@ freeGlobalRefs base bound expr =
         BackendDefaultPattern -> Set.empty
         BackendConstructorPattern _ binders -> Set.fromList binders
 
-collectProgramStrings :: [BindingInfo] -> [Specialization] -> [String]
-collectProgramStrings reachable specializations =
+collectProgramStrings :: [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> [String]
+collectProgramStrings reachable specializations evidenceWrappers functionWrappers =
   sort $
     nub $
       concatMap (collectStringLiterals . ffBody . biForm) (filter (null . ffTypeBinders . biForm) reachable)
         ++ concatMap (collectStringLiterals . ffBody . spForm) specializations
+        ++ concatMap (collectStringLiterals . ffBody . evidenceWrapperForm) evidenceWrappers
+        ++ concatMap (collectStringLiterals . ffBody . functionWrapperForm) functionWrappers
 
 collectStringLiterals :: BackendExpr -> [String]
 collectStringLiterals =
@@ -1303,6 +1406,10 @@ lowerEvidenceWrapper :: ProgramEnv -> EvidenceWrapper -> Either BackendLLVMError
 lowerEvidenceWrapper env wrapper =
   lowerFunction env (ewFunctionName wrapper) True (evidenceWrapperForm wrapper)
 
+lowerFunctionWrapper :: ProgramEnv -> FunctionWrapper -> Either BackendLLVMError LLVMFunction
+lowerFunctionWrapper env wrapper =
+  lowerFunction env (fwFunctionName wrapper) True (functionWrapperForm wrapper)
+
 evidenceWrapperForm :: EvidenceWrapper -> FunctionForm
 evidenceWrapperForm wrapper =
   FunctionForm
@@ -1316,6 +1423,20 @@ evidenceWrapperForm wrapper =
     paramNames = ["__mlfp_evidence_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
     paramExprs = [BackendVar paramTy name | (name, paramTy) <- zip paramNames params]
     body = applyEvidenceWrapperArgs (ewExpr wrapper) (ewExpectedType wrapper) paramExprs
+
+functionWrapperForm :: FunctionWrapper -> FunctionForm
+functionWrapperForm wrapper =
+  FunctionForm
+    { ffTypeBinders = [],
+      ffParams = zip paramNames params,
+      ffBody = body,
+      ffReturnType = returnTy
+    }
+  where
+    (params, returnTy) = collectArrowsType (fwExpectedType wrapper)
+    paramNames = ["__mlfp_function_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
+    paramExprs = [BackendVar paramTy name | (name, paramTy) <- zip paramNames params]
+    body = applyEvidenceWrapperArgs (fwExpr wrapper) (fwExpectedType wrapper) paramExprs
 
 applyEvidenceWrapperArgs :: BackendExpr -> BackendType -> [BackendExpr] -> BackendExpr
 applyEvidenceWrapperArgs expr _ [] =
@@ -1844,7 +1965,10 @@ lookupFunctionFormByName env functionName =
         [] ->
           case [evidenceWrapperForm wrapper | wrapper <- Map.elems (peEvidenceWrappers env), ewFunctionName wrapper == functionName] of
             form : _ -> Just form
-            [] -> Nothing
+            [] ->
+              case [functionWrapperForm wrapper | wrapper <- Map.elems (peFunctionWrappers env), fwFunctionName wrapper == functionName] of
+                form : _ -> Just form
+                [] -> Nothing
 
 functionFormFromType :: BackendType -> FunctionForm
 functionFormFromType ty =
@@ -1888,6 +2012,18 @@ lowerFunctionArgument env exprEnv context expectedTy arg =
       lowerFunctionReference env exprEnv context expectedTy name typeArgs
     _ ->
       liftEither (BackendLLVMUnsupportedExpression context "unsupported function argument")
+
+lowerStoredFunctionArgument :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
+lowerStoredFunctionArgument env exprEnv context expectedTy arg =
+  case collectTyApps arg of
+    (BackendVar _ name, typeArgs) ->
+      lowerFunctionReference env exprEnv context expectedTy name typeArgs
+    _ ->
+      case Map.lookup (functionWrapperKey expectedTy arg) (peFunctionWrappers env) of
+        Just wrapper ->
+          pure (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper)))
+        Nothing ->
+          liftEither (BackendLLVMUnsupportedExpression context "unsupported function argument")
 
 lowerEvidenceArgument :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
 lowerEvidenceArgument env exprEnv context expectedTy arg =
@@ -2567,9 +2703,18 @@ lowerConstruct env exprEnv context resultTy name args =
       liftEither (BackendLLVMUnknownConstructor name)
     Just constructorRuntime -> do
       let constructor = crConstructor constructorRuntime
-      unless (length args == length (backendConstructorFields constructor)) $
-        liftEither (BackendLLVMArityMismatch name (length (backendConstructorFields constructor)) (length args))
-      argValues <- traverse (lowerExpr env exprEnv context) args
+      fieldTys <-
+        case constructorRuntimeFieldTypes constructorRuntime resultTy of
+          Just resolvedFieldTys -> pure resolvedFieldTys
+          Nothing ->
+            liftEither
+              ( BackendLLVMUnsupportedExpression
+                  context
+                  ("could not match constructor result for " ++ backendConstructorName constructor)
+              )
+      unless (length args == length fieldTys) $
+        liftEither (BackendLLVMArityMismatch name (length fieldTys) (length args))
+      argValues <- zipWithM (lowerConstructField env exprEnv context) fieldTys args
       object <- emitMalloc env context (8 * (1 + length args))
       tagPtr <- emitGep "tag.ptr" object 0
       emitStore (LLVMInt 64) (LLVMIntLiteral 64 (crTag constructorRuntime)) tagPtr
@@ -2582,6 +2727,13 @@ lowerConstruct env exprEnv context resultTy name args =
     storeField object index0 value = do
       fieldPtr <- emitGep "field.ptr" object (8 * (index0 + 1))
       emitStore (lvLLVMType value) (lvOperand value) fieldPtr
+
+lowerConstructField :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
+lowerConstructField env exprEnv context fieldTy arg
+  | isFirstOrderFunctionPointerType fieldTy =
+      lowerStoredFunctionArgument env exprEnv context fieldTy arg
+  | otherwise =
+      lowerExpr env exprEnv context arg
 
 lowerCase :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> NonEmpty BackendAlternative -> LowerM LowerValue
 lowerCase env exprEnv context resultTy scrutinee alternatives =
@@ -2701,10 +2853,15 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
           pure Nothing
 
     loadField scrutineeValue index0 fieldTy = do
-      llvmTy <- lowerBackendTypeM env context fieldTy
+      llvmTy <- lowerStoredFieldTypeM env context fieldTy
       fieldPtr <- emitGep "case.field.ptr" (lvOperand scrutineeValue) (8 * (index0 + 1))
       loaded <- emitAssign "case.field" llvmTy (LLVMLoad llvmTy fieldPtr)
       pure (LowerValue fieldTy llvmTy loaded)
+
+lowerStoredFieldTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
+lowerStoredFieldTypeM env context fieldTy
+  | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
+  | otherwise = lowerBackendTypeM env context fieldTy
 
 lowerImmediateConstructCase ::
   ProgramEnv ->
@@ -2826,19 +2983,26 @@ dummyOperandAfterUnreachable context ty =
 
 constructorFieldTypesForScrutinee :: ProgramEnv -> String -> ConstructorRuntime -> BackendType -> LowerM [BackendType]
 constructorFieldTypesForScrutinee _ context constructorRuntime scrutineeTy =
+  case constructorRuntimeFieldTypes constructorRuntime scrutineeTy of
+    Just fieldTys -> pure fieldTys
+    Nothing ->
+      liftEither
+        ( BackendLLVMUnsupportedExpression
+            context
+            ("could not match constructor result for " ++ backendConstructorName (crConstructor constructorRuntime))
+        )
+
+constructorRuntimeFieldTypes :: ConstructorRuntime -> BackendType -> Maybe [BackendType]
+constructorRuntimeFieldTypes constructorRuntime scrutineeTy =
   case structuralConstructorFieldTypes constructorRuntime scrutineeTy of
     Just fieldTys ->
-      pure fieldTys
+      Just fieldTys
     Nothing ->
       case matchConstructorResult (crDataParameters constructorRuntime) parameters Map.empty (backendConstructorResult constructor) scrutineeTy of
         Just substitution ->
-          pure (map (substituteBackendTypes substitution) (backendConstructorFields constructor))
+          Just (map (substituteBackendTypes substitution) (backendConstructorFields constructor))
         Nothing ->
-          liftEither
-            ( BackendLLVMUnsupportedExpression
-                context
-                ("could not match constructor result for " ++ backendConstructorName constructor)
-            )
+          Nothing
   where
     constructor = crConstructor constructorRuntime
     parameters =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -120,7 +120,8 @@ data LowerValue = LowerValue
 
 data LocalFunction = LocalFunction
   { lfForm :: FunctionForm,
-    lfCapturedEnv :: ExprEnv
+    lfCapturedEnv :: ExprEnv,
+    lfStoredReference :: Maybe (BackendType, BackendExpr)
   }
   deriving (Eq, Show)
 
@@ -1821,7 +1822,11 @@ bindLet env exprEnv context name rhs =
               { eeLocalFunctions =
                   Map.insert
                     name
-                    LocalFunction {lfForm = form, lfCapturedEnv = exprEnv}
+                    LocalFunction
+                      { lfForm = form,
+                        lfCapturedEnv = exprEnv,
+                        lfStoredReference = Just (backendExprType rhs, rhs)
+                      }
                     (eeLocalFunctions exprEnv),
                 eeValues = Map.delete name (eeValues exprEnv)
               }
@@ -2017,7 +2022,7 @@ lowerStoredFunctionArgument :: ProgramEnv -> ExprEnv -> String -> BackendType ->
 lowerStoredFunctionArgument env exprEnv context expectedTy arg =
   case collectTyApps arg of
     (BackendVar _ name, typeArgs) ->
-      lowerFunctionReference env exprEnv context expectedTy name typeArgs
+      lowerStoredFunctionReference env exprEnv context expectedTy name typeArgs
     _ ->
       case Map.lookup (functionWrapperKey expectedTy arg) (peFunctionWrappers env) of
         Just wrapper ->
@@ -2045,8 +2050,20 @@ lowerFunctionReference env exprEnv context expectedTy name typeArgs =
     Nothing ->
       lowerNonLocalFunctionReference env exprEnv context expectedTy name typeArgs
 
+lowerStoredFunctionReference :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendType] -> LowerM LowerValue
+lowerStoredFunctionReference env exprEnv context expectedTy name typeArgs =
+  case Map.lookup name (eeLocalFunctions exprEnv) of
+    Just localFunction ->
+      lowerLocalFunctionReferenceWith True env context expectedTy name localFunction typeArgs
+    Nothing ->
+      lowerNonLocalFunctionReference env exprEnv context expectedTy name typeArgs
+
 lowerLocalFunctionReference :: ProgramEnv -> String -> BackendType -> String -> LocalFunction -> [BackendType] -> LowerM LowerValue
-lowerLocalFunctionReference env context expectedTy name localFunction typeArgs = do
+lowerLocalFunctionReference =
+  lowerLocalFunctionReferenceWith False
+
+lowerLocalFunctionReferenceWith :: Bool -> ProgramEnv -> String -> BackendType -> String -> LocalFunction -> [BackendType] -> LowerM LowerValue
+lowerLocalFunctionReferenceWith allowStoredReference env context expectedTy name localFunction typeArgs = do
   form <-
     if null typeArgs
       then pure (lfForm localFunction)
@@ -2057,7 +2074,28 @@ lowerLocalFunctionReference env context expectedTy name localFunction typeArgs =
     Just (targetName, targetTypeArgs) ->
       lowerFunctionReference env (lfCapturedEnv localFunction) context expectedTy targetName targetTypeArgs
     Nothing ->
+      case lowerLocalFunctionStoredReference env expectedTy localFunction of
+        Just value ->
+          if allowStoredReference
+            then pure value
+            else unsupportedFunctionArgument
+        Nothing ->
+          unsupportedFunctionArgument
+  where
+    unsupportedFunctionArgument =
       liftEither (BackendLLVMUnsupportedExpression context ("unsupported function argument " ++ show name))
+
+lowerLocalFunctionStoredReference :: ProgramEnv -> BackendType -> LocalFunction -> Maybe LowerValue
+lowerLocalFunctionStoredReference env expectedTy localFunction =
+  case lfStoredReference localFunction of
+    Just (_, sourceExpr) ->
+      case Map.lookup (functionWrapperKey expectedTy sourceExpr) (peFunctionWrappers env) of
+        Just wrapper ->
+          Just (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper)))
+        Nothing ->
+          Nothing
+    Nothing ->
+      Nothing
 
 etaAliasTarget :: FunctionForm -> Maybe (String, [BackendType])
 etaAliasTarget form =
@@ -2338,7 +2376,8 @@ lowerStaticFunctionArgument env callEnv context paramName expectedTy arg =
                     expectedTy
                     ( LocalFunction
                         { lfForm = form,
-                          lfCapturedEnv = emptyExprEnv
+                          lfCapturedEnv = emptyExprEnv,
+                          lfStoredReference = Nothing
                         }
                     )
             Nothing ->
@@ -2383,7 +2422,8 @@ lowerDirectStaticFunctionArgument callEnv context paramName expectedTy arg = do
     expectedTy
     ( LocalFunction
         { lfForm = form,
-          lfCapturedEnv = callEnv
+          lfCapturedEnv = callEnv,
+          lfStoredReference = Just (expectedTy, arg)
         }
     )
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -759,6 +759,13 @@ collectReferencedFunctionNames base reachable specializations evidenceWrappers f
 
 type LocalFunctionForms = Map String FunctionForm
 
+data LocalStoredFunction = LocalStoredFunction
+  { lsfForm :: FunctionForm,
+    lsfSourceExpr :: BackendExpr
+  }
+
+type LocalStoredFunctions = Map String LocalStoredFunction
+
 shadowLocalFunctionForms :: Set String -> LocalFunctionForms -> LocalFunctionForms
 shadowLocalFunctionForms names forms =
   Map.withoutKeys forms names
@@ -1034,14 +1041,20 @@ evidenceWrapperKey expected expr =
 
 collectFunctionWrappersInForm :: ProgramBase -> Map String BackendType -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
 collectFunctionWrappersInForm base substitution bound form =
-  collectFunctionWrappersInExpr
-    base
-    substitution
-    (Set.union (Set.fromList (map fst (ffParams form))) bound)
-    (ffBody form)
+  collectFunctionWrappersInFormWithLocals base substitution Map.empty bound form
 
-collectFunctionWrappersInExpr :: ProgramBase -> Map String BackendType -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
-collectFunctionWrappersInExpr base substitution bound expr =
+collectFunctionWrappersInFormWithLocals :: ProgramBase -> Map String BackendType -> LocalStoredFunctions -> Set String -> FunctionForm -> [(BackendType, BackendExpr)]
+collectFunctionWrappersInFormWithLocals base substitution localFunctions bound form =
+  let paramNames = Set.fromList (map fst (ffParams form))
+   in collectFunctionWrappersInExpr
+        base
+        substitution
+        (Map.withoutKeys localFunctions paramNames)
+        (Set.union paramNames bound)
+        (ffBody form)
+
+collectFunctionWrappersInExpr :: ProgramBase -> Map String BackendType -> LocalStoredFunctions -> Set String -> BackendExpr -> [(BackendType, BackendExpr)]
+collectFunctionWrappersInExpr base substitution localFunctions bound expr =
   wrapperRequests ++ childRequests
   where
     wrapperRequests =
@@ -1049,16 +1062,54 @@ collectFunctionWrappersInExpr base substitution bound expr =
         BackendConstruct resultTy name args ->
           case Map.lookup name (pbConstructors base) >>= \constructorRuntime -> constructorRuntimeFieldTypes constructorRuntime resultTy of
             Just fieldTys ->
-              [ (fieldTy', arg')
+              [ request
               | (fieldTy, arg) <- zip fieldTys args,
                 let fieldTy' = substituteBackendTypes substitution fieldTy,
                 let arg' = substituteExprTypes substitution arg,
                 isFirstOrderFunctionPointerType fieldTy',
-                not (isSimpleFunctionReference arg'),
-                evidenceWrapperArgumentClosed bound arg'
+                Just request <- [functionWrapperRequest fieldTy' arg']
               ]
             Nothing -> []
         _ -> []
+
+    functionWrapperRequest fieldTy arg =
+      case localStoredFunctionWrapperSource arg of
+        Just sourceExpr
+          | evidenceWrapperArgumentClosed bound sourceExpr ->
+              Just (fieldTy, sourceExpr)
+        _ | not (isSimpleFunctionReference arg),
+            evidenceWrapperArgumentClosed bound arg ->
+              Just (fieldTy, arg)
+        _ ->
+          Nothing
+
+    localStoredFunctionWrapperSource arg =
+      case collectTyApps arg of
+        (BackendVar _ name, typeArgs) ->
+          localStoredFunctionSourceByName Set.empty name typeArgs
+        _ -> Nothing
+
+    localStoredFunctionSourceByName seen name typeArgs
+      | Set.member name seen = Nothing
+      | Just localFunction <- Map.lookup name localFunctions =
+          case instantiateFunctionFormWithTypeArgs ("function wrapper request " ++ name) (lsfForm localFunction) typeArgs [] of
+            Right (_, instantiated) ->
+              case etaAliasTarget instantiated of
+                Just (targetName, targetTypeArgs) ->
+                  localStoredFunctionSourceByName (Set.insert name seen) targetName targetTypeArgs
+                Nothing ->
+                  applyStoredSourceTypeArgs name (lsfSourceExpr localFunction) typeArgs
+            Left _ ->
+              Nothing
+      | otherwise =
+          Nothing
+
+    applyStoredSourceTypeArgs _ sourceExpr [] =
+      Just sourceExpr
+    applyStoredSourceTypeArgs name sourceExpr typeArgs =
+      case applyTypeApplicationsToExprWithType ("function wrapper request " ++ name) sourceExpr typeArgs of
+        Right (applied, _) -> Just applied
+        Left _ -> Nothing
 
     childRequests =
       case expr of
@@ -1067,30 +1118,49 @@ collectFunctionWrappersInExpr base substitution bound expr =
         BackendLit {} ->
           []
         BackendLam _ name _ body ->
-          collectFunctionWrappersInExpr base substitution (Set.insert name bound) body
+          collectFunctionWrappersInExpr base substitution (Map.delete name localFunctions) (Set.insert name bound) body
         BackendApp _ fun arg ->
-          collectFunctionWrappersInExpr base substitution bound fun
-            ++ collectFunctionWrappersInExpr base substitution bound arg
+          collectFunctionWrappersInExpr base substitution localFunctions bound fun
+            ++ collectFunctionWrappersInExpr base substitution localFunctions bound arg
         BackendLet _ name _ rhs body ->
-          collectFunctionWrappersInExpr base substitution bound rhs
-            ++ collectFunctionWrappersInExpr base substitution (Set.insert name bound) body
+          collectFunctionWrappersInExpr base substitution localFunctions bound rhs
+            ++ collectFunctionWrappersInExpr base substitution (collectLetLocalFunction name rhs) (Set.insert name bound) body
         BackendTyAbs _ name _ body ->
-          collectFunctionWrappersInExpr base (Map.delete name substitution) bound body
+          collectFunctionWrappersInExpr base (Map.delete name substitution) localFunctions bound body
         BackendTyApp _ fun _ ->
-          collectFunctionWrappersInExpr base substitution bound fun
+          collectFunctionWrappersInExpr base substitution localFunctions bound fun
         BackendConstruct _ _ args ->
-          concatMap (collectFunctionWrappersInExpr base substitution bound) args
+          concatMap (collectFunctionWrappersInExpr base substitution localFunctions bound) args
         BackendCase _ scrutinee alternatives ->
-          collectFunctionWrappersInExpr base substitution bound scrutinee
+          collectFunctionWrappersInExpr base substitution localFunctions bound scrutinee
             ++ concatMap collectAlternativeWrappers (NE.toList alternatives)
         BackendRoll _ payload ->
-          collectFunctionWrappersInExpr base substitution bound payload
+          collectFunctionWrappersInExpr base substitution localFunctions bound payload
         BackendUnroll _ payload ->
-          collectFunctionWrappersInExpr base substitution bound payload
+          collectFunctionWrappersInExpr base substitution localFunctions bound payload
+
+    collectLetLocalFunction name rhs =
+      case functionFormFromExpected (backendExprType rhs) rhs of
+        form
+          | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+              Map.insert
+                name
+                LocalStoredFunction
+                  { lsfForm = substituteFunctionFormTypes substitution form,
+                    lsfSourceExpr = substituteExprTypes substitution rhs
+                  }
+                localFunctions
+        _ ->
+          Map.delete name localFunctions
 
     collectAlternativeWrappers alternative =
       let binders = patternBinders (backendAltPattern alternative)
-       in collectFunctionWrappersInExpr base substitution (Set.union binders bound) (backendAltBody alternative)
+       in collectFunctionWrappersInExpr
+            base
+            substitution
+            (Map.withoutKeys localFunctions binders)
+            (Set.union binders bound)
+            (backendAltBody alternative)
 
     patternBinders =
       \case
@@ -2072,9 +2142,11 @@ lowerLocalFunctionReferenceWith allowStoredReference env context expectedTy name
   requireEvidenceFunctionType context name expectedTy actualTy
   case etaAliasTarget form of
     Just (targetName, targetTypeArgs) ->
-      lowerFunctionReference env (lfCapturedEnv localFunction) context expectedTy targetName targetTypeArgs
+      if allowStoredReference
+        then lowerStoredFunctionReference env (lfCapturedEnv localFunction) context expectedTy targetName targetTypeArgs
+        else lowerFunctionReference env (lfCapturedEnv localFunction) context expectedTy targetName targetTypeArgs
     Nothing ->
-      case lowerLocalFunctionStoredReference env expectedTy localFunction of
+      lowerLocalFunctionStoredReference env context expectedTy localFunction typeArgs >>= \case
         Just value ->
           if allowStoredReference
             then pure value
@@ -2085,17 +2157,26 @@ lowerLocalFunctionReferenceWith allowStoredReference env context expectedTy name
     unsupportedFunctionArgument =
       liftEither (BackendLLVMUnsupportedExpression context ("unsupported function argument " ++ show name))
 
-lowerLocalFunctionStoredReference :: ProgramEnv -> BackendType -> LocalFunction -> Maybe LowerValue
-lowerLocalFunctionStoredReference env expectedTy localFunction =
+lowerLocalFunctionStoredReference :: ProgramEnv -> String -> BackendType -> LocalFunction -> [BackendType] -> LowerM (Maybe LowerValue)
+lowerLocalFunctionStoredReference env context expectedTy localFunction typeArgs =
   case lfStoredReference localFunction of
-    Just (_, sourceExpr) ->
+    Just (_, sourceExpr0) -> do
+      sourceExpr <- storedReferenceSourceExpr context sourceExpr0 typeArgs
       case Map.lookup (functionWrapperKey expectedTy sourceExpr) (peFunctionWrappers env) of
         Just wrapper ->
-          Just (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper)))
+          pure (Just (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper))))
         Nothing ->
-          Nothing
+          pure Nothing
     Nothing ->
-      Nothing
+      pure Nothing
+
+storedReferenceSourceExpr :: String -> BackendExpr -> [BackendType] -> LowerM BackendExpr
+storedReferenceSourceExpr _ sourceExpr [] =
+  pure sourceExpr
+storedReferenceSourceExpr context sourceExpr typeArgs =
+  case applyTypeApplicationsToExprWithType context sourceExpr typeArgs of
+    Right (applied, _) -> pure applied
+    Left err -> liftEither err
 
 etaAliasTarget :: FunctionForm -> Maybe (String, [BackendType])
 etaAliasTarget form =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -532,6 +532,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
+  it "re-stores immediate constructor fields carrying closed direct functions" $ do
+    output <- requireRight (renderBackendProgramLLVM immediateRestoredFunctionFieldProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    output `shouldNotSatisfy` isInfixOf "unsupported function argument"
+    validateLLVMAssembly output
+
   it "rejects captured function constructor fields until closure conversion exists" $ do
     renderBackendProgramLLVM capturedFunctionFieldProgram
       `shouldSatisfyLeft` isInfixOf "unsupported function argument"
@@ -2431,6 +2439,34 @@ directFunctionFieldProgram =
                     { backendBindingName = "main",
                       backendBindingType = fnBoxTy,
                       backendBindingExpr = BackendConstruct fnBoxTy "FnBox" [intIdentityExpr],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+immediateRestoredFunctionFieldProgram :: BackendProgram
+immediateRestoredFunctionFieldProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = fnBoxTy,
+                      backendBindingExpr =
+                        BackendCase
+                          fnBoxTy
+                          (BackendConstruct fnBoxTy "FnBox" [intIdentityExpr])
+                          ( BackendAlternative
+                              (BackendConstructorPattern "FnBox" ["f"])
+                              (BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"])
+                              :| []
+                          ),
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -474,8 +474,11 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
 
   it "preserves inline function argument shadowing for bare references" $ do
-    renderBackendProgramLLVM inlineFunctionArgumentShadowsValueProgram
-      `shouldSatisfyLeft` isInfixOf "escaping function \"f\""
+    output <- requireRight (renderBackendProgramLLVM inlineFunctionArgumentShadowsValueProgram)
+
+    output `shouldSatisfy` isInfixOf "store ptr @\"idInt\""
+    output `shouldNotSatisfy` isInfixOf "escaping function \"f\""
+    validateLLVMAssembly output
 
   it "rejects evidence wrappers that capture local term bindings" $ do
     renderBackendProgramLLVM capturingEvidenceWrapperProgram
@@ -499,15 +502,11 @@ spec = describe "MLF.Backend.LLVM" $ do
     it "classifies every interpreter-success case exactly once" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
           uniqueCaseNames = Set.fromList caseNames
-          unsupportedNames = Set.fromList (map fst unsupportedLLVMParityCases)
           objectCodeNames = Set.fromList llvmObjectCodeParityCases
 
       length caseNames `shouldBe` Set.size uniqueCaseNames
-      length unsupportedLLVMParityCases `shouldBe` Set.size unsupportedNames
-      unsupportedNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
-      objectCodeNames `Set.isSubsetOf` Set.difference uniqueCaseNames unsupportedNames `shouldBe` True
+      objectCodeNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
       Map.keysSet llvmParityExpectations `shouldBe` uniqueCaseNames
-      llvmUnsupportedParityCount `shouldBe` expectedLLVMUnsupportedParityCount
 
     mapM_ runLLVMParityCase programSpecToLLVMParityCases
 
@@ -519,9 +518,23 @@ spec = describe "MLF.Backend.LLVM" $ do
     renderBackendProgramLLVM escapingLambdaProgram
       `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
 
-  it "rejects function-typed constructor fields" $ do
-    renderBackendProgramLLVM functionFieldProgram
-      `shouldSatisfyLeft` isInfixOf "escaping function"
+  it "lowers stored top-level function constructor fields" $ do
+    output <- requireRight (renderBackendProgramLLVM functionFieldProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"helper\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"helper\""
+    validateLLVMAssembly output
+
+  it "lowers stored direct function constructor fields through private wrappers" $ do
+    output <- requireRight (renderBackendProgramLLVM directFunctionFieldProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    validateLLVMAssembly output
+
+  it "rejects captured function constructor fields until closure conversion exists" $ do
+    renderBackendProgramLLVM capturedFunctionFieldProgram
+      `shouldSatisfyLeft` isInfixOf "unsupported function argument"
 
   it "rejects unknown base types" $ do
     renderBackendProgramLLVM unknownBaseProgram
@@ -2406,6 +2419,61 @@ functionFieldProgram =
       backendProgramMain = "main"
     }
 
+directFunctionFieldProgram :: BackendProgram
+directFunctionFieldProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = fnBoxTy,
+                      backendBindingExpr = BackendConstruct fnBoxTy "FnBox" [intIdentityExpr],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+capturedFunctionFieldProgram :: BackendProgram
+capturedFunctionFieldProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = fnBoxTy,
+                      backendBindingExpr =
+                        BackendLet
+                          fnBoxTy
+                          "captured"
+                          intTy
+                          (intLit 1)
+                          ( BackendConstruct
+                              fnBoxTy
+                              "FnBox"
+                              [ BackendLam
+                                  unaryIntTy
+                                  "x"
+                                  intTy
+                                  (BackendVar intTy "captured")
+                              ]
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
 unknownBaseProgram :: BackendProgram
 unknownBaseProgram =
   programWithMainExpr mysteryTy (BackendVar mysteryTy "main")
@@ -2638,35 +2706,12 @@ recIntTy =
 
 data LLVMParityExpectation
   = ExpectLLVMAssembly
-  | ExpectLLVMUnsupported String
 
 llvmParityExpectations :: Map.Map String LLVMParityExpectation
 llvmParityExpectations =
   Map.fromList
-    [ ( runtimeCaseName runtimeCase,
-        case Map.lookup (runtimeCaseName runtimeCase) unsupportedByName of
-          Just reason -> ExpectLLVMUnsupported reason
-          Nothing -> ExpectLLVMAssembly
-      )
+    [ (runtimeCaseName runtimeCase, ExpectLLVMAssembly)
     | runtimeCase <- programSpecToLLVMParityCases
-    ]
-  where
-    unsupportedByName = Map.fromList unsupportedLLVMParityCases
-
-unsupportedLLVMParityCases :: [(String, String)]
-unsupportedLLVMParityCases =
-  [ ("standalone: does not decode typed non-data constructor fields through fallback ADT decoding", "escaping lambda")
-  ]
-
-expectedLLVMUnsupportedParityCount :: Int
-expectedLLVMUnsupportedParityCount =
-  1
-
-llvmUnsupportedParityCount :: Int
-llvmUnsupportedParityCount =
-  length
-    [ ()
-    | ExpectLLVMUnsupported _ <- Map.elems llvmParityExpectations
     ]
 
 llvmObjectCodeParityCases :: [String]
@@ -2677,7 +2722,8 @@ llvmObjectCodeParityCases =
       "boundary: runs value-exported constructor when owner type is not exported",
       "boundary: runs aliased bulk-imported hidden-owner constructors in one case",
       "boundary: runs exposed constructor with qualified alias type identity",
-      "unified fixture: test/programs/unified/first-class-polymorphism.mlfp"
+      "unified fixture: test/programs/unified/first-class-polymorphism.mlfp",
+      "standalone: does not decode typed non-data constructor fields through fallback ADT decoding"
     ]
 
 llvmObjectCodeParityCaseNames :: Set.Set String
@@ -2696,14 +2742,6 @@ runLLVMParityCase runtimeCase =
         validateLLVMAssembly output
         when (runtimeCaseName runtimeCase `Set.member` llvmObjectCodeParityCaseNames) $
           validateLLVMObjectCode output
-      Just (ExpectLLVMUnsupported expectedFragment) ->
-        case result of
-          Left err ->
-            err `shouldSatisfy` isInfixOf expectedFragment
-          Right output ->
-            expectationFailure $
-              "LLVM parity case is now supported; remove its ExpectLLVMUnsupported classification:\n"
-                ++ output
 
 emitProgramRuntimeLLVM :: ProgramMatrixSource -> IO (Either String String)
 emitProgramRuntimeLLVM source =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -532,6 +532,20 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
+  it "lowers stored local function constructor fields through private wrappers" $ do
+    output <- requireRight (renderBackendProgramLLVM localFunctionFieldProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    validateLLVMAssembly output
+
+  it "lowers stored transitive local function aliases through private wrappers" $ do
+    output <- requireRight (renderBackendProgramLLVM transitiveLocalFunctionFieldProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    validateLLVMAssembly output
+
   it "re-stores immediate constructor fields carrying closed direct functions" $ do
     output <- requireRight (renderBackendProgramLLVM immediateRestoredFunctionFieldProgram)
 
@@ -2447,6 +2461,35 @@ directFunctionFieldProgram =
       backendProgramMain = "main"
     }
 
+localFunctionFieldProgram :: BackendProgram
+localFunctionFieldProgram =
+  programWithFnBoxMainExpr $
+    BackendLet
+      { backendExprType = fnBoxTy,
+        backendLetName = "f",
+        backendLetType = unaryIntTy,
+        backendLetRhs = intIdentityExpr,
+        backendLetBody = BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"]
+      }
+
+transitiveLocalFunctionFieldProgram :: BackendProgram
+transitiveLocalFunctionFieldProgram =
+  programWithFnBoxMainExpr $
+    BackendLet
+      { backendExprType = fnBoxTy,
+        backendLetName = "f",
+        backendLetType = unaryIntTy,
+        backendLetRhs = intIdentityExpr,
+        backendLetBody =
+          BackendLet
+            { backendExprType = fnBoxTy,
+              backendLetName = "g",
+              backendLetType = unaryIntTy,
+              backendLetRhs = BackendVar unaryIntTy "f",
+              backendLetBody = BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "g"]
+            }
+      }
+
 immediateRestoredFunctionFieldProgram :: BackendProgram
 immediateRestoredFunctionFieldProgram =
   BackendProgram
@@ -2650,6 +2693,26 @@ programWithMainExpr mainTy expr =
           backendBindingExportedAsMain = True
         }
     ]
+
+programWithFnBoxMainExpr :: BackendExpr -> BackendProgram
+programWithFnBoxMainExpr expr =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = fnBoxTy,
+                      backendBindingExpr = expr,
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
 
 programWithBindings :: [BackendBinding] -> BackendProgram
 programWithBindings bindings =


### PR DESCRIPTION
Closes #74.

## Implementation Plan

---
issue_number: 74
pr_number: 85
branch: codex/issue-74
---

# Implementation Plan

1. Start from a clean `codex/issue-74` worktree against `origin/HEAD`; reread the watcher-written `issue-plan.md`, verify PR #85 still targets `master` from `codex/issue-74`, and avoid any watcher state/runtime files.
2. Confirm the current remaining gap: `test/BackendLLVMSpec.hs` has one `ExpectLLVMUnsupported` entry for `standalone: does not decode typed non-data constructor fields through fallback ADT decoding`. Keep `programRuntimeSuccessCases = programSpecToLLVMParityCases`; do not remove this interpreter-success case from LLVM coverage.
3. In `src/MLF/Backend/LLVM/Lower.hs`, support stored first-order function constructor fields without broad closure conversion: derive constructor field types from metadata/result type before lowering `BackendConstruct` args; lower ordinary fields as today; lower first-order function fields to `LLVMPtr` via existing function-reference/static-function machinery; allow closed direct lambdas through a precollected private wrapper; continue rejecting captured closures or non-first-order function values.
4. Extend wrapper/reference collection so constructor-field function references and closed direct function expressions are emitted before use. Prefer generalizing the existing evidence-wrapper helpers into neutral static function wrappers rather than duplicating wrapper naming, keying, and closure checks.
5. Update heap case field loading so used first-order function fields load as `LLVMPtr` with the original backend function type, letting the existing indirect-call path handle calls from extracted fields.
6. Update `test/BackendLLVMSpec.hs`: replace the current `rejects function-typed constructor fields` expectation with positive coverage for a stored first-order function constructor field; add or keep a negative test for a captured/unsupported closure; remove `ExpectLLVMUnsupported`, `unsupportedLLVMParityCases`, and the fixed unsupported count so every `programSpecToLLVMParityCases` row must assemble.
7. Add the formerly unsupported standalone parity row to `llvmObjectCodeParityCases` if it keeps runtime acceptable, giving `llc -filetype=obj -o /dev/null` representative coverage for stored function-pointer constructor fields.
8. Update `CHANGELOG.md` and `implementation_notes.md` to record that the final LLVM parity unsupported classification was eliminated and that representative `llc` coverage includes the stored function-field case.
9. Validate with focused checks first: `rg -n 'ExpectLLVMUnsupported|unsupportedLLVMParityCases' test/BackendLLVMSpec.hs` should find no remaining unsupported classification; run the focused Backend LLVM parity matrix and the new function-field tests with `cabal test mlf2-test --test-show-details=direct --test-options=...`. Since `/usr/bin/llvm-as` and `/usr/bin/llc` are available, expect assembly and object-code checks to run rather than pend.
10. Run the required final gate `cabal build all && cabal test`. Before publishing, run `gh auth status` and `gh auth setup-git`, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, and push the existing `codex/issue-74` branch for PR #85 without creating a duplicate PR.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.