### PR TITLE
Implement #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Changed
+- Supported expected-type resolution for nullary overloaded `.mlfp` methods.
+  Associated values such as `mempty : a` now resolve from an explicit or
+  propagated expected source type while bare uses without such evidence still
+  fail closed as ambiguous.
 - Eliminated the final temporary LLVM unsupported classification from the
   shared `ProgramSpec` runtime-success parity matrix. Stored first-order
   function constructor fields now lower as function pointers, closed direct

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -252,7 +252,11 @@ instance Eq a => Eq (Option a) {
 
 Method calls lower to deferred obligations and resolve after eMLF inference.
 Partial overloaded method application is supported by eta-expanding the missing
-arguments. Bare overloaded method names remain ambiguous and are rejected.
+arguments. Nullary overloaded methods / associated values can also resolve from
+an explicit or propagated expected source type when the method result determines
+the class parameter; for example, `(mempty : Nat)` can select a `Monoid Nat`
+instance. Bare overloaded method names without enough term arguments or
+expected-type evidence remain ambiguous and are rejected.
 
 Instance resolution is coherent and fail-closed: duplicate and overlapping
 instance heads are rejected by unification, and a missing instance remains a

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,14 @@
+## 2026-04-29 - Nullary overloaded method expected-type resolution
+
+- `.mlfp` nullary overloaded methods / associated values now carry expected
+  source-type evidence through deferred method finalization. A use such as
+  `(mempty : Nat)` resolves by matching the method result against the expected
+  type to recover the class argument, then reuses the existing coherent
+  instance/evidence resolution path.
+- Ambiguity remains fail-closed: bare nullary method uses without an explicit
+  or propagated expected type still report `ProgramAmbiguousMethodUse`, and
+  ordinary overloaded methods still require enough term arguments.
+
 ## 2026-04-29 - Final ProgramSpec-to-LLVM parity closure
 
 - Removed the last temporary LLVM unsupported classification from the shared

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -27,6 +27,7 @@ module MLF.Frontend.Program.Elaborate
     resolveInstanceInfoByConstraint,
     resolveMethodInstanceInfoWithSubst,
     resolveMethodInstanceInfoByTypeView,
+    lookupEvidenceMethodByClass,
   )
 where
 
@@ -705,7 +706,7 @@ compileExpr scope mbExpected expr = case expr of
       Just OverloadedMethod {valueMethodInfo = methodInfo} ->
         compileNullaryMethodUse scope mbExpected methodInfo
       Just valueInfo@OrdinaryValue {valueRuntimeName = runtimeName} -> do
-        evidenceSurfaces <- valueEvidenceArgs scope valueInfo []
+        evidenceSurfaces <- valueEvidenceArgs scope valueInfo mbExpected []
         pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
       Just ConstructorValue {valueCtorInfo = ctorInfo} -> do
         compileConstructorHead scope ctorInfo 0 (constructorInitialSubst scope ctorInfo 0 mbExpected)
@@ -782,7 +783,7 @@ compileResolvedExpr scope mbExpected expr = case expr of
       OverloadedMethod {valueMethodInfo = methodInfo} ->
         compileNullaryMethodUse scope mbExpected methodInfo
       OrdinaryValue {valueRuntimeName = runtimeName} -> do
-        evidenceSurfaces <- valueResolvedEvidenceArgs scope valueInfo []
+        evidenceSurfaces <- valueResolvedEvidenceArgs scope valueInfo mbExpected []
         pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
       ConstructorValue {valueCtorInfo = ctorInfo} -> do
         compileConstructorHead scope ctorInfo 0 (constructorInitialSubst scope ctorInfo 0 mbExpected)
@@ -969,7 +970,7 @@ compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} arg
 compileValueApp scope mbExpected valueInfo args = do
   let expectedArgTys = valueExpectedArgTypes scope valueInfo mbExpected args
   argSurfaces <- zipWithM compileValueArg (expectedArgTys ++ repeat Nothing) args
-  evidenceSurfaces <- valueEvidenceArgs scope valueInfo args
+  evidenceSurfaces <- valueEvidenceArgs scope valueInfo mbExpected args
   let headSurface =
         case valueInfo of
           OrdinaryValue {valueRuntimeName = runtimeName} -> surfaceVar runtimeName
@@ -1023,7 +1024,7 @@ compileResolvedValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorI
 compileResolvedValueApp scope mbExpected valueInfo args = do
   let expectedArgTys = valueExpectedArgTypes scope valueInfo mbExpected args
   argSurfaces <- zipWithM compileValueArg (expectedArgTys ++ repeat Nothing) args
-  evidenceSurfaces <- valueResolvedEvidenceArgs scope valueInfo args
+  evidenceSurfaces <- valueResolvedEvidenceArgs scope valueInfo mbExpected args
   let headSurface =
         case valueInfo of
           OrdinaryValue {valueRuntimeName = runtimeName} -> surfaceVar runtimeName
@@ -1266,13 +1267,13 @@ constructorInitialSubst scope ctorInfo argCount mbExpected =
     Just subst -> subst
     Nothing -> Map.empty
 
-valueEvidenceArgs :: ElaborateScope -> ValueInfo -> [P.Expr] -> ElaborateM [SurfaceExpr]
-valueEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, valueType = visibleTy, valueConstraints = displayConstraints, valueConstraintInfos = constraints} args
+valueEvidenceArgs :: ElaborateScope -> ValueInfo -> Maybe SrcType -> [P.Expr] -> ElaborateM [SurfaceExpr]
+valueEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, valueType = visibleTy, valueConstraints = displayConstraints, valueConstraintInfos = constraints} mbExpected args
   | null constraints = pure []
   | otherwise = do
       subst <-
         case inferCallSubst scope visibleTy args of
-          Just subst0 -> pure (fmap (sourceTypeViewInScope scope) subst0)
+          Just subst0 -> pure (fmap (sourceTypeViewInScope scope) (refineValueEvidenceSubst scope visibleTy mbExpected args subst0))
           Nothing ->
             case displayConstraints of
               constraint : _ -> throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
@@ -1285,15 +1286,15 @@ valueEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, valueType
     usesLocalPolymorphicEvidence constraint =
       not (Set.null (freeTypeVarsTypeView (constraintTypeView constraint)))
         && constraintCoveredByEvidenceInfo scope constraint
-valueEvidenceArgs _ _ _ = pure []
+valueEvidenceArgs _ _ _ _ = pure []
 
-valueResolvedEvidenceArgs :: ElaborateScope -> ValueInfo -> [P.ResolvedExpr] -> ElaborateM [SurfaceExpr]
-valueResolvedEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, valueType = visibleTy, valueConstraints = displayConstraints, valueConstraintInfos = constraints} args
+valueResolvedEvidenceArgs :: ElaborateScope -> ValueInfo -> Maybe SrcType -> [P.ResolvedExpr] -> ElaborateM [SurfaceExpr]
+valueResolvedEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, valueType = visibleTy, valueConstraints = displayConstraints, valueConstraintInfos = constraints} mbExpected args
   | null constraints = pure []
   | otherwise = do
       subst <-
         case inferResolvedCallSubst scope visibleTy args of
