### PR TITLE
Implement #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
   propagated expected source type while bare uses without such evidence still
   fail closed as ambiguous. Parameterized associated values used through
   constrained aliases, such as `DefaultBox a => Box a`, now preserve local
-  evidence and expected result annotations without over-instantiating the
-  rewrite.
+  evidence, expected result annotations, and recovered ADT instantiation
+  identity without over-instantiating the rewrite.
 - Added a native LLVM emission contract for pure `.mlfp` entrypoints. The
   backend can now emit an `i32 @main()` wrapper that renders supported
   `Int`, `Bool`, and first-order ADT results to stdout, returns exit status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
   constrained aliases, such as `DefaultBox a => Box a`, now preserve local
   evidence and expected result annotations without over-instantiating the
   rewrite; backend conversion preserves nominal ADT instantiation identity from
-  expected-result context instead of rewriting checked terms.
+  expected-result context instead of rewriting checked terms. Finalization now
+  strips vacuous checked `forall` binders only together with their matching
+  term type abstractions, preserving binder scope for retained instantiations.
 - Added a native LLVM emission contract for pure `.mlfp` entrypoints. The
   backend can now emit an `i32 @main()` wrapper that renders supported
   `Int`, `Bool`, and first-order ADT results to stdout, returns exit status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
   propagated expected source type while bare uses without such evidence still
   fail closed as ambiguous. Parameterized associated values used through
   constrained aliases, such as `DefaultBox a => Box a`, now preserve local
-  evidence, expected result annotations, and recovered ADT instantiation
-  identity without over-instantiating the rewrite.
+  evidence and expected result annotations without over-instantiating the
+  rewrite; backend conversion preserves nominal ADT instantiation identity from
+  expected-result context instead of rewriting checked terms.
 - Added a native LLVM emission contract for pure `.mlfp` entrypoints. The
   backend can now emit an `i32 @main()` wrapper that renders supported
   `Int`, `Bool`, and first-order ADT results to stdout, returns exit status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still
-  fail closed as ambiguous.
+  fail closed as ambiguous. Parameterized associated values used through
+  constrained aliases, such as `DefaultBox a => Box a`, now preserve local
+  evidence and expected result annotations without over-instantiating the
+  rewrite.
 - Added a native LLVM emission contract for pure `.mlfp` entrypoints. The
   backend can now emit an `i32 @main()` wrapper that renders supported
   `Int`, `Bool`, and first-order ADT results to stdout, returns exit status

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,15 @@
+## 2026-04-30 - Nullary local evidence for parameterized result aliases
+
+- Tightened nullary overloaded method finalization so placeholder type
+  instantiations are replayed for concrete instance methods but not blindly
+  applied to already-instantiated local evidence parameters. This keeps
+  constrained aliases such as `DefaultBox a => Box a` usable at `Box Nat`
+  without over-instantiating the local evidence rewrite.
+- The `.mlfp` elaborator now preserves expected result annotations on bare
+  constrained value uses, matching the existing application path so source
+  aliases can instantiate their hidden evidence arguments from the surrounding
+  expected type.
+
 ## 2026-04-29 - Nullary overloaded method expected-type resolution
 
 - `.mlfp` nullary overloaded methods / associated values now carry expected

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -13,6 +13,10 @@
   nominal ADT instantiation arguments for retained type applications, avoiding
   finalizer-wide head recovery while keeping the constrained alias row in
   shared interpreter and LLVM parity coverage.
+- Finalization now decides vacuous `forall` stripping from the checked type and
+  the matching term type-abstraction spine together, so a binder retained by a
+  term-level instantiation remains in both `checkedBindingType` and
+  `checkedBindingTerm`.
 
 ## 2026-04-29 - Nullary overloaded method expected-type resolution
 

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -9,6 +9,9 @@
   constrained value uses, matching the existing application path so source
   aliases can instantiate their hidden evidence arguments from the surrounding
   expected type.
+- Retained type-instantiation arguments are recovered back through source ADT
+  identity during finalization, so constrained alias evidence keeps the same
+  `Box Nat` shape through shared interpreter and LLVM parity coverage.
 
 ## 2026-04-29 - Nullary overloaded method expected-type resolution
 

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -9,9 +9,10 @@
   constrained value uses, matching the existing application path so source
   aliases can instantiate their hidden evidence arguments from the surrounding
   expected type.
-- Retained type-instantiation arguments are recovered back through source ADT
-  identity during finalization, so constrained alias evidence keeps the same
-  `Box Nat` shape through shared interpreter and LLVM parity coverage.
+- Backend conversion now uses expected-result function context to infer
+  nominal ADT instantiation arguments for retained type applications, avoiding
+  finalizer-wide head recovery while keeping the constrained alias row in
+  shared interpreter and LLVM parity coverage.
 
 ## 2026-04-29 - Nullary overloaded method expected-type resolution
 

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1748,8 +1748,13 @@ convertApplication ::
   ElabTerm ->
   Either BackendConversionError BackendExpr
 convertApplication context env resultTy fun arg =
