### PR TITLE
Implement #91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+- Added the checked `.mlfp` source surface for `Unit`, opaque `IO`, initial IO
+  primitives, and the built-in `Monad IO` Prelude instance; backend conversion
+  remains fail-closed for IO entrypoints until concrete IO lowering is added.
 - Added native LLVM toolchain runner support to the test harness. LLVM backend
   tests can now discover `llc` plus a native linker, build a temporary
   executable from emitted `.ll`, run it, and capture stdout, stderr, and exit

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The unified `.mlfp` surface includes:
 - existential constructors via `forall`
 - single-parameter typeclasses, class constraints, and schema instances
 - `deriving Eq` for nullary, recursive, and parameterized ADTs whose fields have Eq evidence
+- a built-in Prelude with `Nat`, `Option`, `List`, `Eq`, `Unit`, opaque
+  `IO`, minimal `Monad IO`, `pure`, `bind`, `putStrLn`, `and`, and `id`
 
 `.mlfp` modules are same-compilation-unit modules today: imports resolve among
 modules in the parsed program, with the CLI runner adding the built-in Prelude

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -403,10 +403,14 @@ module Main export (main) {
 
 Current prelude contents:
 
+- `Unit(..)` with the `Unit` value constructor
+- opaque `IO`
 - `Nat(..)` with derived `Eq Nat`
 - `Option(..)` with derived `Eq a => Eq (Option a)`
 - `List(..)` with `Nil`, `Cons`, and derived `Eq a => Eq (List a)`
 - `Eq` and `eq`
+- `Monad`, with the built-in `Monad IO` instance
+- `pure`, `bind`, and `putStrLn`
 - `and`
 - `id`
 

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -252,11 +252,13 @@ instance Eq a => Eq (Option a) {
 
 Method calls lower to deferred obligations and resolve after eMLF inference.
 Partial overloaded method application is supported by eta-expanding the missing
-arguments. Nullary overloaded methods / associated values can also resolve from
-an explicit or propagated expected source type when the method result determines
-the class parameter; for example, `(mempty : Nat)` can select a `Monoid Nat`
-instance. Bare overloaded method names without enough term arguments or
-expected-type evidence remain ambiguous and are rejected.
+arguments. Overloaded methods can also resolve from an explicit or propagated
+expected source type when the supplied term arguments alone do not determine the
+class parameter but the method result does; for example, `(mempty : Nat)` can
+select a `Monoid Nat` instance, and `pure Unit` can select `Monad IO` under an
+expected result type of `IO Unit`. Bare overloaded method names or applications
+without enough term arguments or expected-type evidence remain ambiguous and are
+rejected.
 
 Instance resolution is coherent and fail-closed: duplicate and overlapping
 instance heads are rejected by unification, and a missing instance remains a
@@ -320,7 +322,7 @@ module Main export (main) {
 }
 ```
 
-The effectful entrypoint mode is `main : IO Unit`:
+The checked effectful entrypoint mode is `main : IO Unit`:
 
 ```mlf
 module Main export (main) {
@@ -331,10 +333,11 @@ module Main export (main) {
 }
 ```
 
-An `IO` action is still a pure value while the program is checked and normalized.
-Effects occur only when the runner executes the final checked `main` action, and
-sequencing is determined by `bind` through the runtime interpretation of the
-opaque `IO` primitive boundary. The initial runner contract does not render
+An `IO` action is still an opaque value while the program is checked and
+normalized. The current `run-program` implementation fails closed for `IO`
+entrypoints until the runtime IO issue adds concrete primitive interpretation.
+When runtime support exists, sequencing is determined by `bind` through that
+opaque primitive boundary, and the initial runtime contract should not render
 `main : IO a` results for non-`Unit` `a`.
 
 The backend contract is fail-closed for the first IO slice. `emit-backend`

--- a/mlf2.cabal
+++ b/mlf2.cabal
@@ -78,6 +78,7 @@ library mlf2-internal
                       MLF.Frontend.Program.Parse,
                       MLF.Frontend.Program.Pretty,
                       MLF.Frontend.Program.Types,
+                      MLF.Frontend.Program.Builtins,
                       MLF.Frontend.Program.Resolve,
                       MLF.Frontend.Program.Surface,
                       MLF.Frontend.Program.Prelude,

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -45,6 +45,7 @@ import MLF.Elab.Types
     schemeFromType,
     tyToElab,
   )
+import qualified MLF.Frontend.Program.Builtins as Builtins
 import MLF.Frontend.Program.Elaborate (ElaborateScope, elaborateScopeDataTypes, lowerType, mkElaborateScope)
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
@@ -116,6 +117,7 @@ type LiftM = StateT LiftState (Either BackendConversionError)
 
 convertCheckedProgram :: CheckedProgram -> Either BackendConversionError BackendProgram
 convertCheckedProgram checked = do
+  rejectOpaqueBuiltinMain checked
   context <- buildConvertContext checked
   initialEnv <- buildInitialEnv context checked
   modules0 <- mapM (convertCheckedModule context initialEnv) (checkedProgramModules checked)
@@ -184,13 +186,35 @@ backendBuiltinTermTypes =
 convertCheckedModule :: ConvertContext -> Env -> CheckedModule -> Either BackendConversionError BackendModule
 convertCheckedModule context env checkedModule = do
   dataDecls <- mapM (convertDataInfo context) (Map.elems (checkedModuleData checkedModule))
-  bindings <- concat <$> mapM (convertCheckedBinding context env checkedModule) (checkedModuleBindings checkedModule)
+  bindings <-
+    concat
+      <$> mapM
+        (convertCheckedBinding context env checkedModule)
+        (filter (not . checkedBindingMentionsOpaqueBuiltin) (checkedModuleBindings checkedModule))
   Right
     BackendModule
       { backendModuleName = checkedModuleName checkedModule,
         backendModuleData = dataDecls,
         backendModuleBindings = bindings
       }
+
+rejectOpaqueBuiltinMain :: CheckedProgram -> Either BackendConversionError ()
+rejectOpaqueBuiltinMain checked =
+  case
+    [ binding
+      | checkedModule <- checkedProgramModules checked,
+        binding <- checkedModuleBindings checkedModule,
+        checkedBindingName binding == checkedProgramMain checked
+    ]
+  of
+    binding : _
+      | checkedBindingMentionsOpaqueBuiltin binding ->
+          Left (BackendUnsupportedCaseShape "IO programs are not supported by backend conversion yet")
+    _ -> Right ()
+
+checkedBindingMentionsOpaqueBuiltin :: CheckedBinding -> Bool
+checkedBindingMentionsOpaqueBuiltin =
+  Builtins.srcTypeMentionsOpaqueBuiltin . checkedBindingSourceType
 
 convertCheckedBinding :: ConvertContext -> Env -> CheckedModule -> CheckedBinding -> Either BackendConversionError [BackendBinding]
 convertCheckedBinding context env checkedModule binding = do

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -210,7 +210,38 @@ rejectOpaqueBuiltinMain checked =
     binding : _
       | checkedBindingMentionsOpaqueBuiltin binding ->
           Left (BackendUnsupportedCaseShape "IO programs are not supported by backend conversion yet")
-    _ -> Right ()
+    _ ->
+      case referencedOpaqueBuiltinBindings checked of
+        [] -> Right ()
+        refs ->
+          Left
+            ( BackendUnsupportedCaseShape
+                ( "IO dependencies are not supported by backend conversion yet: "
+                    ++ intercalate ", " [owner ++ " -> " ++ opaque | (owner, opaque) <- refs]
+                )
+            )
+
+referencedOpaqueBuiltinBindings :: CheckedProgram -> [(String, String)]
+referencedOpaqueBuiltinBindings checked =
+  [ (checkedBindingName binding, opaqueName)
+    | binding <- allCheckedBindings checked,
+      not (checkedBindingMentionsOpaqueBuiltin binding),
+      opaqueName <- Set.toList (freeTermVariables (checkedBindingTerm binding) `Set.intersection` opaqueNames)
+  ]
+  where
+    opaqueNames =
+      Set.fromList
+        [ checkedBindingName binding
+          | binding <- allCheckedBindings checked,
+            checkedBindingMentionsOpaqueBuiltin binding
+        ]
+
+allCheckedBindings :: CheckedProgram -> [CheckedBinding]
+allCheckedBindings checked =
+  [ binding
+    | checkedModule <- checkedProgramModules checked,
+      binding <- checkedModuleBindings checkedModule
+  ]
 
 checkedBindingMentionsOpaqueBuiltin :: CheckedBinding -> Bool
 checkedBindingMentionsOpaqueBuiltin =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -230,7 +230,8 @@ referencedOpaqueBuiltinBindings checked =
   ]
   where
     opaqueNames =
-      Set.fromList
+      Builtins.builtinOpaqueValueNames
+        `Set.union` Set.fromList
         [ checkedBindingName binding
           | binding <- allCheckedBindings checked,
             checkedBindingMentionsOpaqueBuiltin binding

--- a/src/MLF/Frontend/Program/Builtins.hs
+++ b/src/MLF/Frontend/Program/Builtins.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE GADTs #-}
+
+module MLF.Frontend.Program.Builtins
+  ( builtinModuleName,
+    builtinTypeNames,
+    builtinTypeKind,
+    builtinTypeSymbol,
+    builtinValueSymbol,
+    builtinValues,
+    builtinOpaqueTypes,
+    builtinOpaqueTypeNames,
+    isBuiltinTypeName,
+    isBuiltinTypeSymbol,
+    isOpaqueBuiltinDataInfo,
+    srcTypeMentionsOpaqueBuiltin,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import MLF.Frontend.Program.Types
+  ( DataInfo (..),
+    ResolvedSymbol,
+    SymbolIdentity (..),
+    SymbolNamespace (..),
+    SymbolOrigin (..),
+    ValueInfo (..),
+    mkResolvedSymbol,
+    resolvedSymbolIdentity,
+  )
+import MLF.Frontend.Syntax (SrcBound (..), SrcTy (..), SrcType, firstOrderTypeParam)
+import qualified MLF.Frontend.Syntax.Program as P
+
+builtinModuleName :: String
+builtinModuleName = "<builtin>"
+
+builtinTypeKinds :: Map String P.SrcKind
+builtinTypeKinds =
+  Map.fromList
+    [ ("Int", P.KType),
+      ("Bool", P.KType),
+      ("String", P.KType),
+      ("IO", P.KArrow P.KType P.KType)
+    ]
+
+builtinTypeNames :: Set String
+builtinTypeNames = Map.keysSet builtinTypeKinds
+
+builtinOpaqueTypeNames :: Set String
+builtinOpaqueTypeNames = Set.singleton "IO"
+
+isBuiltinTypeName :: String -> Bool
+isBuiltinTypeName = (`Map.member` builtinTypeKinds)
+
+builtinTypeKind :: String -> Maybe P.SrcKind
+builtinTypeKind = (`Map.lookup` builtinTypeKinds)
+
+builtinTypeSymbol :: String -> ResolvedSymbol
+builtinTypeSymbol = builtinSymbol SymbolType
+
+builtinValueSymbol :: String -> ResolvedSymbol
+builtinValueSymbol = builtinSymbol SymbolValue
+
+builtinSymbol :: SymbolNamespace -> String -> ResolvedSymbol
+builtinSymbol namespace name =
+  mkResolvedSymbol
+    ( SymbolIdentity
+        { symbolNamespace = namespace,
+          symbolDefiningModule = builtinModuleName,
+          symbolDefiningName = name,
+          symbolOwnerIdentity = Nothing
+        }
+    )
+    name
+    name
+    SymbolBuiltin
+
+isBuiltinTypeSymbol :: ResolvedSymbol -> Bool
+isBuiltinTypeSymbol symbol =
+  let identity = resolvedSymbolIdentity symbol
+   in symbolNamespace identity == SymbolType
+        && symbolDefiningModule identity == builtinModuleName
+
+builtinValues :: Map String ValueInfo
+builtinValues =
+  Map.fromList
+    [ builtinOrdinary "__mlfp_and" (bool `STArrow` (bool `STArrow` bool)),
+      builtinOrdinary "__io_pure" (STForall "a" Nothing (STVar "a" `STArrow` ioOf (STVar "a"))),
+      builtinOrdinary "__io_bind" (STForall "a" Nothing (STForall "b" Nothing ioBindType)),
+      builtinOrdinary "__io_putStrLn" (string `STArrow` ioOf unit)
+    ]
+  where
+    bool = STBase "Bool"
+    string = STBase "String"
+    unit = STBase "Unit"
+    ioOf ty = STCon "IO" (ty :| [])
+    ioBindType =
+      ioOf (STVar "a")
+        `STArrow` ((STVar "a" `STArrow` ioOf (STVar "b")) `STArrow` ioOf (STVar "b"))
+
+builtinOrdinary :: String -> SrcType -> (String, ValueInfo)
+builtinOrdinary name ty =
+  ( name,
+    OrdinaryValue
+      { valueDisplayName = name,
+        valueInfoSymbol = builtinIdentity SymbolValue name,
+        valueRuntimeName = name,
+        valueType = ty,
+        valueIdentityType = canonicalBuiltinSrcType ty,
+        valueConstraints = [],
+        valueConstraintInfos = [],
+        valueOriginModule = builtinModuleName
+      }
+  )
+
+builtinOpaqueTypes :: Map String DataInfo
+builtinOpaqueTypes =
+  Map.singleton
+    "IO"
+    DataInfo
+      { dataName = "IO",
+        dataInfoSymbol = builtinIdentity SymbolType "IO",
+        dataModule = builtinModuleName,
+        dataTypeParams = [firstOrderTypeParam "a"],
+        dataParams = ["a"],
+        dataConstructors = []
+      }
+
+isOpaqueBuiltinDataInfo :: DataInfo -> Bool
+isOpaqueBuiltinDataInfo info =
+  dataInfoSymbol info == builtinIdentity SymbolType "IO"
+
+srcTypeMentionsOpaqueBuiltin :: SrcType -> Bool
+srcTypeMentionsOpaqueBuiltin = go
+  where
+    go ty =
+      case ty of
+        STVar {} -> False
+        STBase name -> isOpaqueName name
+        STCon name args -> isOpaqueName name || any go args
+        STVarApp _ args -> any go args
+        STArrow dom cod -> go dom || go cod
+        STForall _ mb body -> maybe False (go . unSrcBound) mb || go body
+        STMu _ body -> go body
+        STBottom -> False
+
+    isOpaqueName name =
+      name `Set.member` builtinOpaqueTypeNames
+        || name `Set.member` Set.map qualifyBuiltin builtinOpaqueTypeNames
+
+    qualifyBuiltin name = builtinModuleName ++ "." ++ name
+
+builtinIdentity :: SymbolNamespace -> String -> SymbolIdentity
+builtinIdentity namespace name =
+  SymbolIdentity
+    { symbolNamespace = namespace,
+      symbolDefiningModule = builtinModuleName,
+      symbolDefiningName = name,
+      symbolOwnerIdentity = Nothing
+    }
+
+canonicalBuiltinSrcType :: SrcType -> SrcType
+canonicalBuiltinSrcType = go
+  where
+    go ty =
+      case ty of
+        STVar {} -> ty
+        STBase name
+          | isBuiltinTypeName name -> STBase (builtinModuleName ++ "." ++ name)
+          | otherwise -> ty
+        STCon name args
+          | isBuiltinTypeName name -> STCon (builtinModuleName ++ "." ++ name) (fmap go args)
+          | otherwise -> STCon name (fmap go args)
+        STVarApp name args -> STVarApp name (fmap go args)
+        STArrow dom cod -> STArrow (go dom) (go cod)
+        STForall name mb body -> STForall name (fmap (SrcBound . go . unSrcBound) mb) (go body)
+        STMu name body -> STMu name (go body)
+        STBottom -> STBottom

--- a/src/MLF/Frontend/Program/Builtins.hs
+++ b/src/MLF/Frontend/Program/Builtins.hs
@@ -7,6 +7,7 @@ module MLF.Frontend.Program.Builtins
     builtinTypeSymbol,
     builtinValueSymbol,
     builtinValues,
+    builtinOpaqueValueNames,
     builtinOpaqueTypes,
     builtinOpaqueTypeNames,
     isBuiltinTypeName,
@@ -115,6 +116,14 @@ builtinOrdinary name ty =
         valueOriginModule = builtinModuleName
       }
   )
+
+builtinOpaqueValueNames :: Set String
+builtinOpaqueValueNames =
+  Set.fromList
+    [ runtimeName
+      | OrdinaryValue {valueRuntimeName = runtimeName, valueType = ty} <- Map.elems builtinValues,
+        srcTypeMentionsOpaqueBuiltin ty
+    ]
 
 builtinOpaqueTypes :: Map String DataInfo
 builtinOpaqueTypes =

--- a/src/MLF/Frontend/Program/Check.hs
+++ b/src/MLF/Frontend/Program/Check.hs
@@ -31,6 +31,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
+import qualified MLF.Frontend.Program.Builtins as Builtins
 import MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
     lowerConstructorBinding,
@@ -40,7 +41,7 @@ import MLF.Frontend.Program.Elaborate
     resolveInstanceInfoWithIdentityType,
     sourceTypeViewInScope,
   )
-import MLF.Frontend.Program.Finalize (finalizeBinding)
+import MLF.Frontend.Program.Finalize (finalizeBinding, finalizeBindingAllowOpaque)
 import MLF.Frontend.Program.Resolve (resolveProgram)
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
@@ -142,11 +143,7 @@ data KindTerm
   deriving (Eq, Show)
 
 emptyScope :: Scope
-emptyScope = mkScope builtinValues Map.empty Map.empty []
-
-mkScope :: Map String ValueInfo -> Map String DataInfo -> Map String ClassInfo -> [InstanceInfo] -> Scope
-mkScope values0 types0 classes0 instances0 =
-  mkScopeWithHidden values0 types0 Map.empty classes0 instances0
+emptyScope = mkScopeWithHidden Builtins.builtinValues Map.empty Builtins.builtinOpaqueTypes Map.empty []
 
 mkScopeWithHidden ::
   Map String ValueInfo ->
@@ -194,27 +191,6 @@ scopeElaborateTypes scope =
 indexByIdentity :: (a -> SymbolIdentity) -> Map String a -> Map SymbolIdentity [(String, a)]
 indexByIdentity identityOf =
   Map.fromListWith (++) . map (\(name, info) -> (identityOf info, [(name, info)])) . Map.toList
-
-builtinValues :: Map String ValueInfo
-builtinValues =
-  Map.singleton
-    "__mlfp_and"
-    OrdinaryValue
-      { valueDisplayName = "__mlfp_and",
-        valueInfoSymbol =
-          SymbolIdentity
-            { symbolNamespace = SymbolValue,
-              symbolDefiningModule = "<builtin>",
-              symbolDefiningName = "__mlfp_and",
-              symbolOwnerIdentity = Nothing
-        },
-        valueRuntimeName = "__mlfp_and",
-        valueType = STArrow (STBase "Bool") (STArrow (STBase "Bool") (STBase "Bool")),
-        valueIdentityType = STArrow (STBase "Bool") (STArrow (STBase "Bool") (STBase "Bool")),
-        valueConstraints = [],
-        valueConstraintInfos = [],
-        valueOriginModule = "<builtin>"
-      }
 
 emptyDisplayNameEnv :: DisplayNameEnv
 emptyDisplayNameEnv =
@@ -366,10 +342,7 @@ resolvedSymbolDisplayName =
   P.refDisplayName
 
 isBuiltinTypeSymbol :: ResolvedSymbol -> Bool
-isBuiltinTypeSymbol symbol =
-  let identity = resolvedSymbolIdentity symbol
-   in symbolNamespace identity == SymbolType
-        && symbolDefiningModule identity == "<builtin>"
+isBuiltinTypeSymbol = Builtins.isBuiltinTypeSymbol
 
 -- Program checking ------------------------------------------------------------
 
@@ -1408,7 +1381,7 @@ kindEnvFromScope scope =
     { kindTypeConstructors =
         Map.fromList
           [ (dataInfoSymbolIdentity dataInfo, dataKind (dataTypeParams dataInfo))
-            | dataInfo <- Map.elems (scopeTypes scope)
+            | dataInfo <- Map.elems (scopeElaborateTypes scope)
           ],
       kindTypeVariables = Map.empty,
       kindMetaSubst = Map.empty,
@@ -1709,7 +1682,7 @@ resolvedTypeHeadKind env symbol =
 
 resolvedTypeHeadKindMaybe :: KindEnv -> ResolvedSymbol -> Maybe P.SrcKind
 resolvedTypeHeadKindMaybe env symbol
-  | isBuiltinTypeSymbol symbol = Just P.KType
+  | isBuiltinTypeSymbol symbol = Builtins.builtinTypeKind (symbolDefiningName (resolvedSymbolIdentity symbol))
   | otherwise = Map.lookup (resolvedSymbolIdentity symbol) (kindTypeConstructors env)
 
 buildLocalDataInfo :: DisplayNameEnv -> ResolvedModule -> P.ResolvedModuleSyntax -> TcM (Map String DataInfo)
@@ -2083,7 +2056,7 @@ synthesizeDerivedInstances displayEnv scope resolvedModule mod0 = do
 
     mkEqInstance classSymbol classInfo eqMethodSymbol resolvedDataDecl displayDataDecl = do
       dataSymbol <- uniqueResolvedLocalSymbol ProgramDuplicateType (P.dataDeclName resolvedDataDecl) (resolvedModuleLocalTypes resolvedModule)
-      boolSymbol <- pure (builtinTypeSymbol "Bool")
+      boolSymbol <- pure (Builtins.builtinTypeSymbol "Bool")
       andSymbol <- valueSymbolForName "__mlfp_and"
       ctorEntries <-
         forM (P.dataDeclConstructors resolvedDataDecl) $ \ctor -> do
@@ -2177,19 +2150,6 @@ synthesizeDerivedInstances displayEnv scope resolvedModule mod0 = do
       case P.typeParamNames (P.dataDeclParams dataDecl) of
         [] -> RSTBase dataSymbol
         param0 : paramsRest -> RSTCon dataSymbol (RSTVar param0 :| map RSTVar paramsRest)
-
-    builtinTypeSymbol name =
-      mkResolvedSymbol
-        ( SymbolIdentity
-            { symbolNamespace = SymbolType,
-              symbolDefiningModule = "<builtin>",
-              symbolDefiningName = name,
-              symbolOwnerIdentity = Nothing
-            }
-        )
-        name
-        name
-        SymbolBuiltin
 
     valueSymbolForName name =
       case Map.lookup name (scopeValues scope) of
@@ -2495,7 +2455,7 @@ checkInstance elaborateScope scope instDecl = do
                 }
         liftEither
           ( lowerConstrainedResolvedExprBinding elaborateScope methodRuntimeName (valueConstraintInfos valueInfo) methodSourceView False (P.methodDefExpr methodDef)
-              >>= finalizeBinding elaborateScope
+              >>= finalizeBindingAllowOpaque elaborateScope
           )
       _ -> throwError (ProgramUnexpectedInstanceMethod (className classInfo) (P.methodDefName methodDef))
   where
@@ -2514,7 +2474,7 @@ checkDef elaborateScope scope defDecl = do
     ordinary@OrdinaryValue {} -> do
       liftEither
         ( lowerResolvedConstrainedExprBinding elaborateScope (valueRuntimeName ordinary) (P.defDeclType defDecl) (P.defDeclName defDecl == "main") (P.defDeclExpr defDecl)
-            >>= finalizeBinding elaborateScope
+            >>= finalizeBindingAllowOpaque elaborateScope
         )
     _ -> throwError (ProgramDuplicateValue (P.defDeclName defDecl))
 
@@ -2534,7 +2494,7 @@ buildExports mod0 localData localClasses localValues = do
           }
     Just items -> do
       values <- foldM (collectResolvedExportValue localValues localClasses localData) Map.empty items
-      types <- foldM (collectResolvedExportType localData) Map.empty items
+      types <- foldM (collectResolvedExportType (P.moduleName mod0) localData) Map.empty items
       classes <- foldM (collectResolvedExportClass localClasses) Map.empty items
       pure
         ModuleExports
@@ -2586,11 +2546,15 @@ collectResolvedExportValue localValues localClasses localData acc = \case
          in liftEither (addValues acc methodValues)
       Nothing -> pure acc
 
-collectResolvedExportType :: Map String DataInfo -> Map String ExportedTypeInfo -> P.ResolvedExportItem -> TcM (Map String ExportedTypeInfo)
-collectResolvedExportType localData acc = \case
+collectResolvedExportType :: P.ModuleName -> Map String DataInfo -> Map String ExportedTypeInfo -> P.ResolvedExportItem -> TcM (Map String ExportedTypeInfo)
+collectResolvedExportType moduleName0 localData acc = \case
   P.ExportType ref ->
     case localDataByRef ref localData of
       Just (typeName, dataInfo) -> pure (Map.insert typeName (ExportedTypeInfo dataInfo Map.empty) acc)
+      Nothing
+        | moduleName0 == "Prelude",
+          Just dataInfo <- builtinOpaqueDataByRef ref ->
+            pure (Map.insert (P.resolvedExportTypeName ref) (ExportedTypeInfo dataInfo Map.empty) acc)
       Nothing -> pure acc
   P.ExportTypeWithConstructors ref ->
     case localDataByRef ref localData of
@@ -2599,6 +2563,18 @@ collectResolvedExportType localData acc = \case
           (Map.insert typeName (ExportedTypeInfo dataInfo (Map.fromList [(ctorName ctor, ctor) | ctor <- dataConstructors dataInfo])) acc)
       Nothing -> throwError (ProgramExportNotLocal (P.resolvedExportTypeName ref))
   P.ExportValue _ -> pure acc
+
+builtinOpaqueDataByRef :: P.ResolvedExportTypeRef -> Maybe DataInfo
+builtinOpaqueDataByRef ref =
+  case
+    [ dataInfo
+      | symbol <- P.resolvedExportTypeSymbols ref,
+        Builtins.isBuiltinTypeSymbol symbol,
+        Just dataInfo <- [Map.lookup (symbolDefiningName (resolvedSymbolIdentity symbol)) Builtins.builtinOpaqueTypes]
+    ]
+  of
+    dataInfo : _ -> Just dataInfo
+    [] -> Nothing
 
 collectResolvedExportClass :: Map String ClassInfo -> Map String ClassInfo -> P.ResolvedExportItem -> TcM (Map String ClassInfo)
 collectResolvedExportClass localClasses acc = \case

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -1428,7 +1428,9 @@ annotateExpectedValueUse scope mbExpected valueInfo applied =
   case mbExpected of
     Just expectedTy
       | not (isLocalOrdinaryValue valueInfo),
-        isRecursiveResultType expectedTy || isRecursiveResultType (lowerType scope expectedTy) ->
+        isRecursiveResultType expectedTy
+          || isRecursiveResultType (lowerType scope expectedTy)
+          || Builtins.srcTypeMentionsOpaqueBuiltin expectedTy ->
           surfaceAnn applied (lowerType scope expectedTy)
     _ -> applied
 
@@ -1786,6 +1788,11 @@ shouldResolveMethodBeforeInference :: ElaborateScope -> MethodInfo -> SrcType ->
 shouldResolveMethodBeforeInference scope methodInfo classArgTy =
   case lookupEvidenceMethodByClass scope (methodInfoClassIdentity methodInfo) (typeViewIdentity (sourceTypeViewInScope scope classArgTy)) (methodName methodInfo) of
     Just _ -> True
+    Nothing
+      | Builtins.srcTypeMentionsOpaqueBuiltin classArgTy ->
+          case resolveMethodInstanceInfoByTypeView scope methodInfo (sourceTypeViewInScope scope classArgTy) of
+            Right _ -> True
+            Left _ -> False
     Nothing -> False
 
 resolveConstraintEvidenceExpr :: ElaborateScope -> Set (SymbolIdentity, String) -> ConstraintInfo -> ElaborateM [SurfaceExpr]
@@ -2100,7 +2107,13 @@ placeholderMethodType scope methodInfo args mbExpectedResult =
       quantifiedMethodTy = quantifiedMethodType methodInfo
       knownClassArg = knownMethodClassArg scope methodInfo args mbExpectedResult
    in case knownClassArg of
-        Just classArgTy -> stripVacuousSrcForalls (specializeMethodType methodTy paramName classArgTy)
+        Just classArgTy ->
+          let specializedTy = stripVacuousSrcForalls (specializeMethodType methodTy paramName classArgTy)
+              callSubst =
+                case inferMethodCallSubst scope methodInfo classArgTy args of
+                  Just subst -> subst
+                  Nothing -> Map.empty
+           in stripVacuousSrcForalls (specializeQuantifiedType callSubst specializedTy)
         Nothing -> quantifiedMethodTy
 
 placeholderResolvedMethodType :: ElaborateScope -> MethodInfo -> [P.ResolvedExpr] -> Maybe SrcType -> SrcType
@@ -2110,7 +2123,13 @@ placeholderResolvedMethodType scope methodInfo args mbExpectedResult =
       quantifiedMethodTy = quantifiedMethodType methodInfo
       knownClassArg = knownResolvedMethodClassArg scope methodInfo args mbExpectedResult
    in case knownClassArg of
-        Just classArgTy -> stripVacuousSrcForalls (specializeMethodType methodTy paramName classArgTy)
+        Just classArgTy ->
+          let specializedTy = stripVacuousSrcForalls (specializeMethodType methodTy paramName classArgTy)
+              callSubst =
+                case inferResolvedMethodCallSubst scope methodInfo classArgTy args of
+                  Just subst -> subst
+                  Nothing -> Map.empty
+           in stripVacuousSrcForalls (specializeQuantifiedType callSubst specializedTy)
         Nothing -> quantifiedMethodTy
 
 knownMethodClassArg :: ElaborateScope -> MethodInfo -> [P.Expr] -> Maybe SrcType -> Maybe SrcType

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -2186,6 +2186,10 @@ inferKnownExprType scope expr =
         Just valueInfo@OrdinaryValue {} -> Just (ordinaryValueTypeInScope scope valueInfo)
         Just ConstructorValue {valueCtorInfo = ctorInfo} -> Just (constructorVisibleType scope ctorInfo)
         _ -> Nothing
+    ELam param body -> do
+      paramTy <- P.paramType param
+      let scope' = extendLocalSourceTypePure scope (P.paramName param) (P.paramName param) paramTy
+      STArrow paramTy <$> inferKnownExprType scope' body
     EAnn _ annTy -> Just annTy
     EApp _ _ ->
       case collectApps expr of
@@ -2196,7 +2200,7 @@ inferKnownExprType scope expr =
                   | let ty = ordinaryValueTypeInScope scope valueInfo,
                     not (null args),
                     hasLeadingForall ty ->
-                      Nothing
+                      appliedKnownOrdinaryValueResultType scope ty (map (inferKnownExprType scope) args) (length args)
                 ConstructorValue {valueCtorInfo = ctorInfo}
                   | length args == length (ctorArgs ctorInfo) ->
                       knownConstructorResultType scope ctorInfo args
@@ -2213,6 +2217,10 @@ inferKnownResolvedExprType scope expr =
         Right valueInfo@OrdinaryValue {} -> Just (ordinaryValueTypeInScope scope valueInfo)
         Right ConstructorValue {valueCtorInfo = ctorInfo} -> Just (constructorVisibleType scope ctorInfo)
         _ -> Nothing
+    ELam param body -> do
+      paramTy <- P.paramType param >>= either (const Nothing) Just . displaySrcTypeForResolved scope
+      let scope' = extendLocalSourceTypePure scope (P.paramName param) (P.paramName param) paramTy
+      STArrow paramTy <$> inferKnownResolvedExprType scope' body
     EAnn _ annTy -> either (const Nothing) Just (displaySrcTypeForResolved scope annTy)
     EApp _ _ ->
       case collectResolvedApps expr of
@@ -2223,7 +2231,7 @@ inferKnownResolvedExprType scope expr =
                   | let ty = ordinaryValueTypeInScope scope valueInfo,
                     not (null args),
                     hasLeadingForall ty ->
-                      Nothing
+                      appliedKnownOrdinaryValueResultType scope ty (map (inferKnownResolvedExprType scope) args) (length args)
                 ConstructorValue {valueCtorInfo = ctorInfo}
                   | length args == length (ctorArgs ctorInfo) ->
                       knownResolvedConstructorResultType scope ctorInfo args
@@ -2236,6 +2244,21 @@ hasLeadingForall ty =
   case ty of
     STForall {} -> True
     _ -> False
+
+appliedKnownOrdinaryValueResultType :: ElaborateScope -> SrcType -> [Maybe SrcType] -> Int -> Maybe SrcType
+appliedKnownOrdinaryValueResultType scope visibleTy mbArgTypes argCount = do
+  let (_, bodyTy) = splitForalls visibleTy
+      (argTys, _) = splitArrows bodyTy
+  if argCount > length argTys
+    then Nothing
+    else do
+      actualArgTypes <- sequence (take argCount mbArgTypes)
+      subst <-
+        foldM
+          (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy)
+          Map.empty
+          (zip argTys actualArgTypes)
+      peelAppliedType (specializeQuantifiedType subst visibleTy) argCount
 
 litSrcType :: Lit -> SrcType
 litSrcType lit =

--- a/src/MLF/Frontend/Program/Elaborate.hs
+++ b/src/MLF/Frontend/Program/Elaborate.hs
@@ -33,6 +33,7 @@ module MLF.Frontend.Program.Elaborate
   )
 where
 
+import Control.Applicative ((<|>))
 import Control.Monad ((>=>), foldM, replicateM, when, zipWithM)
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
 import Control.Monad.State.Strict (State, get, modify, runState)
@@ -43,6 +44,7 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import MLF.Frontend.Normalize (substSrcType)
+import qualified MLF.Frontend.Program.Builtins as Builtins
 import MLF.Frontend.Program.Surface
   ( surfaceAnn,
     surfaceApp,
@@ -251,14 +253,14 @@ sourceTypeIdentityInScope scope = canonical
           case Map.lookup name (esTypes scope) of
             Just info -> STBase (qualifiedDataName info)
             Nothing
-              | name `Set.member` builtinTypeNames -> STBase ("<builtin>." ++ name)
+              | Builtins.isBuiltinTypeName name -> STBase (Builtins.builtinModuleName ++ "." ++ name)
               | otherwise -> ty
         STCon name args ->
           let args' = fmap canonical args
            in case Map.lookup name (esTypes scope) of
                 Just info -> STCon (qualifiedDataName info) args'
                 Nothing
-                  | name `Set.member` builtinTypeNames -> STCon ("<builtin>." ++ name) args'
+                  | Builtins.isBuiltinTypeName name -> STCon (Builtins.builtinModuleName ++ "." ++ name) args'
                   | otherwise -> STCon name args'
         STVarApp name args -> STVarApp name (fmap canonical args)
         STArrow dom cod -> STArrow (canonical dom) (canonical cod)
@@ -270,9 +272,6 @@ sourceTypeIdentityInScope scope = canonical
     qualifiedDataName info =
       let identity = dataInfoSymbolIdentity info
        in symbolDefiningModule identity ++ "." ++ symbolDefiningName identity
-
-builtinTypeNames :: Set String
-builtinTypeNames = Set.fromList ["Bool", "Int", "String"]
 
 constrainedRuntimeType :: ElaborateScope -> [P.ClassConstraint] -> SrcType -> SrcType
 constrainedRuntimeType scope =
@@ -360,10 +359,15 @@ lowerTypeRaw dataTypes = lower Map.empty Nothing
       STArrow dom cod -> STArrow (lowerWith seen subst currentData dom) (lowerWith seen subst currentData cod)
       STBase name ->
         case Map.lookup name dataTypes of
+          Just info
+            | Builtins.isOpaqueBuiltinDataInfo info -> STBase name
           Just info -> encodeDataType subst info []
           Nothing -> STBase name
       STCon name args ->
         case Map.lookup name dataTypes of
+          Just info
+            | Builtins.isOpaqueBuiltinDataInfo info ->
+                STCon name (fmap (lowerWith seen subst currentData) args)
           Just info -> encodeDataType subst info (actualArgsForData (lowerWith seen subst currentData) info (toListNE args))
           Nothing -> STCon name (fmap (lowerWith seen subst currentData) args)
       STVarApp name args ->
@@ -639,10 +643,7 @@ displayNameForSymbol namesByIdentity symbol =
     Nothing -> Nothing
 
 isBuiltinTypeSymbol :: ResolvedSymbol -> Bool
-isBuiltinTypeSymbol symbol =
-  let identity = resolvedSymbolIdentity symbol
-   in symbolNamespace identity == SymbolType
-        && symbolDefiningModule identity == "<builtin>"
+isBuiltinTypeSymbol = Builtins.isBuiltinTypeSymbol
 
 constructorSurfaceExpr :: ElaborateScope -> ConstructorInfo -> SurfaceExpr
 constructorSurfaceExpr scope ctorInfo =
@@ -1354,7 +1355,7 @@ deferMethodEvidenceExpr scope classArgView methodInfo = do
         stripVacuousSrcForalls $
           specializeMethodType (methodType methodInfo) (methodParamName methodInfo) (typeViewDisplay classArgView)
       fullArity = methodFullArity methodInfo
-  placeholder <- deferMethodCall scope methodInfo fullArity methodTy
+  placeholder <- deferMethodCall scope methodInfo fullArity methodTy Nothing
   expanded <- etaExpandMissingArgs scope methodInfo methodTy Nothing 0 fullArity (surfaceVar placeholder)
   pure (surfaceAnn expanded (lowerTypeView scope (TypeView methodTy (specializeMethodType (methodTypeIdentity methodInfo) (methodParamName methodInfo) (typeViewIdentity classArgView)))))
 
@@ -1448,6 +1449,18 @@ sourceTypeHasAppliedHead ty =
     STForall _ _ body -> sourceTypeHasAppliedHead body
     _ -> False
 
+sourceTypeHasVariableHeadApplication :: SrcType -> Bool
+sourceTypeHasVariableHeadApplication ty =
+  case ty of
+    STVar {} -> False
+    STBase {} -> False
+    STCon _ args -> any sourceTypeHasVariableHeadApplication args
+    STVarApp {} -> True
+    STArrow dom cod -> sourceTypeHasVariableHeadApplication dom || sourceTypeHasVariableHeadApplication cod
+    STForall _ mb body -> maybe False (sourceTypeHasVariableHeadApplication . unSrcBound) mb || sourceTypeHasVariableHeadApplication body
+    STMu _ body -> sourceTypeHasVariableHeadApplication body
+    STBottom -> False
+
 knownConstructorResultType :: ElaborateScope -> ConstructorInfo -> [P.Expr] -> Maybe SrcType
 knownConstructorResultType scope ctorInfo args = do
   argTypes <- traverse (inferKnownExprType scope) args
@@ -1474,8 +1487,12 @@ compileMethodApp scope mbExpected methodInfo args
   | otherwise = do
       let fullArity = methodFullArity methodInfo
           suppliedArity = length args
-          knownClassArg = knownMethodClassArg scope methodInfo args
-          placeholderTy = placeholderMethodType scope methodInfo args
+          mbExpectedResult =
+            if suppliedArity >= fullArity
+              then mbExpected
+              else Nothing
+          knownClassArg = knownMethodClassArg scope methodInfo args mbExpectedResult
+          placeholderTy = placeholderMethodType scope methodInfo args mbExpectedResult
           knownArgTys =
             case knownClassArg of
               Just _ -> Just (take suppliedArity (methodArgumentTypes placeholderTy))
@@ -1492,7 +1509,9 @@ compileMethodApp scope mbExpected methodInfo args
               expanded <- etaExpandMissingArgs scope methodInfo placeholderTy mbExpected suppliedArity fullArity applied
               pure (annotatePartialMethod expanded placeholderTy suppliedArity fullArity)
         _ -> do
-          placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy
+          when (sourceTypeHasVariableHeadApplication placeholderTy) $
+            throwError (ProgramAmbiguousMethodUse (methodName methodInfo))
+          placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy (sourceTypeViewInScope scope <$> mbExpectedResult)
           let applied = foldl surfaceApp (surfaceVar placeholder) argSurfaces
           expanded <- etaExpandMissingArgs scope methodInfo placeholderTy mbExpected suppliedArity fullArity applied
           pure (annotatePartialMethod expanded placeholderTy suppliedArity fullArity)
@@ -1513,8 +1532,12 @@ compileResolvedMethodApp scope mbExpected methodInfo args
   | otherwise = do
       let fullArity = methodFullArity methodInfo
           suppliedArity = length args
-          knownClassArg = knownResolvedMethodClassArg scope methodInfo args
-          placeholderTy = placeholderResolvedMethodType scope methodInfo args
+          mbExpectedResult =
+            if suppliedArity >= fullArity
+              then mbExpected
+              else Nothing
+          knownClassArg = knownResolvedMethodClassArg scope methodInfo args mbExpectedResult
+          placeholderTy = placeholderResolvedMethodType scope methodInfo args mbExpectedResult
           knownArgTys =
             case knownClassArg of
               Just _ -> Just (take suppliedArity (methodArgumentTypes placeholderTy))
@@ -1531,7 +1554,9 @@ compileResolvedMethodApp scope mbExpected methodInfo args
               expanded <- etaExpandMissingArgs scope methodInfo placeholderTy mbExpected suppliedArity fullArity applied
               pure (annotatePartialMethod expanded placeholderTy suppliedArity fullArity)
         _ -> do
-          placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy
+          when (sourceTypeHasVariableHeadApplication placeholderTy) $
+            throwError (ProgramAmbiguousMethodUse (methodName methodInfo))
+          placeholder <- deferMethodCall scope methodInfo fullArity placeholderTy (sourceTypeViewInScope scope <$> mbExpectedResult)
           let applied = foldl surfaceApp (surfaceVar placeholder) argSurfaces
           expanded <- etaExpandMissingArgs scope methodInfo placeholderTy mbExpected suppliedArity fullArity applied
           pure (annotatePartialMethod expanded placeholderTy suppliedArity fullArity)
@@ -1882,8 +1907,8 @@ methodArgumentTypes ty =
       (argTys, _) = splitArrows bodyTy
    in argTys
 
-deferMethodCall :: ElaborateScope -> MethodInfo -> Int -> SrcType -> ElaborateM String
-deferMethodCall scope methodInfo fullArity placeholderSourceTy = do
+deferMethodCall :: ElaborateScope -> MethodInfo -> Int -> SrcType -> Maybe TypeView -> ElaborateM String
+deferMethodCall scope methodInfo fullArity placeholderSourceTy mbExpectedResult = do
   placeholder <- freshDeferredMethodName (methodName methodInfo)
   let placeholderTy = lowerType scope placeholderSourceTy
       deferred =
@@ -1893,7 +1918,7 @@ deferMethodCall scope methodInfo fullArity placeholderSourceTy = do
             deferredMethodArgCount = fullArity,
             deferredMethodFullArity = fullArity,
             deferredMethodName = methodName methodInfo,
-            deferredMethodExpectedResult = Nothing,
+            deferredMethodExpectedResult = mbExpectedResult,
             deferredMethodEvidence = Nothing,
             deferredMethodLocalEvidence = esEvidence scope
           }
@@ -2068,48 +2093,60 @@ registerDeferredObligation placeholder placeholderTy obligation =
           }
     )
 
-placeholderMethodType :: ElaborateScope -> MethodInfo -> [P.Expr] -> SrcType
-placeholderMethodType scope methodInfo args =
+placeholderMethodType :: ElaborateScope -> MethodInfo -> [P.Expr] -> Maybe SrcType -> SrcType
+placeholderMethodType scope methodInfo args mbExpectedResult =
   let paramName = methodParamName methodInfo
       methodTy = methodType methodInfo
       quantifiedMethodTy = quantifiedMethodType methodInfo
-      knownClassArg = knownMethodClassArg scope methodInfo args
+      knownClassArg = knownMethodClassArg scope methodInfo args mbExpectedResult
    in case knownClassArg of
         Just classArgTy -> stripVacuousSrcForalls (specializeMethodType methodTy paramName classArgTy)
         Nothing -> quantifiedMethodTy
 
-placeholderResolvedMethodType :: ElaborateScope -> MethodInfo -> [P.ResolvedExpr] -> SrcType
-placeholderResolvedMethodType scope methodInfo args =
+placeholderResolvedMethodType :: ElaborateScope -> MethodInfo -> [P.ResolvedExpr] -> Maybe SrcType -> SrcType
+placeholderResolvedMethodType scope methodInfo args mbExpectedResult =
   let paramName = methodParamName methodInfo
       methodTy = methodType methodInfo
       quantifiedMethodTy = quantifiedMethodType methodInfo
-      knownClassArg = knownResolvedMethodClassArg scope methodInfo args
+      knownClassArg = knownResolvedMethodClassArg scope methodInfo args mbExpectedResult
    in case knownClassArg of
         Just classArgTy -> stripVacuousSrcForalls (specializeMethodType methodTy paramName classArgTy)
         Nothing -> quantifiedMethodTy
 
-knownMethodClassArg :: ElaborateScope -> MethodInfo -> [P.Expr] -> Maybe SrcType
-knownMethodClassArg scope methodInfo args = do
+knownMethodClassArg :: ElaborateScope -> MethodInfo -> [P.Expr] -> Maybe SrcType -> Maybe SrcType
+knownMethodClassArg scope methodInfo args mbExpectedResult =
+  knownMethodClassArgFromArgs scope methodInfo (map (inferKnownExprType scope) args)
+    <|> knownMethodClassArgFromExpected scope methodInfo (map (inferKnownExprType scope) args) mbExpectedResult
+
+knownResolvedMethodClassArg :: ElaborateScope -> MethodInfo -> [P.ResolvedExpr] -> Maybe SrcType -> Maybe SrcType
+knownResolvedMethodClassArg scope methodInfo args mbExpectedResult =
+  knownMethodClassArgFromArgs scope methodInfo (map (inferKnownResolvedExprType scope) args)
+    <|> knownMethodClassArgFromExpected scope methodInfo (map (inferKnownResolvedExprType scope) args) mbExpectedResult
+
+knownMethodClassArgFromArgs :: ElaborateScope -> MethodInfo -> [Maybe SrcType] -> Maybe SrcType
+knownMethodClassArgFromArgs scope methodInfo argTypes = do
   let (_, bodyTy) = splitForalls (methodType methodInfo)
       (paramTys, _) = splitArrows bodyTy
       knownPairs =
         [ (templateTy, actualTy)
-          | (templateTy, arg) <- zip paramTys args,
-            Just actualTy <- [inferKnownExprType scope arg]
+          | (templateTy, mbActualTy) <- zip paramTys argTypes,
+            Just actualTy <- [mbActualTy]
         ]
   subst <- foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty knownPairs
   Map.lookup (methodParamName methodInfo) subst
 
-knownResolvedMethodClassArg :: ElaborateScope -> MethodInfo -> [P.ResolvedExpr] -> Maybe SrcType
-knownResolvedMethodClassArg scope methodInfo args = do
+knownMethodClassArgFromExpected :: ElaborateScope -> MethodInfo -> [Maybe SrcType] -> Maybe SrcType -> Maybe SrcType
+knownMethodClassArgFromExpected _ _ _ Nothing = Nothing
+knownMethodClassArgFromExpected scope methodInfo argTypes (Just expectedTy) = do
   let (_, bodyTy) = splitForalls (methodType methodInfo)
       (paramTys, _) = splitArrows bodyTy
       knownPairs =
         [ (templateTy, actualTy)
-          | (templateTy, arg) <- zip paramTys args,
-            Just actualTy <- [inferKnownResolvedExprType scope arg]
+          | (templateTy, mbActualTy) <- zip paramTys argTypes,
+            Just actualTy <- [mbActualTy]
         ]
-  subst <- foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty knownPairs
+  substFromArgs <- foldM (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy) Map.empty knownPairs
+  subst <- matchTypesInScope scope substFromArgs (specializeSrcType substFromArgs (snd (splitArrows bodyTy))) expectedTy
   Map.lookup (methodParamName methodInfo) subst
 
 quantifiedMethodType :: MethodInfo -> SrcType
@@ -2229,6 +2266,7 @@ compileCase scope mbExpected scrutinee alts = do
             case (mbInferredScrutineeTy, mbAnnotationScrutineeTy) of
               (Nothing, Just annTy) -> Just annTy
               _ -> Nothing
+      rejectOpaqueBuiltinCase scope mbScrutineeTy
       mapM_ (\scrutineeTy -> mapM_ (validatePatternType scope scrutineeTy . P.altPattern) alts) mbScrutineeTy
       scrutineeExpr0 <- compileExpr scope mbScrutineeTy scrutinee
       let scrutineeExpr =
@@ -2274,6 +2312,7 @@ compileResolvedCase scope mbExpected scrutinee alts = do
             case (mbInferredScrutineeTy, mbAnnotationScrutineeTy) of
               (Nothing, Just annTy) -> Just annTy
               _ -> Nothing
+      rejectOpaqueBuiltinCase scope mbScrutineeTy
       mapM_ (\scrutineeTy -> mapM_ (validateResolvedPatternType scope scrutineeTy . P.altPattern) alts) mbScrutineeTy
       scrutineeExpr0 <- compileResolvedExpr scope mbScrutineeTy scrutinee
       let scrutineeExpr =
@@ -2328,6 +2367,14 @@ localResolvedIdentityScrutinee scope expr =
         Just OrdinaryValue {valueOriginModule = "<local>"} <- Map.lookup name (esValues scope) ->
           Just arg
     _ -> Nothing
+
+rejectOpaqueBuiltinCase :: ElaborateScope -> Maybe SrcType -> ElaborateM ()
+rejectOpaqueBuiltinCase scope mbScrutineeTy =
+  case mbScrutineeTy of
+    Just scrutineeTy
+      | Builtins.srcTypeMentionsOpaqueBuiltin (canonicalSourceType scope scrutineeTy) ->
+          throwError (ProgramCaseOnNonDataType scrutineeTy)
+    _ -> pure ()
 
 compileCatchAllOnly :: ElaborateScope -> Maybe SrcType -> Maybe SrcType -> SurfaceExpr -> [P.Alt] -> ElaborateM SurfaceExpr
 compileCatchAllOnly scope mbExpected mbScrutineeTy scrutineeExpr alts =

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -105,25 +105,45 @@ finalizeBindingAllowOpaque scope lowered
                 checkedBindingExportedAsMain = loweredBindingExportedAsMain lowered
               }
       case finalizeBinding scope lowered of
-        Right checked -> Right (placeholder checked)
+        Right checked
+          | Map.null (loweredBindingDeferredObligations lowered) ->
+              -- Successful elaboration can still satisfy an opaque forall by
+              -- instantiating the expected type. Re-check no-obligation
+              -- surfaces before replacing the checked term with a placeholder.
+              case validateOpaqueBindingSurface scope lowered of
+                Right () -> Right (placeholder checked)
+                Left validationErr -> Left validationErr
+          | otherwise -> Right (placeholder checked)
         Left err ->
-          if validatesOpaqueBindingSurface scope lowered
-            then Right uncheckedPlaceholder
-            else Left err
+          case validateOpaqueBindingSurface scope lowered of
+            Right () -> Right uncheckedPlaceholder
+            Left _ -> Left err
   | otherwise = finalizeBinding scope lowered
 
-validatesOpaqueBindingSurface :: ElaborateScope -> LoweredBinding -> Bool
-validatesOpaqueBindingSurface scope lowered
-  | not (Map.null (loweredBindingDeferredObligations lowered)) = False
+validateOpaqueBindingSurface :: ElaborateScope -> LoweredBinding -> Either ProgramError ()
+validateOpaqueBindingSurface scope lowered
+  | not (Map.null (loweredBindingDeferredObligations lowered)) =
+      Left (ProgramPipelineError "opaque validation does not support deferred obligations")
   | otherwise =
-      case inferOpaqueSurfaceType scope runtimeTypes Map.empty (loweredBindingSurfaceExpr lowered) of
-        Right actualTy -> opaqueSourceCompatible scope actualTy (loweredBindingExpectedType lowered)
-        Left _ -> False
+      case inferOpaqueSurfaceType scope rigidVars runtimeTypes Map.empty (loweredBindingSurfaceExpr lowered) of
+        Right actualTy
+          | opaqueSourceCompatibleWithRigid rigidVars scope actualTy (loweredBindingExpectedType lowered) -> Right ()
+          | otherwise -> Left (ProgramTypeMismatch actualTy (loweredBindingExpectedType lowered))
+        Left err -> Left err
   where
-    runtimeTypes = loweredBindingExternalTypes lowered `Map.union` elaborateScopeRuntimeTypes scope
+    rigidVars = sourceForallBinders (loweredBindingExpectedType lowered)
+    runtimeTypes =
+      Map.withoutKeys (loweredBindingExternalTypes lowered) Builtins.builtinOpaqueValueNames
+        `Map.union` elaborateScopeRuntimeTypes scope
 
-inferOpaqueSurfaceType :: ElaborateScope -> Map String SrcType -> Map String SrcType -> SurfaceExpr -> Either ProgramError SrcType
-inferOpaqueSurfaceType scope runtimeTypes localTypes expr =
+sourceForallBinders :: SrcType -> Set String
+sourceForallBinders ty =
+  case ty of
+    STForall name _ body -> Set.insert name (sourceForallBinders body)
+    _ -> Set.empty
+
+inferOpaqueSurfaceType :: ElaborateScope -> Set String -> Map String SrcType -> Map String SrcType -> SurfaceExpr -> Either ProgramError SrcType
+inferOpaqueSurfaceType scope rigidVars runtimeTypes localTypes expr =
   case expr of
     EVar name ->
       case Map.lookup name localTypes <|> Map.lookup name runtimeTypes of
@@ -131,19 +151,19 @@ inferOpaqueSurfaceType scope runtimeTypes localTypes expr =
         Nothing -> Left (ProgramUnknownValue name)
     ELit lit -> Right (literalSourceType lit)
     ELamAnn name ty body ->
-      STArrow ty <$> inferOpaqueSurfaceType scope runtimeTypes (Map.insert name ty localTypes) body
+      STArrow ty <$> inferOpaqueSurfaceType scope rigidVars runtimeTypes (Map.insert name ty localTypes) body
     ELam {} ->
       Left (ProgramPipelineError "opaque validation needs lambda annotations")
     EApp fun arg -> do
-      funTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes fun
-      argTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes arg
+      funTy <- inferOpaqueSurfaceType scope rigidVars runtimeTypes localTypes fun
+      argTy <- inferOpaqueSurfaceType scope rigidVars runtimeTypes localTypes arg
       applyOpaqueFunctionType scope funTy argTy
     ELet name rhs body -> do
-      rhsTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes rhs
-      inferOpaqueSurfaceType scope runtimeTypes (Map.insert name rhsTy localTypes) body
+      rhsTy <- inferOpaqueSurfaceType scope rigidVars runtimeTypes localTypes rhs
+      inferOpaqueSurfaceType scope rigidVars runtimeTypes (Map.insert name rhsTy localTypes) body
     EAnn inner annTy -> do
-      actualTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes inner
-      if opaqueSourceCompatible scope actualTy annTy
+      actualTy <- inferOpaqueSurfaceType scope rigidVars runtimeTypes localTypes inner
+      if opaqueSourceCompatibleWithRigid rigidVars scope actualTy annTy
         then Right annTy
         else Left (ProgramTypeMismatch actualTy annTy)
 
@@ -159,12 +179,30 @@ applyOpaqueFunctionType scope funTy argTy =
     other -> Left (ProgramExpectedFunction other)
 
 opaqueSourceCompatible :: ElaborateScope -> SrcType -> SrcType -> Bool
-opaqueSourceCompatible scope actualTy expectedTy =
+opaqueSourceCompatible = opaqueSourceCompatibleWithRigid Set.empty
+
+opaqueSourceCompatibleWithRigid :: Set String -> ElaborateScope -> SrcType -> SrcType -> Bool
+opaqueSourceCompatibleWithRigid rigidVars scope actualTy expectedTy =
   alphaEqSrcType actualTy expectedTy
     || alphaEqSrcType (lowerType scope actualTy) (lowerType scope expectedTy)
-    || sourceForallMatches expectedTy actualTy
-    || matchTypesInScope scope Map.empty expectedTy actualTy /= Nothing
-    || matchTypesInScope scope Map.empty actualTy expectedTy /= Nothing
+    || sourceForallMatchesWithRigidForalls expectedTy actualTy
+    || matchTypesInScopePreservingRigid scope rigidVars expectedTy actualTy /= Nothing
+    || matchTypesInScopePreservingRigid scope rigidVars actualTy expectedTy /= Nothing
+
+matchTypesInScopePreservingRigid :: ElaborateScope -> Set String -> SrcType -> SrcType -> Maybe (Map String SrcType)
+matchTypesInScopePreservingRigid scope rigidVars template actual = do
+  subst <- matchTypesInScope scope Map.empty template actual
+  if all preservesRigid (Map.toList subst)
+    then Just subst
+    else Nothing
+  where
+    preservesRigid (name, ty)
+      | name `Set.notMember` rigidVars = True
+      | otherwise =
+          case ty of
+            STVar {} -> True
+            STVarApp {} -> True
+            _ -> False
 
 literalSourceType :: Lit -> SrcType
 literalSourceType lit =
@@ -208,11 +246,15 @@ finalizeBinding scope lowered = do
           recoveredActualSrcTy = recoverSourceType scope (elabTypeToSrcType actualTyForCompare)
       expectedTyForCompare <- stripVacuousForalls <$> srcTypeToElabType (loweredBindingExpectedType lowered)
       recoveredActualTy <- srcTypeToElabType (lowerType scope recoveredActualSrcTy)
+      let sourceForallCompatible =
+            if Builtins.srcTypeMentionsOpaqueBuiltin (loweredBindingSourceType lowered)
+              then sourceForallMatchesWithRigidForalls (recoverSourceType scope (loweredBindingExpectedType lowered)) recoveredActualSrcTy
+              else sourceForallMatches (recoverSourceType scope (loweredBindingExpectedType lowered)) recoveredActualSrcTy
       if alphaEqType actualTyForCompare expectedTyForCompare
         || churchAwareEqType actualTyForCompare expectedTyForCompare
         || alphaEqType recoveredActualTy expectedTyForCompare
         || churchAwareEqType recoveredActualTy expectedTyForCompare
-        || sourceForallMatches (recoverSourceType scope (loweredBindingExpectedType lowered)) recoveredActualSrcTy
+        || sourceForallCompatible
         then
           Right
             CheckedBinding
@@ -459,11 +501,58 @@ inferRewrittenLetType env rhs fallback =
     Right ty -> inlineTypeEnvBounds env (stripVacuousForalls ty)
     Left _ -> fallback
 
+freeSourceTypeVars :: SrcType -> Set String
+freeSourceTypeVars = go Set.empty
+  where
+    go boundVars ty =
+      case ty of
+        STVar name
+          | name `Set.member` boundVars -> Set.empty
+          | otherwise -> Set.singleton name
+        STArrow dom cod -> go boundVars dom `Set.union` go boundVars cod
+        STBase {} -> Set.empty
+        STCon _ args -> foldMap (go boundVars) args
+        STVarApp name args ->
+          let headVars =
+                if name `Set.member` boundVars
+                  then Set.empty
+                  else Set.singleton name
+           in headVars `Set.union` foldMap (go boundVars) args
+        STForall name mb body ->
+          maybe Set.empty (go boundVars . unSrcBound) mb
+            `Set.union` go (Set.insert name boundVars) body
+        STMu name body -> go (Set.insert name boundVars) body
+        STBottom -> Set.empty
+
+sourceForallMatchesWithRigidForalls :: SrcType -> SrcType -> Bool
+sourceForallMatchesWithRigidForalls expected actual =
+  case sourceForallMatchSubst expected actual of
+    Just subst -> all (forallBinderRemainsPolymorphic subst) (usedLeadingForallNames expected)
+    Nothing -> False
+  where
+    forallBinderRemainsPolymorphic subst name =
+      case Map.lookup name subst of
+        Just STVar {} -> True
+        Just STVarApp {} -> True
+        Just _ -> False
+        Nothing -> True
+
+    usedLeadingForallNames ty =
+      case ty of
+        STForall name _ body
+          | name `Set.member` freeSourceTypeVars body -> name : usedLeadingForallNames body
+          | otherwise -> usedLeadingForallNames body
+        _ -> []
+
 sourceForallMatches :: SrcType -> SrcType -> Bool
 sourceForallMatches expected actual =
-  case match Set.empty Map.empty expected actual of
+  case sourceForallMatchSubst expected actual of
     Just _ -> True
     Nothing -> False
+
+sourceForallMatchSubst :: SrcType -> SrcType -> Maybe (Map String SrcType)
+sourceForallMatchSubst expected actual =
+  match Set.empty Map.empty expected actual
   where
     match bound subst template actualTy =
       case template of
@@ -523,28 +612,6 @@ sourceForallMatches expected actual =
           match bound subst expectedBound actualBound
         _ -> Nothing
 
-    freeTypeVarsSrcTypeLocal = go Set.empty
-      where
-        go boundVars ty =
-          case ty of
-            STVar name
-              | name `Set.member` boundVars -> Set.empty
-              | otherwise -> Set.singleton name
-            STArrow dom cod -> go boundVars dom `Set.union` go boundVars cod
-            STBase {} -> Set.empty
-            STCon _ args -> foldMap (go boundVars) args
-            STVarApp name args ->
-              let headVars =
-                    if name `Set.member` boundVars
-                      then Set.empty
-                      else Set.singleton name
-               in headVars `Set.union` foldMap (go boundVars) args
-            STForall name mb body ->
-              maybe Set.empty (go boundVars . unSrcBound) mb
-                `Set.union` go (Set.insert name boundVars) body
-            STMu name body -> go (Set.insert name boundVars) body
-            STBottom -> Set.empty
-
     matchVarApp bound subst expectedName args actualTy
       | expectedName `Set.member` bound =
           case actualTy of
@@ -591,6 +658,8 @@ sourceForallMatches expected actual =
         Just existing
           | alphaEqSrcType existing actualTy -> Just subst
           | otherwise -> Nothing
+
+    freeTypeVarsSrcTypeLocal = freeSourceTypeVars
 
 alphaEqSrcType :: SrcType -> SrcType -> Bool
 alphaEqSrcType = go Map.empty Map.empty

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -83,23 +83,95 @@ import MLF.Frontend.Program.Types
     specializeMethodType,
     substituteTypeVar,
   )
-import MLF.Frontend.Syntax (Expr (..), SrcBound (..), SrcTy (..), SrcType, SurfaceExpr)
+import MLF.Frontend.Syntax (Expr (..), Lit (..), SrcBound (..), SrcTy (..), SrcType, SurfaceExpr)
 import MLF.Reify.TypeOps (alphaEqType, churchAwareEqType, freeTypeVarsType)
 
 finalizeBindingAllowOpaque :: ElaborateScope -> LoweredBinding -> Either ProgramError CheckedBinding
 finalizeBindingAllowOpaque scope lowered
   | Builtins.srcTypeMentionsOpaqueBuiltin (loweredBindingSourceType lowered) = do
-      expectedTy <- srcTypeToElabType (loweredBindingExpectedType lowered)
-      Right
-        CheckedBinding
-          { checkedBindingName = loweredBindingName lowered,
-            checkedBindingSourceType = loweredBindingSourceType lowered,
-            checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
-            checkedBindingTerm = X.EVar (loweredBindingName lowered),
-            checkedBindingType = expectedTy,
-            checkedBindingExportedAsMain = loweredBindingExportedAsMain lowered
-          }
+      placeholderTy <- srcTypeToElabType (loweredBindingExpectedType lowered)
+      let placeholder checked =
+            checked
+              { checkedBindingTerm = X.EVar (loweredBindingName lowered),
+                checkedBindingType = placeholderTy
+              }
+          uncheckedPlaceholder =
+            CheckedBinding
+              { checkedBindingName = loweredBindingName lowered,
+                checkedBindingSourceType = loweredBindingSourceType lowered,
+                checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
+                checkedBindingTerm = X.EVar (loweredBindingName lowered),
+                checkedBindingType = placeholderTy,
+                checkedBindingExportedAsMain = loweredBindingExportedAsMain lowered
+              }
+      case finalizeBinding scope lowered of
+        Right checked -> Right (placeholder checked)
+        Left err ->
+          if validatesOpaqueBindingSurface scope lowered
+            then Right uncheckedPlaceholder
+            else Left err
   | otherwise = finalizeBinding scope lowered
+
+validatesOpaqueBindingSurface :: ElaborateScope -> LoweredBinding -> Bool
+validatesOpaqueBindingSurface scope lowered
+  | not (Map.null (loweredBindingDeferredObligations lowered)) = False
+  | otherwise =
+      case inferOpaqueSurfaceType scope runtimeTypes Map.empty (loweredBindingSurfaceExpr lowered) of
+        Right actualTy -> opaqueSourceCompatible scope actualTy (loweredBindingExpectedType lowered)
+        Left _ -> False
+  where
+    runtimeTypes = loweredBindingExternalTypes lowered `Map.union` elaborateScopeRuntimeTypes scope
+
+inferOpaqueSurfaceType :: ElaborateScope -> Map String SrcType -> Map String SrcType -> SurfaceExpr -> Either ProgramError SrcType
+inferOpaqueSurfaceType scope runtimeTypes localTypes expr =
+  case expr of
+    EVar name ->
+      case Map.lookup name localTypes <|> Map.lookup name runtimeTypes of
+        Just ty -> Right ty
+        Nothing -> Left (ProgramUnknownValue name)
+    ELit lit -> Right (literalSourceType lit)
+    ELamAnn name ty body ->
+      STArrow ty <$> inferOpaqueSurfaceType scope runtimeTypes (Map.insert name ty localTypes) body
+    ELam {} ->
+      Left (ProgramPipelineError "opaque validation needs lambda annotations")
+    EApp fun arg -> do
+      funTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes fun
+      argTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes arg
+      applyOpaqueFunctionType scope funTy argTy
+    ELet name rhs body -> do
+      rhsTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes rhs
+      inferOpaqueSurfaceType scope runtimeTypes (Map.insert name rhsTy localTypes) body
+    EAnn inner annTy -> do
+      actualTy <- inferOpaqueSurfaceType scope runtimeTypes localTypes inner
+      if opaqueSourceCompatible scope actualTy annTy
+        then Right annTy
+        else Left (ProgramTypeMismatch actualTy annTy)
+
+applyOpaqueFunctionType :: ElaborateScope -> SrcType -> SrcType -> Either ProgramError SrcType
+applyOpaqueFunctionType scope funTy argTy =
+  case snd (splitForalls funTy) of
+    STArrow paramTy resultTy ->
+      case matchTypesInScope scope Map.empty paramTy argTy <|> matchTypesInScope scope Map.empty (lowerType scope paramTy) (lowerType scope argTy) of
+        Just subst -> Right (Map.foldrWithKey substituteTypeVar resultTy subst)
+        Nothing
+          | opaqueSourceCompatible scope argTy paramTy -> Right resultTy
+          | otherwise -> Left (ProgramTypeMismatch argTy paramTy)
+    other -> Left (ProgramExpectedFunction other)
+
+opaqueSourceCompatible :: ElaborateScope -> SrcType -> SrcType -> Bool
+opaqueSourceCompatible scope actualTy expectedTy =
+  alphaEqSrcType actualTy expectedTy
+    || alphaEqSrcType (lowerType scope actualTy) (lowerType scope expectedTy)
+    || sourceForallMatches expectedTy actualTy
+    || matchTypesInScope scope Map.empty expectedTy actualTy /= Nothing
+    || matchTypesInScope scope Map.empty actualTy expectedTy /= Nothing
+
+literalSourceType :: Lit -> SrcType
+literalSourceType lit =
+  case lit of
+    LInt _ -> STBase "Int"
+    LBool _ -> STBase "Bool"
+    LString _ -> STBase "String"
 
 finalizeBinding :: ElaborateScope -> LoweredBinding -> Either ProgramError CheckedBinding
 finalizeBinding scope lowered = do

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -2,6 +2,7 @@
 
 module MLF.Frontend.Program.Finalize
   ( finalizeBinding,
+    finalizeBindingAllowOpaque,
     recoverSourceType,
     sourceForallMatches,
     stripVacuousForallsAndTypeAbs,
@@ -9,6 +10,7 @@ module MLF.Frontend.Program.Finalize
 where
 
 import Control.Monad (foldM)
+import Control.Applicative ((<|>))
 import Data.List (isPrefixOf, sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict (Map)
@@ -32,6 +34,7 @@ import MLF.Elab.Types (ElabTerm, ElabType)
 import qualified MLF.Elab.Types as X
 import MLF.Frontend.ConstraintGen (ExternalBinding (..), ExternalBindingMode (..), ExternalBindings)
 import MLF.Frontend.Normalize (normalizeExpr, normalizeType)
+import qualified MLF.Frontend.Program.Builtins as Builtins
 import MLF.Frontend.Program.Elaborate
   ( ElaborateScope,
     elaborateScopeDataTypes,
@@ -82,6 +85,21 @@ import MLF.Frontend.Program.Types
   )
 import MLF.Frontend.Syntax (Expr (..), SrcBound (..), SrcTy (..), SrcType, SurfaceExpr)
 import MLF.Reify.TypeOps (alphaEqType, churchAwareEqType, freeTypeVarsType)
+
+finalizeBindingAllowOpaque :: ElaborateScope -> LoweredBinding -> Either ProgramError CheckedBinding
+finalizeBindingAllowOpaque scope lowered
+  | Builtins.srcTypeMentionsOpaqueBuiltin (loweredBindingSourceType lowered) = do
+      expectedTy <- srcTypeToElabType (loweredBindingExpectedType lowered)
+      Right
+        CheckedBinding
+          { checkedBindingName = loweredBindingName lowered,
+            checkedBindingSourceType = loweredBindingSourceType lowered,
+            checkedBindingSurfaceExpr = loweredBindingSurfaceExpr lowered,
+            checkedBindingTerm = X.EVar (loweredBindingName lowered),
+            checkedBindingType = expectedTy,
+            checkedBindingExportedAsMain = loweredBindingExportedAsMain lowered
+          }
+  | otherwise = finalizeBinding scope lowered
 
 finalizeBinding :: ElaborateScope -> LoweredBinding -> Either ProgramError CheckedBinding
 finalizeBinding scope lowered = do
@@ -950,11 +968,9 @@ resolveDeferredMethods scope deferredMethods = go
         else do
           argViews <- mapM (inferDeferredArgType env) (take requiredArgCount args)
           classArgView <-
-            case inferClassArgument (lowerTypeView scope (TypeView (methodType methodInfo) (methodTypeIdentity methodInfo))) (methodParamName methodInfo) (map typeViewDisplay argViews) of
-              Just ty -> Right ty
+            case inferDeferredMethodClassArgument methodInfo argViews (deferredMethodExpectedResult deferred) of
+              Just view -> Right view
               Nothing -> Left (ProgramAmbiguousMethodUse (deferredMethodName deferred))
-            >>= \displayTy ->
-              Right (sourceTypeViewInScope scope displayTy)
           (instanceInfo, subst) <- resolveMethodInstanceInfoByTypeView scope methodInfo classArgView
           methodValue <- concreteMethodValue instanceInfo methodInfo
           methodSubst <-
@@ -1011,6 +1027,26 @@ resolveDeferredMethods scope deferredMethods = go
           evidenceArgs <- resolveConstraintEvidenceTerms scope (deferredMethodLocalEvidence deferred) Set.empty eagerConstraints
           methodHead <- instantiateMethodValue scope methodSubst methodValue
           Right (reapplyHeadInsts headInsts (foldl X.EApp methodHead evidenceArgs))
+
+    inferDeferredMethodClassArgument methodInfo argViews mbExpectedResult =
+      let methodTy = lowerTypeView scope (TypeView (methodType methodInfo) (methodTypeIdentity methodInfo))
+          argDisplayTypes = map typeViewDisplay argViews
+       in (sourceTypeViewInScope scope <$> inferClassArgument methodTy (methodParamName methodInfo) argDisplayTypes)
+            <|> inferDeferredMethodClassArgumentFromExpected methodInfo methodTy argDisplayTypes mbExpectedResult
+
+    inferDeferredMethodClassArgumentFromExpected _ _ _ Nothing = Nothing
+    inferDeferredMethodClassArgumentFromExpected methodInfo methodTy argDisplayTypes (Just expectedView) = do
+      let (_, bodyTy) = splitForalls methodTy
+          (paramTys, resultTy) = splitArrows bodyTy
+      substFromArgs <-
+        foldM
+          (\acc (templateTy, actualTy) -> matchTypesInScope scope acc templateTy actualTy)
+          Map.empty
+          (zip paramTys argDisplayTypes)
+      let resultTy' = Map.foldrWithKey substituteTypeVar resultTy substFromArgs
+      subst <- matchTypesInScope scope substFromArgs resultTy' (typeViewDisplay expectedView)
+      displayTy <- Map.lookup (methodParamName methodInfo) subst
+      pure (sourceTypeViewInScope scope displayTy)
 
     lookupNullaryEvidence deferred methodInfo classArgView =
       case

--- a/src/MLF/Frontend/Program/Finalize.hs
+++ b/src/MLF/Frontend/Program/Finalize.hs
@@ -122,7 +122,7 @@ finalizeBindingAllowOpaque scope lowered
 
 validateOpaqueBindingSurface :: ElaborateScope -> LoweredBinding -> Either ProgramError ()
 validateOpaqueBindingSurface scope lowered
-  | not (Map.null (loweredBindingDeferredObligations lowered)) =
+  | any (not . opaqueSurfaceObligationSupported) (Map.elems (loweredBindingDeferredObligations lowered)) =
       Left (ProgramPipelineError "opaque validation does not support deferred obligations")
   | otherwise =
       case inferOpaqueSurfaceType scope rigidVars runtimeTypes Map.empty (loweredBindingSurfaceExpr lowered) of
@@ -135,6 +135,15 @@ validateOpaqueBindingSurface scope lowered
     runtimeTypes =
       Map.withoutKeys (loweredBindingExternalTypes lowered) Builtins.builtinOpaqueValueNames
         `Map.union` elaborateScopeRuntimeTypes scope
+
+-- Opaque placeholders discard the checked term, so constructor rewrites are
+-- harmless after source-level retyping. Method and case obligations still carry
+-- evidence or inspection behavior and must not be skipped here.
+opaqueSurfaceObligationSupported :: DeferredProgramObligation -> Bool
+opaqueSurfaceObligationSupported obligation =
+  case obligation of
+    DeferredConstructor {} -> True
+    _ -> False
 
 sourceForallBinders :: SrcType -> Set String
 sourceForallBinders ty =

--- a/src/MLF/Frontend/Program/Prelude.hs
+++ b/src/MLF/Frontend/Program/Prelude.hs
@@ -13,10 +13,18 @@ import qualified MLF.Frontend.Syntax.Program as P
 preludeSource :: String
 preludeSource =
   unlines
-    [ "module Prelude export (Nat(..), Option(..), List(..), Eq, eq, and, id) {",
+    [ "module Prelude export (Unit(..), IO, Nat(..), Option(..), List(..), Eq, Monad, eq, pure, bind, putStrLn, and, id) {",
       "  class Eq a {",
       "    eq : a -> a -> Bool;",
       "  }",
+      "",
+      "  class Monad (m :: * -> *) {",
+      "    pure : forall a. a -> m a;",
+      "    bind : forall a b. m a -> (a -> m b) -> m b;",
+      "  }",
+      "",
+      "  data Unit =",
+      "      Unit : Unit;",
       "",
       "  data Nat =",
       "      Zero : Nat",
@@ -33,6 +41,12 @@ preludeSource =
       "    | Cons : a -> List a -> List a",
       "    deriving Eq;",
       "",
+      "  instance Monad IO {",
+      "    pure = \\value __io_pure value;",
+      "    bind = \\action \\next __io_bind action next;",
+      "  }",
+      "",
+      "  def putStrLn : String -> IO Unit = __io_putStrLn;",
       "  def and : Bool -> Bool -> Bool = \\left \\right __mlfp_and left right;",
       "  def id : forall a. a -> a = \\x x;",
       "}"

--- a/src/MLF/Frontend/Program/Resolve.hs
+++ b/src/MLF/Frontend/Program/Resolve.hs
@@ -11,6 +11,12 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import qualified Data.Set as Set
+import MLF.Frontend.Program.Builtins
+  ( builtinTypeNames,
+    builtinTypeSymbol,
+    builtinValueSymbol,
+    builtinValues,
+  )
 import MLF.Frontend.Program.Types
 import MLF.Frontend.Syntax
   ( ResolvedSrcType,
@@ -141,25 +147,15 @@ buildImportScope priorExports =
             Just items -> foldM (applyImportItem moduleName0 exports) qualifiedScope items
 
 addBuiltinSymbols :: CandidateScope -> CandidateScope
-addBuiltinSymbols =
-  addCandidateValue "__mlfp_and" (builtinSymbol SymbolValue "__mlfp_and")
-    . addCandidateType "Int" (builtinSymbol SymbolType "Int")
-    . addCandidateType "Bool" (builtinSymbol SymbolType "Bool")
-    . addCandidateType "String" (builtinSymbol SymbolType "String")
-
-builtinSymbol :: SymbolNamespace -> String -> ResolvedSymbol
-builtinSymbol namespace name =
-  mkResolvedSymbol
-    ( SymbolIdentity
-        { symbolNamespace = namespace,
-          symbolDefiningModule = "<builtin>",
-          symbolDefiningName = name,
-          symbolOwnerIdentity = Nothing
-        }
+addBuiltinSymbols scope =
+  foldr
+    (\name acc -> addCandidateValue name (builtinValueSymbol name) acc)
+    ( foldr
+        (\name acc -> addCandidateType name (builtinTypeSymbol name) acc)
+        scope
+        (Set.toList builtinTypeNames)
     )
-    name
-    name
-    SymbolBuiltin
+    (Map.keys builtinValues)
 
 addAllExports ::
   SymbolOrigin ->
@@ -277,15 +273,21 @@ buildExports mod0 locals =
   where
     collectExport acc = \case
       P.ExportValue name ->
-        case Map.lookup name (localValues locals) of
-          Just symbols -> pure acc {candidateValues = Map.insertWith (++) name symbols (candidateValues acc)}
-          Nothing -> Left (ProgramExportNotLocal name)
+        case builtinPreludeExportType name of
+          Just symbol -> pure acc {candidateTypes = Map.insertWith (++) name [symbol] (candidateTypes acc)}
+          Nothing ->
+            case Map.lookup name (localValues locals) of
+              Just symbols -> pure acc {candidateValues = Map.insertWith (++) name symbols (candidateValues acc)}
+              Nothing -> Left (ProgramExportNotLocal name)
       P.ExportType typeName ->
         case (Map.lookup typeName (localTypes locals), Map.lookup typeName (localClasses locals)) of
           (Nothing, Nothing) ->
-            case Map.lookup typeName (localValues locals) of
-              Just symbols -> pure acc {candidateValues = Map.insertWith (++) typeName symbols (candidateValues acc)}
-              Nothing -> Left (ProgramExportNotLocal typeName)
+            case builtinPreludeExportType typeName of
+              Just symbol -> pure acc {candidateTypes = Map.insertWith (++) typeName [symbol] (candidateTypes acc)}
+              Nothing ->
+                case Map.lookup typeName (localValues locals) of
+                  Just symbols -> pure acc {candidateValues = Map.insertWith (++) typeName symbols (candidateValues acc)}
+                  Nothing -> Left (ProgramExportNotLocal typeName)
           (mbTypes, mbClasses) ->
             pure
               acc
@@ -330,6 +332,12 @@ buildExports mod0 locals =
     isConstructorOf typeName symbol =
       symbolOwnerIdentity (resolvedSymbolIdentity symbol) == Just (SymbolOwnerType (P.moduleName mod0) typeName)
 
+    builtinPreludeExportType typeName
+      | P.moduleName mod0 == "Prelude",
+        typeName == "IO" =
+          Just (builtinTypeSymbol typeName)
+      | otherwise = Nothing
+
 resolveModuleSyntax ::
   Map P.ModuleName ResolvedScope ->
   LocalSymbols ->
@@ -338,7 +346,7 @@ resolveModuleSyntax ::
   ResolveM (P.ResolvedModuleSyntax, [ResolvedReference])
 resolveModuleSyntax priorExports locals scope mod0 = do
   imports0 <- mapM (resolveImport priorExports) (P.moduleImports mod0)
-  exports0 <- mapM (mapM (resolveExportItem locals)) (P.moduleExports mod0)
+  exports0 <- mapM (mapM (resolveExportItem (P.moduleName mod0) locals)) (P.moduleExports mod0)
   (decls0, refs) <- mapAndRefs resolveDecl (P.moduleDecls mod0)
   pure
     ( P.Module
@@ -392,14 +400,19 @@ resolveImportItem moduleName0 exports item =
             Just ref -> pure (P.ExportTypeWithConstructors ref)
             Nothing -> Left (ProgramImportNotExported moduleName0 typeName)
 
-resolveExportItem :: LocalSymbols -> P.ExportItem -> ResolveM P.ResolvedExportItem
-resolveExportItem locals item =
+resolveExportItem :: P.ModuleName -> LocalSymbols -> P.ExportItem -> ResolveM P.ResolvedExportItem
+resolveExportItem moduleName0 locals item =
   case item of
     P.ExportValue name ->
-      P.ExportValue <$> uniqueLocalSymbol ProgramExportNotLocal name (localValues locals)
+      case builtinPreludeExportType name of
+        Just ref -> pure (P.ExportType ref)
+        Nothing -> P.ExportValue <$> uniqueLocalSymbol ProgramExportNotLocal name (localValues locals)
     P.ExportType typeName ->
       case resolvedLocalExportTypeRef locals typeName of
         Just ref -> pure (P.ExportType ref)
+        Nothing
+          | Just ref <- builtinPreludeExportType typeName ->
+              pure (P.ExportType ref)
         Nothing -> P.ExportValue <$> uniqueLocalSymbol ProgramExportNotLocal typeName (localValues locals)
     P.ExportTypeWithConstructors typeName ->
       case Map.lookup typeName (localTypes locals) of
@@ -408,6 +421,12 @@ resolveExportItem locals item =
           case resolvedLocalExportTypeRef locals typeName of
             Just ref -> pure (P.ExportTypeWithConstructors ref)
             Nothing -> Left (ProgramExportNotLocal typeName)
+  where
+    builtinPreludeExportType typeName
+      | moduleName0 == "Prelude",
+        typeName == "IO" =
+          Just (P.ResolvedExportTypeRef typeName [builtinTypeSymbol typeName])
+      | otherwise = Nothing
 
 resolvedLocalExportTypeRef :: LocalSymbols -> String -> Maybe P.ResolvedExportTypeRef
 resolvedLocalExportTypeRef locals name =
@@ -569,7 +588,7 @@ resolveType scope = \case
 
 resolveTypeName :: CandidateScope -> String -> ResolveM ResolvedReference
 resolveTypeName scope name
-  | name `Set.member` builtinTypeNames = pure (ResolvedReference ResolvedTypeReference name (builtinSymbol SymbolType name))
+  | name `Set.member` builtinTypeNames = pure (ResolvedReference ResolvedTypeReference name (builtinTypeSymbol name))
   | otherwise = resolveReference ResolvedTypeReference ProgramUnknownType candidateTypes scope name
 
 resolveClassRef :: CandidateScope -> P.ClassName -> ResolveM ResolvedReference
@@ -871,9 +890,6 @@ ensureDistinctImportAliases imports0 =
   ensureDistinctPlain
     ProgramDuplicateImportAlias
     [alias | Just alias <- map P.importAlias imports0]
-
-builtinTypeNames :: Set.Set String
-builtinTypeNames = Set.fromList ["Int", "Bool", "String"]
 
 toListNE :: NonEmpty a -> [a]
 toListNE (x :| xs) = x : xs

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -14,6 +14,7 @@ import MLF.Elab.Pipeline (ElabTerm (..), Pretty (..), Ty (..), freeTypeVarsType,
 import MLF.Frontend.Program.Check (checkLocatedProgram, checkProgram)
 import MLF.Frontend.Program.Elaborate (ElaborateScope, mkElaborateScope)
 import MLF.Frontend.Program.Finalize (recoverSourceType)
+import qualified MLF.Frontend.Program.Builtins as Builtins
 import MLF.Frontend.Program.Types
   ( CheckedBinding (..),
     CheckedModule (..),
@@ -23,6 +24,7 @@ import MLF.Frontend.Program.Types
     ProgramDiagnostic,
     ProgramError (..),
     SymbolIdentity (..),
+    diagnosticForProgramError,
   )
 import MLF.Frontend.Syntax (Lit (..), SrcBound (..), SrcTy (..), SrcType)
 import qualified MLF.Frontend.Syntax.Program as ProgramSyntax
@@ -36,12 +38,15 @@ data Value
 runProgram :: ProgramSyntax.Program -> Either ProgramError Value
 runProgram program = do
   checked <- checkProgram program
+  rejectOpaqueMain checked
   pure (toValueWithProgram checked (normalizeProgramTerm (programMainTerm checked)))
 
 runLocatedProgram :: ProgramSyntax.LocatedProgram -> Either ProgramDiagnostic Value
 runLocatedProgram located = do
   checked <- checkLocatedProgram located
-  pure (toValueWithProgram checked (normalizeProgramTerm (programMainTerm checked)))
+  case rejectOpaqueMain checked of
+    Left err -> Left (diagnosticForProgramError (Just located) err)
+    Right () -> pure (toValueWithProgram checked (normalizeProgramTerm (programMainTerm checked)))
 
 programMainTerm :: CheckedProgram -> ElabTerm
 programMainTerm checked =
@@ -50,7 +55,8 @@ programMainTerm checked =
     allBindings =
       [ binding
         | checkedModule <- checkedProgramModules checked,
-          binding <- checkedModuleBindings checkedModule
+          binding <- checkedModuleBindings checkedModule,
+          not (checkedBindingMentionsOpaqueBuiltin binding)
       ]
 
     bindAll binding body =
@@ -59,6 +65,18 @@ programMainTerm checked =
         (schemeFromType (checkedBindingType binding))
         (checkedBindingTerm binding)
         body
+
+rejectOpaqueMain :: CheckedProgram -> Either ProgramError ()
+rejectOpaqueMain checked =
+  case mainSourceType checked of
+    Just ty
+      | Builtins.srcTypeMentionsOpaqueBuiltin ty ->
+          Left (ProgramPipelineError "run-program does not support IO main values yet")
+    _ -> Right ()
+
+checkedBindingMentionsOpaqueBuiltin :: CheckedBinding -> Bool
+checkedBindingMentionsOpaqueBuiltin =
+  Builtins.srcTypeMentionsOpaqueBuiltin . checkedBindingSourceType
 
 normalizeProgramTerm :: ElabTerm -> ElabTerm
 normalizeProgramTerm term =

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -68,15 +68,21 @@ rejectOpaqueMain checked =
       | Builtins.srcTypeMentionsOpaqueBuiltin ty ->
           Left (ProgramPipelineError "run-program does not support IO main values yet")
     _ ->
-      case reachableOpaqueRuntimeBindings checked of
-        [] -> Right ()
-        bindings ->
+      case reachableOpaqueRuntimeDependencies checked of
+        [] ->
+          Right ()
+        dependencies ->
           Left
             ( ProgramPipelineError
                 ( "run-program does not support IO dependencies yet: "
-                    ++ intercalate ", " (map checkedBindingName bindings)
+                    ++ intercalate ", " dependencies
                 )
             )
+
+reachableOpaqueRuntimeDependencies :: CheckedProgram -> [String]
+reachableOpaqueRuntimeDependencies checked =
+  map checkedBindingName (reachableOpaqueRuntimeBindings checked)
+    ++ Set.toAscList (reachableOpaquePrimitiveNames checked)
 
 reachableRuntimeBindings :: CheckedProgram -> [CheckedBinding]
 reachableRuntimeBindings checked =
@@ -95,6 +101,20 @@ reachableOpaqueRuntimeBindings checked =
       checkedBindingName binding `Set.member` reachableNames,
       checkedBindingMentionsOpaqueBuiltin binding
   ]
+  where
+    reachableNames = reachableBindingNames checked (Set.singleton (checkedProgramMain checked))
+
+reachableOpaquePrimitiveNames :: CheckedProgram -> Set.Set String
+reachableOpaquePrimitiveNames checked =
+  reachableFreeRuntimeNames checked `Set.intersection` Builtins.builtinOpaqueValueNames
+
+reachableFreeRuntimeNames :: CheckedProgram -> Set.Set String
+reachableFreeRuntimeNames checked =
+  Set.unions
+    [ freeTermVariables (checkedBindingTerm binding)
+      | binding <- allCheckedBindings checked,
+        checkedBindingName binding `Set.member` reachableNames
+    ]
   where
     reachableNames = reachableBindingNames checked (Set.singleton (checkedProgramMain checked))
 

--- a/src/MLF/Frontend/Program/Run.hs
+++ b/src/MLF/Frontend/Program/Run.hs
@@ -9,7 +9,9 @@ module MLF.Frontend.Program.Run
 where
 
 import Data.Foldable (toList)
+import Data.List (intercalate)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import MLF.Elab.Pipeline (ElabTerm (..), Pretty (..), Ty (..), freeTypeVarsType, normalize, schemeFromType, typeCheck)
 import MLF.Frontend.Program.Check (checkLocatedProgram, checkProgram)
 import MLF.Frontend.Program.Elaborate (ElaborateScope, mkElaborateScope)
@@ -50,15 +52,8 @@ runLocatedProgram located = do
 
 programMainTerm :: CheckedProgram -> ElabTerm
 programMainTerm checked =
-  foldr bindAll (EVar (checkedProgramMain checked)) allBindings
+  foldr bindAll (EVar (checkedProgramMain checked)) (reachableRuntimeBindings checked)
   where
-    allBindings =
-      [ binding
-        | checkedModule <- checkedProgramModules checked,
-          binding <- checkedModuleBindings checkedModule,
-          not (checkedBindingMentionsOpaqueBuiltin binding)
-      ]
-
     bindAll binding body =
       ELet
         (checkedBindingName binding)
@@ -72,11 +67,82 @@ rejectOpaqueMain checked =
     Just ty
       | Builtins.srcTypeMentionsOpaqueBuiltin ty ->
           Left (ProgramPipelineError "run-program does not support IO main values yet")
-    _ -> Right ()
+    _ ->
+      case reachableOpaqueRuntimeBindings checked of
+        [] -> Right ()
+        bindings ->
+          Left
+            ( ProgramPipelineError
+                ( "run-program does not support IO dependencies yet: "
+                    ++ intercalate ", " (map checkedBindingName bindings)
+                )
+            )
+
+reachableRuntimeBindings :: CheckedProgram -> [CheckedBinding]
+reachableRuntimeBindings checked =
+  [ binding
+    | binding <- allCheckedBindings checked,
+      checkedBindingName binding `Set.member` reachableNames,
+      not (checkedBindingMentionsOpaqueBuiltin binding)
+  ]
+  where
+    reachableNames = reachableBindingNames checked (Set.singleton (checkedProgramMain checked))
+
+reachableOpaqueRuntimeBindings :: CheckedProgram -> [CheckedBinding]
+reachableOpaqueRuntimeBindings checked =
+  [ binding
+    | binding <- allCheckedBindings checked,
+      checkedBindingName binding `Set.member` reachableNames,
+      checkedBindingMentionsOpaqueBuiltin binding
+  ]
+  where
+    reachableNames = reachableBindingNames checked (Set.singleton (checkedProgramMain checked))
+
+reachableBindingNames :: CheckedProgram -> Set.Set String -> Set.Set String
+reachableBindingNames checked roots =
+  go Set.empty roots
+  where
+    bindingMap = Map.fromList [(checkedBindingName binding, binding) | binding <- allCheckedBindings checked]
+    topLevelNames = Map.keysSet bindingMap
+
+    go visited pending =
+      case Set.minView pending of
+        Nothing -> visited
+        Just (name, rest)
+          | name `Set.member` visited -> go visited rest
+          | Just binding <- Map.lookup name bindingMap ->
+              let deps = freeTermVariables (checkedBindingTerm binding) `Set.intersection` topLevelNames
+               in go (Set.insert name visited) (rest `Set.union` deps)
+          | otherwise -> go visited rest
+
+allCheckedBindings :: CheckedProgram -> [CheckedBinding]
+allCheckedBindings checked =
+  [ binding
+    | checkedModule <- checkedProgramModules checked,
+      binding <- checkedModuleBindings checkedModule
+  ]
 
 checkedBindingMentionsOpaqueBuiltin :: CheckedBinding -> Bool
 checkedBindingMentionsOpaqueBuiltin =
   Builtins.srcTypeMentionsOpaqueBuiltin . checkedBindingSourceType
+
+freeTermVariables :: ElabTerm -> Set.Set String
+freeTermVariables =
+  go Set.empty
+  where
+    go bound term =
+      case term of
+        EVar name
+          | name `Set.member` bound -> Set.empty
+          | otherwise -> Set.singleton name
+        ELit {} -> Set.empty
+        ELam name _ body -> go (Set.insert name bound) body
+        EApp fun arg -> go bound fun `Set.union` go bound arg
+        ELet name _ rhs body -> go bound rhs `Set.union` go (Set.insert name bound) body
+        ETyAbs _ _ body -> go bound body
+        ETyInst inner _ -> go bound inner
+        ERoll _ body -> go bound body
+        EUnroll body -> go bound body
 
 normalizeProgramTerm :: ElabTerm -> ElabTerm
 normalizeProgramTerm term =

--- a/src/MLF/Parse/Common.hs
+++ b/src/MLF/Parse/Common.hs
@@ -28,6 +28,7 @@ import Text.Megaparsec
     , between
     , choice
     , many
+    , manyTill
     , satisfy
     , try
     , (<|>)
@@ -115,4 +116,4 @@ pLit =
         ]
 
 pString :: Parser String
-pString = lexeme (C.char '"' *> many L.charLiteral <* C.char '"')
+pString = lexeme (C.char '"' *> manyTill L.charLiteral (C.char '"'))

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -37,6 +37,30 @@ spec = describe "MLF.Backend.Convert" $ do
           resultTy `shouldBe` intTy
       other -> expectationFailure ("expected backend application, got " ++ show other)
 
+  it "rejects backend conversion when pure bindings reference opaque Prelude helpers" $ do
+    program <-
+      requireParsed $
+        unlines
+          [ "module Main export (main) {",
+            "  import Prelude exposing (Unit(..), IO, pure);",
+            "  def discard : IO Unit -> Unit = \\(_action : IO Unit) Unit;",
+            "  def main : Unit = discard (pure Unit);",
+            "}"
+          ]
+    checked <- requireRight (checkProgram (withPrelude program))
+    convertCheckedProgram checked
+      `shouldSatisfy` either
+        ( \err -> case err of
+            BackendUnsupportedCaseShape message ->
+              all
+                (`isInfixOf` message)
+                [ "IO dependencies are not supported by backend conversion yet",
+                  "Main__main -> Main__discard"
+                ]
+            _ -> False
+        )
+        (const False)
+
   it "matches the checked backend IR snapshot for a primitive function program" $ do
     checked <- requireChecked simpleFunctionProgram
     backend <- requireRight (convertCheckedProgram checked)

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -61,6 +61,29 @@ spec = describe "MLF.Backend.Convert" $ do
         )
         (const False)
 
+  it "rejects backend conversion when pure bindings directly reference opaque primitives" $ do
+    program <-
+      requireParsed $
+        unlines
+          [ "module Main export (main) {",
+            "  import Prelude exposing (Unit(..), IO);",
+            "  def main : Unit = (\\(_action : IO Unit) Unit) (__io_pure Unit);",
+            "}"
+          ]
+    checked <- requireRight (checkProgram (withPrelude program))
+    convertCheckedProgram checked
+      `shouldSatisfy` either
+        ( \err -> case err of
+            BackendUnsupportedCaseShape message ->
+              all
+                (`isInfixOf` message)
+                [ "IO dependencies are not supported by backend conversion yet",
+                  "Main__main -> __io_pure"
+                ]
+            _ -> False
+        )
+        (const False)
+
   it "matches the checked backend IR snapshot for a primitive function program" $ do
     checked <- requireChecked simpleFunctionProgram
     backend <- requireRight (convertCheckedProgram checked)

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -1,6 +1,6 @@
 module ProgramSpec (spec) where
 
-import Data.Either (isRight)
+import Data.Either (isLeft, isRight)
 import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
@@ -378,6 +378,28 @@ spec = do
                         , "}"
                         ]
             checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` isRight
+
+        it "typechecks direct IO bind primitive uses with consistent arguments" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO);"
+                        , "  def main : IO Unit = __io_bind (__io_pure Unit) (\\(_n : Unit) __io_putStrLn \"world\");"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` isRight
+
+        it "rejects inconsistent direct IO bind primitive arguments" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO);"
+                        , "  def main : IO Unit = __io_bind (__io_pure 1) (\\(_n : Unit) __io_putStrLn \"world\");"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` isLeft
 
         it "rejects non-IO expressions for Prelude IO annotations" $ do
             intLocated <-

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -471,6 +471,26 @@ spec = do
                 ((== ProgramPipelineError "run-program does not support IO main values yet") . diagnosticError)
                 (const False)
 
+        it "rejects running pure mains that depend on opaque Prelude helpers" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO, pure);"
+                        , "  def discard : IO Unit -> Unit = \\(_action : IO Unit) Unit;"
+                        , "  def main : Unit = discard (pure Unit);"
+                        , "}"
+                        ]
+            runLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                ( \diagnostic ->
+                    all
+                        (`isInfixOf` renderProgramDiagnostic diagnostic)
+                        [ "run-program does not support IO dependencies yet"
+                        , "Main__discard"
+                        ]
+                )
+                (const False)
+
         it "rejects a user module named Prelude when the built-in Prelude is active" $ do
             located <-
                 requireLocated $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -366,6 +366,74 @@ spec = do
                         ]
             (prettyValue <$> runLocatedProgram (withPreludeLocated located)) `shouldBe` Right "Some Zero"
 