-          Just subst0 -> pure (fmap (sourceTypeViewInScope scope) subst0)
+          Just subst0 -> pure (fmap (sourceTypeViewInScope scope) (refineValueEvidenceSubst scope visibleTy mbExpected args subst0))
           Nothing ->
             case displayConstraints of
               constraint : _ -> throwError (ProgramNoMatchingInstance (P.constraintClassName constraint) (P.constraintType constraint))
@@ -1306,7 +1307,16 @@ valueResolvedEvidenceArgs scope OrdinaryValue {valueDisplayName = displayName, v
     usesLocalPolymorphicEvidence constraint =
       not (Set.null (freeTypeVarsTypeView (constraintTypeView constraint)))
         && constraintCoveredByEvidenceInfo scope constraint
-valueResolvedEvidenceArgs _ _ _ = pure []
+valueResolvedEvidenceArgs _ _ _ _ = pure []
+
+refineValueEvidenceSubst :: ElaborateScope -> SrcType -> Maybe SrcType -> [arg] -> Map String SrcType -> Map String SrcType
+refineValueEvidenceSubst scope visibleTy mbExpected args subst =
+  case mbExpected >>= matchTypesInScope scope subst resultTyForArity of
+    Just subst' -> subst'
+    Nothing -> subst
+  where
+    (argTys, resultTy) = splitArrows (snd (splitForalls visibleTy))
+    resultTyForArity = foldr STArrow resultTy (drop (length args) argTys)
 
 constraintEvidenceArgExprsInfo :: ElaborateScope -> ConstraintInfo -> ElaborateM [SurfaceExpr]
 constraintEvidenceArgExprsInfo scope constraint
@@ -1865,7 +1875,8 @@ deferMethodCall scope methodInfo fullArity placeholderSourceTy = do
             deferredMethodArgCount = fullArity,
             deferredMethodFullArity = fullArity,
             deferredMethodName = methodName methodInfo,
-            deferredMethodExpectedResult = Nothing
+            deferredMethodExpectedResult = Nothing,
+            deferredMethodEvidence = Nothing
           }
   registerDeferredObligation placeholder placeholderTy (DeferredMethod deferred)
   pure placeholder
@@ -1874,6 +1885,7 @@ deferNullaryMethodCall :: ElaborateScope -> MethodInfo -> TypeView -> ElaborateM
 deferNullaryMethodCall scope methodInfo expectedView = do
   placeholder <- freshDeferredMethodName (methodName methodInfo)
   let placeholderTy = lowerTypeView scope expectedView
+      localEvidence = nullaryMethodEvidence scope methodInfo expectedView
       deferred =
         DeferredMethodCall
           { deferredMethodPlaceholder = placeholder,
@@ -1881,10 +1893,28 @@ deferNullaryMethodCall scope methodInfo expectedView = do
             deferredMethodArgCount = 0,
             deferredMethodFullArity = 0,
             deferredMethodName = methodName methodInfo,
-            deferredMethodExpectedResult = Just expectedView
+            deferredMethodExpectedResult = Just expectedView,
+            deferredMethodEvidence = localEvidence
           }
   registerDeferredObligation placeholder placeholderTy (DeferredMethod deferred)
   pure placeholder
+
+nullaryMethodEvidence :: ElaborateScope -> MethodInfo -> TypeView -> Maybe DeferredMethodEvidence
+nullaryMethodEvidence scope methodInfo expectedView = do
+  classArgTy <- inferNullaryMethodClassArg scope methodInfo (typeViewDisplay expectedView)
+  let classArgView = sourceTypeViewInScope scope classArgTy
+  (runtimeName, evidenceTy) <-
+    lookupEvidenceMethodByClass
+      scope
+      (methodInfoOwnerClassSymbolIdentity methodInfo)
+      (typeViewIdentity classArgView)
+      (methodName methodInfo)
+  pure
+    DeferredMethodEvidence
+      { deferredMethodEvidenceClassArg = classArgView,
+        deferredMethodEvidenceRuntimeName = runtimeName,
+        deferredMethodEvidenceType = evidenceTy
+      }
 
 deferConstructorCall :: ElaborateScope -> ConstructorInfo -> Int -> Map String SrcType -> ElaborateM String
 deferConstructorCall scope ctorInfo argCount initialSubst = do

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -15,6 +15,7 @@ module MLF.Frontend.Program.Elaborate
     lowerResolvedConstrainedExprBinding,
     lowerExprBinding,
     inferClassArgument,
+    classInfoForConstraint,
     lowerType,
     sourceTypeViewInScope,
     matchTypes,
@@ -27,6 +28,7 @@ module MLF.Frontend.Program.Elaborate
     resolveInstanceInfoByConstraint,
     resolveMethodInstanceInfoWithSubst,
     resolveMethodInstanceInfoByTypeView,
+    zeroMethodConstraintCoveredByEvidenceInfo,
     lookupEvidenceMethodByClass,
   )
 where
@@ -1876,7 +1878,8 @@ deferMethodCall scope methodInfo fullArity placeholderSourceTy = do
             deferredMethodFullArity = fullArity,
             deferredMethodName = methodName methodInfo,
             deferredMethodExpectedResult = Nothing,
-            deferredMethodEvidence = Nothing
+            deferredMethodEvidence = Nothing,
+            deferredMethodLocalEvidence = esEvidence scope
           }
   registerDeferredObligation placeholder placeholderTy (DeferredMethod deferred)
   pure placeholder
@@ -1894,7 +1897,8 @@ deferNullaryMethodCall scope methodInfo expectedView = do
             deferredMethodFullArity = 0,
             deferredMethodName = methodName methodInfo,
             deferredMethodExpectedResult = Just expectedView,
-            deferredMethodEvidence = localEvidence
+            deferredMethodEvidence = localEvidence,
+            deferredMethodLocalEvidence = esEvidence scope
           }
   registerDeferredObligation placeholder placeholderTy (DeferredMethod deferred)
   pure placeholder

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -702,7 +702,8 @@ compileExpr :: ElaborateScope -> Maybe SrcType -> P.Expr -> ElaborateM SurfaceEx
 compileExpr scope mbExpected expr = case expr of
   EVar name ->
     case Map.lookup name (esValues scope) of
-      Just OverloadedMethod {} -> throwError (ProgramAmbiguousMethodUse name)
+      Just OverloadedMethod {valueMethodInfo = methodInfo} ->
+        compileNullaryMethodUse scope mbExpected methodInfo
       Just valueInfo@OrdinaryValue {valueRuntimeName = runtimeName} -> do
         evidenceSurfaces <- valueEvidenceArgs scope valueInfo []
         pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