-  convertApplicationFromFunction context env resultTy fun arg
-    `orElseConversion` convertApplicationFromExpectedResult context env resultTy fun arg
+  if termContainsTypeInstantiation fun
+    then
+      convertApplicationFromExpectedResult context env resultTy fun arg
+        `orElseConversion` convertApplicationFromFunction context env resultTy fun arg
+    else
+      convertApplicationFromFunction context env resultTy fun arg
+        `orElseConversion` convertApplicationFromExpectedResult context env resultTy fun arg
 
 convertApplicationFromFunction ::
   ConvertContext ->
@@ -1849,9 +1854,18 @@ convertTypeInstantiation context env resultTy inner inst =
         Just tyArg -> do
           innerExpr <- convertAppLikeInstantiationFunction context env inner
           case backendExprType innerExpr of
-            BTForall name _ bodyTy -> do
-              backendTyArg <- normalizeBackendTypeForContext context <$> convertElabType tyArg
-              let appliedTy = normalizeBackendTypeForContext context (substituteBackendType name backendTyArg bodyTy)
+            BTForall name mbBound bodyTy -> do
+              backendTyArg0 <- normalizeBackendTypeForContext context <$> convertElabType tyArg
+              let appliedTy0 = normalizeBackendTypeForContext context (substituteBackendType name backendTyArg0 bodyTy)
+                  (backendTyArg, appliedTy) =
+                    expectedTypeInstantiation
+                      context
+                      name
+                      mbBound
+                      bodyTy
+                      resultTy
+                      backendTyArg0
+                      appliedTy0
                   resultTy' =
                     if alphaEqBackendType appliedTy resultTy
                       then resultTy
@@ -1866,6 +1880,44 @@ convertTypeInstantiation context env resultTy inner inst =
               | alphaEqBackendType (backendExprType innerExpr) resultTy -> Right innerExpr
               | otherwise -> Left (BackendUnsupportedInstantiation inst)
         Nothing -> Left (BackendUnsupportedInstantiation inst)
+
+expectedTypeInstantiation ::
+  ConvertContext ->
+  String ->
+  Maybe BackendType ->
+  BackendType ->
+  BackendType ->
+  BackendType ->
+  BackendType ->
+  (BackendType, BackendType)
+expectedTypeInstantiation context name mbBound bodyTy resultTy explicitArg explicitAppliedTy =
+  case inferredExpectedTypeArg of
+    Just inferredArg
+      | not (alphaEqBackendType explicitAppliedTy resultTy),
+        let inferredAppliedTy = normalizeBackendTypeForContext context (substituteBackendType name inferredArg bodyTy),
+        alphaEqBackendType inferredAppliedTy resultTy ->
+          (inferredArg, inferredAppliedTy)
+    _ ->
+      (explicitArg, explicitAppliedTy)
+  where
+    parameterBounds =
+      Map.singleton name mbBound
+    inferredExpectedTypeArg = do
+      substitution <- matchBackendTypeParameters Map.empty [] parameterBounds Map.empty bodyTy resultTy
+      Map.lookup name (completeBackendParameterSubstitution parameterBounds substitution)
+
+termContainsTypeInstantiation :: ElabTerm -> Bool
+termContainsTypeInstantiation =
+  \case
+    EVar {} -> False
+    ELit {} -> False
+    ELam _ _ body -> termContainsTypeInstantiation body
+    EApp fun arg -> termContainsTypeInstantiation fun || termContainsTypeInstantiation arg
+    ELet _ _ rhs body -> termContainsTypeInstantiation rhs || termContainsTypeInstantiation body
+    ETyAbs _ _ body -> termContainsTypeInstantiation body
+    ETyInst {} -> True
+    ERoll _ body -> termContainsTypeInstantiation body
+    EUnroll body -> termContainsTypeInstantiation body
 
 convertAppLikeInstantiationFunction ::
   ConvertContext ->

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -709,7 +709,7 @@ compileExpr scope mbExpected expr = case expr of
         compileNullaryMethodUse scope mbExpected methodInfo
       Just valueInfo@OrdinaryValue {valueRuntimeName = runtimeName} -> do
         evidenceSurfaces <- valueEvidenceArgs scope valueInfo mbExpected []
-        pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
+        pure (annotateExpectedBareValueUse scope mbExpected valueInfo (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces))
       Just ConstructorValue {valueCtorInfo = ctorInfo} -> do
         compileConstructorHead scope ctorInfo 0 (constructorInitialSubst scope ctorInfo 0 mbExpected)
       Nothing -> throwError (ProgramUnknownValue name)
@@ -784,9 +784,9 @@ compileResolvedExpr scope mbExpected expr = case expr of
     case valueInfo of
       OverloadedMethod {valueMethodInfo = methodInfo} ->
         compileNullaryMethodUse scope mbExpected methodInfo
