### PR TITLE
Implement #94

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,21 +153,39 @@ The boundary invariants are:
   program constructor metadata for known constructors, constructor arity,
   constructor-local `forall` bounds, argument/result types, case scrutinee
   type, and alternative result type.
+- closure construction and indirect closure calls are explicit backend nodes:
+  closure entry names must be unique, capture and value-parameter binders must
+  be locally unique, capture expressions must match their declared capture
+  types, the closure body must match the declared function result after value
+  parameters are applied, and `BackendClosureCall` arguments must match the
+  function type carried by the closure expression.
 
 This module intentionally lives in the private `mlf2-internal` library for now.
 Conversion and lowering modules should depend on this IR rather than reaching
 back into `MLF.Frontend.Program.*` internals for backend decisions.
 `MLF.Backend.LLVM` preserves that boundary by validating the IR before
-lowering, rendering only the supported first-order subset, and producing
-explicit unsupported-node diagnostics for backend constructs that do not yet
-have LLVM lowering. The LLVM backend is intentionally repo-local: `Syntax`
-models the small LLVM surface used by mlf2, `Lower` maps backend IR into that
-AST, and `Ppr` emits opaque-pointer LLVM IR text accepted by LLVM 15+ tools or
-LLVM 14-era tools run with `-opaque-pointers`.
-Closure conversion, higher-order constructor fields, escaping lambdas, and
-final executable linking remain outside the current backend boundary. Those
-diagnostics do not weaken source inference, checking, module visibility, or
-runtime semantics; they only describe the current IR-to-LLVM lowering surface.
+lowering, rendering the supported first-order subset plus explicit closure IR,
+and producing explicit unsupported-node diagnostics for backend constructs that
+do not yet have LLVM lowering. The LLVM backend is intentionally repo-local:
+`Syntax` models the small LLVM surface used by mlf2, `Lower` maps backend IR
+into that AST, and `Ppr` emits opaque-pointer LLVM IR text accepted by LLVM 15+
+tools or LLVM 14-era tools run with `-opaque-pointers`.
+
+The explicit closure ABI is private to the backend IR-to-LLVM path. A closure
+value is a heap pointer to a two-word record containing a code pointer and an
+environment pointer or null. Non-empty environments are heap records with one
+machine word per captured runtime value. Closure entry functions are private
+LLVM functions named by the backend IR and take a hidden `ptr env` argument
+before erased monomorphic value parameters. Direct first-order calls still use
+the existing direct-call path; indirect calls must be represented with
+`BackendClosureCall`.
+
+Full source-to-source closure conversion, partial application lowering,
+higher-order constructor fields that require captured environments, recursive
+higher-order flows, and final executable linking remain future extension
+points. Those diagnostics do not weaken source inference, checking, module
+visibility, or runtime semantics; they only describe the current IR-to-LLVM
+lowering surface.
 
 ## `Solved` boundary and thesis-exact cleanup rule
 

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -287,17 +287,21 @@ cabal run mlf2 -- emit-backend path/to/file.mlfp
 
 Like `run-program`, `emit-backend` parses one source file and prepends the
 built-in Prelude as an explicit module before checking. The emitted text is
-LLVM IR for the supported first-order backend subset, not a stable ABI or a
-promise of final executable linking. The supported LLVM subset covers checked
-first-order function bindings, saturated direct calls, literals, variables,
-SSA-style lets, type abstraction/application after specialization, ADT
-construction, and ADT case analysis.
+LLVM IR for the supported backend subset, not a stable ABI or a promise of
+final executable linking. The source-facing surface remains primarily
+first-order: checked first-order function bindings, saturated direct calls,
+literals, variables, SSA-style lets, type abstraction/application after
+specialization, ADT construction, and ADT case analysis.
 
 The typed backend IR can also represent data metadata, constructor nodes, case