+        it "typechecks the initial Prelude IO and Monad surface" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (pureUnit, main) {"
+                        , "  import Prelude exposing (Unit(..), IO, Monad, pure, bind, putStrLn);"
+                        , "  def pureUnit : IO Unit = pure Unit;"
+                        , "  def after : Unit -> IO Unit = \\_done putStrLn \"world\";"
+                        , "  def main : IO Unit = bind (putStrLn \"hello\") after;"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` isRight
+
+        it "rejects constructor imports for opaque Prelude IO" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (IO(..));"
+                        , "  def main : Bool = true;"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                ((== ProgramImportNotExported "Prelude" "IO") . diagnosticError)
+                (const False)
+
+        it "rejects case inspection of opaque Prelude IO values" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO, pure);"
+                        , "  def action : IO Unit = pure Unit;"
+                        , "  def main : Unit = case action of {"
+                        , "    _ -> Unit"
+                        , "  };"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                (isInfixOf "case scrutinee is not a data type" . renderProgramDiagnostic)
+                (const False)
+
+        it "keeps overloaded pure ambiguous without an IO expected result" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), pure);"
+                        , "  def main : Unit = pure Unit;"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                ((== ProgramAmbiguousMethodUse "pure") . diagnosticError)
+                (const False)
+
+        it "rejects running IO mains until runtime support exists" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO, putStrLn);"
+                        , "  def main : IO Unit = putStrLn \"hello\";"
+                        , "}"
+                        ]
+            runLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                ((== ProgramPipelineError "run-program does not support IO main values yet") . diagnosticError)
+                (const False)
+
         it "rejects a user module named Prelude when the built-in Prelude is active" $ do
             located <-
                 requireLocated $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -403,6 +403,19 @@ spec = do
                 (isInfixOf "type mismatch" . renderProgramDiagnostic)
                 (const False)
 
+        it "rejects inconsistent Prelude IO bind argument substitutions" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO, bind, putStrLn);"
+                        , "  def main : IO Unit = bind (__io_pure 1) (\\(_n : Unit) putStrLn \"world\");"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                (isInfixOf "ambiguous overloaded method use `bind`" . renderProgramDiagnostic)
+                (const False)
+
         it "rejects constructor imports for opaque Prelude IO" $ do
             located <-
                 requireLocated $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -379,6 +379,30 @@ spec = do
                         ]
             checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` isRight
 
+        it "rejects non-IO expressions for Prelude IO annotations" $ do
+            intLocated <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO);"
+                        , "  def main : IO Unit = 1;"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated intLocated) `shouldSatisfy` either
+                (isInfixOf "type mismatch" . renderProgramDiagnostic)
+                (const False)
+            identityLocated <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO);"
+                        , "  def main : IO Unit = \\x x;"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated identityLocated) `shouldSatisfy` either
+                (isInfixOf "type mismatch" . renderProgramDiagnostic)
+                (const False)
+
         it "rejects constructor imports for opaque Prelude IO" $ do
             located <-
                 requireLocated $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -403,6 +403,19 @@ spec = do
                 (isInfixOf "type mismatch" . renderProgramDiagnostic)
                 (const False)
 