-      OrdinaryValue {valueRuntimeName = runtimeName} -> do
-        evidenceSurfaces <- valueResolvedEvidenceArgs scope valueInfo mbExpected []
-        pure (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces)
+      ordinary@OrdinaryValue {valueRuntimeName = runtimeName} -> do
+        evidenceSurfaces <- valueResolvedEvidenceArgs scope ordinary mbExpected []
+        pure (annotateExpectedBareValueUse scope mbExpected ordinary (foldl surfaceApp (surfaceVar runtimeName) evidenceSurfaces))
       ConstructorValue {valueCtorInfo = ctorInfo} -> do
         compileConstructorHead scope ctorInfo 0 (constructorInitialSubst scope ctorInfo 0 mbExpected)
   ELit lit -> pure (surfaceLit lit)
@@ -979,12 +979,7 @@ compileValueApp scope mbExpected valueInfo args = do
           OverloadedMethod {} -> error "compileValueApp does not handle overloaded methods"
       headWithEvidence = foldl surfaceApp headSurface evidenceSurfaces
       applied = foldl surfaceApp headWithEvidence argSurfaces
-  pure $ case mbExpected of
-    Just expectedTy
-      | not (isLocalOrdinaryValue valueInfo),
-        isRecursiveResultType expectedTy || isRecursiveResultType (lowerType scope expectedTy) ->
-          surfaceAnn applied (lowerType scope expectedTy)
-    _ -> applied
+  pure (annotateExpectedValueUse scope mbExpected valueInfo applied)
   where
     compileValueArg (Just expectedTy) arg
       | isPartialOverloadedMethodApp scope arg =
@@ -1033,12 +1028,7 @@ compileResolvedValueApp scope mbExpected valueInfo args = do
           OverloadedMethod {} -> error "compileResolvedValueApp does not handle overloaded methods"
       headWithEvidence = foldl surfaceApp headSurface evidenceSurfaces
       applied = foldl surfaceApp headWithEvidence argSurfaces
-  pure $ case mbExpected of
-    Just expectedTy
-      | not (isLocalOrdinaryValue valueInfo),
-        isRecursiveResultType expectedTy || isRecursiveResultType (lowerType scope expectedTy) ->
-          surfaceAnn applied (lowerType scope expectedTy)
-    _ -> applied
+  pure (annotateExpectedValueUse scope mbExpected valueInfo applied)
   where
     compileValueArg (Just expectedTy) arg
       | isPartialOverloadedResolvedMethodApp scope arg =
@@ -1431,6 +1421,32 @@ resolvedRhsConsumesAppliedArgs expr argCount =
 isLocalOrdinaryValue :: ValueInfo -> Bool
 isLocalOrdinaryValue OrdinaryValue {valueOriginModule = "<local>"} = True
 isLocalOrdinaryValue _ = False
+
+annotateExpectedValueUse :: ElaborateScope -> Maybe SrcType -> ValueInfo -> SurfaceExpr -> SurfaceExpr
+annotateExpectedValueUse scope mbExpected valueInfo applied =
+  case mbExpected of
+    Just expectedTy
+      | not (isLocalOrdinaryValue valueInfo),
+        isRecursiveResultType expectedTy || isRecursiveResultType (lowerType scope expectedTy) ->
+          surfaceAnn applied (lowerType scope expectedTy)
+    _ -> applied
+
+annotateExpectedBareValueUse :: ElaborateScope -> Maybe SrcType -> ValueInfo -> SurfaceExpr -> SurfaceExpr
+annotateExpectedBareValueUse scope mbExpected valueInfo applied =
+  case mbExpected of
+    Just expectedTy
+      | not (isLocalOrdinaryValue valueInfo),
+        sourceTypeHasAppliedHead expectedTy ->
+          surfaceAnn applied (lowerType scope expectedTy)
+    _ -> applied
+
+sourceTypeHasAppliedHead :: SrcType -> Bool
+sourceTypeHasAppliedHead ty =
+  case ty of
+    STCon {} -> True
+    STVarApp {} -> True
+    STForall _ _ body -> sourceTypeHasAppliedHead body
+    _ -> False
 
 knownConstructorResultType :: ElaborateScope -> ConstructorInfo -> [P.Expr] -> Maybe SrcType
 knownConstructorResultType scope ctorInfo args = do

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -94,11 +94,15 @@ finalizeBinding scope lowered = do
   (term, actualTy) <-
     finalizeDeferredObligations scope (loweredBindingDeferredObligations lowered) tcEnv term0 actualTy0 (loweredBindingExpectedType lowered)
   let isUncheckedConstructor = constructorBindingNeedsUnchecked scope (loweredBindingName lowered)
-      acceptedTerm = repairConstructorBindingTerm scope (loweredBindingName lowered) term
+      acceptedTerm0 = repairConstructorBindingTerm scope (loweredBindingName lowered) term
   acceptedTy <-
     if isUncheckedConstructor
       then srcTypeToElabType (loweredBindingExpectedType lowered)
-      else Right actualTy
+      else Right (stripLeadingVacuousForalls actualTy)
+  let acceptedTerm =
+        if isUncheckedConstructor
+          then acceptedTerm0
+          else stripLeadingVacuousTypeAbs actualTy acceptedTerm0
   if isUncheckedConstructor
     then
       Right