@@ -762,9 +763,15 @@ compileExpr scope mbExpected expr = case expr of
             bodyScope <- extendLocalLowered scope name runtimeName bindingTy
             bodyExpr <- compileExpr bodyScope mbExpected body
             pure (surfaceLet runtimeName rhsExpr' bodyExpr)
-  EAnn inner annTy -> do
-    innerExpr <- compileExpr scope (Just annTy) inner
-    pure (surfaceAnn innerExpr (lowerType scope annTy))
+  EAnn inner annTy ->
+    case inner of
+      EVar name
+        | Just OverloadedMethod {valueMethodInfo = methodInfo} <- Map.lookup name (esValues scope),
+          methodFullArity methodInfo == 0 ->
+            compileExpr scope (Just annTy) inner
+      _ -> do
+        innerExpr <- compileExpr scope (Just annTy) inner
+        pure (surfaceAnn innerExpr (lowerType scope annTy))
   ECase scrutinee alts -> compileCase scope mbExpected scrutinee alts
 
 compileResolvedExpr :: ElaborateScope -> Maybe SrcType -> P.ResolvedExpr -> ElaborateM SurfaceExpr
@@ -772,7 +779,8 @@ compileResolvedExpr scope mbExpected expr = case expr of
   EVar ref -> do
     valueInfo <- lookupResolvedValueInfo scope ref
     case valueInfo of
-      OverloadedMethod {} -> throwError (ProgramAmbiguousMethodUse (resolvedValueRefDisplayName ref))
+      OverloadedMethod {valueMethodInfo = methodInfo} ->
+        compileNullaryMethodUse scope mbExpected methodInfo
       OrdinaryValue {valueRuntimeName = runtimeName} -> do
         evidenceSurfaces <- valueResolvedEvidenceArgs scope valueInfo []
         pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
@@ -835,8 +843,14 @@ compileResolvedExpr scope mbExpected expr = case expr of
             pure (surfaceLet runtimeName rhsExpr' bodyExpr)
   EAnn inner annTy -> do
     annDisplayTy <- liftEitherElab (displaySrcTypeForResolved scope annTy)
-    innerExpr <- compileResolvedExpr scope (Just annDisplayTy) inner
-    pure (surfaceAnn innerExpr (lowerType scope annDisplayTy))
+    case inner of
+      EVar ref
+        | Right OverloadedMethod {valueMethodInfo = methodInfo} <- runElaborateLookup (lookupResolvedValueInfo scope ref),
+          methodFullArity methodInfo == 0 ->
+            compileResolvedExpr scope (Just annDisplayTy) inner
+      _ -> do
+        innerExpr <- compileResolvedExpr scope (Just annDisplayTy) inner
+        pure (surfaceAnn innerExpr (lowerType scope annDisplayTy))
   ECase scrutinee alts -> compileResolvedCase scope mbExpected scrutinee alts
 
 compileApp :: ElaborateScope -> Maybe SrcType -> P.Expr -> ElaborateM SurfaceExpr
@@ -928,9 +942,6 @@ lookupValueInfoBySymbol scope symbol =
             (_, info) : _ -> Just info
             [] -> Nothing
     Nothing -> Nothing
-
-resolvedValueRefDisplayName :: P.ResolvedValueRef -> String
-resolvedValueRefDisplayName = P.refDisplayName
 
 compileValueApp :: ElaborateScope -> Maybe SrcType -> ValueInfo -> [P.Expr] -> ElaborateM SurfaceExpr
 compileValueApp scope mbExpected ConstructorValue {valueCtorInfo = ctorInfo} args = do
@@ -1431,7 +1442,7 @@ knownResolvedConstructorResultType scope ctorInfo args = do
 
 compileMethodApp :: ElaborateScope -> Maybe SrcType -> MethodInfo -> [P.Expr] -> ElaborateM SurfaceExpr
 compileMethodApp scope mbExpected methodInfo args
-  | null args = throwError (ProgramAmbiguousMethodUse (methodName methodInfo))
+  | null args = compileNullaryMethodUse scope mbExpected methodInfo
   | otherwise = do
       let fullArity = methodFullArity methodInfo
           suppliedArity = length args
@@ -1470,7 +1481,7 @@ compileMethodApp scope mbExpected methodInfo args
 
 compileResolvedMethodApp :: ElaborateScope -> Maybe SrcType -> MethodInfo -> [P.ResolvedExpr] -> ElaborateM SurfaceExpr
 compileResolvedMethodApp scope mbExpected methodInfo args
-  | null args = throwError (ProgramAmbiguousMethodUse (methodName methodInfo))
+  | null args = compileNullaryMethodUse scope mbExpected methodInfo
   | otherwise = do
       let fullArity = methodFullArity methodInfo
           suppliedArity = length args
@@ -1507,6 +1518,29 @@ compileResolvedMethodApp scope mbExpected methodInfo args
                 Nothing -> expanded
       | otherwise = expanded
 
+compileNullaryMethodUse :: ElaborateScope -> Maybe SrcType -> MethodInfo -> ElaborateM SurfaceExpr
+compileNullaryMethodUse scope mbExpected methodInfo =
+  case nullaryMethodExpectedResultView scope mbExpected methodInfo of
+    Just expectedView -> do
+      placeholder <- deferNullaryMethodCall scope methodInfo expectedView
+      pure (surfaceVar placeholder)
+    Nothing -> throwError (ProgramAmbiguousMethodUse (methodName methodInfo))
+
+nullaryMethodExpectedResultView :: ElaborateScope -> Maybe SrcType -> MethodInfo -> Maybe TypeView
+nullaryMethodExpectedResultView scope mbExpected methodInfo = do
+  expectedTy <- mbExpected
+  _ <- inferNullaryMethodClassArg scope methodInfo expectedTy
+  pure (sourceTypeViewInScope scope expectedTy)
+
+inferNullaryMethodClassArg :: ElaborateScope -> MethodInfo -> SrcType -> Maybe SrcType
+inferNullaryMethodClassArg scope methodInfo expectedTy
+  | methodFullArity methodInfo /= 0 = Nothing
+  | otherwise = do
+      let (_, bodyTy) = splitForalls (methodType methodInfo)
+          (_, resultTy) = splitArrows bodyTy
+      subst <- matchTypesInScope scope Map.empty resultTy expectedTy
+      Map.lookup (methodParamName methodInfo) subst
+
 compileExpectedMethodArg :: ElaborateScope -> SrcType -> P.Expr -> ElaborateM SurfaceExpr
 compileExpectedMethodArg scope expectedTy expr = do
   case inferKnownExprType scope expr of
@@ -1526,6 +1560,10 @@ compileExpectedMethodArg scope expectedTy expr = do
       pure (surfaceLet runtimeName actualExpr (surfaceAnn bodyExpr (lowerType scope expectedTy)))
     EVar name
       | Just ConstructorValue {} <- Map.lookup name (esValues scope) ->
+          compileExpr scope (Just expectedTy) expr
+    EVar name
+      | Just OverloadedMethod {valueMethodInfo = methodInfo} <- Map.lookup name (esValues scope),
+        methodFullArity methodInfo == 0 ->
           compileExpr scope (Just expectedTy) expr
     EVar {} ->
       compileExpr scope Nothing expr
@@ -1556,6 +1594,10 @@ compileExpectedResolvedMethodArg scope expectedTy expr = do
       pure (surfaceLet runtimeName actualExpr (surfaceAnn bodyExpr (lowerType scope expectedTy)))
     EVar ref
       | Right ConstructorValue {} <- runElaborateLookup (lookupResolvedValueInfo scope ref) ->
+          compileResolvedExpr scope (Just expectedTy) expr
+    EVar ref
+      | Right OverloadedMethod {valueMethodInfo = methodInfo} <- runElaborateLookup (lookupResolvedValueInfo scope ref),
+        methodFullArity methodInfo == 0 ->
           compileResolvedExpr scope (Just expectedTy) expr
     EVar {} ->
       compileResolvedExpr scope Nothing expr
@@ -1822,7 +1864,24 @@ deferMethodCall scope methodInfo fullArity placeholderSourceTy = do
             deferredMethodInfo = methodInfo,
             deferredMethodArgCount = fullArity,
             deferredMethodFullArity = fullArity,
-            deferredMethodName = methodName methodInfo
+            deferredMethodName = methodName methodInfo,
+            deferredMethodExpectedResult = Nothing
+          }
+  registerDeferredObligation placeholder placeholderTy (DeferredMethod deferred)
+  pure placeholder
+
+deferNullaryMethodCall :: ElaborateScope -> MethodInfo -> TypeView -> ElaborateM String
+deferNullaryMethodCall scope methodInfo expectedView = do
+  placeholder <- freshDeferredMethodName (methodName methodInfo)
+  let placeholderTy = lowerTypeView scope expectedView
+      deferred =
+        DeferredMethodCall
+          { deferredMethodPlaceholder = placeholder,
+            deferredMethodInfo = methodInfo,
+            deferredMethodArgCount = 0,
+            deferredMethodFullArity = 0,
+            deferredMethodName = methodName methodInfo,
+            deferredMethodExpectedResult = Just expectedView
           }
   registerDeferredObligation placeholder placeholderTy (DeferredMethod deferred)
   pure placeholder

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -36,6 +36,7 @@ import MLF.Frontend.Program.Elaborate
     elaborateScopeDataTypes,
     elaborateScopeRuntimeTypes,
     inferClassArgument,
+    lookupEvidenceMethodByClass,
     lowerType,
     lowerTypeView,
     matchTypes,
@@ -49,6 +50,7 @@ import MLF.Frontend.Program.Types
     ConstructorInfo (..),
     ConstructorShape (..),
     DataInfo (..),
+    DeferredMethodEvidence (..),
     DeferredCaseCall (..),
     DeferredBindingMode (..),
     DeferredConstructorCall (..),
@@ -66,6 +68,7 @@ import MLF.Frontend.Program.Types
     constructorOwnerShapes,
     constructorShapeFromInfo,
     freeTypeVarsTypeView,
+    methodInfoOwnerClassSymbolIdentity,
     SymbolIdentity,
     splitArrows,
     splitForalls,
@@ -969,19 +972,37 @@ resolveDeferredMethods scope deferredMethods = go
         case inferNullaryMethodClassArgument methodInfo expectedView of
           Just view -> Right view
           Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
-      (instanceInfo, subst) <- resolveMethodInstanceInfoByTypeView scope methodInfo classArgView
-      methodValue <- concreteMethodValue instanceInfo methodInfo
-      methodSubst <-
-        case inferNullaryMethodSubst methodInfo classArgView subst expectedView of
-          Just subst' -> Right subst'
-          Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
-      let eagerConstraints =
-            filter
-              constraintGround
-              (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
-      evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
-      methodHead <- instantiateMethodValue scope methodSubst methodValue
-      Right (foldl X.EApp methodHead evidenceArgs)
+      case lookupNullaryEvidence deferred methodInfo classArgView of
+        Just runtimeName -> Right (X.EVar runtimeName)
+        Nothing -> do
+          (instanceInfo, subst) <- resolveMethodInstanceInfoByTypeView scope methodInfo classArgView
+          methodValue <- concreteMethodValue instanceInfo methodInfo
+          methodSubst <-
+            case inferNullaryMethodSubst methodInfo classArgView subst expectedView of
+              Just subst' -> Right subst'
+              Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
+          let eagerConstraints =
+                filter
+                  constraintGround
+                  (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
+          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
+          methodHead <- instantiateMethodValue scope methodSubst methodValue
+          Right (foldl X.EApp methodHead evidenceArgs)
+
+    lookupNullaryEvidence deferred methodInfo classArgView =
+      case
+        lookupEvidenceMethodByClass
+          scope
+          (methodInfoOwnerClassSymbolIdentity methodInfo)
+          (typeViewIdentity classArgView)
+          (methodName methodInfo)
+      of
+        Just (runtimeName, _) -> Just runtimeName
+        Nothing ->
+          case deferredMethodEvidence deferred of
+            Just DeferredMethodEvidence {deferredMethodEvidenceRuntimeName = runtimeName} ->
+              Just runtimeName
+            _ -> Nothing
 
     inferNullaryMethodClassArgument methodInfo expectedView
       | deferredMethodFullArityFromInfo methodInfo /= 0 = Nothing

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -897,10 +897,10 @@ resolveDeferredMethods scope deferredMethods = go
   where
     go env term =
       case deferredPlaceholderHeadWithInsts term of
-        Just (name, _)
+        Just (name, headInsts)
           | Just deferred <- Map.lookup name deferredMethods,
             deferredMethodArgCount deferred == 0 ->
-              resolveDeferredNullaryMethod deferred
+              reapplyHeadInsts headInsts <$> resolveDeferredNullaryMethod deferred
         _ ->
           case term of
             X.EVar {} -> Right term
@@ -1276,6 +1276,10 @@ deferredPlaceholderHeadWithInsts = go []
         X.ETyInst inner (X.InstApp ty) -> go (ty : insts) inner
         X.ETyInst inner _ -> go insts inner
         _ -> Nothing
+
+reapplyHeadInsts :: [ElabType] -> ElabTerm -> ElabTerm
+reapplyHeadInsts insts term =
+  foldl X.ETyInst term (map X.InstApp insts)
 
 dataInfoHeadNames :: ElaborateScope -> DataInfo -> [String]
 dataInfoHeadNames scope info =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -35,6 +35,7 @@ import MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
     elaborateScopeDataTypes,
     elaborateScopeRuntimeTypes,
+    classInfoForConstraint,
     inferClassArgument,
     lookupEvidenceMethodByClass,
     lowerType,
@@ -44,6 +45,7 @@ import MLF.Frontend.Program.Elaborate
     resolveInstanceInfoByConstraint,
     resolveMethodInstanceInfoByTypeView,
     sourceTypeViewInScope,
+    zeroMethodConstraintCoveredByEvidenceInfo,
   )
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
@@ -56,6 +58,8 @@ import MLF.Frontend.Program.Types
     DeferredConstructorCall (..),
     DeferredMethodCall (..),
     DeferredProgramObligation (..),
+    ClassInfo (..),
+    EvidenceInfo (..),
     InstanceInfo (..),
     LoweredBinding (..),
     MethodInfo (..),
@@ -958,7 +962,7 @@ resolveDeferredMethods scope deferredMethods = go
                 filter
                   constraintGround
                   (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
-          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
+          evidenceArgs <- resolveConstraintEvidenceTerms scope (deferredMethodLocalEvidence deferred) Set.empty eagerConstraints
           methodHead <- instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
@@ -982,6 +986,7 @@ resolveDeferredMethods scope deferredMethods = go
           evidenceArgs <-
             resolveConstraintEvidenceTerms
               scope
+              (deferredMethodLocalEvidence deferred)
               Set.empty
               (nullaryMethodLocalConstraints methodInfo classArgView methodSubst)
           Right (foldl X.EApp evidenceHead evidenceArgs)
@@ -996,7 +1001,7 @@ resolveDeferredMethods scope deferredMethods = go
                 filter
                   constraintGround
                   (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
-          evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
+          evidenceArgs <- resolveConstraintEvidenceTerms scope (deferredMethodLocalEvidence deferred) Set.empty eagerConstraints
           methodHead <- instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp methodHead evidenceArgs)
 
@@ -1007,6 +1012,12 @@ resolveDeferredMethods scope deferredMethods = go
           (methodInfoOwnerClassSymbolIdentity methodInfo)
           (typeViewIdentity classArgView)
           (methodName methodInfo)
+          `orElseEvidenceMethod`
+          lookupEvidenceMethod
+            (deferredMethodLocalEvidence deferred)
+            (methodInfoOwnerClassSymbolIdentity methodInfo)
+            (typeViewIdentity classArgView)
+            (methodName methodInfo)
       of
         Just (runtimeName, evidenceTy) ->
           Just
@@ -1019,10 +1030,6 @@ resolveDeferredMethods scope deferredMethods = go
           case deferredMethodEvidence deferred of
             Just evidence -> Just evidence
             _ -> Nothing
-
-    instantiateLocalMethodEvidence scope0 subst DeferredMethodEvidence {deferredMethodEvidenceRuntimeName = runtimeName, deferredMethodEvidenceType = evidenceTy} =
-      foldl X.ETyInst (X.EVar runtimeName)
-        <$> methodForallInstantiations scope0 subst (fst (splitForalls evidenceTy))
 
     nullaryMethodLocalConstraints methodInfo classArgView methodSubst =
       let headVars = freeTypeVarsTypeView classArgView
@@ -1095,28 +1102,33 @@ resolveDeferredMethods scope deferredMethods = go
               (fmap typeViewDisplay subst)
               (zip paramTys argViews)
 
-resolveConstraintEvidenceTerms :: ElaborateScope -> Set (SymbolIdentity, String) -> [ConstraintInfo] -> Either ProgramError [ElabTerm]
-resolveConstraintEvidenceTerms scope seen constraints =
-  concat <$> mapM (resolveConstraintEvidenceTerm scope seen) constraints
+resolveConstraintEvidenceTerms :: ElaborateScope -> [EvidenceInfo] -> Set (SymbolIdentity, String) -> [ConstraintInfo] -> Either ProgramError [ElabTerm]
+resolveConstraintEvidenceTerms scope localEvidence seen constraints =
+  concat <$> mapM (resolveConstraintEvidenceTerm scope localEvidence seen) constraints
 
-resolveConstraintEvidenceTerm :: ElaborateScope -> Set (SymbolIdentity, String) -> ConstraintInfo -> Either ProgramError [ElabTerm]
-resolveConstraintEvidenceTerm scope seen constraint = do
+resolveConstraintEvidenceTerm :: ElaborateScope -> [EvidenceInfo] -> Set (SymbolIdentity, String) -> ConstraintInfo -> Either ProgramError [ElabTerm]
+resolveConstraintEvidenceTerm scope localEvidence seen constraint = do
   let key = (constraintClassSymbol constraint, show (typeViewIdentity (constraintTypeView constraint)))
   if key `Set.member` seen
     then Left (ProgramNoMatchingInstance (constraintDisplayClass constraint) (typeViewDisplay (constraintTypeView constraint)))
     else do
-      (instanceInfo, subst) <- resolveInstanceInfoByConstraint scope constraint
-      let seen' = Set.insert key seen
-          methodValues = ordinaryInstanceMethods instanceInfo
-      if null methodValues
-        then do
-          _ <-
-            resolveConstraintEvidenceTerms
-              scope
-              seen'
-              (map (applyConstraintInfoSubst subst) (instanceConstraintInfos instanceInfo))
-          Right []
-        else mapM (materializeMethodEvidence (freeTypeVarsTypeView (constraintTypeView constraint)) seen' subst) methodValues
+      mbLocalEvidence <- resolveLocalConstraintEvidenceTerms scope localEvidence constraint
+      case mbLocalEvidence of
+        Just evidenceTerms -> Right evidenceTerms
+        Nothing -> do
+          (instanceInfo, subst) <- resolveInstanceInfoByConstraint scope constraint
+          let seen' = Set.insert key seen
+              methodValues = ordinaryInstanceMethods instanceInfo
+          if null methodValues
+            then do
+              _ <-
+                resolveConstraintEvidenceTerms
+                  scope
+                  localEvidence
+                  seen'
+                  (map (applyConstraintInfoSubst subst) (instanceConstraintInfos instanceInfo))
+              Right []
+            else mapM (materializeMethodEvidence (freeTypeVarsTypeView (constraintTypeView constraint)) seen' subst) methodValues
   where
     ordinaryInstanceMethods instanceInfo =
       [valueInfo | valueInfo@OrdinaryValue {} <- Map.elems (instanceMethods instanceInfo)]
@@ -1129,10 +1141,82 @@ resolveConstraintEvidenceTerm scope seen constraint = do
       nestedEvidence <-
         resolveConstraintEvidenceTerms
           scope
+          localEvidence
           seen'
           eagerConstraints
       methodHead <- instantiateMethodValue scope subst valueInfo
       pure (foldl X.EApp methodHead nestedEvidence)
+
+resolveLocalConstraintEvidenceTerms :: ElaborateScope -> [EvidenceInfo] -> ConstraintInfo -> Either ProgramError (Maybe [ElabTerm])
+resolveLocalConstraintEvidenceTerms scope localEvidence constraint =
+  case classInfoForConstraint scope constraint of
+    Nothing -> Right Nothing
+    Just classInfo
+      | Map.null (classMethods classInfo) ->
+          Right $
+            if zeroMethodConstraintCoveredByEvidenceInfo scope constraint
+              || zeroMethodConstraintCoveredByEvidence localEvidence constraint
+              then Just []
+              else Nothing
+      | otherwise -> do
+          let localMethodEvidence =
+                mapM
+                  ( \methodInfo -> do
+                      (runtimeName, evidenceTy) <-
+                        lookupEvidenceMethodByClass
+                          scope
+                          (constraintClassSymbol constraint)
+                          (typeViewIdentity (constraintTypeView constraint))
+                          (methodName methodInfo)
+                          `orElseEvidenceMethod`
+                          lookupEvidenceMethod
+                            localEvidence
+                            (constraintClassSymbol constraint)
+                            (typeViewIdentity (constraintTypeView constraint))
+                            (methodName methodInfo)
+                      pure
+                        DeferredMethodEvidence
+                          { deferredMethodEvidenceClassArg = constraintTypeView constraint,
+                            deferredMethodEvidenceRuntimeName = runtimeName,
+                            deferredMethodEvidenceType = evidenceTy
+                          }
+                  )
+                  (Map.elems (classMethods classInfo))
+          case localMethodEvidence of
+            Nothing -> Right Nothing
+            Just evidence ->
+              Just <$> mapM (instantiateLocalMethodEvidence scope Map.empty) evidence
+
+lookupEvidenceMethod :: [EvidenceInfo] -> SymbolIdentity -> SrcType -> String -> Maybe (String, SrcType)
+lookupEvidenceMethod evidenceInfos classIdentity headIdentityTy methodName0 =
+  case
+    [ methodEvidence
+      | evidence <- evidenceInfos,
+        evidenceClassSymbol evidence == classIdentity,
+        evidenceTypeIdentity evidence == headIdentityTy,
+        Just methodEvidence <- [Map.lookup methodName0 (evidenceMethods evidence)]
+    ]
+  of
+    methodEvidence : _ -> Just methodEvidence
+    [] -> Nothing
+
+orElseEvidenceMethod :: Maybe (String, SrcType) -> Maybe (String, SrcType) -> Maybe (String, SrcType)
+orElseEvidenceMethod (Just evidence) _ = Just evidence
+orElseEvidenceMethod Nothing fallback = fallback
+
+zeroMethodConstraintCoveredByEvidence :: [EvidenceInfo] -> ConstraintInfo -> Bool
+zeroMethodConstraintCoveredByEvidence evidenceInfos constraint =
+  any
+    ( \evidence ->
+        evidenceClassSymbol evidence == constraintClassSymbol constraint
+          && evidenceTypeIdentity evidence == typeViewIdentity (constraintTypeView constraint)
+    )
+    evidenceInfos
+
+instantiateLocalMethodEvidence :: ElaborateScope -> Map String TypeView -> DeferredMethodEvidence -> Either ProgramError ElabTerm
+instantiateLocalMethodEvidence scope subst DeferredMethodEvidence {deferredMethodEvidenceRuntimeName = runtimeName, deferredMethodEvidenceType = evidenceTy} =
+  foldl X.ETyInst (X.EVar runtimeName)
+    <$> methodForallInstantiations scope subst (fst (splitForalls evidenceTy))
 
 constraintDeterminedByTypeVars :: Set String -> ConstraintInfo -> Bool
 constraintDeterminedByTypeVars typeVars constraint =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -889,31 +889,37 @@ resolveDeferredMethods :: ElaborateScope -> Map String DeferredMethodCall -> Env
 resolveDeferredMethods scope deferredMethods = go
   where
     go env term =
-      case term of
-        X.EVar {} -> Right term
-        X.ELit {} -> Right term
-        X.ELam name ty body -> do
-          let env' = env {termEnv = Map.insert name ty (termEnv env)}
-          X.ELam name ty <$> go env' body
-        X.EApp {} -> rewriteApplication env term
-        X.ELet name scheme rhs body -> do
-          let schemeTy = schemeToType scheme
-              rhsEnv = env {termEnv = Map.insert name schemeTy (termEnv env)}
-          rhs' <- go rhsEnv rhs
-          let rhsTy = inferRewrittenLetType rhsEnv rhs' schemeTy
-              env' = env {termEnv = Map.insert name rhsTy (termEnv env)}
-          body' <- go env' body
-          Right (X.ELet name scheme rhs' body')
-        X.ETyAbs name mbBound body -> do
-          let boundTy = maybe X.TBottom X.tyToElab mbBound
-              env' = env {typeEnv = Map.insert name boundTy (typeEnv env)}
-          X.ETyAbs name mbBound <$> go env' body
-        X.ETyInst inner inst ->
-          (`X.ETyInst` inst) <$> go env inner
-        X.ERoll ty body ->
-          X.ERoll ty <$> go env body
-        X.EUnroll inner ->
-          X.EUnroll <$> go env inner
+      case deferredPlaceholderHeadWithInsts term of
+        Just (name, _)
+          | Just deferred <- Map.lookup name deferredMethods,
+            deferredMethodArgCount deferred == 0 ->
+              resolveDeferredNullaryMethod deferred
+        _ ->
+          case term of
+            X.EVar {} -> Right term
+            X.ELit {} -> Right term
+            X.ELam name ty body -> do
+              let env' = env {termEnv = Map.insert name ty (termEnv env)}
+              X.ELam name ty <$> go env' body
+            X.EApp {} -> rewriteApplication env term
+            X.ELet name scheme rhs body -> do
+              let schemeTy = schemeToType scheme
+                  rhsEnv = env {termEnv = Map.insert name schemeTy (termEnv env)}
+              rhs' <- go rhsEnv rhs
+              let rhsTy = inferRewrittenLetType rhsEnv rhs' schemeTy
+                  env' = env {termEnv = Map.insert name rhsTy (termEnv env)}
+              body' <- go env' body
+              Right (X.ELet name scheme rhs' body')
+            X.ETyAbs name mbBound body -> do
+              let boundTy = maybe X.TBottom X.tyToElab mbBound
+                  env' = env {typeEnv = Map.insert name boundTy (typeEnv env)}
+              X.ETyAbs name mbBound <$> go env' body
+            X.ETyInst inner inst ->
+              (`X.ETyInst` inst) <$> go env inner
+            X.ERoll ty body ->
+              X.ERoll ty <$> go env body
+            X.EUnroll inner ->
+              X.EUnroll <$> go env inner
 
     rewriteApplication env term =
       let (headTerm, args) = collectElabApps term
@@ -952,6 +958,57 @@ resolveDeferredMethods scope deferredMethods = go
           evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
           methodHead <- instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
+
+    resolveDeferredNullaryMethod deferred = do
+      expectedView <-
+        case deferredMethodExpectedResult deferred of
+          Just view -> Right view
+          Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
+      let methodInfo = deferredMethodInfo deferred
+      classArgView <-
+        case inferNullaryMethodClassArgument methodInfo expectedView of
+          Just view -> Right view
+          Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
+      (instanceInfo, subst) <- resolveMethodInstanceInfoByTypeView scope methodInfo classArgView
+      methodValue <- concreteMethodValue instanceInfo methodInfo
+      methodSubst <-
+        case inferNullaryMethodSubst methodInfo classArgView subst expectedView of
+          Just subst' -> Right subst'
+          Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
+      let eagerConstraints =
+            filter
+              constraintGround
+              (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
+      evidenceArgs <- resolveConstraintEvidenceTerms scope Set.empty eagerConstraints
+      methodHead <- instantiateMethodValue scope methodSubst methodValue
+      Right (foldl X.EApp methodHead evidenceArgs)
+
+    inferNullaryMethodClassArgument methodInfo expectedView
+      | deferredMethodFullArityFromInfo methodInfo /= 0 = Nothing
+      | otherwise = do
+          let (_, bodyTy) = splitForalls (methodType methodInfo)
+              (_, resultTy) = splitArrows bodyTy
+          subst <- matchTypesInScope scope Map.empty resultTy (typeViewDisplay expectedView)
+          classArgTy <- Map.lookup (methodParamName methodInfo) subst
+          pure (sourceTypeViewInScope scope classArgTy)
+
+    inferNullaryMethodSubst methodInfo classArgView subst expectedView =
+      let specializedMethodTy =
+            specializeMethodType
+              (methodType methodInfo)
+              (methodParamName methodInfo)
+              (typeViewDisplay classArgView)
+          (_, bodyTy) = splitForalls specializedMethodTy
+          (_, resultTy) = splitArrows bodyTy
+       in fmap (Map.map (sourceTypeViewInScope scope)) $
+            matchTypesInScope
+              scope
+              (fmap typeViewDisplay subst)
+              resultTy
+              (typeViewDisplay expectedView)
+
+    deferredMethodFullArityFromInfo methodInfo =
+      length (fst (splitArrows (snd (splitForalls (methodType methodInfo)))))
 
     inferDeferredArgType env arg =
       case typeCheckWithEnv env arg of

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -580,7 +580,8 @@ data DeferredMethodCall = DeferredMethodCall
     deferredMethodFullArity :: Int,
     deferredMethodName :: P.MethodName,
     deferredMethodExpectedResult :: Maybe TypeView,
-    deferredMethodEvidence :: Maybe DeferredMethodEvidence
+    deferredMethodEvidence :: Maybe DeferredMethodEvidence,
+    deferredMethodLocalEvidence :: [EvidenceInfo]
   }
   deriving (Eq, Show)
 

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -49,6 +49,7 @@ module MLF.Frontend.Program.Types
     ValueInfo (..),
     InstanceInfo (..),
     DeferredBindingMode (..),
+    DeferredMethodEvidence (..),
     DeferredMethodCall (..),
     DeferredConstructorCall (..),
     DeferredCaseCall (..),
@@ -565,13 +566,21 @@ data DeferredBindingMode
   | DeferredBindingMonomorphic
   deriving (Eq, Show)
 
+data DeferredMethodEvidence = DeferredMethodEvidence
+  { deferredMethodEvidenceClassArg :: TypeView,
+    deferredMethodEvidenceRuntimeName :: String,
+    deferredMethodEvidenceType :: SrcType
+  }
+  deriving (Eq, Show)
+
 data DeferredMethodCall = DeferredMethodCall
   { deferredMethodPlaceholder :: String,
     deferredMethodInfo :: MethodInfo,
     deferredMethodArgCount :: Int,
     deferredMethodFullArity :: Int,
     deferredMethodName :: P.MethodName,
-    deferredMethodExpectedResult :: Maybe TypeView
+    deferredMethodExpectedResult :: Maybe TypeView,
+    deferredMethodEvidence :: Maybe DeferredMethodEvidence
   }
   deriving (Eq, Show)
 

--- a/src/MLF/Frontend/Program/Types.hs
+++ b/src/MLF/Frontend/Program/Types.hs
@@ -313,7 +313,7 @@ programErrorHints err =
     ProgramAmbiguousConstructorUse ctor ->
       ["add an explicit result type annotation, for example `" ++ ctor ++ " : <Type>`"]
     ProgramAmbiguousMethodUse methodName0 ->
-      ["apply `" ++ methodName0 ++ "` to enough arguments or add an annotation that fixes the instance type"]
+      ["apply `" ++ methodName0 ++ "` to enough arguments, or give a nullary method an expected type annotation that fixes the instance type"]
     ProgramAmbiguousConstrainedValueUse valueName ->
       ["use `" ++ valueName ++ "` at a concrete instance type; generic constrained value aliases are not supported yet"]
     ProgramNoMatchingInstance className0 ty ->
@@ -570,7 +570,8 @@ data DeferredMethodCall = DeferredMethodCall
     deferredMethodInfo :: MethodInfo,
     deferredMethodArgCount :: Int,
     deferredMethodFullArity :: Int,
-    deferredMethodName :: P.MethodName
+    deferredMethodName :: P.MethodName,
+    deferredMethodExpectedResult :: Maybe TypeView
   }
   deriving (Eq, Show)
 

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -34,6 +34,7 @@ unifiedFixtureExpectations =
     , ("test/programs/unified/authoritative-cross-module-let-polymorphism.mlfp", "1")
     , ("test/programs/unified/authoritative-case-analysis.mlfp", "1")
     , ("test/programs/unified/authoritative-overloaded-method.mlfp", "true")
+    , ("test/programs/unified/authoritative-nullary-overloaded-method.mlfp", "Zero")
     , ("test/programs/unified/authoritative-recursive-let.mlfp", "true")
     , ("test/programs/unified/first-class-polymorphism.mlfp", "true")
     ]
@@ -257,6 +258,99 @@ emlfBoundaryMatrix =
                 ]
         )
         (ExpectCheckFailureContaining "ProgramAmbiguousMethodUse \"eq\"")
+    , ProgramMatrixCase
+        "runs nullary overloaded method from definition expected type"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Monoid, Nat(..), mempty, append, main) {"
+                , "  class Monoid a {"
+                , "    mempty : a;"
+                , "    append : a -> a -> a;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  instance Monoid Nat {"
+                , "    mempty = Zero;"
+                , "    append = \\left \\right left;"
+                , "  }"
+                , ""
+                , "  def main : Nat = mempty;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "Zero")
+    , ProgramMatrixCase
+        "runs nullary overloaded method from expected method argument"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Monoid, Nat(..), mempty, append, main) {"
+                , "  class Monoid a {"
+                , "    mempty : a;"
+                , "    append : a -> a -> a;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  instance Monoid Nat {"
+                , "    mempty = Zero;"
+                , "    append = \\left \\right left;"
+                , "  }"
+                , ""
+                , "  def main : Nat = append mempty Zero;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "Zero")
+    , ProgramMatrixCase
+        "runs parameterized nullary overloaded method from expected result"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (DefaultBox, Nat(..), Box(..), defaultBox, main) {"
+                , "  class DefaultBox a {"
+                , "    defaultBox : Box a;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  instance DefaultBox Nat {"
+                , "    defaultBox = Box Zero;"
+                , "  }"
+                , ""
+                , "  def main : Box Nat = defaultBox;"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "Box Zero")
+    , ProgramMatrixCase
+        "rejects nullary overloaded method without expected type evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Monoid, Nat(..), mempty, main) {"
+                , "  class Monoid a {"
+                , "    mempty : a;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  instance Monoid Nat {"
+                , "    mempty = Zero;"
+                , "  }"
+                , ""
+                , "  def main : Nat = let x = mempty in x;"
+                , "}"
+                ]
+        )
+        (ExpectCheckFailureContaining "ProgramAmbiguousMethodUse \"mempty\"")
     , ProgramMatrixCase
         "rejects deferred overloaded method dispatch with no matching instance"
         ( InlineProgram $

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -283,6 +283,31 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Zero")
     , ProgramMatrixCase
+        "checks generic constrained nullary overloaded method through local evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Monoid, Nat(..), mempty, append, neutral, main) {"
+                , "  class Monoid a {"
+                , "    mempty : a;"
+                , "    append : a -> a -> a;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat"
+                , "    | Succ : Nat -> Nat;"
+                , ""
+                , "  instance Monoid Nat {"
+                , "    mempty = Zero;"
+                , "    append = \\left \\right left;"
+                , "  }"
+                , ""
+                , "  def neutral : Monoid a => a = mempty;"
+                , "  def main : Nat = neutral;"
+                , "}"
+                ]
+        )
+        ExpectCheckSuccess
+    , ProgramMatrixCase
         "runs nullary overloaded method from expected method argument"
         ( InlineProgram $
             unlines

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -337,6 +337,28 @@ emlfBoundaryMatrix =
         )
         ExpectCheckSuccess
     , ProgramMatrixCase