+        it "rejects monomorphic IO actions for polymorphic IO annotations" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (IO);"
+                        , "  def main : forall a. IO a = __io_pure 1;"
+                        , "}"
+                        ]
+            checkLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                (isInfixOf "type mismatch" . renderProgramDiagnostic)
+                (const False)
+
         it "rejects inconsistent Prelude IO bind argument substitutions" $ do
             located <-
                 requireLocated $

--- a/test/ProgramSpec.hs
+++ b/test/ProgramSpec.hs
@@ -491,6 +491,25 @@ spec = do
                 )
                 (const False)
 
+        it "rejects running pure mains that directly call opaque primitives" $ do
+            located <-
+                requireLocated $
+                    unlines
+                        [ "module Main export (main) {"
+                        , "  import Prelude exposing (Unit(..), IO);"
+                        , "  def main : Unit = (\\(_action : IO Unit) Unit) (__io_pure Unit);"
+                        , "}"
+                        ]
+            runLocatedProgram (withPreludeLocated located) `shouldSatisfy` either
+                ( \diagnostic ->
+                    all
+                        (`isInfixOf` renderProgramDiagnostic diagnostic)
+                        [ "run-program does not support IO dependencies yet"
+                        , "__io_pure"
+                        ]
+                )
+                (const False)
+
         it "rejects a user module named Prelude when the built-in Prelude is active" $ do
             located <-
                 requireLocated $