@@ -900,7 +904,7 @@ resolveDeferredMethods scope deferredMethods = go
         Just (name, headInsts)
           | Just deferred <- Map.lookup name deferredMethods,
             deferredMethodArgCount deferred == 0 ->
-              reapplyHeadInsts headInsts <$> resolveDeferredNullaryMethod deferred
+              resolveDeferredNullaryMethod headInsts deferred
         _ ->
           case term of
             X.EVar {} -> Right term
@@ -966,7 +970,7 @@ resolveDeferredMethods scope deferredMethods = go
           methodHead <- instantiateMethodValue scope methodSubst methodValue
           Right (foldl X.EApp (foldl X.EApp methodHead evidenceArgs) args)
 
-    resolveDeferredNullaryMethod deferred = do
+    resolveDeferredNullaryMethod headInsts deferred = do
       expectedView <-
         case deferredMethodExpectedResult deferred of
           Just view -> Right view
@@ -989,7 +993,11 @@ resolveDeferredMethods scope deferredMethods = go
               (deferredMethodLocalEvidence deferred)
               Set.empty
               (nullaryMethodLocalConstraints methodInfo classArgView methodSubst)
-          Right (foldl X.EApp evidenceHead evidenceArgs)
+          let evidenceTerm = foldl X.EApp evidenceHead evidenceArgs
+          Right $
+            if nullaryMethodResultIsClassParameter methodInfo
+              then reapplyHeadInsts headInsts evidenceTerm
+              else evidenceTerm
         Nothing -> do
           (instanceInfo, subst) <- resolveMethodInstanceInfoByTypeView scope methodInfo classArgView
           methodValue <- concreteMethodValue instanceInfo methodInfo
@@ -1003,7 +1011,7 @@ resolveDeferredMethods scope deferredMethods = go
                   (map (applyConstraintInfoSubst methodSubst) (methodValueConstraints methodValue))
           evidenceArgs <- resolveConstraintEvidenceTerms scope (deferredMethodLocalEvidence deferred) Set.empty eagerConstraints
           methodHead <- instantiateMethodValue scope methodSubst methodValue
-          Right (foldl X.EApp methodHead evidenceArgs)
+          Right (reapplyHeadInsts headInsts (foldl X.EApp methodHead evidenceArgs))
 
     lookupNullaryEvidence deferred methodInfo classArgView =
       case
@@ -1075,6 +1083,11 @@ resolveDeferredMethods scope deferredMethods = go
               (fmap typeViewDisplay subst)
               resultTy
               (typeViewDisplay expectedView)
+
+    nullaryMethodResultIsClassParameter methodInfo =
+      let (_, bodyTy) = splitForalls (methodType methodInfo)
+          (_, resultTy) = splitArrows bodyTy
+       in resultTy == STVar (methodParamName methodInfo)
 
     deferredMethodFullArityFromInfo methodInfo =
       length (fst (splitArrows (snd (splitForalls (methodType methodInfo)))))
@@ -1509,6 +1522,64 @@ stripVacuousForalls (X.TArrow dom cod) =
 stripVacuousForalls (X.TMu name body) =
   X.TMu name (stripVacuousForalls body)
 stripVacuousForalls ty = ty
+
+stripLeadingVacuousForalls :: ElabType -> ElabType
+stripLeadingVacuousForalls (X.TForall v _ body)
+  | v `Set.notMember` freeTypeVarsType body = stripLeadingVacuousForalls body
+stripLeadingVacuousForalls (X.TForall v mb body) =
+  X.TForall v mb (stripLeadingVacuousForalls body)
+stripLeadingVacuousForalls ty = ty
+
+stripLeadingVacuousTypeAbs :: ElabType -> ElabTerm -> ElabTerm
+stripLeadingVacuousTypeAbs ty term =
+  case (ty, term) of
+    (X.TForall v _ bodyTy, X.ETyAbs termV _ body)
+      | v `Set.notMember` freeTypeVarsType bodyTy,
+        termV `Set.notMember` freeTypeVarsTerm body ->
+          stripLeadingVacuousTypeAbs bodyTy body
+    (X.TForall _ _ bodyTy, X.ETyAbs termV mb body) ->
+      X.ETyAbs termV mb (stripLeadingVacuousTypeAbs bodyTy body)
+    _ -> term
+
+freeTypeVarsTerm :: ElabTerm -> Set String
+freeTypeVarsTerm term =
+  case term of
+    X.EVar {} -> Set.empty
+    X.ELit {} -> Set.empty
+    X.ELam _ ty body ->
+      freeTypeVarsType ty `Set.union` freeTypeVarsTerm body
+    X.EApp fun arg ->
+      freeTypeVarsTerm fun `Set.union` freeTypeVarsTerm arg
+    X.ELet _ scheme rhs body ->
+      Set.unions
+        [ freeTypeVarsType (schemeToType scheme),
+          freeTypeVarsTerm rhs,
+          freeTypeVarsTerm body
+        ]
+    X.ETyAbs v mb body ->
+      let boundFv = maybe Set.empty freeTypeVarsType mb
+          bodyFv = Set.delete v (freeTypeVarsTerm body)
+       in boundFv `Set.union` bodyFv
+    X.ETyInst inner inst ->
+      freeTypeVarsTerm inner `Set.union` freeTypeVarsInstantiation inst
+    X.ERoll ty body ->
+      freeTypeVarsType ty `Set.union` freeTypeVarsTerm body
+    X.EUnroll body ->
+      freeTypeVarsTerm body
+
+freeTypeVarsInstantiation :: X.Instantiation -> Set String
+freeTypeVarsInstantiation inst =
+  case inst of
+    X.InstId -> Set.empty
+    X.InstApp ty -> freeTypeVarsType ty
+    X.InstBot ty -> freeTypeVarsType ty
+    X.InstIntro -> Set.empty
+    X.InstElim -> Set.empty
+    X.InstAbstr v -> Set.singleton v
+    X.InstUnder v inner -> Set.delete v (freeTypeVarsInstantiation inner)
+    X.InstInside inner -> freeTypeVarsInstantiation inner
+    X.InstSeq left right ->
+      freeTypeVarsInstantiation left `Set.union` freeTypeVarsInstantiation right
 
 surfaceFreeVars :: SurfaceExpr -> Set String
 surfaceFreeVars = go Set.empty

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -4,6 +4,7 @@ module MLF.Frontend.Program.Finalize
   ( finalizeBinding,
     recoverSourceType,
     sourceForallMatches,
+    stripVacuousForallsAndTypeAbs,
   )
 where
 