-nodes, and recursive roll/unroll nodes. The LLVM lowering intentionally rejects
-backend nodes that are not yet supported instead of silently dropping or
-rewriting them. Diagnostics are high-level and name the backend context and
-node, for example:
+nodes, recursive roll/unroll nodes, and explicit closure construction plus
+indirect closure calls. Closure values lower through a private backend ABI that
+stores a code pointer and environment pointer in a heap closure record; this is
+an internal IR-to-LLVM foundation and does not yet imply full `.mlfp` partial
+application or escaping-lambda closure conversion. The LLVM lowering
+intentionally rejects backend nodes that are not yet supported instead of
+silently dropping or rewriting them. Diagnostics are high-level and name the
+backend context and node, for example:
 
 ```text
 Unsupported backend LLVM expression at binding "main": escaping lambda

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -246,6 +246,7 @@ data BackendValidationError
   | BackendUnrollExpectedRecursive BackendType
   | BackendUnrollResultMismatch BackendType BackendType
   | BackendDuplicateClosureEntry String
+  | BackendClosureEntryNameCollision String
   | BackendDuplicateClosureCapture String
   | BackendDuplicateClosureParameter String
   | BackendClosureCaptureTypeMismatch String BackendType BackendType
@@ -607,6 +608,7 @@ validateBackendProgram program = do
   requireUnique BackendDuplicateBinding (map backendBindingName bindings)
   requireUnique BackendDuplicateConstructor (map backendConstructorName constructors)
   requireUnique BackendDuplicateClosureEntry closureEntryNames
+  rejectClosureEntryNameCollisions closureEntryNames (map backendBindingName bindings ++ Map.keys backendRuntimePrimitiveTypes)
   unless (backendProgramMain program `elem` map backendBindingName bindings) $
     Left (BackendMainNotFound (backendProgramMain program))
   mapM_ (validateBackendBindingInContext context0) bindings
@@ -2140,6 +2142,14 @@ requireUnique mkError names =
   case duplicates names of
     name : _ -> Left (mkError name)
     [] -> Right ()
+
+rejectClosureEntryNameCollisions :: [String] -> [String] -> Either BackendValidationError ()
+rejectClosureEntryNameCollisions closureEntryNames reservedNames =
+  case [name | name <- sort closureEntryNames, Set.member name reservedNameSet] of
+    name : _ -> Left (BackendClosureEntryNameCollision name)
+    [] -> Right ()
+  where
+    reservedNameSet = Set.fromList reservedNames
 
 zipAllWith :: (a -> b -> Bool) -> [a] -> [b] -> Bool
 zipAllWith _ [] [] =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -775,7 +775,11 @@ validateBackendClosureCapture mbContext capture = do
     expr = backendClosureCaptureExpr capture
 
 backendAppClosureHead :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
-backendAppClosureHead mbContext =
+backendAppClosureHead =
+  backendClosureValueName
+
+backendClosureValueName :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
+backendClosureValueName mbContext =
   \case
     BackendClosure _ entryName _ _ _ ->
       Just entryName
@@ -784,15 +788,11 @@ backendAppClosureHead mbContext =
         Set.member name (bvcClosureLocals context0) ->
           Just name
     BackendTyApp _ fun _ ->
-      backendAppClosureHead mbContext fun
+      backendClosureValueName mbContext fun
+    BackendLet _ name bindingTy rhs body ->
+      backendClosureValueName (extendLetLocalMaybe mbContext name bindingTy rhs) body
     _ ->
       Nothing
-
-isBackendClosureValue :: BackendExpr -> Bool
-isBackendClosureValue =
-  \case
-    BackendClosure {} -> True
-    _ -> False
 
 validateBackendClosureCall :: BackendType -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
 validateBackendClosureCall resultTy funTy args =
@@ -1143,7 +1143,7 @@ extendClosureLocal context0 name ty =
 
 extendLetLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> BackendExpr -> Maybe BackendValidationContext
 extendLetLocalMaybe mbContext name ty rhs
-  | isBackendClosureValue rhs = extendClosureLocalMaybe mbContext name ty
+  | Just _ <- backendClosureValueName mbContext rhs = extendClosureLocalMaybe mbContext name ty
   | otherwise = extendLocalMaybe mbContext name ty
 
 extendLocals :: BackendValidationContext -> [(String, BackendType)] -> BackendValidationContext

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -234,6 +234,7 @@ data BackendValidationError
   | BackendApplicationExpectedFunction BackendType
   | BackendApplicationArgumentMismatch BackendType BackendType
   | BackendApplicationResultMismatch BackendType BackendType
+  | BackendClosureCalledWithBackendApp String
   | BackendLetTypeMismatch String BackendType BackendType
   | BackendLetBodyTypeMismatch BackendType BackendType
   | BackendTypeAbsTypeMismatch String BackendType BackendType
@@ -268,6 +269,7 @@ data BackendValidationContext = BackendValidationContext
     bvcData :: Map.Map String BackendData,
     bvcConstructors :: Map.Map String BackendConstructorInfo,
     bvcLocals :: Map.Map String BackendType,
+    bvcClosureLocals :: Set.Set String,
     bvcTypeBounds :: Map.Map String (Maybe BackendType)
   }
 
@@ -628,6 +630,7 @@ validateBackendProgram program = do
           bvcData = Map.fromList [(backendDataName dataDecl, dataDecl) | dataDecl <- concatMap backendModuleData modules0],
           bvcConstructors = Map.fromList constructorInfos,
           bvcLocals = Map.empty,
+          bvcClosureLocals = Set.empty,
           bvcTypeBounds = Map.empty
         }
 
@@ -684,6 +687,9 @@ validateBackendExprWith mbContext expr =
     BackendApp resultTy fun arg -> do
       validateBackendExprWith mbContext fun
       validateBackendExprWith mbContext arg
+      case backendAppClosureHead mbContext fun of
+        Just name -> Left (BackendClosureCalledWithBackendApp name)
+        Nothing -> pure ()
       case backendExprType fun of
         BTArrow expectedArg expectedResult -> do
           unless (backendApplicationTypeMatches mbContext expectedArg (backendExprType arg)) $
@@ -696,7 +702,7 @@ validateBackendExprWith mbContext expr =
       validateBackendExprWith mbContext rhs
       unless (alphaEqBackendType (backendExprType rhs) bindingTy) $
         Left (BackendLetTypeMismatch name bindingTy (backendExprType rhs))
-      validateBackendExprWith (extendLocalMaybe mbContext name bindingTy) body
+      validateBackendExprWith (extendLetLocalMaybe mbContext name bindingTy rhs) body
       unless (alphaEqBackendType (backendExprType body) resultTy) $
         Left (BackendLetBodyTypeMismatch resultTy (backendExprType body))
     BackendTyAbs resultTy name mbBound body -> do
@@ -744,7 +750,7 @@ validateBackendExprWith mbContext expr =
       let bodyContext =
             foldl
               (\context0 capture -> extendLocalMaybe context0 (backendClosureCaptureName capture) (backendClosureCaptureType capture))
-              mbContext
+              (dropTermLocalsMaybe mbContext)
               captures
           bodyParamContext =
             foldl
@@ -767,6 +773,26 @@ validateBackendClosureCapture mbContext capture = do
     Left (BackendClosureCaptureTypeMismatch (backendClosureCaptureName capture) (backendClosureCaptureType capture) (backendExprType expr))
   where
     expr = backendClosureCaptureExpr capture
+
+backendAppClosureHead :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
+backendAppClosureHead mbContext =
+  \case
+    BackendClosure _ entryName _ _ _ ->
+      Just entryName
+    BackendVar _ name
+      | Just context0 <- mbContext,
+        Set.member name (bvcClosureLocals context0) ->
+          Just name
+    BackendTyApp _ fun _ ->
+      backendAppClosureHead mbContext fun
+    _ ->
+      Nothing
+
+isBackendClosureValue :: BackendExpr -> Bool
+isBackendClosureValue =
+  \case
+    BackendClosure {} -> True
+    _ -> False
 
 validateBackendClosureCall :: BackendType -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
 validateBackendClosureCall resultTy funTy args =
@@ -1099,11 +1125,37 @@ extendLocalMaybe mbContext name ty =
 
 extendLocal :: BackendValidationContext -> String -> BackendType -> BackendValidationContext
 extendLocal context0 name ty =
-  context0 {bvcLocals = Map.insert name ty (bvcLocals context0)}
+  context0
+    { bvcLocals = Map.insert name ty (bvcLocals context0),
+      bvcClosureLocals = Set.delete name (bvcClosureLocals context0)
+    }
+
+extendClosureLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> Maybe BackendValidationContext
+extendClosureLocalMaybe mbContext name ty =
+  fmap (\context0 -> extendClosureLocal context0 name ty) mbContext
+
+extendClosureLocal :: BackendValidationContext -> String -> BackendType -> BackendValidationContext
+extendClosureLocal context0 name ty =
+  context0
+    { bvcLocals = Map.insert name ty (bvcLocals context0),
+      bvcClosureLocals = Set.insert name (bvcClosureLocals context0)
+    }
+
+extendLetLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> BackendExpr -> Maybe BackendValidationContext
+extendLetLocalMaybe mbContext name ty rhs
+  | isBackendClosureValue rhs = extendClosureLocalMaybe mbContext name ty
+  | otherwise = extendLocalMaybe mbContext name ty
 
 extendLocals :: BackendValidationContext -> [(String, BackendType)] -> BackendValidationContext
 extendLocals context0 bindings =
-  context0 {bvcLocals = foldr (uncurry Map.insert) (bvcLocals context0) bindings}
+  context0
+    { bvcLocals = foldr (uncurry Map.insert) (bvcLocals context0) bindings,
+      bvcClosureLocals = foldr (Set.delete . fst) (bvcClosureLocals context0) bindings
+    }
+
+dropTermLocalsMaybe :: Maybe BackendValidationContext -> Maybe BackendValidationContext
+dropTermLocalsMaybe =
+  fmap (\context0 -> context0 {bvcLocals = Map.empty, bvcClosureLocals = Set.empty})
 
 extendTypeBoundMaybe :: Maybe BackendValidationContext -> String -> Maybe BackendType -> Maybe BackendValidationContext
 extendTypeBoundMaybe mbContext name mbBound =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -791,8 +791,27 @@ backendClosureValueName mbContext =
       backendClosureValueName mbContext fun
     BackendLet _ name bindingTy rhs body ->
       backendClosureValueName (extendLetLocalMaybe mbContext name bindingTy rhs) body
+    BackendCase _ scrutinee alternatives ->
+      backendCaseClosureValueName mbContext (backendExprType scrutinee) alternatives
     _ ->
       Nothing
+
+backendCaseClosureValueName :: Maybe BackendValidationContext -> BackendType -> NonEmpty BackendAlternative -> Maybe String
+backendCaseClosureValueName mbContext scrutineeTy =
+  firstClosureValueName . map closureAlternativeName . NE.toList
+  where
+    closureAlternativeName alternative =
+      case validateBackendPattern mbContext scrutineeTy (backendAltPattern alternative) of
+        Right contextForBody -> backendClosureValueName contextForBody (backendAltBody alternative)
+        Left _ -> Nothing
+
+firstClosureValueName :: [Maybe String] -> Maybe String
+firstClosureValueName [] =
+  Nothing
+firstClosureValueName (Nothing : rest) =
+  firstClosureValueName rest
+firstClosureValueName (Just value : _) =
+  Just value
 
 validateBackendClosureCall :: BackendType -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
 validateBackendClosureCall resultTy funTy args =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -251,6 +251,7 @@ data BackendValidationError
   | BackendClosureCaptureTypeMismatch String BackendType BackendType
   | BackendClosureTypeMismatch String BackendType BackendType
   | BackendClosureCallExpectedFunction BackendType
+  | BackendClosureCallExpectedClosureValue BackendType
   | BackendClosureCallArityMismatch Int Int
   | BackendClosureCallArgumentMismatch Int BackendType BackendType
   | BackendClosureCallResultMismatch BackendType BackendType
@@ -764,7 +765,7 @@ validateBackendExprWith mbContext expr =
     BackendClosureCall resultTy fun args -> do
       validateBackendExprWith mbContext fun
       mapM_ (validateBackendExprWith mbContext) args
-      validateBackendClosureCall resultTy (backendExprType fun) args
+      validateBackendClosureCall mbContext resultTy fun args
 
 validateBackendClosureCapture :: Maybe BackendValidationContext -> BackendClosureCapture -> Either BackendValidationError ()
 validateBackendClosureCapture mbContext capture = do
@@ -813,12 +814,15 @@ firstClosureValueName (Nothing : rest) =
 firstClosureValueName (Just value : _) =
   Just value
 
-validateBackendClosureCall :: BackendType -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
-validateBackendClosureCall resultTy funTy args =
+validateBackendClosureCall :: Maybe BackendValidationContext -> BackendType -> BackendExpr -> [BackendExpr] -> Either BackendValidationError ()
+validateBackendClosureCall mbContext resultTy fun args =
   case collectClosureCallType funTy of
     Nothing ->
       Left (BackendClosureCallExpectedFunction funTy)
     Just (paramTys, expectedResultTy) -> do
+      case backendClosureValueName mbContext fun of
+        Just _ -> pure ()
+        Nothing -> Left (BackendClosureCallExpectedClosureValue funTy)
       unless (length paramTys == length args) $
         Left (BackendClosureCallArityMismatch (length paramTys) (length args))
       zipWithM_
@@ -828,6 +832,9 @@ validateBackendClosureCall resultTy funTy args =
       unless (alphaEqBackendType resultTy expectedResultTy) $
         Left (BackendClosureCallResultMismatch resultTy expectedResultTy)
   where
+    funTy =
+      backendExprType fun
+
     validateArg index0 (expectedArgTy, arg) =
       unless (alphaEqBackendType expectedArgTy (backendExprType arg)) $
         Left (BackendClosureCallArgumentMismatch index0 expectedArgTy (backendExprType arg))

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -250,6 +250,7 @@ data BackendValidationError
   | BackendDuplicateClosureParameter String
   | BackendClosureCaptureTypeMismatch String BackendType BackendType
   | BackendClosureExpectedFunction String BackendType
+  | BackendClosureParameterArityMismatch String Int Int
   | BackendClosureTypeMismatch String BackendType BackendType
   | BackendClosureCallExpectedFunction BackendType
   | BackendClosureCallExpectedClosureValue BackendType
@@ -747,8 +748,6 @@ validateBackendExprWith mbContext expr =
         Nothing ->
           Left (BackendUnrollExpectedRecursive (backendExprType payload))
     BackendClosure resultTy entryName captures params body -> do
-      unless (isBackendArrowType resultTy) $
-        Left (BackendClosureExpectedFunction entryName resultTy)
       requireUnique BackendDuplicateClosureCapture (map backendClosureCaptureName captures)
       requireUnique BackendDuplicateClosureParameter (map fst params)
       requireUnique BackendDuplicateClosureParameter (map backendClosureCaptureName captures ++ map fst params)
@@ -764,9 +763,7 @@ validateBackendExprWith mbContext expr =
               bodyContext
               params
       validateBackendExprWith bodyParamContext body
-      let expected = foldr BTArrow (backendExprType body) (map snd params)
-      unless (alphaEqBackendType resultTy expected) $
-        Left (BackendClosureTypeMismatch entryName resultTy expected)
+      validateBackendClosureFunctionType entryName resultTy params (backendExprType body)
     BackendClosureCall resultTy fun args -> do
       validateBackendExprWith mbContext fun
       mapM_ (validateBackendExprWith mbContext) args
@@ -779,6 +776,18 @@ validateBackendClosureCapture mbContext capture = do
     Left (BackendClosureCaptureTypeMismatch (backendClosureCaptureName capture) (backendClosureCaptureType capture) (backendExprType expr))
   where
     expr = backendClosureCaptureExpr capture
+
+validateBackendClosureFunctionType :: String -> BackendType -> [(String, BackendType)] -> BackendType -> Either BackendValidationError ()
+validateBackendClosureFunctionType entryName resultTy params bodyTy =
+  case collectClosureCallType resultTy of
+    Nothing ->
+      Left (BackendClosureExpectedFunction entryName resultTy)
+    Just (declaredParamTys, declaredResultTy) -> do
+      unless (length declaredParamTys == length params) $
+        Left (BackendClosureParameterArityMismatch entryName (length params) (length declaredParamTys))
+      let expected = foldr BTArrow bodyTy (map snd params)
+      unless (and (zipWith alphaEqBackendType declaredParamTys (map snd params)) && alphaEqBackendType declaredResultTy bodyTy) $
+        Left (BackendClosureTypeMismatch entryName resultTy expected)
 
 backendAppClosureHead :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
 backendAppClosureHead =
@@ -885,12 +894,6 @@ collectClosureCallType =
         other
           | null params -> Nothing
           | otherwise -> Just (params, other)
-
-isBackendArrowType :: BackendType -> Bool
-isBackendArrowType =
-  \case
-    BTArrow {} -> True
-    _ -> False
 
 validateBackendVariable :: Maybe BackendValidationContext -> String -> BackendType -> Either BackendValidationError ()
 validateBackendVariable Nothing _ _ =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -864,14 +864,14 @@ validateBackendClosureCall mbContext resultTy fun args =
         validateArg
         [0 :: Int ..]
         (zip paramTys args)
-      unless (alphaEqBackendType resultTy expectedResultTy) $
+      unless (backendApplicationTypeMatches mbContext expectedResultTy resultTy) $
         Left (BackendClosureCallResultMismatch resultTy expectedResultTy)
   where
     funTy =
       backendExprType fun
 
     validateArg index0 (expectedArgTy, arg) =
-      unless (alphaEqBackendType expectedArgTy (backendExprType arg)) $
+      unless (backendApplicationTypeMatches mbContext expectedArgTy (backendExprType arg)) $
         Left (BackendClosureCallArgumentMismatch index0 expectedArgTy (backendExprType arg))
 
 collectClosureCallType :: BackendType -> Maybe ([BackendType], BackendType)

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -249,6 +249,7 @@ data BackendValidationError
   | BackendDuplicateClosureCapture String
   | BackendDuplicateClosureParameter String
   | BackendClosureCaptureTypeMismatch String BackendType BackendType
+  | BackendClosureExpectedFunction String BackendType
   | BackendClosureTypeMismatch String BackendType BackendType
   | BackendClosureCallExpectedFunction BackendType
   | BackendClosureCallExpectedClosureValue BackendType
@@ -746,6 +747,8 @@ validateBackendExprWith mbContext expr =
         Nothing ->
           Left (BackendUnrollExpectedRecursive (backendExprType payload))
     BackendClosure resultTy entryName captures params body -> do
+      unless (isBackendArrowType resultTy) $
+        Left (BackendClosureExpectedFunction entryName resultTy)
       requireUnique BackendDuplicateClosureCapture (map backendClosureCaptureName captures)
       requireUnique BackendDuplicateClosureParameter (map fst params)
       requireUnique BackendDuplicateClosureParameter (map backendClosureCaptureName captures ++ map fst params)
@@ -882,6 +885,12 @@ collectClosureCallType =
         other
           | null params -> Nothing
           | otherwise -> Just (params, other)
+
+isBackendArrowType :: BackendType -> Bool
+isBackendArrowType =
+  \case
+    BTArrow {} -> True
+    _ -> False
 
 validateBackendVariable :: Maybe BackendValidationContext -> String -> BackendType -> Either BackendValidationError ()
 validateBackendVariable Nothing _ _ =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -39,6 +39,7 @@ module MLF.Backend.IR
     BackendBinding (..),
     BackendData (..),
     BackendConstructor (..),
+    BackendClosureCapture (..),
     BackendTypeBinder (..),
     BackendType (..),
     BackendExpr (..),
@@ -56,7 +57,7 @@ module MLF.Backend.IR
   )
 where
 
-import Control.Monad (foldM, unless)
+import Control.Monad (foldM, unless, zipWithM_)
 import Data.Char (isDigit)
 import Data.List (sort)
 import Data.List.NonEmpty (NonEmpty)
@@ -100,6 +101,13 @@ data BackendConstructor = BackendConstructor
     backendConstructorForalls :: [BackendTypeBinder],
     backendConstructorFields :: [BackendType],
     backendConstructorResult :: BackendType
+  }
+  deriving (Eq, Show)
+
+data BackendClosureCapture = BackendClosureCapture
+  { backendClosureCaptureName :: String,
+    backendClosureCaptureType :: BackendType,
+    backendClosureCaptureExpr :: BackendExpr
   }
   deriving (Eq, Show)
 
@@ -188,6 +196,18 @@ data BackendExpr
       { backendExprType :: BackendType,
         backendUnrollPayload :: BackendExpr
       }
+  | BackendClosure
+      { backendExprType :: BackendType,
+        backendClosureEntryName :: String,
+        backendClosureCaptures :: [BackendClosureCapture],
+        backendClosureParams :: [(String, BackendType)],
+        backendClosureBody :: BackendExpr
+      }
+  | BackendClosureCall
+      { backendExprType :: BackendType,
+        backendClosureFunction :: BackendExpr,
+        backendClosureArguments :: [BackendExpr]
+      }
   deriving (Eq, Show)
 
 data BackendAlternative = BackendAlternative
@@ -224,6 +244,15 @@ data BackendValidationError
   | BackendRollPayloadMismatch BackendType BackendType
   | BackendUnrollExpectedRecursive BackendType
   | BackendUnrollResultMismatch BackendType BackendType
+  | BackendDuplicateClosureEntry String
+  | BackendDuplicateClosureCapture String
+  | BackendDuplicateClosureParameter String
+  | BackendClosureCaptureTypeMismatch String BackendType BackendType
+  | BackendClosureTypeMismatch String BackendType BackendType
+  | BackendClosureCallExpectedFunction BackendType
+  | BackendClosureCallArityMismatch Int Int
+  | BackendClosureCallArgumentMismatch Int BackendType BackendType
+  | BackendClosureCallResultMismatch BackendType BackendType
   | BackendUnknownConstructor String
   | BackendConstructorArityMismatch String Int Int
   | BackendConstructorArgumentMismatch String Int BackendType BackendType
@@ -544,11 +573,34 @@ unfoldBackendRecursiveType ty =
     BTMu name body -> Just (substituteBackendType name ty body)
     _ -> Nothing
 
+backendClosureEntryNames :: BackendExpr -> [String]
+backendClosureEntryNames =
+  \case
+    BackendVar {} -> []
+    BackendLit {} -> []
+    BackendLam _ _ _ body -> backendClosureEntryNames body
+    BackendApp _ fun arg -> backendClosureEntryNames fun ++ backendClosureEntryNames arg
+    BackendLet _ _ _ rhs body -> backendClosureEntryNames rhs ++ backendClosureEntryNames body
+    BackendTyAbs _ _ _ body -> backendClosureEntryNames body
+    BackendTyApp _ fun _ -> backendClosureEntryNames fun
+    BackendConstruct _ _ args -> concatMap backendClosureEntryNames args
+    BackendCase _ scrutinee alternatives ->
+      backendClosureEntryNames scrutinee ++ concatMap (backendClosureEntryNames . backendAltBody) (NE.toList alternatives)
+    BackendRoll _ payload -> backendClosureEntryNames payload
+    BackendUnroll _ payload -> backendClosureEntryNames payload
+    BackendClosure _ entryName captures _ body ->
+      entryName
+        : concatMap (backendClosureEntryNames . backendClosureCaptureExpr) captures
+          ++ backendClosureEntryNames body
+    BackendClosureCall _ fun args ->
+      backendClosureEntryNames fun ++ concatMap backendClosureEntryNames args
+
 validateBackendProgram :: BackendProgram -> Either BackendValidationError ()
 validateBackendProgram program = do
   requireUnique BackendDuplicateModule (map backendModuleName modules0)
   requireUnique BackendDuplicateBinding (map backendBindingName bindings)
   requireUnique BackendDuplicateConstructor (map backendConstructorName constructors)
+  requireUnique BackendDuplicateClosureEntry closureEntryNames
   unless (backendProgramMain program `elem` map backendBindingName bindings) $
     Left (BackendMainNotFound (backendProgramMain program))
   mapM_ (validateBackendBindingInContext context0) bindings
@@ -556,6 +608,7 @@ validateBackendProgram program = do
     modules0 = backendProgramModules program
     bindings = concatMap backendModuleBindings modules0
     constructors = concatMap backendDataConstructors (concatMap backendModuleData modules0)
+    closureEntryNames = concatMap (backendClosureEntryNames . backendBindingExpr) bindings
     constructorInfos =
       [ ( backendConstructorName constructor,
           BackendConstructorInfo
@@ -683,6 +736,68 @@ validateBackendExprWith mbContext expr =
             Left (BackendUnrollResultMismatch resultTy expectedResultTy)
         Nothing ->
           Left (BackendUnrollExpectedRecursive (backendExprType payload))
+    BackendClosure resultTy entryName captures params body -> do
+      requireUnique BackendDuplicateClosureCapture (map backendClosureCaptureName captures)
+      requireUnique BackendDuplicateClosureParameter (map fst params)
+      requireUnique BackendDuplicateClosureParameter (map backendClosureCaptureName captures ++ map fst params)
+      mapM_ (validateBackendClosureCapture mbContext) captures
+      let bodyContext =
+            foldl
+              (\context0 capture -> extendLocalMaybe context0 (backendClosureCaptureName capture) (backendClosureCaptureType capture))
+              mbContext
+              captures
+          bodyParamContext =
+            foldl
+              (\context0 (paramName, paramTy) -> extendLocalMaybe context0 paramName paramTy)
+              bodyContext
+              params
+      validateBackendExprWith bodyParamContext body
+      let expected = foldr BTArrow (backendExprType body) (map snd params)
+      unless (alphaEqBackendType resultTy expected) $
+        Left (BackendClosureTypeMismatch entryName resultTy expected)
+    BackendClosureCall resultTy fun args -> do
+      validateBackendExprWith mbContext fun
+      mapM_ (validateBackendExprWith mbContext) args
+      validateBackendClosureCall resultTy (backendExprType fun) args
+
+validateBackendClosureCapture :: Maybe BackendValidationContext -> BackendClosureCapture -> Either BackendValidationError ()
+validateBackendClosureCapture mbContext capture = do
+  validateBackendExprWith mbContext expr
+  unless (alphaEqBackendType (backendClosureCaptureType capture) (backendExprType expr)) $
+    Left (BackendClosureCaptureTypeMismatch (backendClosureCaptureName capture) (backendClosureCaptureType capture) (backendExprType expr))
+  where
+    expr = backendClosureCaptureExpr capture
+
+validateBackendClosureCall :: BackendType -> BackendType -> [BackendExpr] -> Either BackendValidationError ()
+validateBackendClosureCall resultTy funTy args =
+  case collectClosureCallType funTy of
+    Nothing ->
+      Left (BackendClosureCallExpectedFunction funTy)
+    Just (paramTys, expectedResultTy) -> do
+      unless (length paramTys == length args) $
+        Left (BackendClosureCallArityMismatch (length paramTys) (length args))
+      zipWithM_
+        validateArg
+        [0 :: Int ..]
+        (zip paramTys args)
+      unless (alphaEqBackendType resultTy expectedResultTy) $
+        Left (BackendClosureCallResultMismatch resultTy expectedResultTy)
+  where
+    validateArg index0 (expectedArgTy, arg) =
+      unless (alphaEqBackendType expectedArgTy (backendExprType arg)) $
+        Left (BackendClosureCallArgumentMismatch index0 expectedArgTy (backendExprType arg))
+
+collectClosureCallType :: BackendType -> Maybe ([BackendType], BackendType)
+collectClosureCallType =
+  go []
+  where
+    go params =
+      \case
+        BTArrow paramTy resultTy ->
+          go (params ++ [paramTy]) resultTy
+        other
+          | null params -> Nothing
+          | otherwise -> Just (params, other)
 
 validateBackendVariable :: Maybe BackendValidationContext -> String -> BackendType -> Either BackendValidationError ()
 validateBackendVariable Nothing _ _ =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -271,6 +271,7 @@ data BackendValidationContext = BackendValidationContext
     bvcConstructors :: Map.Map String BackendConstructorInfo,
     bvcLocals :: Map.Map String BackendType,
     bvcClosureLocals :: Set.Set String,
+    bvcPossibleClosureLocals :: Set.Set String,
     bvcTypeBounds :: Map.Map String (Maybe BackendType)
   }
 
@@ -632,6 +633,7 @@ validateBackendProgram program = do
           bvcConstructors = Map.fromList constructorInfos,
           bvcLocals = Map.empty,
           bvcClosureLocals = Set.empty,
+          bvcPossibleClosureLocals = Set.empty,
           bvcTypeBounds = Map.empty
         }
 
@@ -750,7 +752,7 @@ validateBackendExprWith mbContext expr =
       mapM_ (validateBackendClosureCapture mbContext) captures
       let bodyContext =
             foldl
-              (\context0 capture -> extendLocalMaybe context0 (backendClosureCaptureName capture) (backendClosureCaptureType capture))
+              (extendClosureCaptureLocalMaybe mbContext)
               (dropTermLocalsMaybe mbContext)
               captures
           bodyParamContext =
@@ -786,7 +788,8 @@ backendClosureValueName mbContext =
       Just entryName
     BackendVar _ name
       | Just context0 <- mbContext,
-        Set.member name (bvcClosureLocals context0) ->
+        Set.member name (bvcClosureLocals context0)
+          || Set.member name (bvcPossibleClosureLocals context0) ->
           Just name
     BackendTyApp _ fun _ ->
       backendClosureValueName mbContext fun
@@ -797,6 +800,24 @@ backendClosureValueName mbContext =
     _ ->
       Nothing
 
+backendDefiniteClosureValueName :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
+backendDefiniteClosureValueName mbContext =
+  \case
+    BackendClosure _ entryName _ _ _ ->
+      Just entryName
+    BackendVar _ name
+      | Just context0 <- mbContext,
+        Set.member name (bvcClosureLocals context0) ->
+          Just name
+    BackendTyApp _ fun _ ->
+      backendDefiniteClosureValueName mbContext fun
+    BackendLet _ name bindingTy rhs body ->
+      backendDefiniteClosureValueName (extendLetLocalMaybe mbContext name bindingTy rhs) body
+    BackendCase _ scrutinee alternatives ->
+      backendCaseDefiniteClosureValueName mbContext (backendExprType scrutinee) alternatives
+    _ ->
+      Nothing
+
 backendCaseClosureValueName :: Maybe BackendValidationContext -> BackendType -> NonEmpty BackendAlternative -> Maybe String
 backendCaseClosureValueName mbContext scrutineeTy =
   firstClosureValueName . map closureAlternativeName . NE.toList
@@ -804,6 +825,17 @@ backendCaseClosureValueName mbContext scrutineeTy =
     closureAlternativeName alternative =
       case validateBackendPattern mbContext scrutineeTy (backendAltPattern alternative) of
         Right contextForBody -> backendClosureValueName contextForBody (backendAltBody alternative)
+        Left _ -> Nothing
+
+backendCaseDefiniteClosureValueName :: Maybe BackendValidationContext -> BackendType -> NonEmpty BackendAlternative -> Maybe String
+backendCaseDefiniteClosureValueName mbContext scrutineeTy alternatives =
+  case traverse closureAlternativeName (NE.toList alternatives) of
+    Just names -> firstClosureValueName (map Just names)
+    Nothing -> Nothing
+  where
+    closureAlternativeName alternative =
+      case validateBackendPattern mbContext scrutineeTy (backendAltPattern alternative) of
+        Right contextForBody -> backendDefiniteClosureValueName contextForBody (backendAltBody alternative)
         Left _ -> Nothing
 
 firstClosureValueName :: [Maybe String] -> Maybe String
@@ -820,7 +852,7 @@ validateBackendClosureCall mbContext resultTy fun args =
     Nothing ->
       Left (BackendClosureCallExpectedFunction funTy)
     Just (paramTys, expectedResultTy) -> do
-      case backendClosureValueName mbContext fun of
+      case backendDefiniteClosureValueName mbContext fun of
         Just _ -> pure ()
         Nothing -> Left (BackendClosureCallExpectedClosureValue funTy)
       unless (length paramTys == length args) $
@@ -1153,7 +1185,8 @@ extendLocal :: BackendValidationContext -> String -> BackendType -> BackendValid
 extendLocal context0 name ty =
   context0
     { bvcLocals = Map.insert name ty (bvcLocals context0),
-      bvcClosureLocals = Set.delete name (bvcClosureLocals context0)
+      bvcClosureLocals = Set.delete name (bvcClosureLocals context0),
+      bvcPossibleClosureLocals = Set.delete name (bvcPossibleClosureLocals context0)
     }
 
 extendClosureLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> Maybe BackendValidationContext
@@ -1164,24 +1197,72 @@ extendClosureLocal :: BackendValidationContext -> String -> BackendType -> Backe
 extendClosureLocal context0 name ty =
   context0
     { bvcLocals = Map.insert name ty (bvcLocals context0),
-      bvcClosureLocals = Set.insert name (bvcClosureLocals context0)
+      bvcClosureLocals = Set.insert name (bvcClosureLocals context0),
+      bvcPossibleClosureLocals = Set.delete name (bvcPossibleClosureLocals context0)
+    }
+
+extendPossibleClosureLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> Maybe BackendValidationContext
+extendPossibleClosureLocalMaybe mbContext name ty =
+  fmap (\context0 -> extendPossibleClosureLocal context0 name ty) mbContext
+
+extendPossibleClosureLocal :: BackendValidationContext -> String -> BackendType -> BackendValidationContext
+extendPossibleClosureLocal context0 name ty =
+  context0
+    { bvcLocals = Map.insert name ty (bvcLocals context0),
+      bvcClosureLocals = Set.delete name (bvcClosureLocals context0),
+      bvcPossibleClosureLocals = Set.insert name (bvcPossibleClosureLocals context0)
     }
 
 extendLetLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> BackendExpr -> Maybe BackendValidationContext
-extendLetLocalMaybe mbContext name ty rhs
-  | Just _ <- backendClosureValueName mbContext rhs = extendClosureLocalMaybe mbContext name ty
-  | otherwise = extendLocalMaybe mbContext name ty
+extendLetLocalMaybe mbContext name ty rhs =
+  extendClosureShapeLocalMaybe mbContext mbContext name ty rhs
+
+extendClosureCaptureLocalMaybe ::
+  Maybe BackendValidationContext ->
+  Maybe BackendValidationContext ->
+  BackendClosureCapture ->
+  Maybe BackendValidationContext
+extendClosureCaptureLocalMaybe outerContext bodyContext capture =
+  extendClosureShapeLocalMaybe
+    outerContext
+    bodyContext
+    (backendClosureCaptureName capture)
+    (backendClosureCaptureType capture)
+    (backendClosureCaptureExpr capture)
+
+extendClosureShapeLocalMaybe ::
+  Maybe BackendValidationContext ->
+  Maybe BackendValidationContext ->
+  String ->
+  BackendType ->
+  BackendExpr ->
+  Maybe BackendValidationContext
+extendClosureShapeLocalMaybe sourceContext targetContext name ty rhs
+  | Just _ <- backendDefiniteClosureValueName sourceContext rhs =
+      extendClosureLocalMaybe targetContext name ty
+  | Just _ <- backendClosureValueName sourceContext rhs =
+      extendPossibleClosureLocalMaybe targetContext name ty
+  | otherwise =
+      extendLocalMaybe targetContext name ty
 
 extendLocals :: BackendValidationContext -> [(String, BackendType)] -> BackendValidationContext
 extendLocals context0 bindings =
   context0
     { bvcLocals = foldr (uncurry Map.insert) (bvcLocals context0) bindings,
-      bvcClosureLocals = foldr (Set.delete . fst) (bvcClosureLocals context0) bindings
+      bvcClosureLocals = foldr (Set.delete . fst) (bvcClosureLocals context0) bindings,
+      bvcPossibleClosureLocals = foldr (Set.delete . fst) (bvcPossibleClosureLocals context0) bindings
     }
 
 dropTermLocalsMaybe :: Maybe BackendValidationContext -> Maybe BackendValidationContext
 dropTermLocalsMaybe =
-  fmap (\context0 -> context0 {bvcLocals = Map.empty, bvcClosureLocals = Set.empty})
+  fmap
+    ( \context0 ->
+        context0
+          { bvcLocals = Map.empty,
+            bvcClosureLocals = Set.empty,
+            bvcPossibleClosureLocals = Set.empty
+          }
+    )
 
 extendTypeBoundMaybe :: Maybe BackendValidationContext -> String -> Maybe BackendType -> Maybe BackendValidationContext
 extendTypeBoundMaybe mbContext name mbBound =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3324,7 +3324,8 @@ lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> String -> [BackendType] ->
 lowerGlobalCall env exprEnv context name typeArgs args =
   case Map.lookup name (pbBindings (peBase env)) of
     Just binding -> do
-      (resolvedTypeArgs, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
+      (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
+      let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
       unless (length args == length (ffParams form)) $
         liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
       if requiresInlineCall form

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -1244,7 +1244,7 @@ collectEvidenceWrappers base reachable specializations =
   where
     requests =
       concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . biForm) monomorphicReachable
-        ++ concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . spForm) specializations
+        ++ concatMap (collectEvidenceWrappersInForm base Map.empty Set.empty . qualifiedSpecializationForm) specializations
     monomorphicReachable =
       filter (null . ffTypeBinders . biForm) reachable
     uniqueRequests =
@@ -1263,7 +1263,7 @@ collectFunctionWrappers base reachable specializations =
   where
     requests =
       concatMap (collectFunctionWrappersInForm base Map.empty Set.empty . biForm) monomorphicReachable
-        ++ concatMap (collectFunctionWrappersInForm base Map.empty Set.empty . spForm) specializations
+        ++ concatMap (collectFunctionWrappersInForm base Map.empty Set.empty . qualifiedSpecializationForm) specializations
     monomorphicReachable =
       filter (null . ffTypeBinders . biForm) reachable
     uniqueRequests =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2180,14 +2180,20 @@ collectClosureEntriesInExpr localForms expr =
     BackendLam _ name _ body ->
       collectClosureEntriesInExpr (Map.delete name localForms) body
     BackendApp _ fun arg ->
-      collectAppliedLocalClosureEntries
-        ++ collectClosureEntriesInExpr localForms fun
-        ++ collectClosureEntriesInExpr localForms arg
+      case collectAdministrativeCallEntries of
+        Just entries -> entries
+        Nothing ->
+          collectAppliedLocalClosureEntries
+            ++ collectClosureEntriesInExpr localForms fun
+            ++ collectClosureEntriesInExpr localForms arg
     BackendLet _ name bindingTy rhs body ->
       collectClosureEntriesInExpr localForms rhs
         ++ collectClosureEntriesInExpr (collectLetLocalForm name bindingTy rhs) body
     BackendTyAbs {} -> []
-    BackendTyApp {} -> collectTypeAppliedClosureEntries
+    BackendTyApp {} ->
+      case collectAdministrativeTypeAppEntries of
+        Just entries -> entries
+        Nothing -> collectTypeAppliedClosureEntries
     BackendConstruct _ _ args -> concatMap (collectClosureEntriesInExpr localForms) args
     BackendCase _ scrutinee alternatives ->
       collectClosureEntriesInExpr localForms scrutinee ++ concatMap collectAlternativeEntries (NE.toList alternatives)
@@ -2215,6 +2221,14 @@ collectClosureEntriesInExpr localForms expr =
               collectInstantiatedLocalClosureEntries name form typeArgs args
         _ -> []
 
+    collectAdministrativeCallEntries =
+      case collectCall expr of
+        Just (headExpr, typeArgs, args) ->
+          case pushCallIntoExpression "closure entry collection" (backendExprType expr) headExpr typeArgs args of
+            Right (Just applied) -> Just (collectClosureEntriesInExpr localForms applied)
+            _ -> Nothing
+        Nothing -> Nothing
+
     collectTypeAppliedClosureEntries =
       case collectTyApps expr of
         (BackendVar _ name, typeArgs)
@@ -2228,6 +2242,13 @@ collectClosureEntriesInExpr localForms expr =
             []
         (fun, _) ->
           collectClosureEntriesInExpr localForms fun
+
+    collectAdministrativeTypeAppEntries =
+      case collectTyApps expr of
+        (headExpr, typeArgs) ->
+          case pushTypeApplicationsIntoExpression "closure entry collection" (backendExprType expr) headExpr typeArgs of
+            Right (Just applied) -> Just (collectClosureEntriesInExpr localForms applied)
+            _ -> Nothing
 
     collectInstantiatedLocalClosureEntries name form typeArgs args =
       collectInstantiatedClosureEntries name form typeArgs args
@@ -2860,10 +2881,11 @@ lowerClosureCall env exprEnv context resultTy fun args = do
     liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
   unless (length paramTys == length args) $
     liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
-  unless (alphaEqBackendType resultTy returnTy) $
+  resultLLVMType <- lowerBackendTypeM env context resultTy
+  returnLLVMType <- lowerBackendTypeM env context returnTy
+  unless (resultLLVMType == returnLLVMType) $
     liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
   callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
-  resultLLVMType <- lowerBackendTypeM env context resultTy
   codePtrField <- emitGep "closure.code.ptr" (lvOperand callee) 0
   codePtr <- emitAssign "closure.code" LLVMPtr (LLVMLoad LLVMPtr codePtrField)
   envPtrField <- emitGep "closure.env.ptr" (lvOperand callee) 8

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2074,18 +2074,24 @@ lowerFunctionWrapper env wrapper =
 
 collectClosureEntries :: [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> [ClosureEntry]
 collectClosureEntries reachable specializations evidenceWrappers functionWrappers =
-  concatMap (collectClosureEntriesInExpr . ffBody . biForm) (filter (null . ffTypeBinders . biForm) reachable)
-    ++ concatMap (collectClosureEntriesInExpr . ffBody . qualifiedSpecializationForm) specializations
-    ++ concatMap (collectClosureEntriesInExpr . ffBody . qualifiedEvidenceWrapperForm) evidenceWrappers
-    ++ concatMap (collectClosureEntriesInExpr . ffBody . qualifiedFunctionWrapperForm) functionWrappers
+  concatMap (collectClosureEntriesInForm . biForm) (filter (null . ffTypeBinders . biForm) reachable)
+    ++ concatMap (collectClosureEntriesInForm . qualifiedSpecializationForm) specializations
+    ++ concatMap (collectClosureEntriesInForm . qualifiedEvidenceWrapperForm) evidenceWrappers
+    ++ concatMap (collectClosureEntriesInForm . qualifiedFunctionWrapperForm) functionWrappers
 
 requireUniqueClosureEntries :: [ClosureEntry] -> Either BackendLLVMError [ClosureEntry]
 requireUniqueClosureEntries entries =
-  case firstDuplicate (map ceEntryName entries) of
-    Just entryName ->
-      Left (BackendLLVMInternalError ("duplicate closure entry after specialization: " ++ entryName))
-    Nothing ->
-      Right entries
+  reverse <$> foldM includeEntry [] entries
+  where
+    includeEntry kept entry =
+      case filter ((== ceEntryName entry) . ceEntryName) kept of
+        [] ->
+          Right (entry : kept)
+        existing : _
+          | existing == entry ->
+              Right kept
+          | otherwise ->
+              Left (BackendLLVMInternalError ("duplicate closure entry after specialization: " ++ ceEntryName entry))
 
 qualifiedSpecializationForm :: Specialization -> FunctionForm
 qualifiedSpecializationForm specialization =
@@ -2102,6 +2108,11 @@ qualifiedFunctionWrapperForm wrapper =
 qualifyClosureEntriesInForm :: String -> FunctionForm -> FunctionForm
 qualifyClosureEntriesInForm ownerName form =
   form {ffBody = qualifyClosureEntriesInExpr ownerName (ffBody form)}
+
+qualifyInstantiatedClosureEntries :: String -> [BackendType] -> FunctionForm -> FunctionForm
+qualifyInstantiatedClosureEntries ownerName resolvedTypeArgs form
+  | null resolvedTypeArgs = form
+  | otherwise = qualifyClosureEntriesInForm (closureEntryOwnerName ownerName resolvedTypeArgs) form
 
 qualifyClosureEntriesInExpr :: String -> BackendExpr -> BackendExpr
 qualifyClosureEntriesInExpr ownerName =
@@ -2151,21 +2162,37 @@ qualifiedClosureEntryName :: String -> String -> String
 qualifiedClosureEntryName ownerName entryName =
   ownerName ++ "$" ++ entryName
 
-collectClosureEntriesInExpr :: BackendExpr -> [ClosureEntry]
-collectClosureEntriesInExpr =
-  \case
+collectClosureEntriesInForm :: FunctionForm -> [ClosureEntry]
+collectClosureEntriesInForm =
+  collectClosureEntriesInFormWithLocals Map.empty
+
+collectClosureEntriesInFormWithLocals :: LocalFunctionForms -> FunctionForm -> [ClosureEntry]
+collectClosureEntriesInFormWithLocals localForms form =
+  collectClosureEntriesInExpr (shadowLocalFunctionForms paramNames localForms) (ffBody form)
+  where
+    paramNames = Set.fromList (map fst (ffParams form))
+
+collectClosureEntriesInExpr :: LocalFunctionForms -> BackendExpr -> [ClosureEntry]
+collectClosureEntriesInExpr localForms expr =
+  case expr of
     BackendVar {} -> []
     BackendLit {} -> []
-    BackendLam _ _ _ body -> collectClosureEntriesInExpr body
-    BackendApp _ fun arg -> collectClosureEntriesInExpr fun ++ collectClosureEntriesInExpr arg
-    BackendLet _ _ _ rhs body -> collectClosureEntriesInExpr rhs ++ collectClosureEntriesInExpr body
-    BackendTyAbs _ _ _ body -> collectClosureEntriesInExpr body
-    BackendTyApp _ fun _ -> collectClosureEntriesInExpr fun
-    BackendConstruct _ _ args -> concatMap collectClosureEntriesInExpr args
+    BackendLam _ name _ body ->
+      collectClosureEntriesInExpr (Map.delete name localForms) body
+    BackendApp _ fun arg ->
+      collectAppliedLocalClosureEntries
+        ++ collectClosureEntriesInExpr localForms fun
+        ++ collectClosureEntriesInExpr localForms arg
+    BackendLet _ name bindingTy rhs body ->
+      collectClosureEntriesInExpr localForms rhs
+        ++ collectClosureEntriesInExpr (collectLetLocalForm name bindingTy rhs) body
+    BackendTyAbs {} -> []
+    BackendTyApp {} -> collectTypeAppliedClosureEntries
+    BackendConstruct _ _ args -> concatMap (collectClosureEntriesInExpr localForms) args
     BackendCase _ scrutinee alternatives ->
-      collectClosureEntriesInExpr scrutinee ++ concatMap (collectClosureEntriesInExpr . backendAltBody) (NE.toList alternatives)
-    BackendRoll _ payload -> collectClosureEntriesInExpr payload
-    BackendUnroll _ payload -> collectClosureEntriesInExpr payload
+      collectClosureEntriesInExpr localForms scrutinee ++ concatMap collectAlternativeEntries (NE.toList alternatives)
+    BackendRoll _ payload -> collectClosureEntriesInExpr localForms payload
+    BackendUnroll _ payload -> collectClosureEntriesInExpr localForms payload
     BackendClosure resultTy entryName captures params body ->
       ClosureEntry
         { ceFunctionType = resultTy,
@@ -2174,10 +2201,68 @@ collectClosureEntriesInExpr =
           ceParams = params,
           ceBody = body
         }
-        : concatMap (collectClosureEntriesInExpr . backendClosureCaptureExpr) captures
-          ++ collectClosureEntriesInExpr body
+        : concatMap (collectClosureEntriesInExpr localForms . backendClosureCaptureExpr) captures
+          ++ collectClosureEntriesInExpr (shadowLocalFunctionForms closureBound localForms) body
+      where
+        closureBound = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
     BackendClosureCall _ fun args ->
-      collectClosureEntriesInExpr fun ++ concatMap collectClosureEntriesInExpr args
+      collectClosureEntriesInExpr localForms fun ++ concatMap (collectClosureEntriesInExpr localForms) args
+  where
+    collectAppliedLocalClosureEntries =
+      case collectCall expr of
+        Just (BackendVar _ name, typeArgs, args)
+          | Just form <- Map.lookup name localForms ->
+              collectInstantiatedLocalClosureEntries name form typeArgs args
+        _ -> []
+
+    collectTypeAppliedClosureEntries =
+      case collectTyApps expr of
+        (BackendVar _ name, typeArgs)
+          | Just form <- Map.lookup name localForms ->
+              collectInstantiatedLocalClosureEntries name form typeArgs []
+        (fun@BackendTyAbs {}, typeArgs) ->
+          collectInstantiatedClosureEntries
+            "__mlfp_direct_typeapp"
+            (functionFormFromExpr fun)
+            typeArgs
+            []
+        (fun, _) ->
+          collectClosureEntriesInExpr localForms fun
+
+    collectInstantiatedLocalClosureEntries name form typeArgs args =
+      collectInstantiatedClosureEntries name form typeArgs args
+
+    collectInstantiatedClosureEntries ownerName form typeArgs args =
+      case instantiateFunctionFormWithTypeArgs ("closure entry collection " ++ ownerName) form typeArgs args of
+        Right (resolvedTypeArgs, instantiated) ->
+          collectClosureEntriesInFormWithLocals
+            localForms
+            (qualifyInstantiatedClosureEntries ownerName resolvedTypeArgs instantiated)
+        Left _ ->
+          []
+
+    collectLetLocalForm name bindingTy rhs =
+      case functionFormFromExpected bindingTy rhs of
+        form
+          | not (null (ffTypeBinders form)) ->
+              Map.insert name form localForms
+        _ ->
+          Map.delete name localForms
+
+    collectAlternativeEntries alternative =
+      let binders = patternBinders (backendAltPattern alternative)
+       in collectClosureEntriesInExpr
+            (shadowLocalFunctionForms binders localForms)
+            (backendAltBody alternative)
+
+    patternBinders =
+      \case
+        BackendDefaultPattern -> Set.empty
+        BackendConstructorPattern _ binders -> Set.fromList binders
+
+closureEntryOwnerName :: String -> [BackendType] -> String
+closureEntryOwnerName name typeArgs =
+  name ++ concatMap (("$" ++) . backendTypeKey) typeArgs
 
 evidenceWrapperForm :: EvidenceWrapper -> FunctionForm
 evidenceWrapperForm wrapper =
@@ -2562,7 +2647,8 @@ lowerDirectFunctionValue env exprEnv context resultTy fun typeArgs = do
     Right (Just applied) ->
       lowerExpr env exprEnv context applied
     Right Nothing -> do
-      form <- instantiateFunctionFormM context (functionFormFromExpr fun) typeArgs []
+      (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (functionFormFromExpr fun) typeArgs []
+      let form = qualifyInstantiatedClosureEntries "__mlfp_direct_typeapp" resolvedTypeArgs form0
       lowerInstantiatedFunctionValue env exprEnv context "type-applied expression" resultTy form
     Left err ->
       liftEither err
@@ -2636,7 +2722,8 @@ applyCallToExpr context expectedTy expr typeArgs args = do
 
 lowerLocalFunctionValue :: ProgramEnv -> String -> BackendType -> String -> LocalFunction -> [BackendType] -> LowerM LowerValue
 lowerLocalFunctionValue env context resultTy name localFunction typeArgs = do
-  form <- instantiateFunctionFormM context (lfForm localFunction) typeArgs []
+  (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (lfForm localFunction) typeArgs []
+  let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
   lowerInstantiatedFunctionValue env (lfCapturedEnv localFunction) context name resultTy form
 
 lowerInstantiatedFunctionValue :: ProgramEnv -> ExprEnv -> String -> String -> BackendType -> FunctionForm -> LowerM LowerValue
@@ -2962,10 +3049,11 @@ lowerLocalFunctionReference =
 
 lowerLocalFunctionReferenceWith :: Bool -> ProgramEnv -> String -> BackendType -> String -> LocalFunction -> [BackendType] -> LowerM LowerValue
 lowerLocalFunctionReferenceWith allowStoredReference env context expectedTy name localFunction typeArgs = do
-  form <-
+  (resolvedTypeArgs, form0) <-
     if null typeArgs
-      then pure (lfForm localFunction)
-      else instantiateFunctionFormM context (lfForm localFunction) typeArgs []
+      then pure ([], lfForm localFunction)
+      else instantiateFunctionFormWithTypeArgsM context (lfForm localFunction) typeArgs []
+  let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
   let actualTy = functionTypeFromFormWithBinders form
   requireEvidenceFunctionType context name expectedTy actualTy
   case etaAliasTarget form of
@@ -3177,7 +3265,8 @@ backendTypeVariableNames =
 lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do
   let allowNestedEvidence = isEvidenceName name
-  form <- instantiateFunctionFormM context (lfForm localFunction) typeArgs args
+  (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (lfForm localFunction) typeArgs args
+  let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
   bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form args
   lowerExpr env bodyEnv context (ffBody form)
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -60,6 +60,7 @@ data BackendLLVMError
   | BackendLLVMUnknownConstructor String
   | BackendLLVMArityMismatch String Int Int
   | BackendLLVMUnsupportedString String
+  | BackendLLVMDuplicateSymbol String
   | BackendLLVMInternalError String
   deriving (Eq, Show)
 
@@ -193,7 +194,7 @@ type LowerM = StateT FunctionState (Either BackendLLVMError)
 lowerBackendProgram :: BackendProgram -> Either BackendLLVMError LLVMModule
 lowerBackendProgram program = do
   lowered <- lowerBackendProgramCore program
-  pure
+  validateLLVMModuleSymbols
     LLVMModule
       { llvmModuleGlobals = rawLLVMGlobals lowered,
         llvmModuleDeclarations = runtimeDeclarations (lpBase lowered),
@@ -262,7 +263,7 @@ lowerNativeProgram lowered = do
   let renderMap = Map.fromList [(backendTypeKey (nrsType spec), nrsFunctionName spec) | spec <- renderSpecs]
   renderers <- traverse (lowerNativeRenderer env renderMap) renderSpecs
   entrypoint <- lowerNativeEntrypoint env mainBinding renderMap
-  pure
+  validateLLVMModuleSymbols
     LLVMModule
       { llvmModuleGlobals = rawLLVMGlobals lowered ++ nativeGlobals base renderSpecs,
         llvmModuleDeclarations = nativeRuntimeDeclarations base,
@@ -272,6 +273,26 @@ lowerNativeProgram lowered = do
             ++ renderers
             ++ [entrypoint]
       }
+
+validateLLVMModuleSymbols :: LLVMModule -> Either BackendLLVMError LLVMModule
+validateLLVMModuleSymbols module0 =
+  case duplicateSymbols symbolNames of
+    name : _ -> Left (BackendLLVMDuplicateSymbol name)
+    [] -> Right module0
+  where
+    symbolNames =
+      map llvmGlobalName (llvmModuleGlobals module0)
+        ++ map llvmDeclarationName (llvmModuleDeclarations module0)
+        ++ map llvmFunctionName (llvmModuleFunctions module0)
+
+    duplicateSymbols =
+      go . sort
+
+    go [] = []
+    go [_] = []
+    go (x : y : rest)
+      | x == y = x : go (dropWhile (== x) rest)
+      | otherwise = go (y : rest)
 
 nativeRuntimeDeclarations :: ProgramBase -> [LLVMDeclaration]
 nativeRuntimeDeclarations base =
@@ -4465,5 +4486,7 @@ renderBackendLLVMError =
       "Backend LLVM arity mismatch for " ++ name ++ ": expected " ++ show expected ++ ", got " ++ show actual
     BackendLLVMUnsupportedString value ->
       "Unsupported backend LLVM string literal: " ++ show value
+    BackendLLVMDuplicateSymbol name ->
+      "Duplicate backend LLVM symbol: " ++ show name
     BackendLLVMInternalError detail ->
       "Internal backend LLVM error: " ++ detail

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -4,6 +4,23 @@
 Module      : MLF.Backend.LLVM.Lower
 Description : Lower typed backend IR into real LLVM IR syntax
 -}
+
+{- Note [Closure ABI]
+~~~~~~~~~~~~~~~~~~~~~
+Backend closure values are heap pointers to a two-word record:
+
+* word 0 stores the closure entry code pointer;
+* word 1 stores the environment pointer, or null when the closure has no
+  captures.
+
+The environment object is owned by the closure value and contains one machine
+word per captured runtime value in the order written in the backend IR. Closure
+entry functions are private LLVM functions with debug-friendly names supplied
+by `BackendClosure`; they take a hidden `ptr env` parameter before the erased
+monomorphic runtime arguments. Direct first-order backend calls keep using
+their existing first-order function symbols; indirect closure calls must use
+the explicit `BackendClosureCall` node.
+-}
 module MLF.Backend.LLVM.Lower
   ( BackendLLVMError (..),
     evidenceFunctionTypesCompatible,
@@ -111,6 +128,15 @@ data FunctionWrapper = FunctionWrapper
   }
   deriving (Eq, Show)
 
+data ClosureEntry = ClosureEntry
+  { ceFunctionType :: BackendType,
+    ceEntryName :: String,
+    ceCaptures :: [(String, BackendType)],
+    ceParams :: [(String, BackendType)],
+    ceBody :: BackendExpr
+  }
+  deriving (Eq, Show)
+
 data LowerValue = LowerValue
   { lvBackendType :: BackendType,
     lvLLVMType :: LLVMType,
@@ -151,6 +177,7 @@ lowerBackendProgram program = do
   specializations <- collectRequiredSpecializations base reachable
   let evidenceWrappers = collectEvidenceWrappers base reachable specializations
       functionWrappers = collectFunctionWrappers base reachable specializations
+      closureEntries = collectClosureEntries reachable specializations evidenceWrappers functionWrappers
       referencedFunctionNames = collectReferencedFunctionNames base reachable specializations evidenceWrappers functionWrappers
       stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations evidenceWrappers functionWrappers)
       env =
@@ -167,7 +194,8 @@ lowerBackendProgram program = do
         [ traverse (lowerMonomorphicBinding env) (filter (shouldLowerReachableBinding referencedFunctionNames) reachable),
           traverse (lowerSpecialization env) (filter (shouldLowerSpecialization referencedFunctionNames) specializations),
           traverse (lowerEvidenceWrapper env) evidenceWrappers,
-          traverse (lowerFunctionWrapper env) functionWrappers
+          traverse (lowerFunctionWrapper env) functionWrappers,
+          traverse (lowerClosureEntry env) closureEntries
         ]
   mainBinding <- requireBinding base (backendProgramMain program)
   when (not (null (ffTypeBinders (biForm mainBinding)))) $
@@ -229,6 +257,11 @@ functionFormCallsGlobal name form =
           go bound payload
         BackendUnroll _ payload ->
           go bound payload
+        BackendClosure _ _ captures params body ->
+          any (go bound . backendClosureCaptureExpr) captures
+            || go (Set.unions [bound, Set.fromList (map backendClosureCaptureName captures), Set.fromList (map fst params)]) body
+        BackendClosureCall _ fun args ->
+          go bound fun || any (go bound) args
 
     alternativeCalls bound (BackendAlternative pattern0 body) =
       go (Set.union bound (patternBinders pattern0)) body
@@ -563,9 +596,24 @@ renameBackendVars renaming0 =
           BackendRoll resultTy (go renaming payload)
         BackendUnroll resultTy payload ->
           BackendUnroll resultTy (go renaming payload)
+        BackendClosure resultTy entryName captures params body ->
+          BackendClosure
+            resultTy
+            entryName
+            (map (renameCapture renaming) captures)
+            params
+            (go (withoutNames (map backendClosureCaptureName captures ++ map fst params) renaming) body)
+        BackendClosureCall resultTy fun args ->
+          BackendClosureCall resultTy (go renaming fun) (map (go renaming) args)
 
     renameAlternative renaming (BackendAlternative pattern0 body) =
       BackendAlternative pattern0 (go (withoutPatternBinders pattern0 renaming) body)
+
+    renameCapture renaming capture =
+      capture {backendClosureCaptureExpr = go renaming (backendClosureCaptureExpr capture)}
+
+    withoutNames names renaming =
+      foldr Map.delete renaming names
 
     withoutPatternBinders pattern0 renaming =
       case pattern0 of
@@ -603,6 +651,11 @@ freeBackendExprVars =
           go bound payload
         BackendUnroll _ payload ->
           go bound payload
+        BackendClosure _ _ captures params body ->
+          Set.unions (map (go bound . backendClosureCaptureExpr) captures)
+            `Set.union` go (Set.unions [bound, Set.fromList (map backendClosureCaptureName captures), Set.fromList (map fst params)]) body
+        BackendClosureCall _ fun args ->
+          go bound fun `Set.union` Set.unions (map (go bound) args)
 
     freeAlternative bound (BackendAlternative pattern0 body) =
       go (Set.union (patternBinders pattern0) bound) body
@@ -643,6 +696,11 @@ backendExprVarTypesFor targets =
           go shadowed payload
         BackendUnroll _ payload ->
           go shadowed payload
+        BackendClosure _ _ captures params body ->
+          Map.unions (map (go shadowed . backendClosureCaptureExpr) captures)
+            `Map.union` go (Set.unions [shadowed, Set.fromList (map backendClosureCaptureName captures), Set.fromList (map fst params)]) body
+        BackendClosureCall _ fun args ->
+          go shadowed fun `Map.union` Map.unions (map (go shadowed) args)
 
     goAlternative shadowed (BackendAlternative pattern0 body) =
       go (Set.union shadowed (patternBinders pattern0)) body
@@ -884,6 +942,19 @@ collectReferencedFunctionNamesInExpr base substitution localForms bound expr =
           collectReferencedFunctionNamesInExpr base substitution localForms bound payload
         BackendUnroll _ payload ->
           collectReferencedFunctionNamesInExpr base substitution localForms bound payload
+        BackendClosure _ _ captures params body ->
+          Set.unions (map (collectReferencedFunctionNamesInExpr base substitution localForms bound . backendClosureCaptureExpr) captures)
+            `Set.union` collectReferencedFunctionNamesInExpr
+              base
+              substitution
+              (shadowLocalFunctionForms closureBound localForms)
+              (Set.union closureBound bound)
+              body
+          where
+            closureBound = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+        BackendClosureCall _ fun args ->
+          collectReferencedFunctionNamesInExpr base substitution localForms bound fun
+            `Set.union` Set.unions (map (collectReferencedFunctionNamesInExpr base substitution localForms bound) args)
 
     collectLetRhsReferences bindingTy rhs =
       case functionFormFromExpected bindingTy rhs of
@@ -978,6 +1049,19 @@ collectEvidenceWrappersInExpr base substitution localForms bound expr =
           collectEvidenceWrappersInExpr base substitution localForms bound payload
         BackendUnroll _ payload ->
           collectEvidenceWrappersInExpr base substitution localForms bound payload
+        BackendClosure _ _ captures params body ->
+          concatMap (collectEvidenceWrappersInExpr base substitution localForms bound . backendClosureCaptureExpr) captures
+            ++ collectEvidenceWrappersInExpr
+              base
+              substitution
+              (shadowLocalFunctionForms closureBound localForms)
+              (Set.union closureBound bound)
+              body
+          where
+            closureBound = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+        BackendClosureCall _ fun args ->
+          collectEvidenceWrappersInExpr base substitution localForms bound fun
+            ++ concatMap (collectEvidenceWrappersInExpr base substitution localForms bound) args
 
     evidenceArgumentWrappers form args =
       [ (paramTy, arg)
@@ -1138,6 +1222,19 @@ collectFunctionWrappersInExpr base substitution localFunctions bound expr =
           collectFunctionWrappersInExpr base substitution localFunctions bound payload
         BackendUnroll _ payload ->
           collectFunctionWrappersInExpr base substitution localFunctions bound payload
+        BackendClosure _ _ captures params body ->
+          concatMap (collectFunctionWrappersInExpr base substitution localFunctions bound . backendClosureCaptureExpr) captures
+            ++ collectFunctionWrappersInExpr
+              base
+              substitution
+              (Map.withoutKeys localFunctions closureBound)
+              (Set.union closureBound bound)
+              body
+          where
+            closureBound = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+        BackendClosureCall _ fun args ->
+          collectFunctionWrappersInExpr base substitution localFunctions bound fun
+            ++ concatMap (collectFunctionWrappersInExpr base substitution localFunctions bound) args
 
     collectLetLocalFunction name rhs =
       case functionFormFromExpected (backendExprType rhs) rhs of
@@ -1212,6 +1309,11 @@ freeTermVars =
           go bound payload
         BackendUnroll _ payload ->
           go bound payload
+        BackendClosure _ _ captures params body ->
+          foldMap (go bound . backendClosureCaptureExpr) captures
+            `Set.union` go (Set.unions [bound, Set.fromList (map backendClosureCaptureName captures), Set.fromList (map fst params)]) body
+        BackendClosureCall _ fun args ->
+          Set.union (go bound fun) (foldMap (go bound) args)
 
     goAlternative bound (BackendAlternative pattern0 body) =
       go (Set.union (patternBinders pattern0) bound) body
@@ -1308,6 +1410,16 @@ collectSpecializationRequestsWithBound base substitution bound expr =
           collectSpecializationRequestsWithBound base substitution bound payload
         BackendUnroll _ payload ->
           collectSpecializationRequestsWithBound base substitution bound payload
+        BackendClosure _ _ captures params body ->
+          concatMap (collectSpecializationRequestsWithBound base substitution bound . backendClosureCaptureExpr) captures
+            ++ collectSpecializationRequestsWithBound
+              base
+              substitution
+              (Set.union (Set.fromList (map backendClosureCaptureName captures ++ map fst params)) bound)
+              body
+        BackendClosureCall _ fun args ->
+          collectSpecializationRequestsWithBound base substitution bound fun
+            ++ concatMap (collectSpecializationRequestsWithBound base substitution bound) args
 
     collectAlternativeRequests alternative =
       collectSpecializationRequestsWithBound
@@ -1401,6 +1513,11 @@ freeGlobalRefs base bound expr =
       freeGlobalRefs base bound payload
     BackendUnroll _ payload ->
       freeGlobalRefs base bound payload
+    BackendClosure _ _ captures params body ->
+      Set.unions (map (freeGlobalRefs base bound . backendClosureCaptureExpr) captures)
+        `Set.union` freeGlobalRefs base (Set.unions [bound, Set.fromList (map backendClosureCaptureName captures), Set.fromList (map fst params)]) body
+    BackendClosureCall _ fun args ->
+      freeGlobalRefs base bound fun `Set.union` Set.unions (map (freeGlobalRefs base bound) args)
   where
     freeAlternativeRefs bound0 alternative =
       freeGlobalRefs base (Set.union (patternBinders (backendAltPattern alternative)) bound0) (backendAltBody alternative)
@@ -1435,6 +1552,10 @@ collectStringLiterals =
       collectStringLiterals scrutinee ++ concatMap (collectStringLiterals . backendAltBody) (NE.toList alternatives)
     BackendRoll _ payload -> collectStringLiterals payload
     BackendUnroll _ payload -> collectStringLiterals payload
+    BackendClosure _ _ captures _ body ->
+      concatMap (collectStringLiterals . backendClosureCaptureExpr) captures ++ collectStringLiterals body
+    BackendClosureCall _ fun args ->
+      collectStringLiterals fun ++ concatMap collectStringLiterals args
 
 assignStringGlobals :: [String] -> Map String String
 assignStringGlobals values =
@@ -1480,6 +1601,41 @@ lowerEvidenceWrapper env wrapper =
 lowerFunctionWrapper :: ProgramEnv -> FunctionWrapper -> Either BackendLLVMError LLVMFunction
 lowerFunctionWrapper env wrapper =
   lowerFunction env (fwFunctionName wrapper) True (functionWrapperForm wrapper)
+
+collectClosureEntries :: [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> [ClosureEntry]
+collectClosureEntries reachable specializations evidenceWrappers functionWrappers =
+  concatMap (collectClosureEntriesInExpr . ffBody . biForm) (filter (null . ffTypeBinders . biForm) reachable)
+    ++ concatMap (collectClosureEntriesInExpr . ffBody . spForm) specializations
+    ++ concatMap (collectClosureEntriesInExpr . ffBody . evidenceWrapperForm) evidenceWrappers
+    ++ concatMap (collectClosureEntriesInExpr . ffBody . functionWrapperForm) functionWrappers
+
+collectClosureEntriesInExpr :: BackendExpr -> [ClosureEntry]
+collectClosureEntriesInExpr =
+  \case
+    BackendVar {} -> []
+    BackendLit {} -> []
+    BackendLam _ _ _ body -> collectClosureEntriesInExpr body
+    BackendApp _ fun arg -> collectClosureEntriesInExpr fun ++ collectClosureEntriesInExpr arg
+    BackendLet _ _ _ rhs body -> collectClosureEntriesInExpr rhs ++ collectClosureEntriesInExpr body
+    BackendTyAbs _ _ _ body -> collectClosureEntriesInExpr body
+    BackendTyApp _ fun _ -> collectClosureEntriesInExpr fun
+    BackendConstruct _ _ args -> concatMap collectClosureEntriesInExpr args
+    BackendCase _ scrutinee alternatives ->
+      collectClosureEntriesInExpr scrutinee ++ concatMap (collectClosureEntriesInExpr . backendAltBody) (NE.toList alternatives)
+    BackendRoll _ payload -> collectClosureEntriesInExpr payload
+    BackendUnroll _ payload -> collectClosureEntriesInExpr payload
+    BackendClosure resultTy entryName captures params body ->
+      ClosureEntry
+        { ceFunctionType = resultTy,
+          ceEntryName = entryName,
+          ceCaptures = [(backendClosureCaptureName capture, backendClosureCaptureType capture) | capture <- captures],
+          ceParams = params,
+          ceBody = body
+        }
+        : concatMap (collectClosureEntriesInExpr . backendClosureCaptureExpr) captures
+          ++ collectClosureEntriesInExpr body
+    BackendClosureCall _ fun args ->
+      collectClosureEntriesInExpr fun ++ concatMap collectClosureEntriesInExpr args
 
 evidenceWrapperForm :: EvidenceWrapper -> FunctionForm
 evidenceWrapperForm wrapper =
@@ -1548,6 +1704,65 @@ lowerFunction env name private form = do
     lowerParam (paramName, paramTy) = do
       llvmTy <- lowerFunctionParameterType env ("parameter " ++ show paramName ++ " of " ++ name) paramName paramTy
       pure (LLVMParameter llvmTy paramName)
+
+lowerClosureEntry :: ProgramEnv -> ClosureEntry -> Either BackendLLVMError LLVMFunction
+lowerClosureEntry env entry = do
+  returnTy <- lowerBackendType env ("return type of closure " ++ ceEntryName entry) (closureReturnType entry)
+  params <- traverse lowerParam (ceParams entry)
+  let envParameter = LLVMParameter LLVMPtr "__mlfp_env"
+      initialExprEnv =
+        ExprEnv
+          { eeValues =
+              Map.fromList
+                [ (paramName, LowerValue paramTy (llvmParameterType param) (LLVMLocal (llvmParameterType param) paramName))
+                | ((paramName, paramTy), param) <- zip (ceParams entry) params
+                ],
+            eeLocalFunctions = Map.empty,
+            eeActiveGlobalInlines = Set.empty
+          }
+  result <-
+    evalStateT
+      ( do
+          bodyEnv <- loadClosureCaptures initialExprEnv
+          bodyValue <- lowerExpr env bodyEnv ("closure " ++ show (ceEntryName entry)) (ceBody entry)
+          unless (lvLLVMType bodyValue == returnTy) $
+            liftEither (BackendLLVMInternalError ("closure return type mismatch in " ++ ceEntryName entry))
+          finishCurrentBlock (LLVMRet returnTy (lvOperand bodyValue))
+          gets (reverse . fsCompletedBlocks)
+      )
+      initialFunctionState
+  pure
+    LLVMFunction
+      { llvmFunctionName = ceEntryName entry,
+        llvmFunctionPrivate = True,
+        llvmFunctionReturnType = returnTy,
+        llvmFunctionParameters = envParameter : params,
+        llvmFunctionBlocks = result
+      }
+  where
+    closureReturnType closureEntry =
+      case collectArrowsType (ceFunctionType closureEntry) of
+        (_, returnTy) -> returnTy
+
+    lowerParam (paramName, paramTy) = do
+      llvmTy <- lowerArgumentType env ("closure parameter " ++ show paramName ++ " of " ++ ceEntryName entry) False paramName paramTy
+      pure (LLVMParameter llvmTy paramName)
+
+    loadClosureCaptures exprEnv0 =
+      foldM loadOne exprEnv0 (zip [0 :: Int ..] (ceCaptures entry))
+
+    loadOne exprEnv0 (index0, (captureName, captureTy)) = do
+      llvmTy <- lowerClosureStoredTypeM env ("closure capture " ++ show captureName ++ " of " ++ ceEntryName entry) captureTy
+      fieldPtr <- emitGep "closure.env.field.ptr" (LLVMLocal LLVMPtr "__mlfp_env") (8 * index0)
+      loaded <- emitAssign "closure.env.field" llvmTy (LLVMLoad llvmTy fieldPtr)
+      pure
+        exprEnv0
+          { eeValues =
+              Map.insert
+                captureName
+                (LowerValue captureTy llvmTy loaded)
+                (eeValues exprEnv0)
+          }
 
 lowerFunctionParameterType :: ProgramEnv -> String -> String -> BackendType -> Either BackendLLVMError LLVMType
 lowerFunctionParameterType env context paramName paramTy
@@ -1663,6 +1878,14 @@ containsInlineOnlyEvidenceParameterCall form =
             go evidenceParams localFunctions payload
           BackendUnroll _ payload ->
             go evidenceParams localFunctions payload
+          BackendClosure _ _ captures params body ->
+            any (go evidenceParams localFunctions . backendClosureCaptureExpr) captures
+              || go
+                evidenceParams
+                (localFunctions `Set.difference` Set.fromList (map backendClosureCaptureName captures ++ map fst params))
+                body
+          BackendClosureCall _ fun args ->
+            go evidenceParams localFunctions fun || any (go evidenceParams localFunctions) args
 
     goAlternative evidenceParams localFunctions (BackendAlternative pattern0 body) =
       go evidenceParams (localFunctions `Set.difference` patternBinders pattern0) body
@@ -1774,6 +1997,10 @@ lowerExpr env exprEnv context expr =
       lowerRollLike env exprEnv context resultTy payload "roll"
     BackendUnroll resultTy payload ->
       lowerRollLike env exprEnv context resultTy payload "unroll"
+    BackendClosure resultTy entryName captures _ _ ->
+      lowerClosureValue env exprEnv context resultTy entryName captures
+    BackendClosureCall resultTy fun args ->
+      lowerClosureCall env exprEnv context resultTy fun args
 
 lowerTyApp :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
 lowerTyApp env exprEnv context expr =
@@ -1965,6 +2192,65 @@ lowerLit env context ty lit = do
           liftEither (BackendLLVMUnsupportedString value)
         Nothing ->
           liftEither (BackendLLVMInternalError ("missing string global at " ++ context))
+
+lowerClosureValue :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendClosureCapture] -> LowerM LowerValue
+lowerClosureValue env exprEnv context resultTy entryName captures = do
+  captureValues <- traverse lowerCapture captures
+  envPointer <- lowerClosureEnvironment captureValues
+  closurePointer <- emitMalloc env context 16
+  codePtrField <- emitGep "closure.code.ptr" closurePointer 0
+  emitStore LLVMPtr (LLVMGlobalRef LLVMPtr entryName) codePtrField
+  envPtrField <- emitGep "closure.env.ptr" closurePointer 8
+  emitStore LLVMPtr envPointer envPtrField
+  pure (LowerValue resultTy LLVMPtr closurePointer)
+  where
+    lowerCapture capture = do
+      value <- lowerExpr env exprEnv (context ++ ", closure capture " ++ show (backendClosureCaptureName capture)) (backendClosureCaptureExpr capture)
+      expectedTy <- lowerClosureStoredTypeM env context (backendClosureCaptureType capture)
+      requireLLVMType context (backendClosureCaptureName capture) expectedTy value
+      pure (expectedTy, value)
+
+    lowerClosureEnvironment [] =
+      pure LLVMNull
+    lowerClosureEnvironment captureValues = do
+      envPointer <- emitMalloc env context (8 * length captureValues)
+      zipWithM_ (storeCapture envPointer) [0 :: Int ..] captureValues
+      pure envPointer
+
+    storeCapture envPointer index0 (captureTy, value) = do
+      fieldPtr <- emitGep "closure.env.field.ptr" envPointer (8 * index0)
+      emitStore captureTy (lvOperand value) fieldPtr
+
+lowerClosureCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> [BackendExpr] -> LowerM LowerValue
+lowerClosureCall env exprEnv context resultTy fun args = do
+  callee <- lowerExpr env exprEnv context fun
+  unless (lvLLVMType callee == LLVMPtr) $
+    liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a pointer: " ++ show (lvBackendType callee)))
+  let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
+  when (null paramTys) $
+    liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
+  unless (length paramTys == length args) $
+    liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
+  unless (alphaEqBackendType resultTy returnTy) $
+    liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
+  callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
+  resultLLVMType <- lowerBackendTypeM env context resultTy
+  codePtrField <- emitGep "closure.code.ptr" (lvOperand callee) 0
+  codePtr <- emitAssign "closure.code" LLVMPtr (LLVMLoad LLVMPtr codePtrField)
+  envPtrField <- emitGep "closure.env.ptr" (lvOperand callee) 8
+  closureEnv <- emitAssign "closure.env" LLVMPtr (LLVMLoad LLVMPtr envPtrField)
+  result <-
+    emitAssign
+      "closure.call"
+      resultLLVMType
+      ( LLVMCallOperand
+          codePtr
+          ((LLVMPtr, closureEnv) : [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+      )
+  pure (LowerValue resultTy resultLLVMType result)
+  where
+    lowerClosureArg (index0, paramTy) arg =
+      lowerExprForIndirectArgument env exprEnv context ("__mlfp_closure_arg" ++ show index0, paramTy) arg
 
 lowerCall :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
 lowerCall env exprEnv context expr =
@@ -2984,6 +3270,11 @@ lowerStoredFieldTypeM env context fieldTy
   | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
   | otherwise = lowerBackendTypeM env context fieldTy
 
+lowerClosureStoredTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
+lowerClosureStoredTypeM env context fieldTy
+  | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
+  | otherwise = lowerBackendTypeM env context fieldTy
+
 lowerImmediateConstructCase ::
   ProgramEnv ->
   ExprEnv ->
@@ -3482,9 +3773,24 @@ substituteExprTypes substitution =
           BackendRoll (substituteTy resultTy) (go payload)
         BackendUnroll resultTy payload ->
           BackendUnroll (substituteTy resultTy) (go payload)
+        BackendClosure resultTy entryName captures params body ->
+          BackendClosure
+            (substituteTy resultTy)
+            entryName
+            (map substituteCapture captures)
+            [(paramName, substituteTy paramTy) | (paramName, paramTy) <- params]
+            (go body)
+        BackendClosureCall resultTy fun args ->
+          BackendClosureCall (substituteTy resultTy) (go fun) (map go args)
 
     substituteAlternative alternative =
       alternative {backendAltBody = go (backendAltBody alternative)}
+
+    substituteCapture capture =
+      capture
+        { backendClosureCaptureType = substituteTy (backendClosureCaptureType capture),
+          backendClosureCaptureExpr = go (backendClosureCaptureExpr capture)
+        }
 
 renderBackendLLVMError :: BackendLLVMError -> String
 renderBackendLLVMError =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -177,7 +177,7 @@ lowerBackendProgram program = do
   specializations <- collectRequiredSpecializations base reachable
   let evidenceWrappers = collectEvidenceWrappers base reachable specializations
       functionWrappers = collectFunctionWrappers base reachable specializations
-      closureEntries = collectClosureEntries reachable specializations evidenceWrappers functionWrappers
+      closureEntries0 = collectClosureEntries reachable specializations evidenceWrappers functionWrappers
       referencedFunctionNames = collectReferencedFunctionNames base reachable specializations evidenceWrappers functionWrappers
       stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations evidenceWrappers functionWrappers)
       env =
@@ -188,6 +188,7 @@ lowerBackendProgram program = do
             peFunctionWrappers = Map.fromList [(fwKey wrapper, wrapper) | wrapper <- functionWrappers],
             peStringGlobals = stringGlobals
           }
+  closureEntries <- requireUniqueClosureEntries closureEntries0
   functions <-
     concat
       <$> sequence
@@ -1592,22 +1593,94 @@ lowerMonomorphicBinding env binding =
 
 lowerSpecialization :: ProgramEnv -> Specialization -> Either BackendLLVMError LLVMFunction
 lowerSpecialization env specialization =
-  lowerFunction env (spFunctionName specialization) True (spForm specialization)
+  lowerFunction env (spFunctionName specialization) True (qualifiedSpecializationForm specialization)
 
 lowerEvidenceWrapper :: ProgramEnv -> EvidenceWrapper -> Either BackendLLVMError LLVMFunction
 lowerEvidenceWrapper env wrapper =
-  lowerFunction env (ewFunctionName wrapper) True (evidenceWrapperForm wrapper)
+  lowerFunction env (ewFunctionName wrapper) True (qualifiedEvidenceWrapperForm wrapper)
 
 lowerFunctionWrapper :: ProgramEnv -> FunctionWrapper -> Either BackendLLVMError LLVMFunction
 lowerFunctionWrapper env wrapper =
-  lowerFunction env (fwFunctionName wrapper) True (functionWrapperForm wrapper)
+  lowerFunction env (fwFunctionName wrapper) True (qualifiedFunctionWrapperForm wrapper)
 
 collectClosureEntries :: [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> [ClosureEntry]
 collectClosureEntries reachable specializations evidenceWrappers functionWrappers =
   concatMap (collectClosureEntriesInExpr . ffBody . biForm) (filter (null . ffTypeBinders . biForm) reachable)
-    ++ concatMap (collectClosureEntriesInExpr . ffBody . spForm) specializations
-    ++ concatMap (collectClosureEntriesInExpr . ffBody . evidenceWrapperForm) evidenceWrappers
-    ++ concatMap (collectClosureEntriesInExpr . ffBody . functionWrapperForm) functionWrappers
+    ++ concatMap (collectClosureEntriesInExpr . ffBody . qualifiedSpecializationForm) specializations
+    ++ concatMap (collectClosureEntriesInExpr . ffBody . qualifiedEvidenceWrapperForm) evidenceWrappers
+    ++ concatMap (collectClosureEntriesInExpr . ffBody . qualifiedFunctionWrapperForm) functionWrappers
+
+requireUniqueClosureEntries :: [ClosureEntry] -> Either BackendLLVMError [ClosureEntry]
+requireUniqueClosureEntries entries =
+  case firstDuplicate (map ceEntryName entries) of
+    Just entryName ->
+      Left (BackendLLVMInternalError ("duplicate closure entry after specialization: " ++ entryName))
+    Nothing ->
+      Right entries
+
+qualifiedSpecializationForm :: Specialization -> FunctionForm
+qualifiedSpecializationForm specialization =
+  qualifyClosureEntriesInForm (spFunctionName specialization) (spForm specialization)
+
+qualifiedEvidenceWrapperForm :: EvidenceWrapper -> FunctionForm
+qualifiedEvidenceWrapperForm wrapper =
+  qualifyClosureEntriesInForm (ewFunctionName wrapper) (evidenceWrapperForm wrapper)
+
+qualifiedFunctionWrapperForm :: FunctionWrapper -> FunctionForm
+qualifiedFunctionWrapperForm wrapper =
+  qualifyClosureEntriesInForm (fwFunctionName wrapper) (functionWrapperForm wrapper)
+
+qualifyClosureEntriesInForm :: String -> FunctionForm -> FunctionForm
+qualifyClosureEntriesInForm ownerName form =
+  form {ffBody = qualifyClosureEntriesInExpr ownerName (ffBody form)}
+
+qualifyClosureEntriesInExpr :: String -> BackendExpr -> BackendExpr
+qualifyClosureEntriesInExpr ownerName =
+  go
+  where
+    go =
+      \case
+        BackendVar resultTy name ->
+          BackendVar resultTy name
+        BackendLit resultTy lit ->
+          BackendLit resultTy lit
+        BackendLam resultTy name paramTy body ->
+          BackendLam resultTy name paramTy (go body)
+        BackendApp resultTy fun arg ->
+          BackendApp resultTy (go fun) (go arg)
+        BackendLet resultTy name bindingTy rhs body ->
+          BackendLet resultTy name bindingTy (go rhs) (go body)
+        BackendTyAbs resultTy name mbBound body ->
+          BackendTyAbs resultTy name mbBound (go body)
+        BackendTyApp resultTy fun ty ->
+          BackendTyApp resultTy (go fun) ty
+        BackendConstruct resultTy name args ->
+          BackendConstruct resultTy name (map go args)
+        BackendCase resultTy scrutinee alternatives ->
+          BackendCase resultTy (go scrutinee) (fmap qualifyAlternative alternatives)
+        BackendRoll resultTy payload ->
+          BackendRoll resultTy (go payload)
+        BackendUnroll resultTy payload ->
+          BackendUnroll resultTy (go payload)
+        BackendClosure resultTy entryName captures params body ->
+          BackendClosure
+            resultTy
+            (qualifiedClosureEntryName ownerName entryName)
+            (map qualifyCapture captures)
+            params
+            (go body)
+        BackendClosureCall resultTy fun args ->
+          BackendClosureCall resultTy (go fun) (map go args)
+
+    qualifyAlternative alternative =
+      alternative {backendAltBody = go (backendAltBody alternative)}
+
+    qualifyCapture capture =
+      capture {backendClosureCaptureExpr = go (backendClosureCaptureExpr capture)}
+
+qualifiedClosureEntryName :: String -> String -> String
+qualifiedClosureEntryName ownerName entryName =
+  ownerName ++ "$" ++ entryName
 
 collectClosureEntriesInExpr :: BackendExpr -> [ClosureEntry]
 collectClosureEntriesInExpr =
@@ -2321,13 +2394,13 @@ lookupFunctionFormByName env functionName =
   case Map.lookup functionName (pbBindings (peBase env)) of
     Just binding -> Just (biForm binding)
     Nothing ->
-      case [spForm specialization | specialization <- Map.elems (peSpecializations env), spFunctionName specialization == functionName] of
+      case [qualifiedSpecializationForm specialization | specialization <- Map.elems (peSpecializations env), spFunctionName specialization == functionName] of
         form : _ -> Just form
         [] ->
-          case [evidenceWrapperForm wrapper | wrapper <- Map.elems (peEvidenceWrappers env), ewFunctionName wrapper == functionName] of
+          case [qualifiedEvidenceWrapperForm wrapper | wrapper <- Map.elems (peEvidenceWrappers env), ewFunctionName wrapper == functionName] of
             form : _ -> Just form
             [] ->
-              case [functionWrapperForm wrapper | wrapper <- Map.elems (peFunctionWrappers env), fwFunctionName wrapper == functionName] of
+              case [qualifiedFunctionWrapperForm wrapper | wrapper <- Map.elems (peFunctionWrappers env), fwFunctionName wrapper == functionName] of
                 form : _ -> Just form
                 [] -> Nothing
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3272,7 +3272,8 @@ lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do
 
 lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do
-  form <- instantiateFunctionFormM context form0 typeArgs args
+  (resolvedTypeArgs, form1) <- instantiateFunctionFormWithTypeArgsM context form0 typeArgs args
+  let form = qualifyInstantiatedClosureEntries "__mlfp_direct_typeapp" resolvedTypeArgs form1
   bodyEnv <- bindCallArguments env exprEnv exprEnv context False "lambda" form args
   lowerExpr env bodyEnv context (ffBody form)
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -1167,6 +1167,28 @@ renderBackendIRExpr level expr =
         indent (level + 2) "payload:"
       ]
         ++ renderBackendIRExpr (level + 4) payload
+    BackendClosure resultTy entryName captures params body ->
+      [ indent level ("closure " ++ entryName ++ " : " ++ renderBackendIRType resultTy),
+        indent (level + 2) ("params: " ++ renderNamedTypeList params),
+        indent (level + 2) "captures:"
+      ]
+        ++ renderListOrEmpty (level + 4) (renderBackendIRCapture (level + 4)) captures
+        ++ [indent (level + 2) "body:"]
+        ++ renderBackendIRExpr (level + 4) body
+    BackendClosureCall resultTy fun args ->
+      [ indent level ("closure-call : " ++ renderBackendIRType resultTy),
+        indent (level + 2) "function:"
+      ]
+        ++ renderBackendIRExpr (level + 4) fun
+        ++ [indent (level + 2) "arguments:"]
+        ++ renderExprList (level + 4) args
+
+renderBackendIRCapture :: Int -> BackendClosureCapture -> [String]
+renderBackendIRCapture level capture =
+  [ indent level (backendClosureCaptureName capture ++ " : " ++ renderBackendIRType (backendClosureCaptureType capture)),
+    indent (level + 2) "expr:"
+  ]
+    ++ renderBackendIRExpr (level + 4) (backendClosureCaptureExpr capture)
 
 renderBackendIRAlternative :: Int -> BackendAlternative -> [String]
 renderBackendIRAlternative level alternative =
@@ -1221,6 +1243,10 @@ renderPlainTypeParameters params =
 renderTypeList :: [BackendType] -> String
 renderTypeList types0 =
   "[" ++ intercalate ", " (map renderBackendIRType types0) ++ "]"
+
+renderNamedTypeList :: [(String, BackendType)] -> String
+renderNamedTypeList params =
+  "[" ++ intercalate ", " [name ++ " : " ++ renderBackendIRType ty | (name, ty) <- params] ++ "]"
 
 renderLit :: Lit -> String
 renderLit lit =
@@ -1385,6 +1411,13 @@ backendExprBinders expr =
       backendExprBinders scrutinee ++ concatMap alternativeBinders (toList alternatives)
     BackendRoll {backendRollPayload = body} -> backendExprBinders body
     BackendUnroll {backendUnrollPayload = body} -> backendExprBinders body
+    BackendClosure {backendClosureCaptures = captures, backendClosureParams = params, backendClosureBody = body} ->
+      concatMap (backendExprBinders . backendClosureCaptureExpr) captures
+        ++ map backendClosureCaptureName captures
+        ++ map fst params
+        ++ backendExprBinders body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      backendExprBinders fun ++ concatMap backendExprBinders args
   where
     alternativeBinders (BackendAlternative pattern0 body) =
       patternBackendBinders pattern0 ++ backendExprBinders body
@@ -1409,6 +1442,10 @@ containsSelfReferentialLetRhs expr =
       containsSelfReferentialLetRhs scrutinee || any (containsSelfReferentialLetRhs . backendAltBody) (toList alternatives)
     BackendRoll {backendRollPayload = body} -> containsSelfReferentialLetRhs body
     BackendUnroll {backendUnrollPayload = body} -> containsSelfReferentialLetRhs body
+    BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
+      any (containsSelfReferentialLetRhs . backendClosureCaptureExpr) captures || containsSelfReferentialLetRhs body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      containsSelfReferentialLetRhs fun || any containsSelfReferentialLetRhs args
   where
     rhsIsSelfReference name rhs =
       case rhs of

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -166,6 +166,96 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendExpr (BackendLet intTy "x" boolTy (intLit 1) (BackendVar intTy "x"))
       `shouldBe` Left (BackendLetTypeMismatch "x" boolTy intTy)
 
+  it "validates explicit closure construction and indirect closure calls" $ do
+    let closure =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$id",
+              backendClosureCaptures = [],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            }
+        capturedClosure =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$captured",
+              backendClosureCaptures = [BackendClosureCapture "captured" intTy (intLit 7)],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "captured"
+            }
+        callClosure value =
+          BackendLet
+            intTy
+            "f"
+            idTy
+            value
+            (BackendClosureCall intTy (BackendVar idTy "f") [intLit 1])
+
+    validateBackendProgram (programWithMainExpr (callClosure closure))
+      `shouldBe` Right ()
+    validateBackendProgram (programWithMainExpr (callClosure capturedClosure))
+      `shouldBe` Right ()
+
+  it "rejects malformed closure IR" $ do
+    let goodClosure entryName =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = entryName,
+              backendClosureCaptures = [],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            }
+        captureMismatch =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$bad_capture",
+              backendClosureCaptures = [BackendClosureCapture "captured" boolTy (intLit 7)],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            }
+        resultMismatch =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$bad_result",
+              backendClosureCaptures = [],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = boolLit True
+            }
+        duplicateEntries =
+          BackendLet
+            intTy
+            "f"
+            idTy
+            (goodClosure "__mlfp_closure$dup")
+            ( BackendLet
+                intTy
+                "g"
+                idTy
+                (goodClosure "__mlfp_closure$dup")
+                (intLit 0)
+            )
+        duplicateCaptureAndParameter =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$duplicate_binder",
+              backendClosureCaptures = [BackendClosureCapture "x" intTy (intLit 7)],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            }
+        badCall =
+          BackendClosureCall intTy (goodClosure "__mlfp_closure$call") [boolLit True]
+
+    validateBackendProgram (programWithMainExpr captureMismatch)
+      `shouldBe` Left (BackendClosureCaptureTypeMismatch "captured" boolTy intTy)
+    validateBackendProgram (programWithMainExpr resultMismatch)
+      `shouldBe` Left (BackendClosureTypeMismatch "__mlfp_closure$bad_result" idTy (BTArrow intTy boolTy))
+    validateBackendProgram (programWithMainExpr duplicateEntries)
+      `shouldBe` Left (BackendDuplicateClosureEntry "__mlfp_closure$dup")
+    validateBackendProgram (programWithMainExpr duplicateCaptureAndParameter)
+      `shouldBe` Left (BackendDuplicateClosureParameter "x")
+    validateBackendProgram (programWithMainExpr badCall)
+      `shouldBe` Left (BackendClosureCallArgumentMismatch 0 intTy boolTy)
+
   it "checks type application against forall nodes" $ do
     validateBackendExpr
       ( BackendTyApp

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -244,6 +244,27 @@ spec = describe "MLF.Backend.IR" $ do
             }
         badCall =
           BackendClosureCall intTy (goodClosure "__mlfp_closure$call") [boolLit True]
+        unlistedLocalCapture =
+          BackendLet
+            idTy
+            "captured"
+            intTy
+            (intLit 7)
+            ( BackendClosure
+                { backendExprType = idTy,
+                  backendClosureEntryName = "__mlfp_closure$unlisted_capture",
+                  backendClosureCaptures = [],
+                  backendClosureParams = [("x", intTy)],
+                  backendClosureBody = BackendVar intTy "captured"
+                }
+            )
+        appCalledClosure =
+          BackendLet
+            intTy
+            "f"
+            idTy
+            (goodClosure "__mlfp_closure$app")
+            (BackendApp intTy (BackendVar idTy "f") (intLit 1))
 
     validateBackendProgram (programWithMainExpr captureMismatch)
       `shouldBe` Left (BackendClosureCaptureTypeMismatch "captured" boolTy intTy)
@@ -255,6 +276,10 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendDuplicateClosureParameter "x")
     validateBackendProgram (programWithMainExpr badCall)
       `shouldBe` Left (BackendClosureCallArgumentMismatch 0 intTy boolTy)
+    validateBackendProgram (programWithMainExpr unlistedLocalCapture)
+      `shouldBe` Left (BackendUnknownVariable "captured")
+    validateBackendProgram (programWithMainExpr appCalledClosure)
+      `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
 
   it "checks type application against forall nodes" $ do
     validateBackendExpr

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -242,6 +242,14 @@ spec = describe "MLF.Backend.IR" $ do
               backendClosureParams = [("x", intTy)],
               backendClosureBody = BackendVar intTy "x"
             }
