### PR TITLE
Implement #90

### DIFF
--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -265,6 +265,80 @@ constraint, or an existing closed instance. For example, `Option a` derives
 If deriving cannot resolve the first required field instance, it fails with a
 field-specific deriving diagnostic.
 
+## IO And Monad Contract
+
+This section freezes the initial IO contract for the #87 work. Source typing,
+runner execution, and backend behavior remain separate ownership boundaries;
+this contract defines the surface they implement without changing the pure
+eMLF/xMLF core.
+
+The initial standard-library surface is deliberately small:
+
+```mlf
+data Unit =
+    Unit : Unit;
+
+class Monad (m :: * -> *) {
+  pure : forall a. a -> m a;
+  bind : forall a b. m a -> (a -> m b) -> m b;
+}
+```
+
+`Unit` is the unit result type for completed effects. It has one inhabitant,
+`Unit`, and is the only supported result type for effectful program entrypoints
+in the initial IO surface. `Functor` and `Applicative` are explicitly deferred:
+the first IO slice exposes `Monad` directly and does not require the broader
+Haskell class hierarchy.
+
+`IO` is an opaque source type constructor with kind `* -> *`. It is owned by the
+program/runtime boundary rather than declared as an ordinary source ADT. User
+programs may mention `IO a` in types and use the standard-library operations
+below, but they cannot construct, deconstruct, derive, or pattern match on an
+`IO` representation. The standard library provides a coherent `Monad IO`
+instance backed by implementation-reserved primitives such as `__io_pure` and
+`__io_bind`; those primitive names are not the user-facing API.
+
+The initial text operation is:
+
+```mlf
+putStrLn : String -> IO Unit
+```
+
+`putStrLn` uses the existing source `String` base type and string literals.
+There is no narrower byte/character primitive in the first contract, and input
+operations such as `readLine : IO String` are deferred.
+
+Pure program entrypoints remain accepted:
+
+```mlf
+module Main export (main) {
+  def main : Bool = true;
+}
+```
+
+The effectful entrypoint mode is `main : IO Unit`:
+
+```mlf
+module Main export (main) {
+  import Prelude exposing (Unit(..), IO, Monad, bind, pure, putStrLn);
+
+  def main : IO Unit =
+    bind (putStrLn "hello") (\(_done : Unit) putStrLn "world");
+}
+```
+
+An `IO` action is still a pure value while the program is checked and normalized.
+Effects occur only when the runner executes the final checked `main` action, and
+sequencing is determined by `bind` through the runtime interpretation of the
+opaque `IO` primitive boundary. The initial runner contract does not render
+`main : IO a` results for non-`Unit` `a`.
+
+The backend contract is fail-closed for the first IO slice. `emit-backend`
+should reject checked IO programs with a structured unsupported diagnostic until
+the backend IO issue adds a concrete lowering plan for the selected primitives.
+That rejection does not change source typing, pure runtime rendering, or the
+existing first-order LLVM subset.
+
 ## Backend Boundary
 
 Successful `.mlfp` checking may be followed by conversion into the internal


### PR DESCRIPTION
Closes #90.

## Implementation Plan

---
issue_number: 90
pr_number: 105
branch: codex/issue-90
---

## Implementation Plan

1. Keep the change documentation-only unless a tiny doc-driven fixture becomes necessary. Primary target is `docs/mlfp-language-reference.md`; add a short architecture note in `docs/architecture.md` only if the language reference alone does not make the runtime/backend ownership boundary clear.

2. Add a new `.mlfp` IO/Monad contract section to the language reference near the current Typeclasses, Backend Boundary, Built-In Prelude, and Runtime Values sections. Make these decisions explicit:
   - `Unit` is the initial unit result type, exposed through the standard library surface with one inhabitant for completed effects.
   - `IO : * -> *` is opaque and program/runtime-owned, not a normal source ADT and not pattern-matchable or constructible by user code.
   - The initial standard-library class surface is minimal `Monad (m :: * -> *)` with `pure : forall a. a -> m a` and `bind : forall a b. m a -> (a -> m b) -> m b`.
   - `Functor` and `Applicative` are explicitly deferred for this first contract.
   - `Monad IO` is provided by the standard library/builtin primitive boundary, backed by internal primitives such as `__io_pure` and `__io_bind`, not by user-visible ADT constructors.
   - The initial text primitive is `putStrLn : String -> IO Unit`; `String` is in scope using the existing source `String` literal/base type, and input primitives such as `readLine` are deferred.

3. Document execution semantics without changing implementation code:
   - Existing pure `main` programs remain accepted and render values as they do now.
   - The new effectful entry mode is `main : IO Unit` only; broader `main : IO a` result rendering is deferred.
   - IO actions are pure values until the runner executes the checked `main` action; sequencing comes only from `bind`/primitive IO interpretation, so the raw eMLF/xMLF core remains pure.

4. Document backend stance:
   - `emit-backend` should initially reject checked IO programs with a stable structured unsupported diagnostic.
   - LLVM/runtime lowering for IO primitives is reserved for issue #93, so this issue must not add backend lowering, runner execution, or checker support beyond documentation.

5. Cross-check the final docs against sibling ownership:
   - #91 owns source typing and Prelude/builtin exposure.
   - #92 owns runner execution of `main : IO Unit`.
   - #93 owns backend rejection/lowering behavior.
   - This issue only freezes the contract those siblings implement.

6. Validate the documentation change with `git diff --check` and targeted `rg` checks for the required terms (`Unit`, `IO`, `Monad`, `pure`, `bind`, `putStrLn`, `Functor`, `Applicative`, backend unsupported). Do not run the full `cabal build all && cabal test` gate for docs-only edits unless implementation files or test fixtures are added.

7. Before publishing in the implementation turn, run `gh auth status` and `gh auth setup-git`, inspect `git status --short` and the relevant diffs, stage only issue-related docs, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, and push to the existing `codex/issue-90` branch for PR #105.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.