@@ -95,14 +96,12 @@ finalizeBinding scope lowered = do
     finalizeDeferredObligations scope (loweredBindingDeferredObligations lowered) tcEnv term0 actualTy0 (loweredBindingExpectedType lowered)
   let isUncheckedConstructor = constructorBindingNeedsUnchecked scope (loweredBindingName lowered)
       acceptedTerm0 = repairConstructorBindingTerm scope (loweredBindingName lowered) term
-  acceptedTy <-
+  (acceptedTy, acceptedTerm) <-
     if isUncheckedConstructor
-      then srcTypeToElabType (loweredBindingExpectedType lowered)
-      else Right (stripLeadingVacuousForalls actualTy)
-  let acceptedTerm =
-        if isUncheckedConstructor
-          then acceptedTerm0
-          else stripLeadingVacuousTypeAbs actualTy acceptedTerm0
+      then do
+        expectedTy <- srcTypeToElabType (loweredBindingExpectedType lowered)
+        Right (expectedTy, acceptedTerm0)
+      else Right (stripVacuousForallsAndTypeAbs actualTy acceptedTerm0)
   if isUncheckedConstructor
     then
       Right
@@ -1523,23 +1522,17 @@ stripVacuousForalls (X.TMu name body) =
   X.TMu name (stripVacuousForalls body)
 stripVacuousForalls ty = ty
 
-stripLeadingVacuousForalls :: ElabType -> ElabType
-stripLeadingVacuousForalls (X.TForall v _ body)
-  | v `Set.notMember` freeTypeVarsType body = stripLeadingVacuousForalls body
-stripLeadingVacuousForalls (X.TForall v mb body) =
-  X.TForall v mb (stripLeadingVacuousForalls body)
-stripLeadingVacuousForalls ty = ty
-
-stripLeadingVacuousTypeAbs :: ElabType -> ElabTerm -> ElabTerm
-stripLeadingVacuousTypeAbs ty term =
+stripVacuousForallsAndTypeAbs :: ElabType -> ElabTerm -> (ElabType, ElabTerm)
+stripVacuousForallsAndTypeAbs ty term =
   case (ty, term) of
     (X.TForall v _ bodyTy, X.ETyAbs termV _ body)
       | v `Set.notMember` freeTypeVarsType bodyTy,
         termV `Set.notMember` freeTypeVarsTerm body ->
-          stripLeadingVacuousTypeAbs bodyTy body
-    (X.TForall _ _ bodyTy, X.ETyAbs termV mb body) ->
-      X.ETyAbs termV mb (stripLeadingVacuousTypeAbs bodyTy body)
-    _ -> term
+          stripVacuousForallsAndTypeAbs bodyTy body
+    (X.TForall typeV mbTy bodyTy, X.ETyAbs termV mbTerm body) ->
+      let (bodyTy', body') = stripVacuousForallsAndTypeAbs bodyTy body
+       in (X.TForall typeV mbTy bodyTy', X.ETyAbs termV mbTerm body')
+    _ -> (ty, term)
 
 freeTypeVarsTerm :: ElabTerm -> Set String
 freeTypeVarsTerm term =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -100,10 +100,9 @@ finalizeBinding scope lowered = do
       then srcTypeToElabType (loweredBindingExpectedType lowered)
       else Right (stripLeadingVacuousForalls actualTy)
   let acceptedTerm =