+        nonFunctionClosure =
+          BackendClosure
+            { backendExprType = intTy,
+              backendClosureEntryName = "__mlfp_closure$non_function",
+              backendClosureCaptures = [],
+              backendClosureParams = [],
+              backendClosureBody = intLit 0
+            }
         badCall =
           BackendClosureCall intTy (goodClosure "__mlfp_closure$call") [boolLit True]
         nonClosureCall =
@@ -345,6 +353,8 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendDuplicateClosureEntry "__mlfp_closure$dup")
     validateBackendProgram (programWithMainExpr duplicateCaptureAndParameter)
       `shouldBe` Left (BackendDuplicateClosureParameter "x")
+    validateBackendProgram (programWithMainExpr nonFunctionClosure)
+      `shouldBe` Left (BackendClosureExpectedFunction "__mlfp_closure$non_function" intTy)
     validateBackendProgram (programWithMainExpr badCall)
       `shouldBe` Left (BackendClosureCallArgumentMismatch 0 intTy boolTy)
     validateBackendProgram (programWithMainExpr nonClosureCall)

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -190,10 +190,22 @@ spec = describe "MLF.Backend.IR" $ do
             idTy
             value
             (BackendClosureCall intTy (BackendVar idTy "f") [intLit 1])
+        structuralClosureArgTy =
+          BTMu "$Box_self" (singleFieldStructuralBody (BTVar "a"))
+        structuralClosure =
+          BackendClosure
+            { backendExprType = BTArrow structuralClosureArgTy boolTy,
+              backendClosureEntryName = "__mlfp_closure$structural",
+              backendClosureCaptures = [],
+              backendClosureParams = [("box", structuralClosureArgTy)],
+              backendClosureBody = boolLit True
+            }
 
     validateBackendProgram (programWithMainExpr (callClosure closure))
       `shouldBe` Right ()
     validateBackendProgram (programWithMainExpr (callClosure capturedClosure))
