### PR TITLE
Implement #94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   status while skipping explicitly when tools are unavailable.
 
 ### Changed
+- LLVM case lowering now treats closure-valued case results as closure
+  pointers, so `BackendClosureCall` can use a case-selected closure callee
+  without rejecting the callee's arrow result type.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3836,7 +3836,7 @@ lowerCase env exprEnv context resultTy scrutinee alternatives =
 lowerHeapCase :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> NonEmpty BackendAlternative -> LowerM LowerValue
 lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
   rejectNonTailDefaultAlternative
-  resultLLVMType <- lowerBackendTypeM env context resultTy
+  resultLLVMType <- lowerCaseResultTypeM env context resultTy
   scrutineeValue <- lowerExpr env exprEnv context scrutinee
   unless (lvLLVMType scrutineeValue == LLVMPtr) $
     liftEither (BackendLLVMUnsupportedType (context ++ " case scrutinee") (lvBackendType scrutineeValue))
@@ -3951,6 +3951,17 @@ lowerClosureStoredTypeM env context fieldTy
   | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
   | otherwise = lowerBackendTypeM env context fieldTy
 
+lowerCaseResultTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
+lowerCaseResultTypeM env context resultTy
+  | isCaseClosureResultType resultTy = pure LLVMPtr
+  | otherwise = lowerBackendTypeM env context resultTy
+
+isCaseClosureResultType :: BackendType -> Bool
+isCaseClosureResultType =
+  \case
+    BTArrow {} -> True
+    _ -> False
+
 lowerImmediateConstructCase ::
   ProgramEnv ->
   ExprEnv ->
@@ -3970,7 +3981,7 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
     Just alternative -> do
       exprEnv' <- bindImmediateAlternativePattern alternative
       bodyValue <- lowerExpr env exprEnv' context (backendAltBody alternative)
-      expectedTy <- lowerBackendTypeM env context resultTy
+      expectedTy <- lowerCaseResultTypeM env context resultTy
       unless (lvLLVMType bodyValue == expectedTy) $
         liftEither (BackendLLVMInternalError ("immediate case alternative type mismatch at " ++ context))
       pure bodyValue
@@ -4008,7 +4019,7 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
 
     lowerUnmatchedImmediateCase = do
       zipWithM_ evaluateUnusedField fieldTys args
-      expectedTy <- lowerBackendTypeM env context resultTy
+      expectedTy <- lowerCaseResultTypeM env context resultTy
       finishCurrentBlock LLVMUnreachable
       continuationLabel <- freshBlock "case.unreachable.cont"
       startBlock continuationLabel

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -612,6 +612,15 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
     validateLLVMAssembly output
 
+  it "lowers case-selected closure callees through the explicit closure ABI" $ do
+    output <- requireRight (renderBackendProgramLLVM caseSelectedClosureCalleeProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$case_some\"(ptr %\"__mlfp_env\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$case_none\"(ptr %\"__mlfp_env\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "phi ptr"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+
   it "qualifies closure entry names emitted from type specializations" $ do
     output <- requireRight (renderBackendProgramLLVM polymorphicClosureSpecializationProgram)
 
@@ -2895,6 +2904,50 @@ capturedClosureProgram =
               backendLetBody = BackendClosureCall intTy (BackendVar unaryIntTy "f") [intLit 0]
             }
       }