-        recoverTermInstantiations scope $
-          if isUncheckedConstructor
-            then acceptedTerm0
-            else stripLeadingVacuousTypeAbs actualTy acceptedTerm0
+        if isUncheckedConstructor
+          then acceptedTerm0
+          else stripLeadingVacuousTypeAbs actualTy acceptedTerm0
   if isUncheckedConstructor
     then
       Right
@@ -1541,42 +1540,6 @@ stripLeadingVacuousTypeAbs ty term =
     (X.TForall _ _ bodyTy, X.ETyAbs termV mb body) ->
       X.ETyAbs termV mb (stripLeadingVacuousTypeAbs bodyTy body)
     _ -> term
-
-recoverTermInstantiations :: ElaborateScope -> ElabTerm -> ElabTerm
-recoverTermInstantiations scope = go
-  where
-    go term =
-      case term of
-        X.EVar {} -> term
-        X.ELit {} -> term
-        X.ELam name ty body ->
-          X.ELam name ty (go body)
-        X.EApp fun arg ->
-          X.EApp (go fun) (go arg)
-        X.ELet name scheme rhs body ->
-          X.ELet name scheme (go rhs) (go body)
-        X.ETyAbs name mb body ->
-          X.ETyAbs name mb (go body)
-        X.ETyInst inner inst ->
-          X.ETyInst (go inner) (recoverInstantiation inst)
-        X.ERoll ty body ->
-          X.ERoll ty (go body)
-        X.EUnroll body ->
-          X.EUnroll (go body)
-
-    recoverInstantiation inst =
-      case inst of
-        X.InstApp ty -> X.InstApp (recoverInstType ty)
-        X.InstBot ty -> X.InstBot (recoverInstType ty)
-        X.InstUnder name inner -> X.InstUnder name (recoverInstantiation inner)
-        X.InstInside inner -> X.InstInside (recoverInstantiation inner)
-        X.InstSeq left right -> X.InstSeq (recoverInstantiation left) (recoverInstantiation right)
-        _ -> inst
-
-    recoverInstType ty =
-      case srcTypeToElabTypeMaybe (lowerType scope (recoverSourceType scope (elabTypeToSrcType (stripVacuousForalls ty)))) of
-        Just recovered -> recovered
-        Nothing -> ty
 
 freeTypeVarsTerm :: ElabTerm -> Set String
 freeTypeVarsTerm term =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -100,9 +100,10 @@ finalizeBinding scope lowered = do
       then srcTypeToElabType (loweredBindingExpectedType lowered)
       else Right (stripLeadingVacuousForalls actualTy)
   let acceptedTerm =
-        if isUncheckedConstructor
-          then acceptedTerm0
-          else stripLeadingVacuousTypeAbs actualTy acceptedTerm0
+        recoverTermInstantiations scope $
+          if isUncheckedConstructor
+            then acceptedTerm0
+            else stripLeadingVacuousTypeAbs actualTy acceptedTerm0
   if isUncheckedConstructor
     then
       Right
@@ -1540,6 +1541,42 @@ stripLeadingVacuousTypeAbs ty term =
     (X.TForall _ _ bodyTy, X.ETyAbs termV mb body) ->
       X.ETyAbs termV mb (stripLeadingVacuousTypeAbs bodyTy body)
     _ -> term
+
+recoverTermInstantiations :: ElaborateScope -> ElabTerm -> ElabTerm
+recoverTermInstantiations scope = go
+  where
+    go term =
+      case term of
+        X.EVar {} -> term
+        X.ELit {} -> term
+        X.ELam name ty body ->
+          X.ELam name ty (go body)
+        X.EApp fun arg ->
+          X.EApp (go fun) (go arg)
+        X.ELet name scheme rhs body ->
+          X.ELet name scheme (go rhs) (go body)
+        X.ETyAbs name mb body ->
+          X.ETyAbs name mb (go body)
+        X.ETyInst inner inst ->
+          X.ETyInst (go inner) (recoverInstantiation inst)
+        X.ERoll ty body ->
+          X.ERoll ty (go body)
+        X.EUnroll body ->
+          X.EUnroll (go body)
+
+    recoverInstantiation inst =
+      case inst of
+        X.InstApp ty -> X.InstApp (recoverInstType ty)
+        X.InstBot ty -> X.InstBot (recoverInstType ty)
+        X.InstUnder name inner -> X.InstUnder name (recoverInstantiation inner)
+        X.InstInside inner -> X.InstInside (recoverInstantiation inner)
+        X.InstSeq left right -> X.InstSeq (recoverInstantiation left) (recoverInstantiation right)
+        _ -> inst
+
+    recoverInstType ty =
+      case srcTypeToElabTypeMaybe (lowerType scope (recoverSourceType scope (elabTypeToSrcType (stripVacuousForalls ty)))) of
+        Just recovered -> recovered
+        Nothing -> ty
 
 freeTypeVarsTerm :: ElabTerm -> Set String
 freeTypeVarsTerm term =

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -407,6 +407,31 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Box Zero")
     , ProgramMatrixCase