+      `shouldBe` Right ()
+    validateBackendExpr (BackendClosureCall boolTy structuralClosure [BackendVar structuralBoxTy "box"])
       `shouldBe` Right ()
 
   it "rejects malformed closure IR" $ do

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -289,6 +289,19 @@ spec = describe "MLF.Backend.IR" $ do
                 (BackendVar idTy "g")
                 (BackendApp intTy (BackendVar idTy "f") (intLit 1))
             )
+        appCalledCaseHeadClosure =
+          BackendApp
+            intTy
+            ( BackendCase
+                idTy
+                (BackendConstruct boxTy "Box" [intLit 0])
+                ( BackendAlternative
+                    (BackendConstructorPattern "Box" ["n"])
+                    (goodClosure "__mlfp_closure$app_case")
+                    :| []
+                )
+            )
+            (intLit 1)
 
     validateBackendProgram (programWithMainExpr captureMismatch)
       `shouldBe` Left (BackendClosureCaptureTypeMismatch "captured" boolTy intTy)
@@ -308,6 +321,8 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
     validateBackendProgram (programWithMainExpr appCalledClosureAlias)
       `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
+    validateBackendProgram (programWithMainExpr appCalledCaseHeadClosure)
+      `shouldBe` Left (BackendClosureCalledWithBackendApp "__mlfp_closure$app_case")
 
   it "checks type application against forall nodes" $ do
     validateBackendExpr

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -309,6 +309,33 @@ spec = describe "MLF.Backend.IR" $ do
                 )
             )
             (intLit 1)
+        appCalledCapturedClosure =
+          BackendLet
+            idTy
+            "g"
+            idTy
+            (goodClosure "__mlfp_closure$app_captured_source")
+            ( BackendClosure
+                { backendExprType = idTy,
+                  backendClosureEntryName = "__mlfp_closure$app_captured",
+                  backendClosureCaptures = [BackendClosureCapture "capturedClosure" idTy (BackendVar idTy "g")],
+                  backendClosureParams = [("x", intTy)],
+                  backendClosureBody = BackendApp intTy (BackendVar idTy "capturedClosure") (intLit 1)
+                }
+            )
+        closureCallMixedCaseHead =
+          BackendClosureCall
+            intTy
+            ( BackendCase
+                idTy
+                (BackendConstruct boxTy "Box" [intLit 0])
+                ( BackendAlternative
+                    (BackendConstructorPattern "Box" ["n"])
+                    (goodClosure "__mlfp_closure$closure_call_case")
+                    :| [BackendAlternative BackendDefaultPattern intIdentityExpr]
+                )
+            )
+            [intLit 1]
 
     validateBackendProgram (programWithMainExpr captureMismatch)
       `shouldBe` Left (BackendClosureCaptureTypeMismatch "captured" boolTy intTy)
@@ -332,6 +359,10 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
     validateBackendProgram (programWithMainExpr appCalledCaseHeadClosure)
       `shouldBe` Left (BackendClosureCalledWithBackendApp "__mlfp_closure$app_case")
+    validateBackendProgram (programWithMainExpr appCalledCapturedClosure)
+      `shouldBe` Left (BackendClosureCalledWithBackendApp "capturedClosure")
+    validateBackendProgram (programWithMainExpr closureCallMixedCaseHead)
+      `shouldBe` Left (BackendClosureCallExpectedClosureValue idTy)
 
   it "checks type application against forall nodes" $ do
     validateBackendExpr

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -265,6 +265,30 @@ spec = describe "MLF.Backend.IR" $ do
             idTy
             (goodClosure "__mlfp_closure$app")
             (BackendApp intTy (BackendVar idTy "f") (intLit 1))
+        appCalledLetHeadClosure =
+          BackendApp
+            intTy
+            ( BackendLet
+                idTy
+                "f"
+                idTy
+                (goodClosure "__mlfp_closure$app_let_head")
+                (BackendVar idTy "f")
+            )
+            (intLit 1)
+        appCalledClosureAlias =
+          BackendLet
+            intTy
+            "g"
+            idTy
+            (goodClosure "__mlfp_closure$app_alias")
+            ( BackendLet
+                intTy
+                "f"
+                idTy
+                (BackendVar idTy "g")
+                (BackendApp intTy (BackendVar idTy "f") (intLit 1))
+            )
 
     validateBackendProgram (programWithMainExpr captureMismatch)
       `shouldBe` Left (BackendClosureCaptureTypeMismatch "captured" boolTy intTy)
@@ -279,6 +303,10 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithMainExpr unlistedLocalCapture)
       `shouldBe` Left (BackendUnknownVariable "captured")
     validateBackendProgram (programWithMainExpr appCalledClosure)
+      `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
+    validateBackendProgram (programWithMainExpr appCalledLetHeadClosure)
+      `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
+    validateBackendProgram (programWithMainExpr appCalledClosureAlias)
       `shouldBe` Left (BackendClosureCalledWithBackendApp "f")
 
   it "checks type application against forall nodes" $ do

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -262,6 +262,14 @@ spec = describe "MLF.Backend.IR" $ do
               backendClosureParams = [],
               backendClosureBody = intLit 0
             }
+        underspecifiedClosureParams =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$underspecified_params",
+              backendClosureCaptures = [],
+              backendClosureParams = [],
+              backendClosureBody = intIdentityExpr
+            }
         badCall =
           BackendClosureCall intTy (goodClosure "__mlfp_closure$call") [boolLit True]
         nonClosureCall =
@@ -367,6 +375,8 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendDuplicateClosureParameter "x")
     validateBackendProgram (programWithMainExpr nonFunctionClosure)
       `shouldBe` Left (BackendClosureExpectedFunction "__mlfp_closure$non_function" intTy)
+    validateBackendProgram (programWithMainExpr underspecifiedClosureParams)
+      `shouldBe` Left (BackendClosureParameterArityMismatch "__mlfp_closure$underspecified_params" 0 1)
     validateBackendProgram (programWithMainExpr badCall)
       `shouldBe` Left (BackendClosureCallArgumentMismatch 0 intTy boolTy)
     validateBackendProgram (programWithMainExpr nonClosureCall)

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -244,6 +244,13 @@ spec = describe "MLF.Backend.IR" $ do
             }
         badCall =
           BackendClosureCall intTy (goodClosure "__mlfp_closure$call") [boolLit True]
+        nonClosureCall =
+          BackendLet
+            intTy
+            "f"
+            idTy
+            intIdentityExpr
+            (BackendClosureCall intTy (BackendVar idTy "f") [intLit 1])
         unlistedLocalCapture =
           BackendLet
             idTy
@@ -313,6 +320,8 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendDuplicateClosureParameter "x")
     validateBackendProgram (programWithMainExpr badCall)
       `shouldBe` Left (BackendClosureCallArgumentMismatch 0 intTy boolTy)
+    validateBackendProgram (programWithMainExpr nonClosureCall)
+      `shouldBe` Left (BackendClosureCallExpectedClosureValue idTy)
     validateBackendProgram (programWithMainExpr unlistedLocalCapture)
       `shouldBe` Left (BackendUnknownVariable "captured")
     validateBackendProgram (programWithMainExpr appCalledClosure)

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -246,6 +246,13 @@ spec = describe "MLF.Backend.IR" $ do
                 (goodClosure "__mlfp_closure$dup")
                 (intLit 0)
             )
+        entryNameBindingCollision =
+          programWithBindings
+            [ binding "helper" intTy (intLit 0),
+              mainBinding (goodClosure "helper")
+            ]
+        entryNameRuntimeCollision =
+          programWithMainExpr (goodClosure "__mlfp_and")
         duplicateCaptureAndParameter =
           BackendClosure
             { backendExprType = idTy,
@@ -371,6 +378,10 @@ spec = describe "MLF.Backend.IR" $ do
       `shouldBe` Left (BackendClosureTypeMismatch "__mlfp_closure$bad_result" idTy (BTArrow intTy boolTy))
     validateBackendProgram (programWithMainExpr duplicateEntries)
       `shouldBe` Left (BackendDuplicateClosureEntry "__mlfp_closure$dup")
+    validateBackendProgram entryNameBindingCollision
+      `shouldBe` Left (BackendClosureEntryNameCollision "helper")
+    validateBackendProgram entryNameRuntimeCollision
+      `shouldBe` Left (BackendClosureEntryNameCollision "__mlfp_and")
     validateBackendProgram (programWithMainExpr duplicateCaptureAndParameter)
       `shouldBe` Left (BackendDuplicateClosureParameter "x")
     validateBackendProgram (programWithMainExpr nonFunctionClosure)

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -145,6 +145,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unknown backend LLVM function"
     validateLLVMAssembly output
 
+  it "collects local polymorphic closure entries after type application" $ do
+    output <- requireRight (renderBackendProgramLLVM localPolymorphicClosureEntryProgram)
+
+    output `shouldSatisfy` isInfixOf "$__mlfp_closure$local_poly"
+    output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
+    validateLLVMAssembly output
+
   it "instantiates direct polymorphic zero-arity expressions used through type application" $ do
     output <- requireRight (renderBackendProgramLLVM directPolymorphicZeroArityProgram)
 
@@ -1890,6 +1897,70 @@ localPolymorphicZeroArityProgram =
         ],
       backendProgramMain = "main"
     }
+
+localPolymorphicClosureEntryProgram :: BackendProgram
+localPolymorphicClosureEntryProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "polyLocal"
+                          localPolymorphicClosureEntryTy
+                          localPolymorphicClosureEntryExpr
+                          ( BackendApp
+                              intTy
+                              ( BackendTyApp
+                                  (BTArrow intTy intTy)
+                                  (BackendVar localPolymorphicClosureEntryTy "polyLocal")
+                                  intTy
+                              )
+                              (intLit 3)
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+localPolymorphicClosureEntryTy :: BackendType
+localPolymorphicClosureEntryTy =
+  BTForall "a" Nothing (BTArrow (BTVar "a") (BTVar "a"))
+
+localPolymorphicClosureEntryExpr :: BackendExpr
+localPolymorphicClosureEntryExpr =
+  BackendTyAbs
+    localPolymorphicClosureEntryTy
+    "a"
+    Nothing
+    ( BackendLam
+        (BTArrow (BTVar "a") (BTVar "a"))
+        "x"
+        (BTVar "a")
+        ( BackendLet
+            (BTVar "a")
+            "f"
+            (BTArrow (BTVar "a") (BTVar "a"))
+            ( BackendClosure
+                { backendExprType = BTArrow (BTVar "a") (BTVar "a"),
+                  backendClosureEntryName = "__mlfp_closure$local_poly",
+                  backendClosureCaptures = [],
+                  backendClosureParams = [("y", BTVar "a")],
+                  backendClosureBody = BackendVar (BTVar "a") "y"
+                }
+            )
+            (BackendClosureCall (BTVar "a") (BackendVar (BTArrow (BTVar "a") (BTVar "a")) "f") [BackendVar (BTVar "a") "x"])
+        )
+    )
 
 directPolymorphicZeroArityProgram :: BackendProgram
 directPolymorphicZeroArityProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -636,6 +636,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "unsupported function argument"
     validateLLVMAssembly output
 
+  it "rejects closure entry names that collide with generated wrapper functions" $
+    renderBackendProgramLLVM closureEntryFunctionWrapperCollisionProgram
+      `shouldSatisfyLeft` isInfixOf "Duplicate backend LLVM symbol: \"__mlfp_function_wrapper$0\""
+
+  it "rejects closure entry names that collide with runtime declarations" $
+    renderBackendProgramLLVM closureEntryRuntimeDeclarationCollisionProgram
+      `shouldSatisfyLeft` isInfixOf "Duplicate backend LLVM symbol: \"malloc\""
+
   it "lowers stored top-level function constructor fields" $ do
     output <- requireRight (renderBackendProgramLLVM functionFieldProgram)
 
@@ -3029,6 +3037,40 @@ polymorphicClosureFunctionWrapperCall argTy arg =
     fnBoxTy
     (BackendTyApp (BTArrow argTy fnBoxTy) (BackendVar polymorphicClosureFunctionWrapperTy "polyWrapper") argTy)
     arg
+
+closureEntryFunctionWrapperCollisionProgram :: BackendProgram
+closureEntryFunctionWrapperCollisionProgram =
+  programWithFnBoxMainExpr $
+    BackendConstruct
+      fnBoxTy
+      "FnBox"
+      [ BackendLet
+          unaryIntTy
+          "unusedClosure"
+          unaryIntTy
+          (closureWithEntry "__mlfp_function_wrapper$0")
+          intIdentityExpr
+      ]
+
+closureEntryRuntimeDeclarationCollisionProgram :: BackendProgram
+closureEntryRuntimeDeclarationCollisionProgram =
+  programWithMainExpr intTy $
+    BackendLet
+      intTy
+      "f"
+      unaryIntTy
+      (closureWithEntry "malloc")
+      (BackendClosureCall intTy (BackendVar unaryIntTy "f") [intLit 7])
+
+closureWithEntry :: String -> BackendExpr
+closureWithEntry entryName =
+  BackendClosure
+    { backendExprType = unaryIntTy,
+      backendClosureEntryName = entryName,
+      backendClosureCaptures = [],
+      backendClosureParams = [("x", intTy)],
+      backendClosureBody = BackendVar intTy "x"
+    }
 
 functionFieldProgram :: BackendProgram
 functionFieldProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -510,13 +510,31 @@ spec = describe "MLF.Backend.LLVM" $ do
 
     mapM_ runLLVMParityCase programSpecToLLVMParityCases
 
-  it "rejects partial applications until closure conversion exists" $ do
+  it "rejects partial applications until closure conversion is explicit in backend IR" $ do
     renderBackendProgramLLVM partialApplicationProgram
       `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
 