+        "checks generic constrained nullary overloaded method with polymorphic method-local evidence"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (Eq, Pick, Pair(..), eq, pick, picked, main) {"
+                , "  class Eq a {"
+                , "    eq : a -> a -> Bool;"
+                , "  }"
+                , ""
+                , "  data Pair a b ="
+                , "      Pair : a -> b -> Pair a b;"
+                , ""
+                , "  class Pick a {"
+                , "    pick : Eq b => Pair a b;"
+                , "  }"
+                , ""
+                , "  def picked : (Pick a, Eq b) => Pair a b = pick;"
+                , "  def main : Bool = true;"
+                , "}"
+                ]
+        )
+        ExpectCheckSuccess
+    , ProgramMatrixCase
         "runs nullary overloaded method from expected method argument"
         ( InlineProgram $
             unlines

--- a/test/programs/unified/authoritative-nullary-overloaded-method.mlfp
+++ b/test/programs/unified/authoritative-nullary-overloaded-method.mlfp
@@ -1,0 +1,17 @@
+module Main export (Monoid, Nat(..), mempty, append, main) {
+  class Monoid a {
+    mempty : a;
+    append : a -> a -> a;
+  }
+
+  data Nat =
+      Zero : Nat
+    | Succ : Nat -> Nat;
+
+  instance Monoid Nat {
+    mempty = Zero;
+    append = \left \right left;
+  }
+
+  def main : Nat = append (mempty : Nat) Zero;
+}


### PR DESCRIPTION
Closes #9.

## Implementation Plan

---
issue_number: 9
pr_number: 103
branch: codex/issue-9
---

## Implementation Plan

1. Keep the existing branch/PR setup intact: work on `codex/issue-9` for PR #103 and do not create another PR. Start implementation by reading this plan plus `git status --short --branch`.

2. Add expected-type lowering for bare nullary overloaded methods in `src/MLF/Frontend/Program/Elaborate.hs`:
   - Replace the immediate `ProgramAmbiguousMethodUse` for `EVar` / resolved `EVar` `OverloadedMethod` with a helper that only proceeds when `methodFullArity methodInfo == 0` and `mbExpected` is present.
   - Infer the class argument by matching the nullary method result type against the expected source type with `matchTypesInScope`; require the class parameter to be bound uniquely. Support any nullary result shape that determines the class parameter, not only result `a` exactly. Keep the old ambiguity error when there is no expected type or the expected type does not determine the class parameter.
   - Leave argument-driven overloaded method resolution unchanged for non-nullary methods and partial applications.

3. Preserve the expected type for finalization instead of relying on value arguments:
   - Extend `DeferredMethodCall` in `src/MLF/Frontend/Program/Types.hs` with an optional expected/result `TypeView` or equivalent source-type field for nullary occurrences.
   - Add or adapt a zero-argument method deferral helper so the placeholder external type is the lowered expected type and the deferred obligation records the expected source view. Existing nonzero method deferrals should record `Nothing` and keep their current placeholder behavior.

4. Teach `src/MLF/Frontend/Program/Finalize.hs` to rewrite zero-argument deferred methods:
   - In `resolveDeferredMethods`, detect a bare deferred method placeholder (including type-instantiated heads, as constructor finalization already does) when `deferredMethodArgCount == 0` and there are no term arguments.
   - Use the recorded expected/result type to recompute the class argument view, then reuse the existing instance/evidence machinery: `resolveMethodInstanceInfoByTypeView`, `concreteMethodValue`, method-local constraint evidence resolution, and `instantiateMethodValue`.
   - Fail closed with `ProgramAmbiguousMethodUse` if expected-type matching does not determine the class parameter, and with `ProgramNoMatchingInstance` if it does determine a type but no coherent instance exists.

5. Add coverage:
   - Add a `.mlfp` corpus fixture under `test/programs/unified/`, e.g. `authoritative-nullary-overloaded-method.mlfp`, with `Monoid Nat`, `mempty : a`, `append : a -> a -> a`, and `def main : Nat = append (mempty : Nat) Zero;`. Wire it into `test/Parity/ProgramMatrix.hs` with expected runtime value `Zero`.
   - Add inline matrix cases for `def main : Nat = mempty`, for expected-type propagation through an overloaded method argument such as `append mempty Zero` if the implementation supports it through existing expected-argument flow, and for a parameterized nullary result such as `defaultBox : Box a` resolving from expected `Box Nat`.
   - Keep or add a negative bare use case with no expected evidence, such as `let x = mempty in ...`, asserting `ProgramAmbiguousMethodUse`. Existing `eq` bare-method coverage should remain unchanged.

6. Update documentation and diagnostics:
   - Change `docs/mlfp-language-reference.md` so it no longer says all bare overloaded method names are rejected. Document that nullary overloaded methods / associated values resolve from an explicit or propagated expected source type when the method result determines the class parameter; otherwise they remain ambiguous.
   - Refine the `ProgramAmbiguousMethodUse` hint in `Program.Types` to mention expected-type annotations for nullary methods and sufficient term arguments for ordinary methods.
   - Add a concise `CHANGELOG.md` entry, and update `implementation_notes.md` if the repository’s recent-note style expects feature-level `.mlfp` behavior changes there.

7. Validate before publishing:
   - Run a focused test slice first, e.g. `cabal test mlf2-test --test-show-details=direct --test-options='--match "nullary overloaded"'` or the exact new matrix-case names.
   - Run `cabal run mlf2 -- run-program test/programs/unified/authoritative-nullary-overloaded-method.mlfp` and confirm it prints the expected value.
   - Finish with the repo gate required for behavior changes: `cabal build all && cabal test`.

8. Publish handoff after validation succeeds:
   - Run `gh auth status` and `gh auth setup-git`.
   - Inspect `git status --short` and relevant diffs; stage only issue-related source, test, fixture, and doc files.
   - Commit as `codex-watcher <codex-watcher@users.noreply.github.com>` with an imperative message such as `Support nullary overloaded method resolution`.
   - Push `codex/issue-9` to origin for existing PR #103, then return completion for watcher handoff.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.