+        "checks parameterized nullary overloaded method through local evidence alias"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (DefaultBox, Nat(..), Box(..), defaultBox, selected, main) {"
+                , "  class DefaultBox a {"
+                , "    defaultBox : Box a;"
+                , "  }"
+                , ""
+                , "  data Nat ="
+                , "      Zero : Nat;"
+                , ""
+                , "  data Box a ="
+                , "      Box : a -> Box a;"
+                , ""
+                , "  instance DefaultBox Nat {"
+                , "    defaultBox = Box Zero;"
+                , "  }"
+                , ""
+                , "  def selected : DefaultBox a => Box a = defaultBox;"
+                , "  def main : Box Nat = selected;"
+                , "}"
+                ]
+        )
+        ExpectCheckSuccess
+    , ProgramMatrixCase
         "rejects nullary overloaded method without expected type evidence"
         ( InlineProgram $
             unlines

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -407,7 +407,7 @@ emlfBoundaryMatrix =
         )
         (ExpectRunValue "Box Zero")
     , ProgramMatrixCase
-        "checks parameterized nullary overloaded method through local evidence alias"
+        "runs parameterized nullary overloaded method through local evidence alias"
         ( InlineProgram $
             unlines
                 [ "module Main export (DefaultBox, Nat(..), Box(..), defaultBox, selected, main) {"
@@ -430,7 +430,7 @@ emlfBoundaryMatrix =
                 , "}"
                 ]
         )