-  it "rejects escaping lambdas until closure conversion exists" $ do
+  it "rejects raw escaping lambdas until closure construction is explicit in backend IR" $ do
     renderBackendProgramLLVM escapingLambdaProgram
       `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
+
+  it "lowers zero-capture closures through the explicit closure ABI" $ do
+    output <- requireRight (renderBackendProgramLLVM zeroCaptureClosureProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$identity\"(ptr %\"__mlfp_env\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$identity\""
+    output `shouldSatisfy` isInfixOf "load ptr"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+
+  it "lowers captured local values through closure environments" $ do
+    output <- requireRight (renderBackendProgramLLVM capturedClosureProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$constCaptured\"(ptr %\"__mlfp_env\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "store i64 41"
+    output `shouldSatisfy` isInfixOf "load i64"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
 
   it "lowers stored top-level function constructor fields" $ do
     output <- requireRight (renderBackendProgramLLVM functionFieldProgram)
@@ -2418,6 +2436,49 @@ escapingLambdaProgram =
         backendLetType = unaryIntTy,
         backendLetRhs = intIdentityExpr,
         backendLetBody = BackendVar unaryIntTy "f"
+      }
+
+zeroCaptureClosureProgram :: BackendProgram
+zeroCaptureClosureProgram =
+  programWithMainExpr intTy $
+    BackendLet
+      { backendExprType = intTy,
+        backendLetName = "f",
+        backendLetType = unaryIntTy,
+        backendLetRhs =
+          BackendClosure
+            { backendExprType = unaryIntTy,
+              backendClosureEntryName = "__mlfp_closure$identity",
+              backendClosureCaptures = [],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            },
+        backendLetBody = BackendClosureCall intTy (BackendVar unaryIntTy "f") [intLit 7]
+      }
+
+capturedClosureProgram :: BackendProgram
+capturedClosureProgram =
+  programWithMainExpr intTy $
+    BackendLet
+      { backendExprType = intTy,
+        backendLetName = "captured",
+        backendLetType = intTy,
+        backendLetRhs = intLit 41,
+        backendLetBody =
+          BackendLet
+            { backendExprType = intTy,
+              backendLetName = "f",
+              backendLetType = unaryIntTy,
+              backendLetRhs =
+                BackendClosure
+                  { backendExprType = unaryIntTy,
+                    backendClosureEntryName = "__mlfp_closure$constCaptured",
+                    backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                    backendClosureParams = [("x", intTy)],
+                    backendClosureBody = BackendVar intTy "captured"
+                  },
+              backendLetBody = BackendClosureCall intTy (BackendVar unaryIntTy "f") [intLit 0]
+            }
       }
 
 functionFieldProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -636,6 +636,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "unsupported function argument"
     validateLLVMAssembly output
 
+  it "qualifies closure entries in inlined polymorphic global calls" $ do
+    output <- requireRight (renderBackendProgramLLVM inlinePolymorphicClosureProgram)
+
+    let qualifiedStores =
+          filter
+            (\line -> "store ptr @\"polyInline$t" `isInfixOf` line && "$__mlfp_closure$inline\"" `isInfixOf` line)
+            (lines output)
+    length qualifiedStores `shouldBe` 1
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$inline\""
+    validateLLVMAssembly output
+
   it "rejects closure entry names that collide with generated wrapper functions" $
     renderBackendProgramLLVM closureEntryFunctionWrapperCollisionProgram
       `shouldSatisfyLeft` isInfixOf "Duplicate backend LLVM symbol: \"__mlfp_function_wrapper$0\""
@@ -3037,6 +3048,71 @@ polymorphicClosureFunctionWrapperCall argTy arg =
     fnBoxTy
     (BackendTyApp (BTArrow argTy fnBoxTy) (BackendVar polymorphicClosureFunctionWrapperTy "polyWrapper") argTy)
     arg
+
+inlinePolymorphicClosureProgram :: BackendProgram
+inlinePolymorphicClosureProgram =
+  programWithBindings
+    [ helperBinding,
+      BackendBinding
+        { backendBindingName = "polyInline",
+          backendBindingType = inlinePolymorphicClosureTy,
+          backendBindingExpr = inlinePolymorphicClosureExpr,
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              ( BackendApp
+                  (BTArrow intTy intTy)
+                  (BackendTyApp (BTArrow unaryIntTy (BTArrow intTy intTy)) (BackendVar inlinePolymorphicClosureTy "polyInline") intTy)
+                  (BackendVar unaryIntTy "helper")
+              )
+              (intLit 0),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+inlinePolymorphicClosureTy :: BackendType
+inlinePolymorphicClosureTy =
+  BTForall "a" Nothing (BTArrow unaryIntTy (BTArrow (BTVar "a") intTy))
+
+inlinePolymorphicClosureExpr :: BackendExpr
+inlinePolymorphicClosureExpr =
+  BackendTyAbs
+    inlinePolymorphicClosureTy
+    "a"
+    Nothing
+    ( BackendLam
+        (BTArrow unaryIntTy (BTArrow (BTVar "a") intTy))
+        "f"
+        unaryIntTy
+        ( BackendLam
+            (BTArrow (BTVar "a") intTy)
+            "ignored"
+            (BTVar "a")
+            ( BackendLet
+                intTy
+                "closure"
+                unaryIntTy
+                ( BackendClosure
+                    { backendExprType = unaryIntTy,
+                      backendClosureEntryName = "__mlfp_closure$inline",
+                      backendClosureCaptures = [],
+                      backendClosureParams = [("x", intTy)],
+                      backendClosureBody = BackendVar intTy "x"
+                    }
+                )
+                ( BackendApp
+                    intTy
+                    (BackendVar unaryIntTy "f")
+                    (BackendClosureCall intTy (BackendVar unaryIntTy "closure") [intLit 9])
+                )
+            )
+        )
+    )
 
 closureEntryFunctionWrapperCollisionProgram :: BackendProgram
 closureEntryFunctionWrapperCollisionProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -152,6 +152,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
     validateLLVMAssembly output
 
+  it "uses qualified closure entries for directly called type applications" $ do
+    output <- requireRight (renderBackendProgramLLVM directPolymorphicClosureCallProgram)
+
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_direct_typeapp$"
+    output `shouldSatisfy` isInfixOf "$__mlfp_closure$direct_call_poly\""
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$direct_call_poly\""
+    validateLLVMAssembly output
+
   it "instantiates direct polymorphic zero-arity expressions used through type application" $ do
     output <- requireRight (renderBackendProgramLLVM directPolymorphicZeroArityProgram)
 
@@ -1953,6 +1961,56 @@ localPolymorphicClosureEntryExpr =
             ( BackendClosure
                 { backendExprType = BTArrow (BTVar "a") (BTVar "a"),
                   backendClosureEntryName = "__mlfp_closure$local_poly",
+                  backendClosureCaptures = [],
+                  backendClosureParams = [("y", BTVar "a")],
+                  backendClosureBody = BackendVar (BTVar "a") "y"
+                }
+            )
+            (BackendClosureCall (BTVar "a") (BackendVar (BTArrow (BTVar "a") (BTVar "a")) "f") [BackendVar (BTVar "a") "x"])
+        )
+    )
+
+directPolymorphicClosureCallProgram :: BackendProgram
+directPolymorphicClosureCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          (BackendTyApp (BTArrow intTy intTy) directPolymorphicClosureCallExpr intTy)
+                          (intLit 3),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+directPolymorphicClosureCallExpr :: BackendExpr
+directPolymorphicClosureCallExpr =
+  BackendTyAbs
+    localPolymorphicClosureEntryTy
+    "a"
+    Nothing
+    ( BackendLam
+        (BTArrow (BTVar "a") (BTVar "a"))
+        "x"
+        (BTVar "a")
+        ( BackendLet
+            (BTVar "a")
+            "f"
+            (BTArrow (BTVar "a") (BTVar "a"))
+            ( BackendClosure
+                { backendExprType = BTArrow (BTVar "a") (BTVar "a"),
+                  backendClosureEntryName = "__mlfp_closure$direct_call_poly",
                   backendClosureCaptures = [],
                   backendClosureParams = [("y", BTVar "a")],
                   backendClosureBody = BackendVar (BTVar "a") "y"

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -595,6 +595,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$poly\""
     validateLLVMAssembly output
 
+  it "keys function wrappers from qualified specialization forms" $ do
+    output <- requireRight (renderBackendProgramLLVM polymorphicClosureFunctionWrapperProgram)
+
+    let wrapperDefinitions =
+          filter
+            (\line -> "define private i64 @\"__mlfp_function_wrapper$" `isInfixOf` line)
+            (lines output)
+    length wrapperDefinitions `shouldSatisfy` (>= 2)
+    output `shouldSatisfy` isInfixOf "$__mlfp_closure$wrapper_key"
+    output `shouldNotSatisfy` isInfixOf "unsupported function argument"
+    validateLLVMAssembly output
+
   it "lowers stored top-level function constructor fields" $ do
     output <- requireRight (renderBackendProgramLLVM functionFieldProgram)
 
@@ -2721,6 +2733,84 @@ polymorphicClosureSpecializationCall argTy arg =
   BackendApp
     intTy
     (BackendTyApp (BTArrow argTy intTy) (BackendVar polymorphicClosureSpecializationTy "poly") argTy)
+    arg
+
+polymorphicClosureFunctionWrapperProgram :: BackendProgram
+polymorphicClosureFunctionWrapperProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "polyWrapper",
+                      backendBindingType = polymorphicClosureFunctionWrapperTy,
+                      backendBindingExpr = polymorphicClosureFunctionWrapperExpr,
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "left"
+                          fnBoxTy
+                          (polymorphicClosureFunctionWrapperCall intTy (intLit 7))
+                          ( BackendLet
+                              intTy
+                              "right"
+                              fnBoxTy
+                              (polymorphicClosureFunctionWrapperCall boolTy (boolLit True))
+                              (intLit 0)
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+polymorphicClosureFunctionWrapperTy :: BackendType
+polymorphicClosureFunctionWrapperTy =
+  BTForall "a" Nothing (BTArrow (BTVar "a") fnBoxTy)
+
+polymorphicClosureFunctionWrapperExpr :: BackendExpr
+polymorphicClosureFunctionWrapperExpr =
+  BackendTyAbs
+    polymorphicClosureFunctionWrapperTy
+    "a"
+    Nothing
+    ( BackendLam
+        (BTArrow (BTVar "a") fnBoxTy)
+        "ignored"
+        (BTVar "a")
+        (BackendConstruct fnBoxTy "FnBox" [closureContainingFunctionExpr])
+    )
+
+closureContainingFunctionExpr :: BackendExpr
+closureContainingFunctionExpr =
+  BackendLet
+    unaryIntTy
+    "unusedClosure"
+    unaryIntTy
+    ( BackendClosure
+        { backendExprType = unaryIntTy,
+          backendClosureEntryName = "__mlfp_closure$wrapper_key",
+          backendClosureCaptures = [],
+          backendClosureParams = [("x", intTy)],
+          backendClosureBody = BackendVar intTy "x"
+        }
+    )
+    intIdentityExpr
+
+polymorphicClosureFunctionWrapperCall :: BackendType -> BackendExpr -> BackendExpr
+polymorphicClosureFunctionWrapperCall argTy arg =
+  BackendApp
+    fnBoxTy
+    (BackendTyApp (BTArrow argTy fnBoxTy) (BackendVar polymorphicClosureFunctionWrapperTy "polyWrapper") argTy)
     arg
 
 functionFieldProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -536,6 +536,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
     validateLLVMAssembly output
 
+  it "qualifies closure entry names emitted from type specializations" $ do
+    output <- requireRight (renderBackendProgramLLVM polymorphicClosureSpecializationProgram)
+
+    let closureDefinitions =
+          filter
+            (\line -> "define private i64 @\"poly$t" `isInfixOf` line && "$__mlfp_closure$poly\"" `isInfixOf` line)
+            (lines output)
+    length closureDefinitions `shouldBe` 2
+    output `shouldNotSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$poly\""
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$poly\""
+    validateLLVMAssembly output
+
   it "lowers stored top-level function constructor fields" $ do
     output <- requireRight (renderBackendProgramLLVM functionFieldProgram)
 
