### PR TITLE
Implement #99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- Added native LLVM toolchain runner support to the test harness. LLVM backend
+  tests can now discover `llc` plus a native linker, build a temporary
+  executable from emitted `.ll`, run it, and capture stdout, stderr, and exit
+  status while skipping explicitly when tools are unavailable.
+
 ### Changed
 - Eliminated the final temporary LLVM unsupported classification from the
   shared `ProgramSpec` runtime-success parity matrix. Stored first-order

--- a/README.md
+++ b/README.md
@@ -131,11 +131,13 @@ cabal run mlf2 -- emit-backend test/programs/unified/authoritative-let-polymorph
 
 Backend LLVM validation tests use LLVM command-line tools with opaque pointer
 support when available. The test suite looks for `llvm-as` and `llc` on `PATH`,
-with standard Homebrew LLVM locations also accepted on macOS; LLVM-dependent
-assertions are marked pending when the tools are absent, so `cabal test` can run
-in environments without LLVM while still exercising the checks wherever the tools
-are installed. LLVM 14 tools are run with `-opaque-pointers` when needed, while
-LLVM 15+ tools accept the emitted opaque-pointer IR by default.
+with standard Homebrew LLVM locations also accepted on macOS. Native executable
+runner tests additionally look for a C compiler/linker via `CC`, then `cc`,
+`clang`, or `gcc` on `PATH`. LLVM-dependent assertions are marked pending when
+required tools are absent, so `cabal test` can run in environments without LLVM
+or a native linker while still exercising the checks wherever the tools are
+installed. LLVM 14 tools are run with `-opaque-pointers` when needed, while LLVM
+15+ tools accept the emitted opaque-pointer IR by default.
 
 ## Syntax and paper alignment
 

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,9 +1,10 @@
 ## 2026-04-29 - Native LLVM toolchain runner harness
 
 - Extended `LLVMToolSupport` with native toolchain discovery for `llc` plus a
-  C compiler/linker selected from `CC`, `cc`, `clang`, or `gcc`. Missing pieces
-  mark the relevant Hspec examples pending instead of failing unrelated backend
-  tests.
+  C compiler/linker selected from `CC`, `cc`, `clang`, or `gcc`. The `CC`
+  value may be a command line such as `ccache clang` or `xcrun clang`, with
+  launcher arguments preserved after executable lookup. Missing pieces mark the
+  relevant Hspec examples pending instead of failing unrelated backend tests.
 - Added a temporary-build runner that lowers `.ll` to an object, links a native
   executable, runs it, captures stdout/stderr/exit status, and removes build
   products. The coverage is harness-only and does not define `.mlfp` result

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,14 @@
+## 2026-04-29 - Native LLVM toolchain runner harness
+
+- Extended `LLVMToolSupport` with native toolchain discovery for `llc` plus a
+  C compiler/linker selected from `CC`, `cc`, `clang`, or `gcc`. Missing pieces
+  mark the relevant Hspec examples pending instead of failing unrelated backend
+  tests.
+- Added a temporary-build runner that lowers `.ll` to an object, links a native
+  executable, runs it, captures stdout/stderr/exit status, and removes build
+  products. The coverage is harness-only and does not define `.mlfp` result
+  rendering semantics.
+
 ## 2026-04-29 - Final ProgramSpec-to-LLVM parity closure
 
 - Removed the last temporary LLVM unsupported classification from the shared

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -7,10 +7,13 @@ import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import System.Exit (ExitCode (..))
 import Test.Hspec
 
 import LLVMToolSupport