+
+caseSelectedClosureCalleeProgram :: BackendProgram
+caseSelectedClosureCalleeProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [optionData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendClosureCall
+                          intTy
+                          ( BackendCase
+                              unaryIntTy
+                              (BackendConstruct (optionTy intTy) "Some" [intLit 0])
+                              ( BackendAlternative
+                                  (BackendConstructorPattern "Some" ["n"])
+                                  (caseClosure "__mlfp_closure$case_some" (BackendVar intTy "x"))
+                                  :| [ BackendAlternative
+                                         (BackendConstructorPattern "None" [])
+                                         (caseClosure "__mlfp_closure$case_none" (intLit 0))
+                                     ]
+                              )
+                          )
+                          [intLit 7],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+  where
+    caseClosure entryName body =
+      BackendClosure
+        { backendExprType = unaryIntTy,
+          backendClosureEntryName = entryName,
+          backendClosureCaptures = [],
+          backendClosureParams = [("x", intTy)],
+          backendClosureBody = body
+        }
 
 polymorphicClosureSpecializationProgram :: BackendProgram
 polymorphicClosureSpecializationProgram =


### PR DESCRIPTION
Closes #94.

## Implementation Plan

---
issue_number: 94
pr_number: 110
branch: codex/issue-94-2
---

**Implementation Plan**

Context from inspection: issue #94 is open because post-merge verification found one rework item. PR #110 is open on `codex/issue-94-2` with no file changes yet. The old local `issue-plan.md` content belongs to PR #106 / `codex/issue-94` and is superseded by this plan.

1. Preserve the existing branch and PR setup.
   - Work only on `codex/issue-94-2` for PR #110.
   - Start implementation by rereading the watcher-written plan and checking `git status --short --branch`.
   - Do not create another PR and do not touch watcher-owned runtime/state files.

2. Fix the backend lowering mismatch by supporting closure-valued case results at the LLVM case boundary.
   - Edit `src/MLF/Backend/LLVM/Lower.hs`.
   - Keep `lowerBackendType` rejecting generic `BTArrow`; do not broaden ordinary escaping function lowering.
   - Add a small helper for case result LLVM types, for example `lowerCaseResultTypeM`, that returns `LLVMPtr` when the `BackendCase` result type is a runtime closure/function value (`BTArrow{}`) and otherwise delegates to `lowerBackendTypeM`.
   - Use that helper anywhere `lowerCase` materializes a case result slot: `lowerHeapCase`, `lowerImmediateConstructCase`, and the unmatched-immediate-case dummy path.
   - Let alternative lowering continue to enforce correctness: all selected closure alternatives should lower to `LLVMPtr`; direct first-order escaping functions or unsupported alternatives should still fail closed.

3. Add focused regressions for the exact issue.
   - In `test/BackendLLVMSpec.hs`, add a program where `BackendClosureCall` uses a `BackendCase unaryIntTy ...` as its callee and every alternative returns a `BackendClosure`.
   - Assert LLVM rendering succeeds, contains closure pointer selection evidence such as a `phi ptr`/closure indirect call, and passes `validateLLVMAssembly`.
   - Prefer a direct case-shaped callee fixture over only a let-bound variant, because that matches the post-merge finding.
   - Optionally add a small `BackendIRSpec` positive assertion documenting that an all-closure case callee is valid IR, beside the existing mixed-case rejection.

4. Update docs/changelog only for durable behavior notes.
   - Add a concise `CHANGELOG.md` Unreleased entry noting that LLVM lowering now handles case-selected closure callees as closure pointers.
   - Do not add `Bugs.md` churn unless implementation reveals a broader tracked defect.

5. Validate in increasing scope.
   - Run the new focused test by Hspec match name.
   - Run the backend LLVM slice, for example `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.LLVM"'`.
   - If `BackendIRSpec` is touched, also run its focused slice.
   - Before claiming completion for this behavior-changing backend fix, run `cabal build all && cabal test`.

6. Publish the existing PR branch after validation.
   - Inspect `git status --short` and relevant diffs.
   - Stage only issue-related files.
   - Commit as `codex-watcher <codex-watcher@users.noreply.github.com>` with an imperative message such as `Lower case-selected closure callees`.
   - Run `gh auth status` and `gh auth setup-git`, then push `codex/issue-94-2` to update PR #110.
   - Return `complete` only after validation and push succeed; return `blocked` if branch/PR verification fails or unrelated dirty changes make safe staging unclear.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.