@@ -2480,6 +2492,81 @@ capturedClosureProgram =
               backendLetBody = BackendClosureCall intTy (BackendVar unaryIntTy "f") [intLit 0]
             }
       }
+
+polymorphicClosureSpecializationProgram :: BackendProgram
+polymorphicClosureSpecializationProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "poly",
+                      backendBindingType = polymorphicClosureSpecializationTy,
+                      backendBindingExpr = polymorphicClosureSpecializationExpr,
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "left"
+                          intTy
+                          (polymorphicClosureSpecializationCall intTy (intLit 7))
+                          ( BackendLet
+                              intTy
+                              "right"
+                              intTy
+                              (polymorphicClosureSpecializationCall boolTy (boolLit True))
+                              (intLit 0)
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+polymorphicClosureSpecializationTy :: BackendType
+polymorphicClosureSpecializationTy =
+  BTForall "a" Nothing (BTArrow (BTVar "a") intTy)
+
+polymorphicClosureSpecializationExpr :: BackendExpr
+polymorphicClosureSpecializationExpr =
+  BackendTyAbs
+    polymorphicClosureSpecializationTy
+    "a"
+    Nothing
+    ( BackendLam
+        (BTArrow (BTVar "a") intTy)
+        "ignored"
+        (BTVar "a")
+        ( BackendLet
+            intTy
+            "f"
+            unaryIntTy
+            ( BackendClosure
+                { backendExprType = unaryIntTy,
+                  backendClosureEntryName = "__mlfp_closure$poly",
+                  backendClosureCaptures = [],
+                  backendClosureParams = [("x", intTy)],
+                  backendClosureBody = BackendVar intTy "x"
+                }
+            )
+            (BackendClosureCall intTy (BackendVar unaryIntTy "f") [intLit 11])
+        )
+    )
+
+polymorphicClosureSpecializationCall :: BackendType -> BackendExpr -> BackendExpr
+polymorphicClosureSpecializationCall argTy arg =
+  BackendApp
+    intTy
+    (BackendTyApp (BTArrow argTy intTy) (BackendVar polymorphicClosureSpecializationTy "poly") argTy)
+    arg
 
 functionFieldProgram :: BackendProgram
 functionFieldProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -160,6 +160,20 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$direct_call_poly\""
     validateLLVMAssembly output
 
+  it "collects closure entries when direct type applications cross let heads" $ do
+    output <- requireRight (renderBackendProgramLLVM letHeadPolymorphicClosureCallProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"polyLocal$"
+    output `shouldSatisfy` isInfixOf "store ptr @\"polyLocal$"
+    output `shouldSatisfy` isInfixOf "$__mlfp_closure$direct_call_poly\""
+    validateLLVMAssembly output
+
+  it "lowers structurally matched closure call results" $ do
+    output <- requireRight (renderBackendProgramLLVM structuralClosureResultProgram)
+
+    output `shouldSatisfy` isInfixOf "__mlfp_closure$result_structural"
+    validateLLVMAssembly output
+
   it "instantiates direct polymorphic zero-arity expressions used through type application" $ do
     output <- requireRight (renderBackendProgramLLVM directPolymorphicZeroArityProgram)
 
@@ -2020,6 +2034,72 @@ directPolymorphicClosureCallExpr =
         )
     )
 