-  ( validateLLVMAssembly,
+  ( NativeRunResult (..),
+    runLLVMNativeExecutable,
+    validateLLVMAssembly,
     validateLLVMObjectCode,
     withTempProgram,
   )
@@ -52,6 +55,13 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "; mlf2 LLVM backend v0"
     output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
     validateLLVMAssembly output
+
+  it "runs a linked native executable and captures process output" $ do
+    result <- runLLVMNativeExecutable nativeOutputCaptureLLVM
+
+    nativeRunExitCode result `shouldBe` ExitFailure 7
+    nativeRunStdout result `shouldBe` "native stdout\n"
+    nativeRunStderr result `shouldBe` "native stderr\n"
 
   describe "shared ProgramSpec first-order parity" $ do
     it "keeps the selected shared first-order parity rows wired" $
@@ -641,6 +651,25 @@ simpleFunctionProgram =
     [ "module Main export (id, main) {",
       "  def id : Int -> Int = \\x x;",
       "  def main : Int = id 1;",
+      "}"
+    ]
+
+nativeOutputCaptureLLVM :: String
+nativeOutputCaptureLLVM =
+  unlines
+    [ "; mlf2 native runner smoke",
+      "source_filename = \"mlf2-native-runner-smoke\"",
+      "@\"stdout_text\" = private unnamed_addr constant [14 x i8] c\"native stdout\\0A\"",
+      "@\"stderr_text\" = private unnamed_addr constant [14 x i8] c\"native stderr\\0A\"",
+      "declare i64 @\"write\"(i32, ptr, i64)",
+      "",
+      "define i32 @\"main\"() {",
+      "entry:",
+      "  %\"stdout.ptr\" = getelementptr inbounds [14 x i8], ptr @\"stdout_text\", i64 0, i64 0",
+      "  %\"stderr.ptr\" = getelementptr inbounds [14 x i8], ptr @\"stderr_text\", i64 0, i64 0",
+      "  call i64 @\"write\"(i32 1, ptr %\"stdout.ptr\", i64 14)",
+      "  call i64 @\"write\"(i32 2, ptr %\"stderr.ptr\", i64 14)",
+      "  ret i32 7",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -12,6 +12,7 @@ import Test.Hspec
 
 import LLVMToolSupport
   ( NativeRunResult (..),
+    parseExecutableCommand,
     runLLVMNativeExecutable,
     validateLLVMAssembly,
     validateLLVMObjectCode,
@@ -62,6 +63,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     nativeRunExitCode result `shouldBe` ExitFailure 7
     nativeRunStdout result `shouldBe` "native stdout\n"
     nativeRunStderr result `shouldBe` "native stderr\n"
+
+  it "parses CC launchers and flags before executable lookup" $ do
+    parseExecutableCommand "ccache clang -m64"
+      `shouldBe` Just ("ccache", ["clang", "-m64"])
+    parseExecutableCommand "xcrun clang"
+      `shouldBe` Just ("xcrun", ["clang"])
+    parseExecutableCommand "\"/opt/LLVM Tools/bin/clang\" -fuse-ld=lld"
+      `shouldBe` Just ("/opt/LLVM Tools/bin/clang", ["-fuse-ld=lld"])
+    parseExecutableCommand "'/opt/LLVM Tools/bin/clang' '-Wl,-dead_strip'"
+      `shouldBe` Just ("/opt/LLVM Tools/bin/clang", ["-Wl,-dead_strip"])
+    parseExecutableCommand "\"unterminated"
+      `shouldBe` Nothing
 
   describe "shared ProgramSpec first-order parity" $ do
     it "keeps the selected shared first-order parity rows wired" $

--- a/test/LLVMToolSupport.hs
+++ b/test/LLVMToolSupport.hs
@@ -1,7 +1,9 @@
 module LLVMToolSupport
     ( LLVMToolchain (..)
     , NativeRunResult (..)
+    , ToolCommand (..)
     , discoverNativeLLVMToolchain
+    , parseExecutableCommand
     , runLLVMNativeExecutable
     , validateLLVMAssembly
     , validateLLVMObjectCode
@@ -11,6 +13,7 @@ module LLVMToolSupport
 
 import Control.Exception (bracket)
 import Control.Monad (filterM)
+import Data.Char (isSpace)
 import System.Directory
     ( createDirectory
     , doesFileExist
@@ -28,7 +31,13 @@ import Test.Hspec
 
 data LLVMToolchain = LLVMToolchain
     { llvmToolchainLlc :: FilePath
-    , llvmToolchainNativeLinker :: FilePath
+    , llvmToolchainNativeLinker :: ToolCommand
+    }
+    deriving (Eq, Show)
+
+data ToolCommand = ToolCommand
+    { toolCommandExecutable :: FilePath
+    , toolCommandArguments :: [String]
     }
     deriving (Eq, Show)
 
@@ -131,7 +140,10 @@ runLLVMNativeExecutableWith toolchain output =
         expectProcessSuccess "llc rejected native-runner LLVM input" llcExitCode "" llcStderr
 
         (linkExitCode, linkStdout, linkStderr) <-
-            readProcessWithExitCode nativeLinker [objectPath, "-o", executablePath] ""
+            readProcessWithExitCode
+                (toolCommandExecutable nativeLinker)
+                (toolCommandArguments nativeLinker ++ [objectPath, "-o", executablePath])
+                ""
         expectProcessSuccess "native linker rejected LLVM object" linkExitCode linkStdout linkStderr
 
         (runExitCode, runStdout, runStderr) <- readProcessWithExitCode executablePath [] ""
@@ -184,17 +196,30 @@ findLLVMTool name = do
                 Just path -> pure (Just path)
                 Nothing -> findKnownLLVMTool name knownLLVMToolPaths
 
-findNativeLinker :: IO (Maybe FilePath)
+findNativeLinker :: IO (Maybe ToolCommand)
 findNativeLinker = do
-    mbEnvCandidate <- findEnvExecutable ["CC"]
+    mbEnvCandidate <- findEnvToolCommand ["CC"]
     case mbEnvCandidate of
-        Just path -> pure (Just path)
-        Nothing -> firstJustM findExecutable ["cc", "clang", "gcc"]
+        Just command -> pure (Just command)
+        Nothing -> firstJustM findExecutableToolCommand ["cc", "clang", "gcc"]
 
 findEnvExecutable :: [String] -> IO (Maybe FilePath)
 findEnvExecutable names = do
     values <- traverse lookupEnv names
     firstJustM resolveExecutableCandidate [path | Just path <- values]
+
+findEnvToolCommand :: [String] -> IO (Maybe ToolCommand)
+findEnvToolCommand names = do
+    values <- traverse lookupEnv names
+    firstJustM resolveExecutableCommandCandidate [path | Just path <- values]
+
+resolveExecutableCommandCandidate :: String -> IO (Maybe ToolCommand)
+resolveExecutableCommandCandidate candidate =
+    case parseExecutableCommand candidate of
+        Nothing -> pure Nothing
+        Just (executable, arguments) -> do
+            mbPath <- resolveExecutableCandidate executable
+            pure $ fmap (`ToolCommand` arguments) mbPath
 
 resolveExecutableCandidate :: FilePath -> IO (Maybe FilePath)
 resolveExecutableCandidate candidate
@@ -206,6 +231,62 @@ resolveExecutableCandidate candidate
                 else Nothing
     | otherwise =
         findExecutable candidate
+
+findExecutableToolCommand :: FilePath -> IO (Maybe ToolCommand)
+findExecutableToolCommand candidate =
+    fmap (`ToolCommand` []) <$> findExecutable candidate
+
+parseExecutableCommand :: String -> Maybe (FilePath, [String])
+parseExecutableCommand candidate =
+    case parseCommandWords candidate of
+        Just (executable : arguments) -> Just (executable, arguments)
+        _ -> Nothing
+
+parseCommandWords :: String -> Maybe [String]
+parseCommandWords = go False [] [] Unquoted
+  where
+    go inWord current wordsSoFar mode input =
+        case (mode, input) of
+            (Unquoted, []) -> Just (reverse (finishWord inWord current wordsSoFar))
+            (SingleQuoted, []) -> Nothing
+            (DoubleQuoted, []) -> Nothing
+            (Unquoted, char : rest)
+                | isSpace char ->
+                    go False [] (finishWord inWord current wordsSoFar) Unquoted rest
+                | char == '\'' ->
+                    go True current wordsSoFar SingleQuoted rest
+                | char == '"' ->
+                    go True current wordsSoFar DoubleQuoted rest
+                | char == '\\' ->
+                    escaped inWord current wordsSoFar Unquoted rest
+                | otherwise ->
+                    go True (char : current) wordsSoFar Unquoted rest
+            (SingleQuoted, char : rest)
+                | char == '\'' ->
+                    go True current wordsSoFar Unquoted rest
+                | otherwise ->
+                    go True (char : current) wordsSoFar SingleQuoted rest
+            (DoubleQuoted, char : rest)
+                | char == '"' ->
+                    go True current wordsSoFar Unquoted rest
+                | char == '\\' ->
+                    escaped inWord current wordsSoFar DoubleQuoted rest
+                | otherwise ->
+                    go True (char : current) wordsSoFar DoubleQuoted rest
+
+    escaped _ _ _ _ [] = Nothing
+    escaped _ current wordsSoFar mode (char : rest) =
+        go True (char : current) wordsSoFar mode rest
+
+    finishWord inWord current wordsSoFar =
+        if inWord
+            then reverse current : wordsSoFar
+            else wordsSoFar
+
+data QuoteMode
+    = Unquoted
+    | SingleQuoted
+    | DoubleQuoted
 
 firstJustM :: (a -> IO (Maybe b)) -> [a] -> IO (Maybe b)
 firstJustM _ [] = pure Nothing
@@ -229,7 +310,7 @@ findKnownLLVMTool name paths = do
         path : _ -> pure (Just path)
         [] -> pure Nothing
 
-missingTool :: String -> Maybe FilePath -> [String]
+missingTool :: String -> Maybe a -> [String]
 missingTool name mbPath =
     case mbPath of
         Just _ -> []

--- a/test/LLVMToolSupport.hs
+++ b/test/LLVMToolSupport.hs
@@ -1,5 +1,9 @@
 module LLVMToolSupport
-    ( validateLLVMAssembly
+    ( LLVMToolchain (..)
+    , NativeRunResult (..)
+    , discoverNativeLLVMToolchain
+    , runLLVMNativeExecutable
+    , validateLLVMAssembly
     , validateLLVMObjectCode
     , withTempLLVM
     , withTempProgram
@@ -7,13 +11,33 @@ module LLVMToolSupport
 
 import Control.Exception (bracket)
 import Control.Monad (filterM)
-import System.Directory (doesFileExist, findExecutable, getTemporaryDirectory, removeFile)
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , findExecutable
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    , removeFile
+    )
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
-import System.FilePath (takeFileName)
+import System.FilePath (isPathSeparator, takeFileName, (</>))
 import System.IO (hClose, hPutStr, openTempFile)
 import System.Process (readProcessWithExitCode)
 import Test.Hspec
+
+data LLVMToolchain = LLVMToolchain
+    { llvmToolchainLlc :: FilePath
+    , llvmToolchainNativeLinker :: FilePath
+    }
+    deriving (Eq, Show)
+
+data NativeRunResult = NativeRunResult
+    { nativeRunExitCode :: ExitCode
+    , nativeRunStdout :: String
+    , nativeRunStderr :: String
+    }
+    deriving (Eq, Show)
 
 validateLLVMAssembly :: String -> Expectation
 validateLLVMAssembly output = do
@@ -41,6 +65,34 @@ validateLLVMObjectCode output = do
                     ExitSuccess -> pure ()
                     ExitFailure _ -> expectationFailure ("llc rejected backend output:\n" ++ stderr)
 
+discoverNativeLLVMToolchain :: IO (Either [String] LLVMToolchain)
+discoverNativeLLVMToolchain = do
+    mbLlc <- findLLVMTool "llc"
+    mbNativeLinker <- findNativeLinker
+    pure $
+        case (mbLlc, mbNativeLinker) of
+            (Just llc, Just nativeLinker) ->
+                Right
+                    LLVMToolchain
+                        { llvmToolchainLlc = llc
+                        , llvmToolchainNativeLinker = nativeLinker
+                        }
+            _ ->
+                Left $
+                    missingTool "llc" mbLlc
+                        ++ missingTool
+                            "native C compiler/linker (set CC or install cc, clang, or gcc)"
+                            mbNativeLinker
+
+runLLVMNativeExecutable :: String -> IO NativeRunResult
+runLLVMNativeExecutable output = do
+    discovered <- discoverNativeLLVMToolchain
+    case discovered of
+        Left missing ->
+            skipMissingNativeToolchain missing
+        Right toolchain ->
+            runLLVMNativeExecutableWith toolchain output
+
 withTempLLVM :: String -> (FilePath -> IO a) -> IO a
 withTempLLVM output action = do
     tempDir <- getTemporaryDirectory
@@ -63,6 +115,46 @@ withTempProgram contents action = do
         hClose handle
         pure path
 
+runLLVMNativeExecutableWith :: LLVMToolchain -> String -> IO NativeRunResult
+runLLVMNativeExecutableWith toolchain output =
+    withTempLLVMBuildDirectory $ \buildDir -> do
+        let llvmPath = buildDir </> "program.ll"
+            objectPath = buildDir </> "program.o"
+            executablePath = buildDir </> "program"
+            llc = llvmToolchainLlc toolchain
+            nativeLinker = llvmToolchainNativeLinker toolchain
+
+        writeFile llvmPath output
+
+        (llcExitCode, llcStderr) <-
+            runLLVMTool llc ["-filetype=obj", "-o", objectPath, llvmPath]
+        expectProcessSuccess "llc rejected native-runner LLVM input" llcExitCode "" llcStderr
+
+        (linkExitCode, linkStdout, linkStderr) <-
+            readProcessWithExitCode nativeLinker [objectPath, "-o", executablePath] ""
+        expectProcessSuccess "native linker rejected LLVM object" linkExitCode linkStdout linkStderr
+
+        (runExitCode, runStdout, runStderr) <- readProcessWithExitCode executablePath [] ""
+        pure
+            NativeRunResult
+                { nativeRunExitCode = runExitCode
+                , nativeRunStdout = runStdout
+                , nativeRunStderr = runStderr
+                }
+
+withTempLLVMBuildDirectory :: (FilePath -> IO a) -> IO a
+withTempLLVMBuildDirectory action = do
+    tempDir <- getTemporaryDirectory
+    bracket (createTempLLVMBuildDirectory tempDir) removeDirectoryRecursive action
+
+createTempLLVMBuildDirectory :: FilePath -> IO FilePath
+createTempLLVMBuildDirectory tempDir = do
+    (path, handle) <- openTempFile tempDir "mlf2-llvm-native"
+    hClose handle
+    removeFile path
+    createDirectory path
+    pure path
+
 runLLVMTool :: FilePath -> [String] -> IO (ExitCode, String)
 runLLVMTool tool args = do
     (plainExitCode, _plainStdout, plainStderr) <- readProcessWithExitCode tool args ""
@@ -83,19 +175,45 @@ runLLVMTool tool args = do
 
 findLLVMTool :: String -> IO (Maybe FilePath)
 findLLVMTool name = do
-    envCandidates <- filterM doesFileExist =<< traverseMaybeEnv (toolEnvNames name)
-    case envCandidates of
-        path : _ -> pure (Just path)
-        [] -> do
+    mbEnvCandidate <- findEnvExecutable (toolEnvNames name)
+    case mbEnvCandidate of
+        Just path -> pure (Just path)
+        Nothing -> do
             result <- findExecutable name
             case result of
                 Just path -> pure (Just path)
                 Nothing -> findKnownLLVMTool name knownLLVMToolPaths
 
-traverseMaybeEnv :: [String] -> IO [FilePath]
-traverseMaybeEnv names = do
+findNativeLinker :: IO (Maybe FilePath)
+findNativeLinker = do
+    mbEnvCandidate <- findEnvExecutable ["CC"]
+    case mbEnvCandidate of
+        Just path -> pure (Just path)
+        Nothing -> firstJustM findExecutable ["cc", "clang", "gcc"]
+
+findEnvExecutable :: [String] -> IO (Maybe FilePath)
+findEnvExecutable names = do
     values <- traverse lookupEnv names
-    pure [path | Just path <- values]
+    firstJustM resolveExecutableCandidate [path | Just path <- values]
+
+resolveExecutableCandidate :: FilePath -> IO (Maybe FilePath)
+resolveExecutableCandidate candidate
+    | any isPathSeparator candidate = do
+        exists <- doesFileExist candidate
+        pure $
+            if exists
+                then Just candidate
+                else Nothing
+    | otherwise =
+        findExecutable candidate
+
+firstJustM :: (a -> IO (Maybe b)) -> [a] -> IO (Maybe b)
+firstJustM _ [] = pure Nothing
+firstJustM action (candidate : candidates) = do
+    result <- action candidate
+    case result of
+        Just _ -> pure result
+        Nothing -> firstJustM action candidates
 
 toolEnvNames :: String -> [String]
 toolEnvNames name =
@@ -110,6 +228,29 @@ findKnownLLVMTool name paths = do
     case existing of
         path : _ -> pure (Just path)
         [] -> pure Nothing
+
+missingTool :: String -> Maybe FilePath -> [String]
+missingTool name mbPath =
+    case mbPath of
+        Just _ -> []
+        Nothing -> [name]
+
+skipMissingNativeToolchain :: [String] -> IO a
+skipMissingNativeToolchain missing = do
+    pendingWith ("required native LLVM toolchain pieces not found: " ++ unwords missing)
+    fail "native LLVM toolchain unavailable"
+
+expectProcessSuccess :: String -> ExitCode -> String -> String -> IO ()
+expectProcessSuccess label exitCode stdout stderr =
+    case exitCode of
+        ExitSuccess -> pure ()
+        ExitFailure _ ->
+            expectationFailure $
+                label
+                    ++ ":\nstdout:\n"
+                    ++ stdout
+                    ++ "\nstderr:\n"
+                    ++ stderr
 
 knownLLVMToolPaths :: [FilePath]
 knownLLVMToolPaths =


### PR DESCRIPTION
Closes #99.

## Implementation Plan

---
issue_number: 99
pr_number: 107
branch: codex/issue-99
---

## Implementation Plan

1. Reconfirm the implementation turn is on `codex/issue-99` with PR #107 still targeting `master`, then inspect `git status --short` before editing.

2. Extend `test/LLVMToolSupport.hs` as the single harness owner for LLVM/native execution support:
   - Keep `validateLLVMAssembly`, `validateLLVMObjectCode`, `withTempLLVM`, and `withTempProgram` behavior intact.
   - Generalize tool discovery so existing `llvm-as`/`llc` lookup still honors `LLVM_AS`, `LLC`, `LLVM_LLC`, PATH, and Homebrew paths.
   - Add native linker discovery for `CC` first, then `cc`, `clang`, and `gcc` on PATH.
   - Add a small `LLVMToolchain`/missing-tool result shape and a helper that turns missing required tools into one explicit `pendingWith` skip message.
   - Add a `NativeRunResult` record containing `ExitCode`, stdout, and stderr.
   - Add a runner helper that writes `.ll` into a temporary build directory, invokes `llc -filetype=obj`, links the object with the discovered C compiler, runs the executable, captures stdout/stderr/exit code, and cleans the whole temp directory with `bracket`.
   - Reuse the existing opaque-pointer retry path for LLVM tool invocations. Build/link failures should be expectation failures with stderr; executable nonzero exit should be returned in `NativeRunResult`, not treated as a harness failure.

3. Add focused coverage in `test/BackendLLVMSpec.hs` without broadening parity rows or defining `.mlfp` result-rendering semantics:
   - Import the new runner helper and `System.Exit` constructors as needed.
   - Add a small spec near the existing LLVM tool smoke checks that compiles and runs a minimal LLVM module with a real `main`, asserts stdout/stderr capture and exit status, and is skipped explicitly if `llc` or the native linker is unavailable.
   - Optionally include a direct backend-rendered `main` smoke if it stays low-level and does not infer module-entry/result printing policy.

4. Update relevant guidance docs only for the new test harness capability:
   - Refresh the README LLVM validation paragraph to mention native executable runner discovery and skip behavior.
   - Add a short `implementation_notes.md` entry for the native LLVM toolchain runner support.
   - Add a concise `CHANGELOG.md` Unreleased bullet because this is meaningful test/back-end harness progress.

5. Validate in increasing scope:
   - Run a focused matcher for the new native runner spec.
   - Run the LLVM backend spec slice, e.g. `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.LLVM"'`.
   - Run the required full gate before completion: `cabal build all && cabal test`.

6. Before publishing, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as the configured `codex-watcher`, run `gh auth status` and `gh auth setup-git`, then push the existing `codex/issue-99` branch for PR #107. Do not create another PR and do not resolve PR review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.