### PR TITLE
Implement #100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Changed
+- Added a native LLVM emission contract for pure `.mlfp` entrypoints. The
+  backend can now emit an `i32 @main()` wrapper that renders supported
+  `Int`, `Bool`, and first-order ADT results to stdout, returns exit status
+  `0`, defines the backend-owned `__mlfp_and` runtime primitive for native
+  runs, and rejects unsupported native result shapes before execution.
 - Eliminated the final temporary LLVM unsupported classification from the
   shared `ProgramSpec` runtime-success parity matrix. Stored first-order
   function constructor fields now lower as function pointers, closed direct

--- a/README.md
+++ b/README.md
@@ -129,13 +129,33 @@ Emit LLVM IR for a checked program:
 cabal run mlf2 -- emit-backend test/programs/unified/authoritative-let-polymorphism.mlfp
 ```
 
+Emit LLVM IR with a native process entrypoint:
+
+```bash
+cabal run mlf2 -- emit-native test/programs/unified/authoritative-let-polymorphism.mlfp
+```
+
+`emit-backend` keeps the raw backend contract: the checked `.mlfp` `main`
+binding remains a module-qualified LLVM function such as `Main__main`.
+`emit-native` adds the process contract used by native execution tests. It emits
+a C ABI `i32 @main()` wrapper that calls the checked zero-argument `.mlfp`
+`main`, renders supported pure results to stdout with the same value text used
+by `run-program`, prints one trailing newline, writes no stderr on success, and
+returns exit status `0`. Native rendering currently supports `Int`, `Bool`, and
+first-order ADT results whose fields are recursively renderable. Function,
+polymorphic, `String`, unknown, and IO-like results are rejected before native
+run assertions use them. Native mode declares libc `malloc` and vararg `printf`
+and defines the backend-owned `__mlfp_and` primitive when no program binding owns
+that runtime name; broader IO behavior remains outside this pure contract.
+
 Backend LLVM validation tests use LLVM command-line tools with opaque pointer
-support when available. The test suite looks for `llvm-as` and `llc` on `PATH`,
-with standard Homebrew LLVM locations also accepted on macOS; LLVM-dependent
-assertions are marked pending when the tools are absent, so `cabal test` can run
-in environments without LLVM while still exercising the checks wherever the tools
-are installed. LLVM 14 tools are run with `-opaque-pointers` when needed, while
-LLVM 15+ tools accept the emitted opaque-pointer IR by default.
+support when available. The test suite looks for `llvm-as`, `llc`, and `lli` on
+`PATH`, with standard Homebrew LLVM locations also accepted on macOS;
+LLVM-dependent assertions are marked pending when the tools are absent, so
+`cabal test` can run in environments without LLVM while still exercising the
+checks wherever the tools are installed. LLVM 14 tools are run with
+`-opaque-pointers` when needed, while LLVM 15+ tools accept the emitted
+opaque-pointer IR by default.
 
 ## Syntax and paper alignment
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,7 @@ import System.Exit (die)
 
 import MLF.Program.CLI
     ( emitBackendFile
+    , emitNativeFile
     , programCliUsage
     , runProgramFile
     )
@@ -25,6 +26,10 @@ main = do
         ["emit-backend", path] ->
             emitBackendFile path >>= either die putStr
         ["emit-backend"] ->
+            die programCliUsage
+        ["emit-native", path] ->
+            emitNativeFile path >>= either die putStr
+        ["emit-native"] ->
             die programCliUsage
         ["--help"] ->
             putStrLn programCliUsage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,16 @@ have LLVM lowering. The LLVM backend is intentionally repo-local: `Syntax`
 models the small LLVM surface used by mlf2, `Lower` maps backend IR into that
 AST, and `Ppr` emits opaque-pointer LLVM IR text accepted by LLVM 15+ tools or
 LLVM 14-era tools run with `-opaque-pointers`.
+The backend has two emission contracts. Raw emission keeps the checked `.mlfp`
+`main` as an ordinary module-qualified LLVM function and is the stable IR
+inspection surface. Native emission adds a C ABI `i32 @main()` wrapper around a
+zero-argument checked `.mlfp` `main`, renders supported pure `Int`, `Bool`, and
+first-order ADT results to stdout using the same value text as `ProgramSpec`,
+prints one trailing newline, writes no stderr on success, and returns process
+exit status `0`. Native emission declares libc `malloc`/`printf` and emits
+backend-owned runtime definitions such as `__mlfp_and` when those names are not
+program bindings. Unsupported result types fail before native-run assertions,
+so the native process boundary does not invent source or IO semantics.
 Closure conversion, higher-order constructor fields, escaping lambdas, and
 final executable linking remain outside the current backend boundary. Those
 diagnostics do not weaken source inference, checking, module visibility, or

--- a/src/MLF/Backend/LLVM.hs
+++ b/src/MLF/Backend/LLVM.hs
@@ -5,7 +5,9 @@ Description : Real LLVM IR backend facade for checked .mlfp programs
 module MLF.Backend.LLVM
   ( BackendLLVMError (..),
     renderCheckedProgramLLVM,
+    renderCheckedProgramNativeLLVM,
     renderBackendProgramLLVM,
+    renderBackendProgramNativeLLVM,
     renderBackendLLVMError,
   )
 where
@@ -26,9 +28,18 @@ renderCheckedProgramLLVM checked =
   first BackendLLVMConversionFailed (convertCheckedProgram checked)
     >>= renderBackendProgramLLVM
 
+renderCheckedProgramNativeLLVM :: CheckedProgram -> Either BackendLLVMError String
+renderCheckedProgramNativeLLVM checked =
+  first BackendLLVMConversionFailed (convertCheckedProgram checked)
+    >>= renderBackendProgramNativeLLVM
+
 renderBackendProgramLLVM :: BackendProgram -> Either BackendLLVMError String
 renderBackendProgramLLVM program =
   first BackendLLVMLoweringFailed (renderLLVMModule <$> Lower.lowerBackendProgram program)
+
+renderBackendProgramNativeLLVM :: BackendProgram -> Either BackendLLVMError String
+renderBackendProgramNativeLLVM program =
+  first BackendLLVMLoweringFailed (renderLLVMModule <$> Lower.lowerBackendProgramNative program)
 
 data BackendLLVMError
   = BackendLLVMConversionFailed BackendConversionError

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -18,7 +18,7 @@ import Control.Monad (foldM, unless, when, zipWithM, zipWithM_)
 import Control.Monad.State.Strict (StateT (StateT), evalStateT, get, gets, modify)
 import Data.Bifunctor (first)
 import Data.Char (isAlphaNum, ord)
-import Data.List (intercalate, isPrefixOf, nub, sort, sortOn)
+import Data.List (intercalate, isPrefixOf, nub, sort, sortOn, stripPrefix)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -317,9 +317,12 @@ constructorNameGlobals base spec =
   case nativeDataRuntimeForTypeName (nrsType spec) of
     Nothing -> []
     Just dataName ->
-      [ LLVMStringGlobal (nativeConstructorGlobalName spec constructorRuntime) (displayConstructorName (backendConstructorName (crConstructor constructorRuntime)))
-      | constructorRuntime <- maybe [] drConstructors (Map.lookup dataName (pbData base))
-      ]
+      case Map.lookup dataName (pbData base) of
+        Nothing -> []
+        Just dataRuntime0 ->
+          [ LLVMStringGlobal (nativeConstructorGlobalName spec constructorRuntime) (displayConstructorName dataRuntime0 constructorRuntime)
+          | constructorRuntime <- drConstructors dataRuntime0
+          ]
 
 nativeDataRuntimeForTypeName :: BackendType -> Maybe String
 nativeDataRuntimeForTypeName =
@@ -621,28 +624,20 @@ callNativeRenderer renderMap ty llvmTy value parenthesize =
     Nothing ->
       liftEither (BackendLLVMUnsupportedExpression "native result rendering" ("missing renderer for " ++ show ty))
 
-displayConstructorName :: String -> String
-displayConstructorName runtimeName =
-  case stripModulePrefix runtimeName of
-    "" -> runtimeName
-    name -> name
-
-stripModulePrefix :: String -> String
-stripModulePrefix name =
-  go name
+displayConstructorName :: DataRuntime -> ConstructorRuntime -> String
+displayConstructorName dataRuntime0 constructorRuntime =
+  case runtimeModulePrefix (backendDataName (drData dataRuntime0)) >>= (`stripPrefix` runtimeName) of
+    Just displayName
+      | not (null displayName) -> displayName
+    _ -> runtimeName
   where
-    go remaining =
-      case breakDoubleUnderscore remaining of
-        Just rest -> go rest
-        Nothing -> remaining
+    runtimeName = backendConstructorName (crConstructor constructorRuntime)
 
-breakDoubleUnderscore :: String -> Maybe String
-breakDoubleUnderscore =
-  \case
-    [] -> Nothing
-    [_] -> Nothing
-    '_' : '_' : rest -> Just rest
-    _ : rest -> breakDoubleUnderscore rest
+runtimeModulePrefix :: String -> Maybe String
+runtimeModulePrefix qualifiedDataName0 =
+  case break (== '.') (reverse qualifiedDataName0) of
+    (_, []) -> Nothing
+    (_, _ : reversedModuleName) -> Just (reverse reversedModuleName ++ "__")
 
 shouldLowerReachableBinding :: Set String -> BindingInfo -> Bool
 shouldLowerReachableBinding referencedFunctionNames binding =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -9,6 +9,7 @@ module MLF.Backend.LLVM.Lower
     evidenceFunctionTypesCompatible,
     inferTypeArgumentsForTest,
     lowerBackendProgram,
+    lowerBackendProgramNative,
     renderBackendLLVMError,
   )
 where
@@ -49,8 +50,15 @@ data ProgramBase = ProgramBase
   { pbBindings :: Map String BindingInfo,
     pbBindingOrder :: [String],
     pbConstructors :: Map String ConstructorRuntime,
+    pbData :: Map String DataRuntime,
     pbDataNames :: Set String
   }
+
+data DataRuntime = DataRuntime
+  { drData :: BackendData,
+    drConstructors :: [ConstructorRuntime]
+  }
+  deriving (Eq, Show)
 
 data ProgramEnv = ProgramEnv
   { peBase :: ProgramBase,
@@ -111,6 +119,19 @@ data FunctionWrapper = FunctionWrapper
   }
   deriving (Eq, Show)
 
+data LoweredProgram = LoweredProgram
+  { lpBase :: ProgramBase,
+    lpEnv :: ProgramEnv,
+    lpMainBinding :: BindingInfo,
+    lpFunctions :: [LLVMFunction]
+  }
+
+data NativeRenderSpec = NativeRenderSpec
+  { nrsType :: BackendType,
+    nrsFunctionName :: String
+  }
+  deriving (Eq, Show)
+
 data LowerValue = LowerValue
   { lvBackendType :: BackendType,
     lvLLVMType :: LLVMType,
@@ -145,6 +166,21 @@ type LowerM = StateT FunctionState (Either BackendLLVMError)
 
 lowerBackendProgram :: BackendProgram -> Either BackendLLVMError LLVMModule
 lowerBackendProgram program = do
+  lowered <- lowerBackendProgramCore program
+  pure
+    LLVMModule
+      { llvmModuleGlobals = rawLLVMGlobals lowered,
+        llvmModuleDeclarations = runtimeDeclarations (lpBase lowered),
+        llvmModuleFunctions = lpFunctions lowered
+      }
+
+lowerBackendProgramNative :: BackendProgram -> Either BackendLLVMError LLVMModule
+lowerBackendProgramNative program = do
+  lowered <- lowerBackendProgramCore program
+  lowerNativeProgram lowered
+
+lowerBackendProgramCore :: BackendProgram -> Either BackendLLVMError LoweredProgram
+lowerBackendProgramCore program = do
   first BackendLLVMValidationFailed (validateBackendProgram program)
   base <- buildProgramBase program
   reachable <- reachableBindings base (backendProgramMain program)
@@ -173,12 +209,440 @@ lowerBackendProgram program = do
   when (not (null (ffTypeBinders (biForm mainBinding)))) $
     Left (BackendLLVMUnsupportedExpression "program main" "polymorphic main binding")
   pure
-    LLVMModule
-      { llvmModuleGlobals =
-          [LLVMStringGlobal globalName value | (value, globalName) <- Map.toAscList stringGlobals],
-        llvmModuleDeclarations = runtimeDeclarations base,
-        llvmModuleFunctions = functions
+    LoweredProgram
+      { lpBase = base,
+        lpEnv = env,
+        lpMainBinding = mainBinding,
+        lpFunctions = functions
       }
+
+rawLLVMGlobals :: LoweredProgram -> [LLVMGlobal]
+rawLLVMGlobals lowered =
+  [LLVMStringGlobal globalName value | (value, globalName) <- Map.toAscList (peStringGlobals (lpEnv lowered))]
+
+lowerNativeProgram :: LoweredProgram -> Either BackendLLVMError LLVMModule
+lowerNativeProgram lowered = do
+  let base = lpBase lowered
+      env = lpEnv lowered
+      mainBinding = lpMainBinding lowered
+      mainForm = biForm mainBinding
+  unless (null (ffParams mainForm)) $
+    Left (BackendLLVMUnsupportedExpression "native process main" "main must be a zero-argument pure value")
+  renderSpecs <- collectNativeRenderSpecs base (ffReturnType mainForm)
+  rejectNativeSymbolConflicts base renderSpecs
+  let renderMap = Map.fromList [(backendTypeKey (nrsType spec), nrsFunctionName spec) | spec <- renderSpecs]
+  renderers <- traverse (lowerNativeRenderer env renderMap) renderSpecs
+  entrypoint <- lowerNativeEntrypoint env mainBinding renderMap
+  pure
+    LLVMModule
+      { llvmModuleGlobals = rawLLVMGlobals lowered ++ nativeGlobals base renderSpecs,
+        llvmModuleDeclarations = nativeRuntimeDeclarations base,
+        llvmModuleFunctions =
+          lpFunctions lowered
+            ++ nativeRuntimeFunctions base
+            ++ renderers
+            ++ [entrypoint]
+      }
+
+nativeRuntimeDeclarations :: ProgramBase -> [LLVMDeclaration]
+nativeRuntimeDeclarations base =
+  [ LLVMDeclaration runtimeMallocName LLVMPtr [LLVMInt 64] False
+    | Map.notMember runtimeMallocName (pbBindings base)
+  ]
+    ++ [LLVMDeclaration nativePrintfName (LLVMInt 32) [LLVMPtr] True]
+
+nativeRuntimeFunctions :: ProgramBase -> [LLVMFunction]
+nativeRuntimeFunctions base =
+  [nativeAndFunction | Map.notMember runtimeAndName (pbBindings base)]
+
+nativeCMainName :: String
+nativeCMainName =
+  "main"
+
+nativePrintfName :: String
+nativePrintfName =
+  "printf"
+
+nativeRenderPrefix :: String
+nativeRenderPrefix =
+  "__mlfp_native_render$"
+
+nativeFmtIntName :: String
+nativeFmtIntName =
+  "__mlfp_native_fmt_i64"
+
+nativeFmtStringName :: String
+nativeFmtStringName =
+  "__mlfp_native_fmt_str"
+
+nativeStrTrueName :: String
+nativeStrTrueName =
+  "__mlfp_native_str_true"
+
+nativeStrFalseName :: String
+nativeStrFalseName =
+  "__mlfp_native_str_false"
+
+nativeStrNewlineName :: String
+nativeStrNewlineName =
+  "__mlfp_native_str_newline"
+
+nativeStrSpaceName :: String
+nativeStrSpaceName =
+  "__mlfp_native_str_space"
+
+nativeStrOpenParenName :: String
+nativeStrOpenParenName =
+  "__mlfp_native_str_open_paren"
+
+nativeStrCloseParenName :: String
+nativeStrCloseParenName =
+  "__mlfp_native_str_close_paren"
+
+nativeGlobals :: ProgramBase -> [NativeRenderSpec] -> [LLVMGlobal]
+nativeGlobals base renderSpecs =
+  [ LLVMStringGlobal nativeFmtIntName "%ld",
+    LLVMStringGlobal nativeFmtStringName "%s",
+    LLVMStringGlobal nativeStrTrueName "true",
+    LLVMStringGlobal nativeStrFalseName "false",
+    LLVMStringGlobal nativeStrNewlineName "\n",
+    LLVMStringGlobal nativeStrSpaceName " ",
+    LLVMStringGlobal nativeStrOpenParenName "(",
+    LLVMStringGlobal nativeStrCloseParenName ")"
+  ]
+    ++ concatMap (constructorNameGlobals base) renderSpecs
+
+constructorNameGlobals :: ProgramBase -> NativeRenderSpec -> [LLVMGlobal]
+constructorNameGlobals base spec =
+  case nativeDataRuntimeForTypeName (nrsType spec) of
+    Nothing -> []
+    Just dataName ->
+      [ LLVMStringGlobal (nativeConstructorGlobalName spec constructorRuntime) (displayConstructorName (backendConstructorName (crConstructor constructorRuntime)))
+      | constructorRuntime <- maybe [] drConstructors (Map.lookup dataName (pbData base))
+      ]
+
+nativeDataRuntimeForTypeName :: BackendType -> Maybe String
+nativeDataRuntimeForTypeName =
+  \case
+    BTBase (BaseTy name) -> Just name
+    BTCon (BaseTy name) _ -> Just name
+    BTMu name _ -> structuralMuDataName name
+    _ -> Nothing
+
+nativeConstructorGlobalName :: NativeRenderSpec -> ConstructorRuntime -> String
+nativeConstructorGlobalName spec constructorRuntime =
+  "__mlfp_native_ctor$" ++ backendTypeKey (nrsType spec) ++ "$" ++ show (crTag constructorRuntime)
+
+nativeRendererName :: BackendType -> String
+nativeRendererName ty =
+  nativeRenderPrefix ++ backendTypeKey ty
+
+rejectNativeSymbolConflicts :: ProgramBase -> [NativeRenderSpec] -> Either BackendLLVMError ()
+rejectNativeSymbolConflicts base renderSpecs =
+  case [name | name <- Map.keys (pbBindings base), nativeNameConflicts name] of
+    name : _ ->
+      Left (BackendLLVMUnsupportedExpression "native process" ("reserved native LLVM symbol " ++ show name))
+    [] -> Right ()
+  where
+    reservedNames =
+      Set.fromList
+        ( [ nativeCMainName,
+            nativePrintfName,
+            nativeFmtIntName,
+            nativeFmtStringName,
+            nativeStrTrueName,
+            nativeStrFalseName,
+            nativeStrNewlineName,
+            nativeStrSpaceName,
+            nativeStrOpenParenName,
+            nativeStrCloseParenName
+          ]
+            ++ map nrsFunctionName renderSpecs
+        )
+
+    nativeNameConflicts name =
+      Set.member name reservedNames
+        || nativeRenderPrefix `isPrefixOf` name
+        || "__mlfp_native_" `isPrefixOf` name
+
+collectNativeRenderSpecs :: ProgramBase -> BackendType -> Either BackendLLVMError [NativeRenderSpec]
+collectNativeRenderSpecs base rootTy =
+  reverse . fst <$> go Set.empty [] rootTy
+  where
+    go seen specs ty
+      | Set.member key seen = Right (specs, seen)
+      | otherwise =
+          case nativeRenderableKind base ty of
+            NativeScalar ->
+              Right (NativeRenderSpec ty (nativeRendererName ty) : specs, Set.insert key seen)
+            NativeData dataRuntime0 -> do
+              let seen' = Set.insert key seen
+                  spec = NativeRenderSpec ty (nativeRendererName ty)
+              foldM (collectConstructorFields ty) (spec : specs, seen') (drConstructors dataRuntime0)
+            NativeUnsupported detail ->
+              Left (BackendLLVMUnsupportedExpression "native result rendering" detail)
+      where
+        key = backendTypeKey ty
+
+    collectConstructorFields resultTy (specs, seen) constructorRuntime = do
+      fieldTys <-
+        case constructorRuntimeFieldTypes constructorRuntime resultTy of
+          Just tys -> Right tys
+          Nothing ->
+            Left
+              ( BackendLLVMUnsupportedExpression
+                  "native result rendering"
+                  ("could not match constructor result for " ++ backendConstructorName (crConstructor constructorRuntime))
+              )
+      foldM
+        ( \(specsAcc, seenAcc) fieldTy -> do
+            go seenAcc specsAcc fieldTy
+        )
+        (specs, seen)
+        fieldTys
+
+data NativeRenderableKind
+  = NativeScalar
+  | NativeData DataRuntime
+  | NativeUnsupported String
+
+nativeRenderableKind :: ProgramBase -> BackendType -> NativeRenderableKind
+nativeRenderableKind base ty =
+  case ty of
+    BTBase (BaseTy "Int") -> NativeScalar
+    BTBase (BaseTy "Bool") -> NativeScalar
+    BTBase (BaseTy "String") -> NativeUnsupported "String main values are not supported by native result rendering yet"
+    BTBase (BaseTy name) ->
+      maybe (NativeUnsupported ("unknown native result type " ++ show name)) NativeData (Map.lookup name (pbData base))
+    BTCon (BaseTy name) _ ->
+      maybe (NativeUnsupported ("unknown native result type " ++ show name)) NativeData (Map.lookup name (pbData base))
+    BTArrow {} -> NativeUnsupported "function main values are not native-renderable"
+    BTForall {} -> NativeUnsupported "polymorphic main values are not native-renderable"
+    BTVar {} -> NativeUnsupported "type-variable main values are not native-renderable"
+    BTVarApp {} -> NativeUnsupported "variable-headed main values are not native-renderable"
+    BTMu name _ ->
+      case structuralMuDataName name >>= (`Map.lookup` pbData base) of
+        Just dataRuntime0 -> NativeData dataRuntime0
+        Nothing -> NativeUnsupported "structural recursive main values are not native-renderable"
+    BTBottom -> NativeUnsupported "bottom main values are not native-renderable"
+
+lowerNativeRenderer :: ProgramEnv -> Map String String -> NativeRenderSpec -> Either BackendLLVMError LLVMFunction
+lowerNativeRenderer env renderMap spec =
+  case nativeRenderableKind (peBase env) (nrsType spec) of
+    NativeScalar ->
+      lowerNativeScalarRenderer spec
+    NativeData dataRuntime0 ->
+      lowerNativeDataRenderer env renderMap spec dataRuntime0
+    NativeUnsupported detail ->
+      Left (BackendLLVMUnsupportedExpression "native result rendering" detail)
+
+lowerNativeScalarRenderer :: NativeRenderSpec -> Either BackendLLVMError LLVMFunction
+lowerNativeScalarRenderer spec =
+  case nrsType spec of
+    BTBase (BaseTy "Int") ->
+      lowerNativeFunction
+        (nrsFunctionName spec)
+        (LLVMInt 32)
+        [(LLVMInt 64, "value"), (LLVMInt 1, "parenthesize")]
+        $ \params -> do
+          let value = requireNativeParam "value" params
+          _ <- emitPrintf nativeFmtIntName [(LLVMInt 64, value)]
+          finishNativeSuccess
+    BTBase (BaseTy "Bool") ->
+      lowerNativeFunction
+        (nrsFunctionName spec)
+        (LLVMInt 32)
+        [(LLVMInt 1, "value"), (LLVMInt 1, "parenthesize")]
+        $ \params -> do
+          let value = requireNativeParam "value" params
+          trueLabel <- freshBlock "bool.true"
+          falseLabel <- freshBlock "bool.false"
+          finishCurrentBlock (LLVMSwitch (LLVMInt 1) value falseLabel [(1, trueLabel)])
+          startBlock trueLabel
+          _ <- emitPrintStringGlobal nativeStrTrueName
+          finishNativeSuccess
+          startBlock falseLabel
+          _ <- emitPrintStringGlobal nativeStrFalseName
+          finishNativeSuccess
+    _ ->
+      Left (BackendLLVMUnsupportedExpression "native result rendering" ("unsupported scalar renderer " ++ show (nrsType spec)))
+
+lowerNativeDataRenderer :: ProgramEnv -> Map String String -> NativeRenderSpec -> DataRuntime -> Either BackendLLVMError LLVMFunction
+lowerNativeDataRenderer env renderMap spec dataRuntime0 =
+  lowerNativeFunction
+    (nrsFunctionName spec)
+    (LLVMInt 32)
+    [(LLVMPtr, "value"), (LLVMInt 1, "parenthesize")]
+    $ \params -> do
+      let value = requireNativeParam "value" params
+          parenthesize = requireNativeParam "parenthesize" params
+      tagPtr <- emitGep "native.tag.ptr" value 0
+      tagValue <- emitAssign "native.tag" (LLVMInt 64) (LLVMLoad (LLVMInt 64) tagPtr)
+      altLabels <- traverse (const (freshBlock "native.ctor")) (drConstructors dataRuntime0)
+      defaultLabel <- freshBlock "native.unknown"
+      let switchTargets = [(crTag constructorRuntime, label) | (constructorRuntime, label) <- zip (drConstructors dataRuntime0) altLabels]
+      finishCurrentBlock (LLVMSwitch (LLVMInt 64) tagValue defaultLabel switchTargets)
+      zipWithM_ (lowerNativeConstructorRenderer env renderMap spec value parenthesize) (drConstructors dataRuntime0) altLabels
+      startBlock defaultLabel
+      finishCurrentBlock LLVMUnreachable
+
+lowerNativeConstructorRenderer ::
+  ProgramEnv ->
+  Map String String ->
+  NativeRenderSpec ->
+  LLVMOperand ->
+  LLVMOperand ->
+  ConstructorRuntime ->
+  String ->
+  LowerM ()
+lowerNativeConstructorRenderer env renderMap spec value parenthesize constructorRuntime label = do
+  fieldTys <-
+    case constructorRuntimeFieldTypes constructorRuntime (nrsType spec) of
+      Just tys -> pure tys
+      Nothing ->
+        liftEither
+          ( BackendLLVMUnsupportedExpression
+              "native result rendering"
+              ("could not match constructor result for " ++ backendConstructorName (crConstructor constructorRuntime))
+          )
+  startBlock label
+  if null fieldTys
+    then do
+      _ <- emitPrintStringGlobal (nativeConstructorGlobalName spec constructorRuntime)
+      finishNativeSuccess
+    else do
+      openLabel <- freshBlock "native.open"
+      bodyLabel <- freshBlock "native.body"
+      finishCurrentBlock (LLVMSwitch (LLVMInt 1) parenthesize bodyLabel [(1, openLabel)])
+      startBlock openLabel
+      _ <- emitPrintStringGlobal nativeStrOpenParenName
+      finishCurrentBlock (LLVMBr bodyLabel)
+      startBlock bodyLabel
+      _ <- emitPrintStringGlobal (nativeConstructorGlobalName spec constructorRuntime)
+      zipWithM_ (printField fieldTys) [0 :: Int ..] fieldTys
+      closeLabel <- freshBlock "native.close"
+      doneLabel <- freshBlock "native.done"
+      finishCurrentBlock (LLVMSwitch (LLVMInt 1) parenthesize doneLabel [(1, closeLabel)])
+      startBlock closeLabel
+      _ <- emitPrintStringGlobal nativeStrCloseParenName
+      finishNativeSuccess
+      startBlock doneLabel
+      finishNativeSuccess
+  where
+    printField _ index0 fieldTy = do
+      _ <- emitPrintStringGlobal nativeStrSpaceName
+      fieldLLVMType <- lowerBackendTypeM env "native result field" fieldTy
+      fieldPtr <- emitGep "native.field.ptr" value (8 * (index0 + 1))
+      fieldValue <- emitAssign "native.field" fieldLLVMType (LLVMLoad fieldLLVMType fieldPtr)
+      callNativeRenderer renderMap fieldTy fieldLLVMType fieldValue (nativeFieldParenthesize (peBase env) fieldTy)
+
+nativeFieldParenthesize :: ProgramBase -> BackendType -> Bool
+nativeFieldParenthesize base ty =
+  case nativeRenderableKind base ty of
+    NativeData {} -> True
+    _ -> False
+
+lowerNativeEntrypoint :: ProgramEnv -> BindingInfo -> Map String String -> Either BackendLLVMError LLVMFunction
+lowerNativeEntrypoint env mainBinding renderMap =
+  lowerNativeFunction nativeCMainName (LLVMInt 32) [] $ \_ -> do
+    let mainForm = biForm mainBinding
+    mainLLVMType <- lowerBackendTypeM env "native process main result" (ffReturnType mainForm)
+    mainValue <- emitAssign "native.main" mainLLVMType (LLVMCall (biName mainBinding) [])
+    callNativeRenderer renderMap (ffReturnType mainForm) mainLLVMType mainValue False
+    _ <- emitPrintStringGlobal nativeStrNewlineName
+    finishNativeSuccess
+
+nativeAndFunction :: LLVMFunction
+nativeAndFunction =
+  case
+    lowerNativeFunction runtimeAndName (LLVMInt 1) [(LLVMInt 1, "left"), (LLVMInt 1, "right")] $ \params -> do
+      result <- emitAssign "and" (LLVMInt 1) (LLVMAnd (requireNativeParam "left" params) (requireNativeParam "right" params))
+      finishCurrentBlock (LLVMRet (LLVMInt 1) result)
+  of
+    Right function -> function
+    Left err -> error ("internal native __mlfp_and lowering failed: " ++ renderBackendLLVMError err)
+
+lowerNativeFunction ::
+  String ->
+  LLVMType ->
+  [(LLVMType, String)] ->
+  (Map String LLVMOperand -> LowerM ()) ->
+  Either BackendLLVMError LLVMFunction
+lowerNativeFunction name returnTy params buildBody = do
+  blocks <- evalStateT (buildBody paramOperands >> gets (reverse . fsCompletedBlocks)) initialFunctionState
+  pure
+    LLVMFunction
+      { llvmFunctionName = name,
+        llvmFunctionPrivate = name /= nativeCMainName && name /= runtimeAndName,
+        llvmFunctionReturnType = returnTy,
+        llvmFunctionParameters = [LLVMParameter ty paramName | (ty, paramName) <- params],
+        llvmFunctionBlocks = blocks
+      }
+  where
+    paramOperands =
+      Map.fromList [(paramName, LLVMLocal ty paramName) | (ty, paramName) <- params]
+
+finishNativeSuccess :: LowerM ()
+finishNativeSuccess =
+  finishCurrentBlock (LLVMRet (LLVMInt 32) (LLVMIntLiteral 32 0))
+
+requireNativeParam :: String -> Map String LLVMOperand -> LLVMOperand
+requireNativeParam name params =
+  case Map.lookup name params of
+    Just operand -> operand
+    Nothing -> error ("internal native parameter missing: " ++ name)
+
+emitPrintf :: String -> [(LLVMType, LLVMOperand)] -> LowerM LLVMOperand
+emitPrintf formatGlobal args =
+  emitAssign
+    "printf"
+    (LLVMInt 32)
+    (LLVMCall nativePrintfName ((LLVMPtr, LLVMGlobalRef LLVMPtr formatGlobal) : args))
+
+emitPrintStringGlobal :: String -> LowerM LLVMOperand
+emitPrintStringGlobal globalName =
+  emitPrintf nativeFmtStringName [(LLVMPtr, LLVMGlobalRef LLVMPtr globalName)]
+
+callNativeRenderer :: Map String String -> BackendType -> LLVMType -> LLVMOperand -> Bool -> LowerM ()
+callNativeRenderer renderMap ty llvmTy value parenthesize =
+  case Map.lookup (backendTypeKey ty) renderMap of
+    Just renderName -> do
+      _ <-
+        emitAssign
+          "render"
+          (LLVMInt 32)
+          ( LLVMCall
+              renderName
+              [ (llvmTy, value),
+                (LLVMInt 1, LLVMIntLiteral 1 (if parenthesize then 1 else 0))
+              ]
+          )
+      pure ()
+    Nothing ->
+      liftEither (BackendLLVMUnsupportedExpression "native result rendering" ("missing renderer for " ++ show ty))
+
+displayConstructorName :: String -> String
+displayConstructorName runtimeName =
+  case stripModulePrefix runtimeName of
+    "" -> runtimeName
+    name -> name
+
+stripModulePrefix :: String -> String
+stripModulePrefix name =
+  go name
+  where
+    go remaining =
+      case breakDoubleUnderscore remaining of
+        Just rest -> go rest
+        Nothing -> remaining
+
+breakDoubleUnderscore :: String -> Maybe String
+breakDoubleUnderscore =
+  \case
+    [] -> Nothing
+    [_] -> Nothing
+    '_' : '_' : rest -> Just rest
+    _ : rest -> breakDoubleUnderscore rest
 
 shouldLowerReachableBinding :: Set String -> BindingInfo -> Bool
 shouldLowerReachableBinding referencedFunctionNames binding =
@@ -274,10 +738,10 @@ runtimeMallocName =
 
 runtimeDeclarations :: ProgramBase -> [LLVMDeclaration]
 runtimeDeclarations base =
-  [ LLVMDeclaration runtimeMallocName LLVMPtr [LLVMInt 64]
+  [ LLVMDeclaration runtimeMallocName LLVMPtr [LLVMInt 64] False
     | Map.notMember runtimeMallocName (pbBindings base)
   ]
-    ++ [ LLVMDeclaration runtimeAndName (LLVMInt 1) [LLVMInt 1, LLVMInt 1]
+    ++ [ LLVMDeclaration runtimeAndName (LLVMInt 1) [LLVMInt 1, LLVMInt 1] False
          | Map.notMember runtimeAndName (pbBindings base)
        ]
 
@@ -297,11 +761,14 @@ buildProgramBase program = do
       bindingInfos = map bindingInfo bindings
       constructors =
         concatMap constructorRuntimes dataDecls
+      dataRuntimes =
+        map dataRuntime dataDecls
   pure
         ProgramBase
           { pbBindings = Map.fromList [(biName info, info) | info <- bindingInfos],
             pbBindingOrder = map biName bindingInfos,
             pbConstructors = Map.fromList [(backendConstructorName (crConstructor ctor), ctor) | ctor <- constructors],
+            pbData = Map.fromList [(backendDataName (drData dataRuntime0), dataRuntime0) | dataRuntime0 <- dataRuntimes],
             pbDataNames = Set.fromList (map backendDataName dataDecls)
           }
 
@@ -322,6 +789,13 @@ constructorRuntimes dataDecl =
       }
   | (tag, constructor) <- zip [0 ..] (backendDataConstructors dataDecl)
   ]
+
+dataRuntime :: BackendData -> DataRuntime
+dataRuntime dataDecl =
+  DataRuntime
+    { drData = dataDecl,
+      drConstructors = constructorRuntimes dataDecl
+    }
 
 functionFormFromExpr :: BackendExpr -> FunctionForm
 functionFormFromExpr expr =

--- a/src/MLF/Backend/LLVM/Ppr.hs
+++ b/src/MLF/Backend/LLVM/Ppr.hs
@@ -56,8 +56,12 @@ renderLLVMDeclaration declaration =
     ++ " "
     ++ renderLLVMGlobalName (llvmDeclarationName declaration)
     ++ "("
-    ++ intercalate ", " (map renderLLVMType (llvmDeclarationParameters declaration))
+    ++ intercalate ", " (map renderLLVMType (llvmDeclarationParameters declaration) ++ varArgParameter)
     ++ ")"
+  where
+    varArgParameter
+      | llvmDeclarationVarArgs declaration = ["..."]
+      | otherwise = []
 
 renderLLVMFunctionLines :: LLVMFunction -> [String]
 renderLLVMFunctionLines function =
@@ -123,6 +127,8 @@ renderLLVMExpression resultTy expression =
         ++ "("
         ++ intercalate ", " (map renderLLVMArgument args)
         ++ ")"
+    LLVMAnd left right ->
+      "and " ++ renderLLVMType resultTy ++ " " ++ renderLLVMOperand left ++ ", " ++ renderLLVMOperand right
     LLVMGetElementPtr elementTy base indexes ->
       "getelementptr "
         ++ renderLLVMType elementTy
@@ -167,14 +173,14 @@ renderLLVMTerminator terminator =
         ++ ", label "
         ++ renderLLVMLabelRef defaultLabel
         ++ " [ "
-        ++ intercalate " " (map renderSwitchTarget targets)
+        ++ intercalate " " (map (renderSwitchTarget ty) targets)
         ++ " ]"
     LLVMUnreachable ->
       "unreachable"
 
-renderSwitchTarget :: (Integer, String) -> String
-renderSwitchTarget (tag, label) =
-  "i64 " ++ show tag ++ ", label " ++ renderLLVMLabelRef label
+renderSwitchTarget :: LLVMType -> (Integer, String) -> String
+renderSwitchTarget ty (tag, label) =
+  renderLLVMType ty ++ " " ++ show tag ++ ", label " ++ renderLLVMLabelRef label
 
 renderLLVMType :: LLVMType -> String
 renderLLVMType ty =

--- a/src/MLF/Backend/LLVM/Syntax.hs
+++ b/src/MLF/Backend/LLVM/Syntax.hs
@@ -31,7 +31,8 @@ data LLVMModule = LLVMModule
 data LLVMDeclaration = LLVMDeclaration
   { llvmDeclarationName :: String,
     llvmDeclarationReturnType :: LLVMType,
-    llvmDeclarationParameters :: [LLVMType]
+    llvmDeclarationParameters :: [LLVMType],
+    llvmDeclarationVarArgs :: Bool
   }
   deriving (Eq, Show)
 
@@ -72,6 +73,7 @@ data LLVMInstruction
 data LLVMExpression
   = LLVMCall String [(LLVMType, LLVMOperand)]
   | LLVMCallOperand LLVMOperand [(LLVMType, LLVMOperand)]
+  | LLVMAnd LLVMOperand LLVMOperand
   | LLVMGetElementPtr LLVMType LLVMOperand [(LLVMType, LLVMOperand)]
   | LLVMLoad LLVMType LLVMOperand
   | LLVMPhi LLVMType [(LLVMOperand, String)]

--- a/src/MLF/Program/CLI.hs
+++ b/src/MLF/Program/CLI.hs
@@ -3,6 +3,7 @@
 module MLF.Program.CLI
     ( programCliUsage
     , emitBackendFile
+    , emitNativeFile
     , runProgramFile
     ) where
 
@@ -16,6 +17,7 @@ import qualified Data.Set as Set
 import MLF.Backend.LLVM
     ( renderBackendLLVMError
     , renderCheckedProgramLLVM
+    , renderCheckedProgramNativeLLVM
     )
 import MLF.Elab.Types (ElabTerm (..))
 import MLF.Frontend.Parse.Program
@@ -52,9 +54,11 @@ programCliUsage =
         [ "Usage:"
         , "  mlf2 run-program <file.mlfp>"
         , "  mlf2 emit-backend <file.mlfp>"
+        , "  mlf2 emit-native <file.mlfp>"
         , ""
         , "run-program prepends the built-in Prelude and prints the resulting value."
         , "emit-backend prepends the built-in Prelude and prints LLVM IR."
+        , "emit-native prepends the built-in Prelude and prints LLVM IR with a native process entrypoint."
         ]
 
 runProgramFile :: FilePath -> IO (Either String String)
@@ -73,6 +77,15 @@ emitBackendFile path = do
         program <- first renderProgramParseError (parseLocatedProgramWithFile path source)
         checked <- first renderProgramDiagnostic (checkLocatedProgram (withPreludeLocated program))
         first renderBackendLLVMError (renderCheckedProgramLLVM (emitBackendCheckedProgram checked))
+
+emitNativeFile :: FilePath -> IO (Either String String)
+emitNativeFile path = do
+    fileResult <- try (readFile path) :: IO (Either IOException String)
+    pure $ do
+        source <- first show fileResult
+        program <- first renderProgramParseError (parseLocatedProgramWithFile path source)
+        checked <- first renderProgramDiagnostic (checkLocatedProgram (withPreludeLocated program))
+        first renderBackendLLVMError (renderCheckedProgramNativeLLVM (emitBackendCheckedProgram checked))
 
 emitBackendCheckedProgram :: CheckedProgram -> CheckedProgram
 emitBackendCheckedProgram checked =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -7,10 +7,13 @@ import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import System.Exit (ExitCode (..))
 import Test.Hspec
 
 import LLVMToolSupport
-  ( validateLLVMAssembly,
+  ( LLVMRunResult (..),
+    runLLVMModule,
+    validateLLVMAssembly,
     validateLLVMObjectCode,
     withTempProgram,
   )
@@ -26,7 +29,7 @@ import MLF.Program
     parseRawProgram,
     renderProgramParseError,
   )
-import MLF.Program.CLI (emitBackendFile)
+import MLF.Program.CLI (emitBackendFile, emitNativeFile)
 import Parity.ProgramMatrix
   ( ProgramMatrixCase (..),
     ProgramMatrixExpectation (..),
@@ -52,6 +55,27 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "; mlf2 LLVM backend v0"
     output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
     validateLLVMAssembly output
+
+  describe "native process entrypoint" $ do
+    it "prints an Int main value to stdout and exits successfully" $
+      assertNativeProgram simpleFunctionProgram "1"
+
+    it "prints a Bool main value to stdout and exits successfully" $
+      assertNativeProgram boolMainProgram "true"
+
+    it "prints nested first-order ADT values with ProgramSpec rendering" $
+      assertNativeProgram nativeNestedAdtProgram "Some (Succ Zero)"
+
+    it "links the backend-owned __mlfp_and runtime primitive in native mode" $
+      assertNativeProgram preludeAndProgram "false"
+
+    it "rejects unsupported native string result rendering before native assertions use it" $
+      renderBackendProgramNativeLLVM nativeStringResultProgram
+        `shouldSatisfyLeft` isInfixOf "String main values are not supported"
+
+    it "rejects source/native entrypoint symbol collisions" $
+      renderBackendProgramNativeLLVM nativeMainNameCollisionProgram
+        `shouldSatisfyLeft` isInfixOf "reserved native LLVM symbol \"main\""
 
   describe "shared ProgramSpec first-order parity" $ do
     it "keeps the selected shared first-order parity rows wired" $
@@ -627,6 +651,20 @@ runLLVMUnifiedFixture path =
         validateLLVMObjectCode output
       _ -> validateLLVMAssembly output
 
+assertNativeProgram :: String -> String -> Expectation
+assertNativeProgram programText expectedValue = do
+  output <- requireRight =<< emitNativeSource programText
+  output `shouldSatisfy` isInfixOf "define i32 @\"main\"()"
+  output `shouldSatisfy` isInfixOf "declare i32 @\"printf\"(ptr, ...)"
+  validateLLVMAssembly output
+  validateLLVMObjectCode output
+  runLLVMModule output
+    `shouldReturn` LLVMRunResult ExitSuccess (expectedValue ++ "\n") ""
+
+emitNativeSource :: String -> IO (Either String String)
+emitNativeSource programText =
+  withTempProgram programText emitNativeFile
+
 renderProgramMatrixSourceLLVM :: ProgramMatrixSource -> IO String
 renderProgramMatrixSourceLLVM source =
   case source of
@@ -650,6 +688,30 @@ preludeAndProgram =
     [ "module Main export (main) {",
       "  import Prelude exposing (and);",
       "  def main : Bool = and true false;",
+      "}"
+    ]
+
+boolMainProgram :: String
+boolMainProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Bool = true;",
+      "}"
+    ]
+
+nativeNestedAdtProgram :: String
+nativeNestedAdtProgram =
+  unlines
+    [ "module Main export (Nat(..), Option(..), main) {",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat;",
+      "",
+      "  data Option a =",
+      "      None : Option a",
+      "    | Some : a -> Option a;",
+      "",
+      "  def main : Option Nat = Some (Succ Zero);",
       "}"
     ]
 
@@ -1585,6 +1647,46 @@ stringProgram =
                     { backendBindingName = "main",
                       backendBindingType = stringTy,
                       backendBindingExpr = BackendLit stringTy (LString "hello"),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+nativeStringResultProgram :: BackendProgram
+nativeStringResultProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "Main__main",
+                      backendBindingType = stringTy,
+                      backendBindingExpr = BackendLit stringTy (LString "hello"),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "Main__main"
+    }
+
+nativeMainNameCollisionProgram :: BackendProgram
+nativeMainNameCollisionProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr = intLit 1,
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -66,6 +66,9 @@ spec = describe "MLF.Backend.LLVM" $ do
     it "prints nested first-order ADT values with ProgramSpec rendering" $
       assertNativeProgram nativeNestedAdtProgram "Some (Succ Zero)"
 
+    it "preserves user-authored double underscores in constructor names" $
+      assertNativeProgram nativeDoubleUnderscoreConstructorProgram "A__B"
+
     it "links the backend-owned __mlfp_and runtime primitive in native mode" $
       assertNativeProgram preludeAndProgram "false"
 
@@ -712,6 +715,17 @@ nativeNestedAdtProgram =
       "    | Some : a -> Option a;",
       "",
       "  def main : Option Nat = Some (Succ Zero);",
+      "}"
+    ]
+
+nativeDoubleUnderscoreConstructorProgram :: String
+nativeDoubleUnderscoreConstructorProgram =
+  unlines
+    [ "module Main export (Weird(..), main) {",
+      "  data Weird =",
+      "      A__B : Weird;",
+      "",
+      "  def main : Weird = A__B;",
       "}"
     ]
 

--- a/test/LLVMToolSupport.hs
+++ b/test/LLVMToolSupport.hs
@@ -1,6 +1,8 @@
 module LLVMToolSupport
-    ( validateLLVMAssembly
+    ( LLVMRunResult(..)
+    , validateLLVMAssembly
     , validateLLVMObjectCode
+    , runLLVMModule
     , withTempLLVM
     , withTempProgram
     ) where
@@ -14,6 +16,13 @@ import System.FilePath (takeFileName)
 import System.IO (hClose, hPutStr, openTempFile)
 import System.Process (readProcessWithExitCode)
 import Test.Hspec
+
+data LLVMRunResult = LLVMRunResult
+    { llvmRunExitCode :: ExitCode
+    , llvmRunStdout :: String
+    , llvmRunStderr :: String
+    }
+    deriving (Eq, Show)
 
 validateLLVMAssembly :: String -> Expectation
 validateLLVMAssembly output = do
@@ -40,6 +49,15 @@ validateLLVMObjectCode output = do
                 case exitCode of
                     ExitSuccess -> pure ()
                     ExitFailure _ -> expectationFailure ("llc rejected backend output:\n" ++ stderr)
+
+runLLVMModule :: String -> IO LLVMRunResult
+runLLVMModule output = do
+    mbLli <- findLLVMTool "lli"
+    case mbLli of
+        Nothing ->
+            pendingWith "required LLVM tool not found: lli" >> pure (LLVMRunResult ExitSuccess "" "")
+        Just lli ->
+            withTempLLVM output $ \path -> runLLVMExecutable lli path
 
 withTempLLVM :: String -> (FilePath -> IO a) -> IO a
 withTempLLVM output action = do
@@ -81,6 +99,25 @@ runLLVMTool tool args = do
                             ++ opaqueStderr
                         )
 
+runLLVMExecutable :: FilePath -> FilePath -> IO LLVMRunResult
+runLLVMExecutable tool path = do
+    (plainExitCode, plainStdout, plainStderr) <- readProcessWithExitCode tool [path] ""
+    case plainExitCode of
+        ExitSuccess ->
+            pure (LLVMRunResult plainExitCode plainStdout plainStderr)
+        ExitFailure _ -> do
+            (opaqueExitCode, opaqueStdout, opaqueStderr) <-
+                readProcessWithExitCode tool ["-opaque-pointers", path] ""
+            pure $
+                case opaqueExitCode of
+                    ExitSuccess ->
+                        LLVMRunResult opaqueExitCode opaqueStdout opaqueStderr
+                    ExitFailure _ ->
+                        LLVMRunResult
+                            opaqueExitCode
+                            opaqueStdout
+                            (plainStderr ++ "\nWith -opaque-pointers:\n" ++ opaqueStderr)
+
 findLLVMTool :: String -> IO (Maybe FilePath)
 findLLVMTool name = do
     envCandidates <- filterM doesFileExist =<< traverseMaybeEnv (toolEnvNames name)
@@ -102,6 +139,7 @@ toolEnvNames name =
     case name of
         "llvm-as" -> ["LLVM_AS"]
         "llc" -> ["LLC", "LLVM_LLC"]
+        "lli" -> ["LLI", "LLVM_LLI"]
         _ -> []
 
 findKnownLLVMTool :: String -> [FilePath] -> IO (Maybe FilePath)
@@ -115,6 +153,8 @@ knownLLVMToolPaths :: [FilePath]
 knownLLVMToolPaths =
     [ "/opt/homebrew/opt/llvm/bin/llvm-as"
     , "/opt/homebrew/opt/llvm/bin/llc"
+    , "/opt/homebrew/opt/llvm/bin/lli"
     , "/usr/local/opt/llvm/bin/llvm-as"
     , "/usr/local/opt/llvm/bin/llc"
+    , "/usr/local/opt/llvm/bin/lli"
     ]


### PR DESCRIPTION
Closes #100.

## Implementation Plan

---
issue_number: 100
pr_number: 108
branch: codex/issue-100
---

## Evidence
- Issue #100 asks for the native process contract for emitted `.mlfp` `main` values: entrypoint, result rendering, stdout/stderr, exit status, runtime declarations, tests, and docs.
- PR #108 is open from `codex/issue-100` to `master`; the local branch tracks `origin/codex/issue-100` and currently only has the starter commit.
- Current LLVM output retains source-level functions such as `Main__main`, but does not emit a C ABI `i32 @main()` process entrypoint or native result renderer. Runtime declarations currently include `malloc` and `__mlfp_and`; `__mlfp_and` is still an external declaration in raw backend output.

## Implementation Plan
1. Add a native LLVM emission mode without breaking the raw backend API. Keep `renderBackendProgramLLVM` / `renderCheckedProgramLLVM` as raw library-style LLVM, and add native variants such as `renderBackendProgramNativeLLVM` / `renderCheckedProgramNativeLLVM`. Add a CLI/file helper for native emission, preferably a new command like `emit-native`, rather than switching the broad existing `emit-backend` parity surface in this issue.
2. Extend the small LLVM AST/printer only as needed: support vararg declarations for `printf`, and fix `LLVMSwitch` pretty-printing so switch targets use the switch operand type instead of hard-coded `i64`; this enables `i1` dispatch for booleans and renderer parentheses.
3. Generate the native process wrapper in `MLF.Backend.LLVM.Lower`: reserve/diagnose collisions for `main`, `printf`, native string globals, and renderer helper names; append `define i32 @main()` that calls the checked zero-argument monomorphic source main, prints the rendered value plus newline to stdout, writes nothing to stderr on success, and returns exit code `0`.
4. Implement native result rendering for the supported pure subset: `Int`, `Bool`, and first-order ADT values whose fields recursively render as supported `Int`/`Bool`/ADT values. Use existing backend constructor tags and heap layout; derive display constructor names by stripping the runtime module prefix. Generate monomorphic ADT renderer helpers by concrete result type, including ProgramSpec-compatible nested ADT parentheses such as `Some (Succ Zero)`. Reject function, forall, string, unknown data, type-variable, polymorphic, and IO-like results with explicit `BackendLLVMUnsupportedExpression` diagnostics.
5. In native mode, do not leave `__mlfp_and` as an unresolved external when it is used and not user-owned. Emit a small internal LLVM definition for it. Keep `malloc` and `printf` as libc-provided declarations.
6. Add focused `BackendLLVMSpec` coverage for native `Int`, `Bool`, nullary/unary/nested ADT output, and a Prelude `and` case proving the runtime primitive is linkable/executable. Compare expected stdout as the ProgramSpec value plus `\n`, stderr as empty, and exit status as success. Use existing `llvm-as`/`llc` validation and add only a narrow `lli` execution helper with pending behavior if `lli` is absent; leave full compile/link runner infrastructure to #99/#101.
7. Add negative tests for unsupported native result types and native name collisions so native-run assertions cannot silently target unsupported rows.
8. Update README and backend architecture docs with the native contract: raw backend vs native emission, source main retention, generated `i32 @main`, stdout newline/value rendering, no stderr on success, exit `0`, supported/unsupported result types, libc/runtime declarations, and IO remaining out of scope for #87.
9. Validate with a focused backend LLVM test slice first, then run `cabal build all && cabal test` before publishing. Before committing, inspect `git status --short` and relevant diffs; stage only issue-related code/docs/tests, commit on `codex/issue-100`, and push to PR #108.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.