+letHeadPolymorphicClosureCallProgram :: BackendProgram
+letHeadPolymorphicClosureCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          ( BackendTyApp
+                              (BTArrow intTy intTy)
+                              ( BackendLet
+                                  localPolymorphicClosureEntryTy
+                                  "polyLocal"
+                                  localPolymorphicClosureEntryTy
+                                  directPolymorphicClosureCallExpr
+                                  (BackendVar localPolymorphicClosureEntryTy "polyLocal")
+                              )
+                              intTy
+                          )
+                          (intLit 3),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+structuralClosureResultProgram :: BackendProgram
+structuralClosureResultProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [resultBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = resultBoxStructuralTy,
+                      backendBindingExpr =
+                        BackendClosureCall
+                          resultBoxStructuralTy
+                          ( BackendClosure
+                              { backendExprType = BTArrow intTy resultBoxTy,
+                                backendClosureEntryName = "__mlfp_closure$result_structural",
+                                backendClosureCaptures = [],
+                                backendClosureParams = [("x", intTy)],
+                                backendClosureBody =
+                                  BackendConstruct resultBoxTy "ResultBox" [BackendVar intTy "x"]
+                              }
+                          )
+                          [intLit 3],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
 directPolymorphicZeroArityProgram :: BackendProgram
 directPolymorphicZeroArityProgram =
   BackendProgram
@@ -2614,6 +2694,14 @@ optionData =
         [ BackendConstructor "None" [] [] (optionTy (BTVar "a")),
           BackendConstructor "Some" [] [BTVar "a"] (optionTy (BTVar "a"))
         ]
+    }
+
+resultBoxData :: BackendData
+resultBoxData =
+  BackendData
+    { backendDataName = "ResultBox",
+      backendDataParameters = [],
+      backendDataConstructors = [BackendConstructor "ResultBox" [] [intTy] resultBoxTy]
     }
 
 nonePolyTy :: BackendType