### PR DESCRIPTION
Closes #91.

## Implementation Plan

---
issue_number: 91
pr_number: 111
branch: codex/issue-91
---

## Implementation Plan

1. Reconfirm the implementation turn starts on `codex/issue-91` for PR #111 with a clean status, then read the watcher-written issue plan before editing.

2. Add a small centralized built-in program-surface helper for built-in symbols, type kinds, and primitive value types. Keep existing `Int`, `Bool`, and `String` as kind `*`; add opaque `IO` with kind `* -> *`; add reserved primitive values `__io_pure`, `__io_bind`, and `__io_putStrLn` with source types `forall a. a -> IO a`, `forall a b. IO a -> (a -> IO b) -> IO b`, and `String -> IO Unit`.

3. Represent `IO` as an explicit opaque built-in type, not Church-encoded data. Synthesize it for the built-in `Prelude` export/import path, give it a stable identity such as `<builtin>.IO`, reject user attempts to define an ordinary `IO` data type, allow abstract `IO` imports/exports, and keep `IO(..)`/constructor imports failing because there are no constructors.

4. Update the built-in Prelude source to export `Unit(..)`, `IO`, `Monad`, `pure`, `bind`, and `putStrLn`; add ordinary `Unit`; add `class Monad (m :: * -> *)` with `pure` and `bind`; add `instance Monad IO` backed by `__io_pure`/`__io_bind`; add public `putStrLn` backed by `__io_putStrLn`. Preserve existing Prelude exports and behavior for `Nat`, `Option`, `List`, `Eq`, `eq`, `and`, and `id`.