-        ExpectCheckSuccess
+        (ExpectRunValue "Box Zero")
     , ProgramMatrixCase
         "rejects nullary overloaded method without expected type evidence"
         ( InlineProgram $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1528,6 +1528,26 @@ spec = do
             checkProgram program `shouldSatisfy` either
                 (\err -> not ("ProgramCannotInferLambda" `isInfixOf` show err))
                 (const False)
+
+        it "does not rewrite same-shaped ADT instantiations to another nominal head" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (A(..), B(..), keep, main) {"
+                        , "  data A ="
+                        , "      AZ : A;"
+                        , ""
+                        , "  data B ="
+                        , "      BZ : B;"
+                        , ""
+                        , "  def keep : forall a. a -> a = \\x x;"
+                        , "  def main : B = keep BZ;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            checked <- requireChecked program
+            mainBinding <- requireCheckedBinding "Main__main" checked
+            show (checkedBindingTerm mainBinding) `shouldNotSatisfy` isInfixOf "Main.A"
+            (prettyValue <$> runProgram program) `shouldBe` Right "BZ"
   where
     roundtripFixture path =
         it ("roundtrips " ++ path) $ do
@@ -1580,6 +1600,22 @@ spec = do
         case source of
             InlineProgram programText -> requireParsed programText
             ProgramFile path -> requireParsed =<< readFile path
+
+    requireChecked program =
+        case checkProgram program of
+            Left err -> expectationFailure ("check failed: " ++ show err) >> fail "check failed"
+            Right checked -> pure checked
+
+    requireCheckedBinding name checked =
+        case
+            [ binding
+            | checkedModule <- checkedProgramModules checked
+            , binding <- checkedModuleBindings checkedModule
+            , checkedBindingName binding == name
+            ]
+        of
+            binding : _ -> pure binding
+            [] -> expectationFailure ("missing checked binding: " ++ name) >> fail "missing checked binding"
 
 requireParsed :: String -> IO Program
 requireParsed input =

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -7,7 +7,11 @@ import qualified Data.Map.Strict as Map
 import MLF.API (Lit (..), SrcTy (..))
 import MLF.Frontend.Program.Check (checkResolvedProgram)
 import MLF.Frontend.Program.Elaborate (lowerType, mkElaborateScope)
-import MLF.Frontend.Program.Finalize (recoverSourceType, sourceForallMatches)
+import MLF.Frontend.Program.Finalize
+    ( recoverSourceType
+    , sourceForallMatches
+    , stripVacuousForallsAndTypeAbs
+    )
 import MLF.Frontend.Program.Types
     ( ConstructorInfo (..)
     , ConstructorShape (..)
@@ -17,6 +21,7 @@ import MLF.Frontend.Program.Types
     )
 import MLF.Frontend.Syntax (ResolvedSrcTy (..), mkSrcBound)
 import MLF.Program
+import qualified MLF.Types.Elab as Elab
 import MLF.Program.CLI (runProgramFile)
 import Test.Hspec
 
@@ -131,6 +136,17 @@ spec = do
                             (STVarApp "g" (STVar "a" :| []))
                         )
             sourceForallMatches expected actual `shouldBe` False
+
+        it "keeps vacuous foralls when matching type abstractions still carry instantiations" $ do
+            let ty = Elab.TForall "a" Nothing (Elab.TVar "result")
+                retainedTerm =
+                    Elab.ETyAbs
+                        "a"
+                        Nothing
+                        (Elab.ETyInst (Elab.EVar "poly") (Elab.InstApp (Elab.TVar "a")))
+                strippedTerm = Elab.ETyAbs "a" Nothing (Elab.EVar "value")
+            stripVacuousForallsAndTypeAbs ty retainedTerm `shouldBe` (ty, retainedTerm)
+            stripVacuousForallsAndTypeAbs ty strippedTerm `shouldBe` (Elab.TVar "result", Elab.EVar "value")
 
         it "recovers higher-kinded data heads with partially applied constructor parameters" $ do
             let typeIdentity =

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1528,6 +1528,31 @@ spec = do
             checkProgram program `shouldSatisfy` either
                 (\err -> not ("ProgramCannotInferLambda" `isInfixOf` show err))
                 (const False)
+
+        it "runs a parameterized nullary local-evidence alias at a concrete result type" $ do
+            let programText =
+                    unlines
+                        [ "module Main export (DefaultBox, Nat(..), Box(..), defaultBox, selected, main) {"
+                        , "  class DefaultBox a {"
+                        , "    defaultBox : Box a;"
+                        , "  }"
+                        , ""
+                        , "  data Nat ="
+                        , "      Zero : Nat;"
+                        , ""
+                        , "  data Box a ="
+                        , "      Box : a -> Box a;"
+                        , ""
+                        , "  instance DefaultBox Nat {"
+                        , "    defaultBox = Box Zero;"
+                        , "  }"
+                        , ""
+                        , "  def selected : DefaultBox a => Box a = defaultBox;"
+                        , "  def main : Box Nat = selected;"
+                        , "}"
+                        ]
+            program <- requireParsed programText
+            (prettyValue <$> runProgram program) `shouldBe` Right "Box Zero"
   where
     roundtripFixture path =
         it ("roundtrips " ++ path) $ do

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1528,31 +1528,6 @@ spec = do
             checkProgram program `shouldSatisfy` either
                 (\err -> not ("ProgramCannotInferLambda" `isInfixOf` show err))
                 (const False)
-
-        it "runs a parameterized nullary local-evidence alias at a concrete result type" $ do
-            let programText =
-                    unlines
-                        [ "module Main export (DefaultBox, Nat(..), Box(..), defaultBox, selected, main) {"
-                        , "  class DefaultBox a {"
-                        , "    defaultBox : Box a;"
-                        , "  }"
-                        , ""
-                        , "  data Nat ="
-                        , "      Zero : Nat;"
-                        , ""
-                        , "  data Box a ="
-                        , "      Box : a -> Box a;"
-                        , ""
-                        , "  instance DefaultBox Nat {"
-                        , "    defaultBox = Box Zero;"
-                        , "  }"
-                        , ""
-                        , "  def selected : DefaultBox a => Box a = defaultBox;"
-                        , "  def main : Box Nat = selected;"
-                        , "}"
-                        ]
-            program <- requireParsed programText
-            (prettyValue <$> runProgram program) `shouldBe` Right "Box Zero"
   where
     roundtripFixture path =
         it ("roundtrips " ++ path) $ do


### PR DESCRIPTION
Closes #9.

## Implementation Plan

---
issue_number: 9
pr_number: 109
branch: codex/issue-9-2
---

## Context
- Issue #9 is open and PR #109 is open against `master` from `codex/issue-9-2`.
- Local worktree is clean on `codex/issue-9-2`; the branch currently only contains the watcher start commit on top of `origin/HEAD`.
- The rework target is the post-merge finding: `def selected : DefaultBox a => Box a = defaultBox; def main : Box Nat = selected` fails in Phase 7 with `TCArgumentMismatch`, while direct `def main : Box Nat = defaultBox` already works.

## Implementation Plan
1. Add a regression row in `test/Parity/ProgramMatrix.hs` near the existing nullary overloaded method cases for the parameterized local-evidence alias path: `DefaultBox a`, `Box a`, `selected : DefaultBox a => Box a = defaultBox`, and `main : Box Nat = selected`, expecting runtime value `Box Zero`.
2. Fix `src/MLF/Frontend/Program/Finalize.hs` in the nullary deferred-method rewrite so placeholder head type instantiations are preserved only where they are semantically needed. Specifically, pass the collected head instantiations into nullary resolution and keep the existing preservation for global instance-method replacement, but avoid replaying placeholder instantiations over already-typed local evidence parameters. Local evidence should be instantiated from the recovered method substitution and its own evidence type via `instantiateLocalMethodEvidence`, not by blindly reapplying the placeholder spine.
3. Keep ambiguity fail-closed: no expected result should still produce `ProgramAmbiguousMethodUse`, and missing/no matching evidence should continue through the existing `ProgramNoMatchingInstance`/ambiguous paths.
4. Update `implementation_notes.md` and `CHANGELOG.md` with a short 2026-04-30 note describing the constrained-alias fix for parameterized nullary associated values. Do not change `docs/mlfp-language-reference.md` unless implementation changes the already-documented contract.
5. Validate with a focused Hspec match for the new case, then run nearby nullary overloaded method matrix coverage. Before claiming completion, run `cabal build all && cabal test` as the required behavior-changing full gate.
6. Before publishing, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, then push to the existing `codex/issue-9-2` branch for PR #109. Do not create another PR or resolve review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.