@@ -3272,6 +3360,18 @@ stringTy =
 optionTy :: BackendType -> BackendType
 optionTy ty =
   BTCon (BaseTy "Option") (ty :| [])
+
+resultBoxTy :: BackendType
+resultBoxTy =
+  BTBase (BaseTy "ResultBox")
+
+resultBoxStructuralTy :: BackendType
+resultBoxStructuralTy =
+  BTMu "$ResultBox_self" (singleFieldStructuralBody intTy)
+
+singleFieldStructuralBody :: BackendType -> BackendType
+singleFieldStructuralBody fieldTy =
+  BTForall "r" Nothing (BTArrow (BTArrow fieldTy (BTVar "r")) (BTVar "r"))
 
 unaryIntTy :: BackendType
 unaryIntTy =


### PR DESCRIPTION
Closes #94.

## Implementation Plan

---
issue_number: 94
pr_number: 106
branch: codex/issue-94
---

**Implementation Plan**

1. Preserve the current branch/PR setup: work on `codex/issue-94` for PR #106, with `origin/HEAD` as the base. Before editing in implementation mode, reread the watcher-written issue plan and check `git status --short`.

2. Extend `MLF.Backend.IR` with an explicit closure representation, without changing `BackendProgram`/`BackendModule` shape:
   - Add a `BackendClosureCapture` record carrying capture name, capture type, and capture expression.
   - Add `BackendClosure` for closure construction: result source function type, debug-friendly entry name, captures, value parameters, and body.
   - Add `BackendClosureCall` for indirect closure calls, separate from existing direct `BackendApp` calls.
   - Add validation errors and checks for duplicate closure entry names, closure type/body/parameter agreement, capture arity/type agreement, closure call arity/type agreement, and unknown/invalid closure shapes.

3. Implement the LLVM closure ABI in `MLF.Backend.LLVM.Lower`:
   - Document `Note [Closure ABI]`: closure value is a heap `ptr` to two words, code pointer at offset 0 and environment pointer/null at offset 8; environment allocation is owned by the closure value and contains one machine word per captured runtime value; closure entry functions are private and take hidden `ptr env` before erased monomorphic runtime arguments.
   - Keep generic `BTArrow` lowering unsupported so existing escaping-lambda/direct-call rejection behavior does not silently broaden.
   - Collect closure entries from reachable monomorphic bindings, specializations, evidence wrappers, function wrappers, and nested closure expressions, then emit private LLVM functions with the supplied debug-friendly entry names.
   - Lower `BackendClosure` by evaluating captures, allocating/storing the env record, allocating/storing the closure record, and returning `LLVMPtr`.
   - Lower `BackendClosureCall` by evaluating the closure value, loading code/env pointers, lowering arguments, and emitting `LLVMCallOperand` with hidden env first.
   - Update all backend traversals in `Lower` for the new constructors: free vars, string collection, specialization/evidence/function wrapper collection, referenced-function collection, renaming, substitution, alias detection, and call dispatch.

4. Add focused tests:
   - `test/BackendIRSpec.hs`: positive validation for closure construction plus `BackendClosureCall`; negative cases for capture type mismatch, closure body/result mismatch, duplicate closure entry names, and closure call argument mismatch.
   - `test/BackendLLVMSpec.hs`: smoke tests for a zero-capture closure and a captured local-value closure call. Assert private closure entry names, `malloc`-backed closure/env allocation, stores/loads for code/env, indirect `call`, and LLVM assembly validation.
   - Keep existing first-order direct-call, partial-application, raw escaping-lambda, and function-field behavior covered; rename stale “until closure conversion exists” wording where it would now be misleading.

5. Update documentation near the backend boundary:
   - `docs/architecture.md`: replace the current “closure conversion outside current boundary” wording with the new explicit closure IR/LLVM ABI boundary and clarify that ADT-field closure conversion, partial application, and recursive higher-order flows remain future extension points.
   - `docs/mlfp-language-reference.md`: note that `emit-backend` still primarily covers the first-order surface, while backend IR now has an explicit closure ABI foundation for minimal smoke cases.

6. Validate and publish in implementation mode:
   - Run focused tests first: `cabal test mlf2-test --test-options='--match "MLF.Backend.IR"'` and `cabal test mlf2-test --test-options='--match "MLF.Backend.LLVM"'`.
   - Run the required full gate for behavior-changing backend work: `cabal build all && cabal test`.
   - Before committing, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, then push `codex/issue-94` to update PR #106.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.