5. Extend overloaded method resolution narrowly so non-nullary methods can use an expected result type when arguments alone do not determine the class parameter. This is needed for `def x : IO Unit = pure Unit;`. Store the expected result view in `DeferredMethodCall`, combine argument-derived substitutions with result-template matching, and keep existing ambiguity behavior when neither arguments nor expected type determine the instance.

6. Keep opaque `IO` out of representation-sensitive paths: do not generate constructor bindings for it, do not lower it as a source ADT, do not allow case/constructor inspection of it, and avoid backend/runtime semantic changes beyond any metadata filtering needed so existing pure programs still run and lower unchanged.

7. Add focused tests in `ProgramSpec` or the existing program matrix: positive checks for importing `Unit`, `IO`, `Monad`, `pure`, `bind`, and `putStrLn`; `IO Unit` annotations; `pure Unit`; `bind (putStrLn "...") (\(_done : Unit) putStrLn "...")`; and coherent `Monad IO` instance selection. Add negative tests for `IO(..)` import/constructor inspection and an ambiguity guard showing `pure` is still rejected when no expected `IO` result fixes the instance.

8. Update relevant docs: README Prelude surface list and `.mlfp` language reference only where the implemented behavior differs from the already documented #87 contract; add a concise CHANGELOG entry because this is meaningful source-language progress.

9. Validate with a focused ProgramSpec slice first, then run `cabal build all && cabal test`. Before committing, inspect `git status --short` and related diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status`/`gh auth setup-git` before publishing, and push `codex/issue-91` to the existing PR #111.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.