### PR TITLE
Implement #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   without rejecting the callee's arrow result type. Closure-valued let aliases
   now also stay runtime pointer aliases during lowering instead of being
   reclassified as raw escaping local functions.
+- Fixed checked-program closure conversion to clear shadowed closure locals when
+  classifying nested `let` values, and to fail closed on closure-valued
+  constructor fields until ADT field lowering has a closure-aware representation.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Fixed closure conversion and LLVM lowering for type-abstracted closure-valued
   globals and nested `let` aliases of closure parameters, keeping both on the
   explicit closure-call ABI instead of the raw function-pointer path.
+- Fixed backend closure-value classification for case alternatives so
+  constructor pattern binders shadow outer closure locals before let aliases are
+  classified as closure-valued.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Fixed backend closure-value classification for case alternatives so
   constructor pattern binders shadow outer closure locals before let aliases are
   classified as closure-valued.
+- Fixed closure call-head classification so local non-closure binders shadow
+  same-named closure-valued globals instead of inheriting the global closure
+  ABI.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Fixed checked-program closure conversion to clear shadowed closure locals when
   classifying nested `let` values, and to fail closed on closure-valued
   constructor fields until ADT field lowering has a closure-aware representation.
+- Fixed closure conversion and LLVM lowering for type-abstracted closure-valued
+  globals and nested `let` aliases of closure parameters, keeping both on the
+  explicit closure-call ABI instead of the raw function-pointer path.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - Fixed closure call-head classification so local non-closure binders shadow
   same-named closure-valued globals instead of inheriting the global closure
   ABI.
+- Fixed backend IR validation and closure-global discovery so local non-closure
+  `let` and case-pattern binders shadow same-named closure-valued globals.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Added checked-program closure conversion for ordinary monomorphic escaping
+  `.mlfp` lambdas and closure-valued let aliases. Backend conversion now emits
+  explicit `BackendClosure` / `BackendClosureCall` IR for returned local
+  functions and indirect calls through aliases while preserving direct
+  first-order local calls on the direct application path.
 - Added native LLVM toolchain runner support to the test harness. LLVM backend
   tests can now discover `llc` plus a native linker, build a temporary
   executable from emitted `.ll`, run it, and capture stdout, stderr, and exit
@@ -11,7 +16,9 @@
 ### Changed
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
-  without rejecting the callee's arrow result type.
+  without rejecting the callee's arrow result type. Closure-valued let aliases
+  now also stay runtime pointer aliases during lowering instead of being
+  reclassified as raw escaping local functions.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still
@@ -45,7 +52,8 @@
 - Added LLVM lowering support for first-class polymorphic values at
   non-escaping runtime boundaries. Polymorphic arguments and immediate
   constructor fields are statically specialized/erased at call and case sites,
-  while escaping closures and partial applications remain fail-closed.
+  while raw backend escaping lambdas and partial applications remain
+  fail-closed unless conversion has produced explicit closure IR.
 - Extended LLVM backend support for resolved typeclass evidence and derived
   `Eq`: constrained helper aliases, method-level evidence constraints,
   parameterized instances, recursive `List` deriving, recursive ADT deriving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   ABI.
 - Fixed backend IR validation and closure-global discovery so local non-closure
   `let` and case-pattern binders shadow same-named closure-valued globals.
+- Fixed closure entry naming for lifted recursive helpers so helper-local
+  closure conversion shares one allocator across the source binding.
 - Supported expected-type resolution for nullary overloaded `.mlfp` methods.
   Associated values such as `mempty : a` now resolve from an explicit or
   propagated expected source type while bare uses without such evidence still

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ The code is organized by domain (not by phase) under `src/MLF/`:
 - `MLF.Frontend.Program.Prelude` — built-in source-level `.mlfp` Prelude used by the CLI/file runner as an explicit import target
 - `MLF.Frontend.Program.Run` — runtime entrypoint that evaluates checked `.mlfp` bindings through the existing xMLF runtime and renders recovered closed ADT values with source constructor syntax
 - `MLF.Backend.IR` — typed backend IR boundary for checked `.mlfp` programs, before LLVM lowering
-- `MLF.Backend.Convert` — checked `.mlfp` program to typed backend IR conversion, including backend type conversion and explicit ADT construct/case recovery where the checked xMLF shape is unambiguous
+- `MLF.Backend.Convert` — checked `.mlfp` program to typed backend IR conversion, including backend type conversion, explicit ADT construct/case recovery, and closure conversion where the checked xMLF shape is unambiguous
 - `MLF.Backend.LLVM` — repo-local LLVM backend facade over a small typed LLVM AST, lowerer, and pretty-printer for the supported typed backend IR subset, with explicit diagnostics for unsupported backend nodes
 - `MLF.Constraint.*` — constraint graph types + normalize + acyclicity + presolution + solve
 - `MLF.Binding.*` — binding tree queries + executable χe ops + harmonization
@@ -191,12 +191,15 @@ before erased monomorphic value parameters. Direct first-order calls still use
 the existing direct-call path; indirect calls must be represented with
 `BackendClosureCall`.
 
-Full source-to-source closure conversion, partial application lowering,
-higher-order constructor fields that require captured environments, recursive
-higher-order flows, and final executable linking remain future extension
-points. Those diagnostics do not weaken source inference, checking, module
-visibility, or runtime semantics; they only describe the current IR-to-LLVM
-lowering surface.
+Checked-program conversion now closure-converts ordinary monomorphic escaping
+source lambdas, returned local function values, closure-valued let aliases, and
+indirect calls through those aliases into explicit closure IR. Direct
+first-order local calls remain direct backend applications. Partial application
+lowering, higher-order constructor fields that require captured environments,
+recursive higher-order flows, and final executable linking remain future
+extension points. Those diagnostics do not weaken source inference, checking,
+module visibility, or runtime semantics; they only describe the current
+IR-to-LLVM lowering surface.
 
 ## `Solved` boundary and thesis-exact cleanup rule
 

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -21,7 +21,8 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, forM, unless, when, zipWithM)
-import Control.Monad.State.Strict (StateT (StateT), get, modify, runStateT)
+import Control.Monad.State.Strict (StateT (StateT), evalStateT, get, modify, runStateT)
+import Data.Char (isAlphaNum)
 import Data.List (find, intercalate, nub, stripPrefix)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -113,6 +114,59 @@ data LiftState = LiftState
   }
 
 type LiftM = StateT LiftState (Either BackendConversionError)
+
+data ConvertState = ConvertState
+  { csNextClosureIndex :: Int,
+    csGeneratedClosureNames :: Set.Set String
+  }
+
+type ConvertM = StateT ConvertState (Either BackendConversionError)
+
+data ClosureScope = ClosureScope
+  { closureScopeTerms :: Map String ElabType,
+    closureScopeLocals :: Set.Set String
+  }
+
+data LambdaMode
+  = DirectLambda
+  | ClosureLambda (Maybe String)
+
+emptyClosureScope :: ClosureScope
+emptyClosureScope =
+  ClosureScope
+    { closureScopeTerms = Map.empty,
+      closureScopeLocals = Set.empty
+    }
+
+extendClosureScopeTerm :: String -> ElabType -> Bool -> ClosureScope -> ClosureScope
+extendClosureScopeTerm name ty isClosure scope =
+  scope
+    { closureScopeTerms = Map.insert name ty (closureScopeTerms scope),
+      closureScopeLocals =
+        if isClosure
+          then Set.insert name (closureScopeLocals scope)
+          else Set.delete name (closureScopeLocals scope)
+    }
+
+extendClosureScopeTerms :: [(String, ElabType)] -> ClosureScope -> ClosureScope
+extendClosureScopeTerms bindings scope =
+  foldr (\(name, ty) acc -> extendClosureScopeTerm name ty False acc) scope bindings
+
+runConvertM :: ConvertM a -> Either BackendConversionError a
+runConvertM action =
+  evalStateT
+    action
+    ConvertState
+      { csNextClosureIndex = 0,
+        csGeneratedClosureNames = Set.empty
+      }
+
+liftEitherConvert :: Either BackendConversionError a -> ConvertM a
+liftEitherConvert result =
+  StateT $ \state0 ->
+    case result of
+      Right value -> Right (value, state0)
+      Left err -> Left err
 
 convertCheckedProgram :: CheckedProgram -> Either BackendConversionError BackendProgram
 convertCheckedProgram checked = do
@@ -230,7 +284,7 @@ convertCheckedBinding context env checkedModule binding = do
                 env
                 liftedSpecs
         liftedBindings <- mapM (convertLiftedRecursiveLet bindingContext envWithLifted) liftedSpecs
-        expr <- convertTermExpected bindingContext envWithLifted (Just bindingTy) liftedTerm
+        expr <- runConvertM (convertTermExpectedMode DirectLambda bindingContext envWithLifted emptyClosureScope (Just bindingTy) liftedTerm)
         Right (bindingTy, expr, liftedBindings)
   let convertedBinding =
         BackendBinding
@@ -256,7 +310,7 @@ liftRecursiveLetsInBinding context term = do
 convertLiftedRecursiveLet :: ConvertContext -> Env -> LiftedRecursiveLet -> Either BackendConversionError BackendBinding
 convertLiftedRecursiveLet context env lifted = do
   let bindingTy = canonicalizeBackendType context (lrlBackendType lifted)
-  expr <- convertTermExpected context env (Just bindingTy) (lrlTerm lifted)
+  expr <- runConvertM (convertTermExpectedMode DirectLambda context env emptyClosureScope (Just bindingTy) (lrlTerm lifted))
   Right
     BackendBinding
       { backendBindingName = lrlName lifted,
@@ -327,11 +381,14 @@ liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
 
 capturedTermBindings :: Map String ElabType -> ElabTerm -> LiftM [(String, ElabType)]
 capturedTermBindings lexicalTerms rhs =
-  pure
-    [ (name, ty)
-    | (name, ty) <- Map.toAscList lexicalTerms,
-      Set.member name freeVars
-    ]
+  pure (capturedTermBindingsIn lexicalTerms rhs)
+
+capturedTermBindingsIn :: Map String ElabType -> ElabTerm -> [(String, ElabType)]
+capturedTermBindingsIn lexicalTerms rhs =
+  [ (name, ty)
+  | (name, ty) <- Map.toAscList lexicalTerms,
+    Set.member name freeVars
+  ]
   where
     freeVars = freeTermVariables rhs
 
@@ -1618,87 +1675,109 @@ candidateDataResultTypes context ty =
       let completed = completeBackendParameterSubstitution parameters substitution
     ]
 
-convertTerm :: ConvertContext -> Env -> ElabTerm -> Either BackendConversionError BackendExpr
-convertTerm context env =
-  convertTermExpected context env Nothing
+convertTerm :: ConvertContext -> Env -> ClosureScope -> ElabTerm -> ConvertM BackendExpr
+convertTerm context env scope =
+  convertTermExpectedMode DirectLambda context env scope Nothing
 
-convertTermExpected :: ConvertContext -> Env -> Maybe BackendType -> ElabTerm -> Either BackendConversionError BackendExpr
-convertTermExpected context env mbExpectedTy term =
+convertTermExpectedMode :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> Maybe BackendType -> ElabTerm -> ConvertM BackendExpr
+convertTermExpectedMode mode context env scope mbExpectedTy term =
   case mbExpectedTy of
     Just resultTy0 ->
       let resultTy = canonicalizeBackendType context resultTy0
-       in convertSpecialTerm context env term resultTy
+       in convertSpecialTerm mode context env scope term resultTy
             >>= \case
-              Just expr -> Right expr
-              Nothing -> convertOrdinaryTerm context env term resultTy
+              Just expr -> pure expr
+              Nothing -> convertOrdinaryTerm mode context env scope term resultTy
     Nothing -> do
-      resultTy <- canonicalizeBackendType context <$> inferBackendType env term
-      convertSpecialTerm context env term resultTy
+      resultTy <- canonicalizeBackendType context <$> liftEitherConvert (inferBackendType env term)
+      convertSpecialTerm mode context env scope term resultTy
         >>= \case
-          Just expr -> Right expr
-          Nothing -> convertOrdinaryTerm context env term resultTy
+          Just expr -> pure expr
+          Nothing -> convertOrdinaryTerm mode context env scope term resultTy
 
 convertSpecialTerm ::
+  LambdaMode ->
   ConvertContext ->
   Env ->
+  ClosureScope ->
   ElabTerm ->
   BackendType ->
-  Either BackendConversionError (Maybe BackendExpr)
-convertSpecialTerm context env term resultTy =
-  convertCaseApplication context env term resultTy
+  ConvertM (Maybe BackendExpr)
+convertSpecialTerm mode context env scope term resultTy =
+  convertCaseApplication mode context env scope term resultTy
     >>= \case
-      Just expr -> Right (Just expr)
+      Just expr -> pure (Just expr)
       Nothing ->
-        convertConstructorApplication context env term resultTy
+        convertConstructorApplication mode context env scope term resultTy
 
-convertOrdinaryTerm :: ConvertContext -> Env -> ElabTerm -> BackendType -> Either BackendConversionError BackendExpr
-convertOrdinaryTerm context env term resultTy0 =
+convertOrdinaryTerm :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> ElabTerm -> BackendType -> ConvertM BackendExpr
+convertOrdinaryTerm mode context env scope term resultTy0 =
   let resultTy = normalizeBackendTypeForContext context resultTy0
    in case term of
     EVar name ->
-      Right
+      pure
         BackendVar
           { backendExprType = resultTy,
             backendVarName = name
           }
     ELit lit ->
-      Right
+      pure
         BackendLit
           { backendExprType = resultTy,
             backendLit = lit
           }
+    ELam {}
+      | shouldClosureConvertLambda mode resultTy ->
+          convertLambdaClosure mode context env scope resultTy term
     ELam name paramTy body -> do
-      rawParamBackendTy <- convertElabType paramTy
+      rawParamBackendTy <- liftEitherConvert (convertElabType paramTy)
       let (paramBackendTy, bodyExpected) =
             case resultTy of
               BTArrow expectedParam cod -> (expectedParam, Just cod)
               _ -> (normalizeBackendTypeForContext context rawParamBackendTy, Nothing)
-      let paramEnvTy =
+          paramEnvTy =
             case backendTypeToElabType paramBackendTy of
               Just canonicalTy -> canonicalTy
               Nothing -> paramTy
-      bodyExpr <- convertTermExpected context (extendTermEnv name paramEnvTy env) bodyExpected body
-      Right
+          bodyMode = directLambdaBodyMode bodyExpected body
+          bodyScope = extendClosureScopeTerm name paramEnvTy False scope
+      bodyExpr <- convertTermExpectedMode bodyMode context (extendTermEnv name paramEnvTy env) bodyScope bodyExpected body
+      pure
         BackendLam
           { backendExprType = resultTy,
             backendParamName = name,
             backendParamType = paramBackendTy,
             backendBody = bodyExpr
           }
-    EApp fun arg ->
-      convertApplication context env resultTy fun arg
+    EApp {} ->
+      convertApplicationTerm context env scope resultTy term
     ELet name scheme rhs body -> do
       let schemeTy = schemeToType scheme
       when (termMentionsFreeVariable name rhs) $
-        Left (BackendUnsupportedRecursiveLet name)
-      bindingTy <- normalizeBackendTypeForContext context <$> convertElabType schemeTy
-      rhsExpr <- convertTermExpected context env (Just bindingTy) rhs
+        liftEitherConvert (Left (BackendUnsupportedRecursiveLet name))
+      bindingTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (convertElabType schemeTy)
+      let bindingClosure = letBindingNeedsClosure scope name bindingTy rhs body
+          rhsMode =
+            if bindingClosure
+              then ClosureLambda (Just name)
+              else DirectLambda
+      rhsExpr <- convertTermExpectedMode rhsMode context env scope (Just bindingTy) rhs
       let bindingEnvTy =
             case backendTypeToElabType bindingTy of
               Just canonicalTy -> canonicalTy
               Nothing -> schemeTy
-      bodyExpr <- convertTermExpected context (extendTermEnv name bindingEnvTy env) (Just resultTy) body
-      Right
+          bodyScope =
+            extendClosureScopeTerm
+              name
+              bindingEnvTy
+              (bindingClosure || backendExprIsClosureValue scope rhsExpr)
+              scope
+          bodyMode =
+            if isClosureConvertibleFunctionType resultTy
+              then ClosureLambda Nothing
+              else mode
+      bodyExpr <- convertTermExpectedMode bodyMode context (extendTermEnv name bindingEnvTy env) bodyScope (Just resultTy) body
+      pure
         BackendLet
           { backendExprType = resultTy,
             backendLetName = name,
@@ -1709,11 +1788,11 @@ convertOrdinaryTerm context env term resultTy0 =
     ETyAbs name mbBound body ->
       case resultTy of
         BTForall expectedName _ bodyTy -> do
-          mbBackendBound <- traverse (fmap (normalizeBackendTypeForContext context) . convertElabType . tyToElab) mbBound
+          mbBackendBound <- liftEitherConvert (traverse (fmap (normalizeBackendTypeForContext context) . convertElabType . tyToElab) mbBound)
           let boundTy = maybe TBottom tyToElab mbBound
               bodyExpected = Just (substituteBackendType expectedName (BTVar name) bodyTy)
-          bodyExpr <- convertTermExpected context (extendTypeEnv name boundTy env) bodyExpected body
-          Right
+          bodyExpr <- convertTermExpectedMode mode context (extendTypeEnv name boundTy env) scope bodyExpected body
+          pure
             BackendTyAbs
               { backendExprType = resultTy,
                 backendTyParamName = name,
@@ -1721,20 +1800,20 @@ convertOrdinaryTerm context env term resultTy0 =
                 backendTyAbsBody = bodyExpr
               }
         _ ->
-          convertTermExpected context env (Just resultTy) body
+          convertTermExpectedMode mode context env scope (Just resultTy) body
     ETyInst inner inst ->
-      convertTypeInstantiation context env resultTy inner inst
+      convertTypeInstantiation context env scope resultTy inner inst
     ERoll _ body -> do
       let bodyExpected = unfoldBackendRecursiveType resultTy
-      bodyExpr <- convertTermExpected context env bodyExpected body
-      Right
+      bodyExpr <- convertTermExpectedMode mode context env scope bodyExpected body
+      pure
         BackendRoll
           { backendExprType = resultTy,
             backendRollPayload = bodyExpr
           }
     EUnroll body -> do
-      bodyExpr <- convertTerm context env body
-      Right
+      bodyExpr <- convertTerm context env scope body
+      pure
         BackendUnroll
           { backendExprType = resultTy,
             backendUnrollPayload = bodyExpr
@@ -1743,49 +1822,86 @@ convertOrdinaryTerm context env term resultTy0 =
 convertApplication ::
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendType ->
   ElabTerm ->
   ElabTerm ->
-  Either BackendConversionError BackendExpr
-convertApplication context env resultTy fun arg =
+  ConvertM BackendExpr
+convertApplication context env scope resultTy fun arg =
   if termContainsTypeInstantiation fun
     then
-      convertApplicationFromExpectedResult context env resultTy fun arg
-        `orElseConversion` convertApplicationFromFunction context env resultTy fun arg
+      convertApplicationFromExpectedResult context env scope resultTy fun arg
+        `orElseConvertM` convertApplicationFromFunction context env scope resultTy fun arg
     else
-      convertApplicationFromFunction context env resultTy fun arg
-        `orElseConversion` convertApplicationFromExpectedResult context env resultTy fun arg
+      convertApplicationFromFunction context env scope resultTy fun arg
+        `orElseConvertM` convertApplicationFromExpectedResult context env scope resultTy fun arg
+
+convertApplicationTerm ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  ConvertM BackendExpr
+convertApplicationTerm context env scope resultTy term =
+  case collectApps term of
+    (headTerm, args)
+      | not (null args),
+        isClosureHeadTerm scope headTerm -> do
+          funTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (inferBackendType env headTerm)
+          let (paramTys, expectedResultTy) = splitBackendArrows funTy
+          if length paramTys == length args && not (null paramTys)
+            then do
+              funExpr <- convertTermExpectedMode DirectLambda context env scope (Just funTy) headTerm
+              argExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) paramTys args
+              let callResultTy =
+                    if alphaEqBackendType resultTy expectedResultTy
+                      then resultTy
+                      else expectedResultTy
+              pure
+                BackendClosureCall
+                  { backendExprType = callResultTy,
+                    backendClosureFunction = funExpr,
+                    backendClosureArguments = argExprs
+                  }
+            else convertApplicationFallback
+    _ -> convertApplicationFallback
+  where
+    convertApplicationFallback =
+      case term of
+        EApp fun arg -> convertApplication context env scope resultTy fun arg
+        _ -> liftEitherConvert (Left (BackendUnsupportedCaseShape "expected application term"))
 
 convertApplicationFromFunction ::
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendType ->
   ElabTerm ->
   ElabTerm ->
-  Either BackendConversionError BackendExpr
-convertApplicationFromFunction context env resultTy fun arg = do
-  funExpr <- convertTerm context env fun
+  ConvertM BackendExpr
+convertApplicationFromFunction context env scope resultTy fun arg = do
+  funExpr <- convertTerm context env scope fun
   argExpr <-
     case backendExprType funExpr of
-      BTArrow expectedArg _ -> convertTermExpected context env (Just expectedArg) arg
-      _ -> convertTerm context env arg
-  Right (backendApplication (applicationResultType resultTy funExpr) funExpr argExpr)
+      BTArrow expectedArg _ -> convertTermExpectedMode DirectLambda context env scope (Just expectedArg) arg
+      _ -> convertTerm context env scope arg
+  pure (backendApplication (applicationResultType resultTy funExpr) funExpr argExpr)
 
 convertApplicationFromExpectedResult ::
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendType ->
   ElabTerm ->
   ElabTerm ->
-  Either BackendConversionError BackendExpr
-convertApplicationFromExpectedResult context env resultTy fun arg =
-  case inferBackendType env arg of
-    Right rawArgTy -> do
-      let argTy = canonicalizeBackendType context rawArgTy
-      funExpr <- convertTermExpected context env (Just (BTArrow argTy resultTy)) fun
-      argExpr <- convertTermExpected context env (Just argTy) arg
-      Right (backendApplication resultTy funExpr argExpr)
-    Left err -> Left err
+  ConvertM BackendExpr
+convertApplicationFromExpectedResult context env scope resultTy fun arg = do
+  rawArgTy <- liftEitherConvert (inferBackendType env arg)
+  let argTy = canonicalizeBackendType context rawArgTy
+  funExpr <- convertTermExpectedMode DirectLambda context env scope (Just (BTArrow argTy resultTy)) fun
+  argExpr <- convertTermExpectedMode DirectLambda context env scope (Just argTy) arg
+  pure (backendApplication resultTy funExpr argExpr)
 
 backendApplication :: BackendType -> BackendExpr -> BackendExpr -> BackendExpr
 backendApplication resultTy funExpr argExpr =
@@ -1802,11 +1918,231 @@ applicationResultType resultTy funExpr =
       | not (alphaEqBackendType actualResultTy resultTy) -> actualResultTy
     _ -> resultTy
 
-orElseConversion :: Either BackendConversionError a -> Either BackendConversionError a -> Either BackendConversionError a
-orElseConversion primary fallback =
-  case primary of
-    Right value -> Right value
-    Left _ -> fallback
+orElseConvertM :: ConvertM a -> ConvertM a -> ConvertM a
+orElseConvertM primary fallback =
+  StateT $ \state0 ->
+    case runStateT primary state0 of
+      Right value -> Right value
+      Left _ -> runStateT fallback state0
+
+shouldClosureConvertLambda :: LambdaMode -> BackendType -> Bool
+shouldClosureConvertLambda mode resultTy =
+  case mode of
+    ClosureLambda {} -> isClosureConvertibleFunctionType resultTy
+    DirectLambda -> False
+
+isClosureConvertibleFunctionType :: BackendType -> Bool
+isClosureConvertibleFunctionType =
+  \case
+    BTArrow {} -> True
+    _ -> False
+
+isClosureConvertibleElabType :: ElabType -> Bool
+isClosureConvertibleElabType =
+  \case
+    TArrow {} -> True
+    _ -> False
+
+directLambdaBodyMode :: Maybe BackendType -> ElabTerm -> LambdaMode
+directLambdaBodyMode bodyExpected body =
+  case bodyExpected of
+    Just bodyTy
+      | isClosureConvertibleFunctionType bodyTy,
+        not (isImmediateLambda body) ->
+          ClosureLambda Nothing
+    _ -> DirectLambda
+
+isImmediateLambda :: ElabTerm -> Bool
+isImmediateLambda =
+  \case
+    ELam {} -> True
+    ETyAbs _ _ body -> isImmediateLambda body
+    ETyInst inner _ -> isImmediateLambda inner
+    _ -> False
+
+letBindingNeedsClosure :: ClosureScope -> String -> BackendType -> ElabTerm -> ElabTerm -> Bool
+letBindingNeedsClosure scope name bindingTy rhs body =
+  isClosureConvertibleFunctionType bindingTy
+    && (isClosureAliasTerm scope rhs || (isFunctionValueTerm rhs && termUsesVariableAsValue name body))
+
+isClosureAliasTerm :: ClosureScope -> ElabTerm -> Bool
+isClosureAliasTerm scope term =
+  case stripClosureHeadTypeInsts term of
+    EVar name -> Set.member name (closureScopeLocals scope)
+    _ -> False
+
+backendExprIsClosureValue :: ClosureScope -> BackendExpr -> Bool
+backendExprIsClosureValue scope =
+  \case
+    BackendClosure {} -> True
+    BackendVar _ name -> Set.member name (closureScopeLocals scope)
+    BackendTyApp _ fun _ -> backendExprIsClosureValue scope fun
+    BackendLet _ name _ rhs body ->
+      let bodyScope =
+            if backendExprIsClosureValue scope rhs
+              then scope {closureScopeLocals = Set.insert name (closureScopeLocals scope)}
+              else scope
+       in backendExprIsClosureValue bodyScope body
+    BackendCase {backendAlternatives = alternatives} ->
+      all (backendExprIsClosureValue scope . backendAltBody) (NE.toList alternatives)
+    _ -> False
+
+isClosureHeadTerm :: ClosureScope -> ElabTerm -> Bool
+isClosureHeadTerm scope term =
+  case stripClosureHeadTypeInsts term of
+    EVar name -> Set.member name (closureScopeLocals scope)
+    _ -> False
+
+stripClosureHeadTypeInsts :: ElabTerm -> ElabTerm
+stripClosureHeadTypeInsts =
+  \case
+    ETyInst inner _ -> stripClosureHeadTypeInsts inner
+    other -> other
+
+termUsesVariableAsValue :: String -> ElabTerm -> Bool
+termUsesVariableAsValue needle =
+  go False
+  where
+    go underLambda term =
+      case term of
+        EVar name ->
+          name == needle
+        ELit {} ->
+          False
+        ELam name _ body
+          | name == needle -> False
+          | otherwise -> go True body
+        EApp {} ->
+          let (headTerm, args) = collectApps term
+              headUse =
+                case stripClosureHeadTypeInsts headTerm of
+                  EVar name
+                    | name == needle -> underLambda
+                  _ -> go underLambda headTerm
+           in headUse || any (go underLambda) args
+        ELet name _ rhs body
+          | name == needle -> go underLambda rhs
+          | otherwise -> go underLambda rhs || go underLambda body
+        ETyAbs _ _ body ->
+          go underLambda body
+        ETyInst inner _ ->
+          go underLambda inner
+        ERoll _ body ->
+          go underLambda body
+        EUnroll body ->
+          go underLambda body
+
+convertLambdaClosure :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> BackendType -> ElabTerm -> ConvertM BackendExpr
+convertLambdaClosure mode context env scope resultTy term = do
+  let (rawParams, body) = collectClosureLams term
+  when (null rawParams) $
+    liftEitherConvert (Left (BackendUnsupportedCaseShape "closure conversion expected a lambda"))
+  (params, bodyExpected) <- closureBackendParams context resultTy rawParams
+  let paramEnvBindings =
+        [ (name, maybe rawTy id (backendTypeToElabType backendTy))
+        | ((name, rawTy), backendTy) <- zip rawParams (map snd params)
+        ]
+      captures = capturedTermBindingsIn (closureScopeTerms scope) term
+  captureExprs <- traverse convertCapture captures
+  entryName <- freshClosureEntryName context (closureHint mode rawParams)
+  let captureScope =
+        foldr
+          ( \(name, ty) acc ->
+              extendClosureScopeTerm name ty (Set.member name (closureScopeLocals scope) || isClosureConvertibleElabType ty) acc
+          )
+          emptyClosureScope
+          captures
+      bodyScope = extendClosureScopeTerms paramEnvBindings captureScope
+      bodyEnv =
+        foldr
+          (uncurry extendTermEnv)
+          env
+          (captures ++ paramEnvBindings)
+  bodyExpr <- convertTermExpectedMode (ClosureLambda Nothing) context bodyEnv bodyScope (Just bodyExpected) body
+  pure
+    BackendClosure
+      { backendExprType = resultTy,
+        backendClosureEntryName = entryName,
+        backendClosureCaptures = captureExprs,
+        backendClosureParams = params,
+        backendClosureBody = bodyExpr
+      }
+  where
+    convertCapture (name, ty) = do
+      backendTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (convertElabType ty)
+      expr <- convertTermExpectedMode DirectLambda context env scope (Just backendTy) (EVar name)
+      pure
+        BackendClosureCapture
+          { backendClosureCaptureName = name,
+            backendClosureCaptureType = backendTy,
+            backendClosureCaptureExpr = expr
+          }
+
+closureHint :: LambdaMode -> [(String, ElabType)] -> String
+closureHint mode params =
+  case mode of
+    ClosureLambda (Just hint) -> hint
+    _ ->
+      case params of
+        (name, _) : _ -> name
+        [] -> "lambda"
+
+collectClosureLams :: ElabTerm -> ([(String, ElabType)], ElabTerm)
+collectClosureLams =
+  go []
+  where
+    go params =
+      \case
+        ELam name ty body -> go (params ++ [(name, ty)]) body
+        other -> (params, other)
+
+closureBackendParams :: ConvertContext -> BackendType -> [(String, ElabType)] -> ConvertM ([(String, BackendType)], BackendType)
+closureBackendParams context resultTy rawParams =
+  go resultTy rawParams
+  where
+    go bodyTy [] =
+      pure ([], bodyTy)
+    go (BTArrow expectedParam restTy) ((name, _) : rest) = do
+      (params, finalTy) <- go restTy rest
+      pure ((name, expectedParam) : params, finalTy)
+    go otherTy ((name, rawTy) : rest) = do
+      rawBackendTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (convertElabType rawTy)
+      (params, finalTy) <- go otherTy rest
+      pure ((name, rawBackendTy) : params, finalTy)
+
+freshClosureEntryName :: ConvertContext -> String -> ConvertM String
+freshClosureEntryName context hint = do
+  state0 <- get
+  let generatedNames = csGeneratedClosureNames state0
+      (name, nextIndex) = pickName generatedNames (csNextClosureIndex state0)
+  modify
+    ( \state1 ->
+        state1
+          { csNextClosureIndex = nextIndex,
+            csGeneratedClosureNames = Set.insert name (csGeneratedClosureNames state1)
+          }
+    )
+  pure name
+  where
+    pickName generatedNames index0 =
+      let candidate =
+            "__mlfp_closure$"
+              ++ sanitizeClosureName (ccCurrentBindingName context)
+              ++ "$"
+              ++ sanitizeClosureName hint
+              ++ "$"
+              ++ show index0
+       in if Set.member candidate (ccGlobalTerms context) || Set.member candidate generatedNames
+            then pickName generatedNames (index0 + 1)
+            else (candidate, index0 + 1)
+
+sanitizeClosureName :: String -> String
+sanitizeClosureName =
+  map sanitizeChar
+  where
+    sanitizeChar c
+      | isAlphaNum c || c == '_' || c == '$' || c == '.' = c
+      | otherwise = '_'
 
 termMentionsFreeVariable :: String -> ElabTerm -> Bool
 termMentionsFreeVariable needle =
@@ -1838,24 +2174,25 @@ termMentionsFreeVariable needle =
 convertTypeInstantiation ::
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendType ->
   ElabTerm ->
   Instantiation ->
-  Either BackendConversionError BackendExpr
-convertTypeInstantiation context env resultTy inner inst =
+  ConvertM BackendExpr
+convertTypeInstantiation context env scope resultTy inner inst =
   case inst of
     InstId -> do
-      innerExpr <- convertTerm context env inner
+      innerExpr <- convertTerm context env scope inner
       if alphaEqBackendType (backendExprType innerExpr) resultTy
-        then Right innerExpr
-        else Left (BackendUnsupportedInstantiation inst)
+        then pure innerExpr
+        else liftEitherConvert (Left (BackendUnsupportedInstantiation inst))
     _ ->
       case appLikeInstantiationType inst of
         Just tyArg -> do
-          innerExpr <- convertAppLikeInstantiationFunction context env inner
+          innerExpr <- convertAppLikeInstantiationFunction context env scope inner
           case backendExprType innerExpr of
             BTForall name mbBound bodyTy -> do
-              backendTyArg0 <- normalizeBackendTypeForContext context <$> convertElabType tyArg
+              backendTyArg0 <- normalizeBackendTypeForContext context <$> liftEitherConvert (convertElabType tyArg)
               let appliedTy0 = normalizeBackendTypeForContext context (substituteBackendType name backendTyArg0 bodyTy)
                   (backendTyArg, appliedTy) =
                     expectedTypeInstantiation
@@ -1870,16 +2207,16 @@ convertTypeInstantiation context env resultTy inner inst =
                     if alphaEqBackendType appliedTy resultTy
                       then resultTy
                       else appliedTy
-              Right
+              pure
                 BackendTyApp
                   { backendExprType = resultTy',
                     backendTyFunction = innerExpr,
                     backendTyArgument = backendTyArg
                   }
             _
-              | alphaEqBackendType (backendExprType innerExpr) resultTy -> Right innerExpr
-              | otherwise -> Left (BackendUnsupportedInstantiation inst)
-        Nothing -> Left (BackendUnsupportedInstantiation inst)
+              | alphaEqBackendType (backendExprType innerExpr) resultTy -> pure innerExpr
+              | otherwise -> liftEitherConvert (Left (BackendUnsupportedInstantiation inst))
+        Nothing -> liftEitherConvert (Left (BackendUnsupportedInstantiation inst))
 
 expectedTypeInstantiation ::
   ConvertContext ->
@@ -1922,22 +2259,25 @@ termContainsTypeInstantiation =
 convertAppLikeInstantiationFunction ::
   ConvertContext ->
   Env ->
+  ClosureScope ->
   ElabTerm ->
-  Either BackendConversionError BackendExpr
-convertAppLikeInstantiationFunction context env inner =
-  case convertTerm context env inner of
-    Right expr
-      | hasForallResult expr -> Right expr
-    Right expr ->
-      case convertStrippedElim of
-        Right strippedExpr
-          | hasForallResult strippedExpr -> Right strippedExpr
-        _ -> Right expr
-    Left err ->
-      case convertStrippedElim of
-        Right strippedExpr -> Right strippedExpr
-        Left _ -> Left err
+  ConvertM BackendExpr
+convertAppLikeInstantiationFunction context env scope inner =
+  convertInner `orElseConvertM` convertStrippedElim
   where
+    convertInner = do
+      expr <- convertTerm context env scope inner
+      if hasForallResult expr
+        then pure expr
+        else
+          ( do
+              strippedExpr <- convertStrippedElim
+              if hasForallResult strippedExpr
+                then pure strippedExpr
+                else pure expr
+          )
+            `orElseConvertM` pure expr
+
     hasForallResult expr =
       case backendExprType expr of
         BTForall {} -> True
@@ -1946,8 +2286,8 @@ convertAppLikeInstantiationFunction context env inner =
     convertStrippedElim =
       let stripped = dropLeadingElimInstantiations inner
        in if stripped == inner
-            then Left (BackendUnsupportedInstantiation InstElim)
-            else convertTerm context env stripped
+            then liftEitherConvert (Left (BackendUnsupportedInstantiation InstElim))
+            else convertTerm context env scope stripped
 
 dropLeadingElimInstantiations :: ElabTerm -> ElabTerm
 dropLeadingElimInstantiations term =
@@ -1964,13 +2304,15 @@ appLikeInstantiationType inst =
     _ -> Nothing
 
 convertConstructorApplication ::
+  LambdaMode ->
   ConvertContext ->
   Env ->
+  ClosureScope ->
   ElabTerm ->
   BackendType ->
-  Either BackendConversionError (Maybe BackendExpr)
-convertConstructorApplication context env term resultTy =
-  constructorApplicationTerm context term >>= \case
+  ConvertM (Maybe BackendExpr)
+convertConstructorApplication _mode context env scope term resultTy =
+  liftEitherConvert (constructorApplicationTerm context term) >>= \case
     Just (ConstructorApplication constructorMeta headTypeArgs args) -> do
       let constructor = cmBackend constructorMeta
           ownerContext = contextForDataMeta context (cmData constructorMeta)
@@ -1979,30 +2321,31 @@ convertConstructorApplication context env term resultTy =
           rawFields = backendConstructorFields constructor
           effectiveResultTy = constructorExpectedResultType context ownerContext constructorMeta resultTy
           constructorResultTy = canonicalizeStructuralMuNames ownerContext (backendConstructorResult constructor)
-      typeBounds <- backendTypeBoundsFromEnv env
-      initialSubstitutions <- constructorTypeApplicationSubstitutions env constructorMeta headTypeArgs
+      typeBounds <- liftEitherConvert (backendTypeBoundsFromEnv env)
+      initialSubstitutions <- liftEitherConvert (constructorTypeApplicationSubstitutions env constructorMeta headTypeArgs)
       substitution <-
-        firstRightOr
-          (constructorResultMismatch constructor)
-          [ do
-              resultSubstitution <-
-                case constructorResultSubstitution
-                  context
-                  ownerContext
-                  typeBounds
-                  dataParameters
-                  parameters
-                  initialSubstitution
-                  constructorResultTy
-                  effectiveResultTy of
-                  Just substitution -> Right substitution
-                  Nothing -> Left (constructorResultMismatch constructor)
-              foldM
-                (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
-                resultSubstitution
-                (zip rawFields args)
-            | initialSubstitution <- initialSubstitutions
-          ]
+        liftEitherConvert $
+          firstRightOr
+            (constructorResultMismatch constructor)
+            [ do
+                resultSubstitution <-
+                  case constructorResultSubstitution
+                    context
+                    ownerContext
+                    typeBounds
+                    dataParameters
+                    parameters
+                    initialSubstitution
+                    constructorResultTy
+                    effectiveResultTy of
+                    Just substitution -> Right substitution
+                    Nothing -> Left (constructorResultMismatch constructor)
+                foldM
+                  (matchConstructorApplicationArgument context env typeBounds dataParameters parameters)
+                  resultSubstitution
+                  (zip rawFields args)
+              | initialSubstitution <- initialSubstitutions
+            ]
       let completedSubstitution = completeBackendParameterSubstitution parameters substitution
           fields = map (substituteBackendTypes completedSubstitution) rawFields
           substitutedResultTy0 = substituteBackendTypes completedSubstitution constructorResultTy
@@ -2015,16 +2358,18 @@ convertConstructorApplication context env term resultTy =
             || constructorBoundaryTypesMatch context ownerContext typeBounds substitutedResultTy0 effectiveResultTy
         )
         $
-        Left
-          ( BackendUnsupportedCaseShape
-              ( "constructor result type does not match expected result for `"
-                  ++ backendConstructorName constructor
-                  ++ "`"
+        liftEitherConvert
+          ( Left
+              ( BackendUnsupportedCaseShape
+                  ( "constructor result type does not match expected result for `"
+                      ++ backendConstructorName constructor
+                      ++ "`"
+                  )
               )
           )
-      argExprs <- zipWithM (convertTermExpected context env . Just) fields args
-      mapM_ (checkConstructorArgumentType context ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs))
-      Right
+      argExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) fields args
+      liftEitherConvert (mapM_ (checkConstructorArgumentType context ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs)))
+      pure
         ( Just
             BackendConstruct
               { backendExprType = effectiveResultTy,
@@ -2032,7 +2377,7 @@ convertConstructorApplication context env term resultTy =
                 backendConstructArgs = argExprs
               }
         )
-    Nothing -> Right Nothing
+    Nothing -> pure Nothing
   where
     constructorResultMismatch constructor =
       BackendUnsupportedCaseShape
@@ -2430,69 +2775,98 @@ structuralConstructorHeadTypeArgs context =
       normalizeBackendTypeForContext context <$> convertElabType ty
 
 convertCaseApplication ::
+  LambdaMode ->
   ConvertContext ->
   Env ->
+  ClosureScope ->
   ElabTerm ->
   BackendType ->
-  Either BackendConversionError (Maybe BackendExpr)
-convertCaseApplication context env term resultTy =
+  ConvertM (Maybe BackendExpr)
+convertCaseApplication mode context env scope term resultTy =
   case collectApps term of
     (headTerm, args) ->
       case caseScrutinee headTerm of
-        Nothing -> Right Nothing
+        Nothing -> pure Nothing
         Just scrutineeTerm -> do
-          (backendScrutineeTy, mbScrutineeData) <- caseScrutineeInfo context env scrutineeTerm
-          scrutineeExpr <- convertTermExpected context env (Just backendScrutineeTy) scrutineeTerm
+          (backendScrutineeTy, mbScrutineeData) <- liftEitherConvert (caseScrutineeInfo context env scrutineeTerm)
+          scrutineeExpr <- convertTermExpectedMode DirectLambda context env scope (Just backendScrutineeTy) scrutineeTerm
           dataMeta <-
             case mbScrutineeData of
-              Just scrutineeData -> Right scrutineeData
+              Just scrutineeData -> pure scrutineeData
               Nothing -> do
-                typeBounds <- backendTypeBoundsFromEnv env
-                requireCaseData context typeBounds (backendExprType scrutineeExpr)
+                typeBounds <- liftEitherConvert (backendTypeBoundsFromEnv env)
+                liftEitherConvert (requireCaseData context typeBounds (backendExprType scrutineeExpr))
           let constructors = backendDataConstructors (dmBackend dataMeta)
           case compare (length args) (length constructors) of
-            EQ -> Just <$> convertCaseWithHandlers context env resultTy scrutineeExpr dataMeta constructors args
+            EQ -> Just <$> convertCaseWithHandlers mode context env scope resultTy scrutineeExpr dataMeta constructors args
             GT -> do
               let (handlers, extraArgs) = splitAt (length constructors) args
-              extraArgTys <- mapM (inferBackendType env) extraArgs
+              extraArgTys <- liftEitherConvert (mapM (inferBackendType env) extraArgs)
               case scanr BTArrow resultTy extraArgTys of
                 caseResultTy : appliedResultTys -> do
-                  caseExpr <- convertCaseWithHandlers context env caseResultTy scrutineeExpr dataMeta constructors handlers
+                  caseExpr <- convertCaseWithHandlers mode context env scope caseResultTy scrutineeExpr dataMeta constructors handlers
                   Just
-                    <$> foldM
-                      (applyCaseExtraArgument context env)
-                      caseExpr
-                      (zip3 extraArgs extraArgTys appliedResultTys)
-                [] -> Right Nothing
-            LT -> Right Nothing
+                    <$> ( if backendExprIsClosureValue scope caseExpr
+                            then applyCaseClosureArguments context env scope resultTy caseExpr (zip extraArgs extraArgTys)
+                            else
+                              foldM
+                                (applyCaseExtraArgument context env scope)
+                                caseExpr
+                                (zip3 extraArgs extraArgTys appliedResultTys)
+                        )
+                [] -> pure Nothing
+            LT -> pure Nothing
 
 convertCaseWithHandlers ::
+  LambdaMode ->
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendType ->
   BackendExpr ->
   DataMeta ->
   [BackendConstructor] ->
   [ElabTerm] ->
-  Either BackendConversionError BackendExpr
-convertCaseWithHandlers context env resultTy scrutineeExpr dataMeta constructors handlers = do
-  alternatives <- zipWithMCase (convertCaseAlternative context env resultTy dataMeta (backendExprType scrutineeExpr)) constructors handlers
-  Right
+  ConvertM BackendExpr
+convertCaseWithHandlers mode context env scope resultTy scrutineeExpr dataMeta constructors handlers = do
+  alternatives <- zipWithMCase (convertCaseAlternative mode context env scope resultTy dataMeta (backendExprType scrutineeExpr)) constructors handlers
+  pure
     BackendCase
       { backendExprType = resultTy,
         backendScrutinee = scrutineeExpr,
         backendAlternatives = alternatives
       }
 
+applyCaseClosureArguments ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  BackendType ->
+  BackendExpr ->
+  [(ElabTerm, BackendType)] ->
+  ConvertM BackendExpr
+applyCaseClosureArguments context env scope resultTy funExpr args = do
+  argExprs <-
+    traverse
+      (\(arg, argTy) -> convertTermExpectedMode DirectLambda context env scope (Just argTy) arg)
+      args
+  pure
+    BackendClosureCall
+      { backendExprType = resultTy,
+        backendClosureFunction = funExpr,
+        backendClosureArguments = argExprs
+      }
+
 applyCaseExtraArgument ::
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendExpr ->
   (ElabTerm, BackendType, BackendType) ->
-  Either BackendConversionError BackendExpr
-applyCaseExtraArgument context env funExpr (arg, argTy, resultTy) = do
-  argExpr <- convertTermExpected context env (Just argTy) arg
-  Right
+  ConvertM BackendExpr
+applyCaseExtraArgument context env scope funExpr (arg, argTy, resultTy) = do
+  argExpr <- convertTermExpectedMode DirectLambda context env scope (Just argTy) arg
+  pure
     BackendApp
       { backendExprType = resultTy,
         backendFunction = funExpr,
@@ -2896,42 +3270,54 @@ dataMatchesScrutinee typeBounds scrutineeTy dataMeta =
     (backendDataConstructors (dmBackend dataMeta))
 
 convertCaseAlternative ::
+  LambdaMode ->
   ConvertContext ->
   Env ->
+  ClosureScope ->
   BackendType ->
   DataMeta ->
   BackendType ->
   BackendConstructor ->
   ElabTerm ->
-  Either BackendConversionError BackendAlternative
-convertCaseAlternative context env resultTy dataMeta scrutineeTy constructor handler = do
-  fields <- caseAlternativeFieldTypes env dataMeta scrutineeTy constructor
+  ConvertM BackendAlternative
+convertCaseAlternative mode context env scope resultTy dataMeta scrutineeTy constructor handler = do
+  fields <- liftEitherConvert (caseAlternativeFieldTypes env dataMeta scrutineeTy constructor)
   let (params, body) = collectLeadingLams (length fields) handler
   when (length params /= length fields) $
-    Left
-      ( BackendUnsupportedCaseShape
-          ("handler arity does not match constructor `" ++ backendConstructorName constructor ++ "`")
+    liftEitherConvert
+      ( Left
+          ( BackendUnsupportedCaseShape
+              ("handler arity does not match constructor `" ++ backendConstructorName constructor ++ "`")
+          )
       )
   fieldEnvTypes <-
-    traverse
-      ( \((name, paramTy), ty) ->
-          case backendTypeToElabType ty of
-            Just elabTy -> Right (name, elabTy)
-            Nothing -> Right (name, paramTy)
-      )
-      (zip params fields)
+    liftEitherConvert $
+      traverse
+        ( \((name, paramTy), ty) ->
+            case backendTypeToElabType ty of
+              Just elabTy -> Right (name, elabTy)
+              Nothing -> Right (name, paramTy)
+        )
+        (zip params fields)
   let env' =
         foldr
           (\(name, ty) acc -> extendTermEnv name ty acc)
           env
           fieldEnvTypes
-  bodyExpr <- convertTermExpected context env' (Just resultTy) body
+      scope' = extendClosureScopeTerms fieldEnvTypes scope
+      bodyMode =
+        if isClosureConvertibleFunctionType resultTy
+          then ClosureLambda Nothing
+          else mode
+  bodyExpr <- convertTermExpectedMode bodyMode context env' scope' (Just resultTy) body
   unless (alphaEqBackendType (backendExprType bodyExpr) resultTy) $
-    Left
-      ( BackendUnsupportedCaseShape
-          ("handler result type does not match case result for `" ++ backendConstructorName constructor ++ "`")
+    liftEitherConvert
+      ( Left
+          ( BackendUnsupportedCaseShape
+              ("handler result type does not match case result for `" ++ backendConstructorName constructor ++ "`")
+          )
       )
-  Right
+  pure
     BackendAlternative
       { backendAltPattern = BackendConstructorPattern (backendConstructorName constructor) (map fst params),
         backendAltBody = bodyExpr
@@ -3001,16 +3387,16 @@ backendTypeBoundsFromEnv env =
     convertTypeBound boundTy = Just <$> convertElabType boundTy
 
 zipWithMCase ::
-  (BackendConstructor -> ElabTerm -> Either BackendConversionError BackendAlternative) ->
+  (BackendConstructor -> ElabTerm -> ConvertM BackendAlternative) ->
   [BackendConstructor] ->
   [ElabTerm] ->
-  Either BackendConversionError (NonEmpty BackendAlternative)
+  ConvertM (NonEmpty BackendAlternative)
 zipWithMCase f constructors handlers =
   case zipWith f constructors handlers of
     firstAlt : restAlts ->
       (:|) <$> firstAlt <*> sequence restAlts
     [] ->
-      Left (BackendUnsupportedCaseShape "case expression has no alternatives")
+      liftEitherConvert (Left (BackendUnsupportedCaseShape "case expression has no alternatives"))
 
 matchBackendTypeParameters ::
   BackendTypeBounds ->

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -379,8 +379,11 @@ convertCheckedBinding context env checkedModule binding = do
                 (\lifted acc -> extendTermEnv (lrlName lifted) (lrlElabType lifted) acc)
                 env
                 liftedSpecs
-        liftedBindings <- mapM (convertLiftedRecursiveLet bindingContext envWithLifted) liftedSpecs
-        expr <- runConvertM (convertTermExpectedMode DirectLambda bindingContext envWithLifted emptyClosureScope (Just bindingTy) liftedTerm)
+        (liftedBindings, expr) <-
+          runConvertM $ do
+            liftedBindings <- mapM (convertLiftedRecursiveLet bindingContext envWithLifted) liftedSpecs
+            expr <- convertTermExpectedMode DirectLambda bindingContext envWithLifted emptyClosureScope (Just bindingTy) liftedTerm
+            pure (liftedBindings, expr)
         Right (bindingTy, expr, liftedBindings)
   let convertedBinding =
         BackendBinding
@@ -403,11 +406,11 @@ liftRecursiveLetsInBinding context term = do
         }
   Right (term', lsLiftedRecursiveLets state')
 
-convertLiftedRecursiveLet :: ConvertContext -> Env -> LiftedRecursiveLet -> Either BackendConversionError BackendBinding
+convertLiftedRecursiveLet :: ConvertContext -> Env -> LiftedRecursiveLet -> ConvertM BackendBinding
 convertLiftedRecursiveLet context env lifted = do
   let bindingTy = canonicalizeBackendType context (lrlBackendType lifted)
-  expr <- runConvertM (convertTermExpectedMode DirectLambda context env emptyClosureScope (Just bindingTy) (lrlTerm lifted))
-  Right
+  expr <- convertTermExpectedMode DirectLambda context env emptyClosureScope (Just bindingTy) (lrlTerm lifted)
+  pure
     BackendBinding
       { backendBindingName = lrlName lifted,
         backendBindingType = bindingTy,

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2142,13 +2142,39 @@ closureHint mode params =
 
 collectClosureLams :: ElabTerm -> ([(String, ElabType)], ElabTerm)
 collectClosureLams =
-  go []
+  go Set.empty []
   where
-    go params =
+    go avoid params =
       \case
-        ELam name ty body -> go (params ++ [(name, ty)]) body
+        ELam name ty body ->
+          let paramNames = Set.fromList (map fst params)
+              needsFreshName =
+                Set.member name avoid || Set.member name paramNames
+              used =
+                Set.unions
+                  [ avoid,
+                    paramNames,
+                    termVariableNames body,
+                    Set.singleton name
+                  ]
+              name' =
+                if needsFreshName
+                  then freshNameLike name used
+                  else name
+              body' =
+                if name' == name
+                  then body
+                  else renameBoundTermVariable name name' body
+           in go avoid (params ++ [(name', ty)]) body'
         ELet name scheme rhs body ->
-          case go [] body of
+          let avoidForBody =
+                Set.insert name $
+                  Set.unions
+                    [ avoid,
+                      Set.fromList (map fst params),
+                      termVariableNames rhs
+                    ]
+           in case go avoidForBody [] body of
             ([], _) -> (params, ELet name scheme rhs body)
             (bodyParams, bodyCore) -> (params ++ bodyParams, ELet name scheme rhs bodyCore)
         other -> (params, other)

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -77,6 +77,7 @@ data ConvertContext = ConvertContext
     ccBindingData :: Map String DataMeta,
     ccData :: [DataMeta],
     ccGlobalTerms :: Set.Set String,
+    ccClosureGlobals :: Set.Set String,
     ccCurrentModuleName :: Maybe String,
     ccCurrentBindingName :: String
   }
@@ -170,8 +171,10 @@ liftEitherConvert result =
 
 convertCheckedProgram :: CheckedProgram -> Either BackendConversionError BackendProgram
 convertCheckedProgram checked = do
-  context <- buildConvertContext checked
-  initialEnv <- buildInitialEnv context checked
+  context0 <- buildConvertContext checked
+  initialEnv <- buildInitialEnv context0 checked
+  closureGlobals <- convertedProgramClosureGlobals context0 initialEnv checked
+  let context = context0 {ccClosureGlobals = closureGlobals}
   modules0 <- mapM (convertCheckedModule context initialEnv) (checkedProgramModules checked)
   let program =
         BackendProgram
@@ -181,6 +184,29 @@ convertCheckedProgram checked = do
   case validateBackendProgram program of
     Right () -> Right program
     Left err -> Left (BackendValidationFailed err)
+
+convertedProgramClosureGlobals :: ConvertContext -> Env -> CheckedProgram -> Either BackendConversionError (Set.Set String)
+convertedProgramClosureGlobals context0 env checked =
+  closureGlobalFixedPoint Set.empty
+  where
+    closureGlobalFixedPoint globals = do
+      let context = context0 {ccClosureGlobals = globals}
+      convertedBindings <-
+        concat
+          <$> mapM
+            ( \checkedModule ->
+                concat <$> mapM (convertCheckedBinding context env checkedModule) (checkedModuleBindings checkedModule)
+            )
+            (checkedProgramModules checked)
+      let globals' =
+            Set.fromList
+              [ backendBindingName binding
+                | binding <- convertedBindings,
+                  backendExprIsClosureValue context emptyClosureScope (backendBindingExpr binding)
+              ]
+      if globals' == globals
+        then pure globals
+        else closureGlobalFixedPoint globals'
 
 buildInitialEnv :: ConvertContext -> CheckedProgram -> Either BackendConversionError Env
 buildInitialEnv context checked = do
@@ -1173,6 +1199,7 @@ buildConvertContext checked = do
         ccBindingData = bindingData,
         ccData = dataMetas,
         ccGlobalTerms = checkedProgramGlobalTerms checked,
+        ccClosureGlobals = Set.empty,
         ccCurrentModuleName = Nothing,
         ccCurrentBindingName = ""
       }
@@ -1383,6 +1410,7 @@ buildDataMeta scope info = do
             ccBindingData = Map.empty,
             ccData = [rawMeta],
             ccGlobalTerms = Set.empty,
+            ccClosureGlobals = Set.empty,
             ccCurrentModuleName = Just (dataModule info),
             ccCurrentBindingName = ""
           }
@@ -1756,7 +1784,7 @@ convertOrdinaryTerm mode context env scope term resultTy0 =
       when (termMentionsFreeVariable name rhs) $
         liftEitherConvert (Left (BackendUnsupportedRecursiveLet name))
       bindingTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (convertElabType schemeTy)
-      let bindingClosure = letBindingNeedsClosure scope name bindingTy rhs body
+      let bindingClosure = letBindingNeedsClosure context scope name bindingTy rhs body
           rhsMode =
             if bindingClosure
               then ClosureLambda (Just name)
@@ -1770,7 +1798,7 @@ convertOrdinaryTerm mode context env scope term resultTy0 =
             extendClosureScopeTerm
               name
               bindingEnvTy
-              (bindingClosure || backendExprIsClosureValue scope rhsExpr)
+              (bindingClosure || backendExprIsClosureValue context scope rhsExpr)
               scope
           bodyMode =
             if isClosureConvertibleFunctionType resultTy
@@ -1847,7 +1875,7 @@ convertApplicationTerm context env scope resultTy term =
   case collectApps term of
     (headTerm, args)
       | not (null args),
-        isClosureHeadTerm scope headTerm -> do
+        isClosureHeadTerm context scope headTerm -> do
           funTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (inferBackendType env headTerm)
           let (paramTys, expectedResultTy) = splitBackendArrows funTy
           if length paramTys == length args && not (null paramTys)
@@ -1960,37 +1988,37 @@ isImmediateLambda =
     ETyInst inner _ -> isImmediateLambda inner
     _ -> False
 
-letBindingNeedsClosure :: ClosureScope -> String -> BackendType -> ElabTerm -> ElabTerm -> Bool
-letBindingNeedsClosure scope name bindingTy rhs body =
+letBindingNeedsClosure :: ConvertContext -> ClosureScope -> String -> BackendType -> ElabTerm -> ElabTerm -> Bool
+letBindingNeedsClosure context scope name bindingTy rhs body =
   isClosureConvertibleFunctionType bindingTy
-    && (isClosureAliasTerm scope rhs || (isFunctionValueTerm rhs && termUsesVariableAsValue name body))
+    && (isClosureAliasTerm context scope rhs || (isFunctionValueTerm rhs && termUsesVariableAsValue name body))
 
-isClosureAliasTerm :: ClosureScope -> ElabTerm -> Bool
-isClosureAliasTerm scope term =
+isClosureAliasTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
+isClosureAliasTerm context scope term =
   case stripClosureHeadTypeInsts term of
-    EVar name -> Set.member name (closureScopeLocals scope)
+    EVar name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
     _ -> False
 
-backendExprIsClosureValue :: ClosureScope -> BackendExpr -> Bool
-backendExprIsClosureValue scope =
+backendExprIsClosureValue :: ConvertContext -> ClosureScope -> BackendExpr -> Bool
+backendExprIsClosureValue context scope =
   \case
     BackendClosure {} -> True
-    BackendVar _ name -> Set.member name (closureScopeLocals scope)
-    BackendTyApp _ fun _ -> backendExprIsClosureValue scope fun
+    BackendVar _ name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
+    BackendTyApp _ fun _ -> backendExprIsClosureValue context scope fun
     BackendLet _ name _ rhs body ->
       let bodyScope =
-            if backendExprIsClosureValue scope rhs
+            if backendExprIsClosureValue context scope rhs
               then scope {closureScopeLocals = Set.insert name (closureScopeLocals scope)}
               else scope
-       in backendExprIsClosureValue bodyScope body
+       in backendExprIsClosureValue context bodyScope body
     BackendCase {backendAlternatives = alternatives} ->
-      all (backendExprIsClosureValue scope . backendAltBody) (NE.toList alternatives)
+      all (backendExprIsClosureValue context scope . backendAltBody) (NE.toList alternatives)
     _ -> False
 
-isClosureHeadTerm :: ClosureScope -> ElabTerm -> Bool
-isClosureHeadTerm scope term =
+isClosureHeadTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
+isClosureHeadTerm context scope term =
   case stripClosureHeadTypeInsts term of
-    EVar name -> Set.member name (closureScopeLocals scope)
+    EVar name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
     _ -> False
 
 stripClosureHeadTypeInsts :: ElabTerm -> ElabTerm
@@ -2035,8 +2063,20 @@ termUsesVariableAsValue needle =
 convertLambdaClosure :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> BackendType -> ElabTerm -> ConvertM BackendExpr
 convertLambdaClosure mode context env scope resultTy term = do
   let (rawParams, body) = collectClosureLams term
+      (declaredParamTys, _) = splitBackendArrows resultTy
   when (null rawParams) $
     liftEitherConvert (Left (BackendUnsupportedCaseShape "closure conversion expected a lambda"))
+  unless (length rawParams == length declaredParamTys) $
+    liftEitherConvert
+      ( Left
+          ( BackendUnsupportedCaseShape
+              ( "closure conversion expected "
+                  ++ show (length declaredParamTys)
+                  ++ " lambda parameters, collected "
+                  ++ show (length rawParams)
+              )
+          )
+      )
   (params, bodyExpected) <- closureBackendParams context resultTy rawParams
   let paramEnvBindings =
         [ (name, maybe rawTy id (backendTypeToElabType backendTy))
@@ -2094,6 +2134,10 @@ collectClosureLams =
     go params =
       \case
         ELam name ty body -> go (params ++ [(name, ty)]) body
+        ELet name scheme rhs body ->
+          case go [] body of
+            ([], _) -> (params, ELet name scheme rhs body)
+            (bodyParams, bodyCore) -> (params ++ bodyParams, ELet name scheme rhs bodyCore)
         other -> (params, other)
 
 closureBackendParams :: ConvertContext -> BackendType -> [(String, ElabType)] -> ConvertM ([(String, BackendType)], BackendType)
@@ -2806,7 +2850,7 @@ convertCaseApplication mode context env scope term resultTy =
                 caseResultTy : appliedResultTys -> do
                   caseExpr <- convertCaseWithHandlers mode context env scope caseResultTy scrutineeExpr dataMeta constructors handlers
                   Just
-                    <$> ( if backendExprIsClosureValue scope caseExpr
+                    <$> ( if backendExprIsClosureValue context scope caseExpr
                             then applyCaseClosureArguments context env scope resultTy caseExpr (zip extraArgs extraArgTys)
                             else
                               foldM

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2017,6 +2017,7 @@ backendExprIsClosureValue context scope =
   \case
     BackendClosure {} -> True
     BackendVar _ name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
+    BackendTyAbs _ _ _ body -> backendExprIsClosureValue context scope body
     BackendTyApp _ fun _ -> backendExprIsClosureValue context scope fun
     BackendLet _ name _ rhs body ->
       let bodyScope =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2020,9 +2020,15 @@ backendExprIsClosureValue context scope =
     BackendTyApp _ fun _ -> backendExprIsClosureValue context scope fun
     BackendLet _ name _ rhs body ->
       let bodyScope =
-            if backendExprIsClosureValue context scope rhs
-              then scope {closureScopeLocals = Set.insert name (closureScopeLocals scope)}
-              else scope
+            scope
+              { closureScopeLocals =
+                  ( if backendExprIsClosureValue context scope rhs
+                      then Set.insert
+                      else Set.delete
+                  )
+                    name
+                    (closureScopeLocals scope)
+              }
        in backendExprIsClosureValue context bodyScope body
     BackendCase {backendAlternatives = alternatives} ->
       all (backendExprIsClosureValue context scope . backendAltBody) (NE.toList alternatives)
@@ -2451,6 +2457,7 @@ convertConstructorApplication _mode context env scope term resultTy =
               )
           )
       argExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) fields args
+      liftEitherConvert (mapM_ (rejectClosureValuedConstructorField constructor) (zip3 [0 :: Int ..] fields argExprs))
       liftEitherConvert (mapM_ (checkConstructorArgumentType context ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs)))
       pure
         ( Just
@@ -2468,6 +2475,20 @@ convertConstructorApplication _mode context env scope term resultTy =
             ++ backendConstructorName constructor
             ++ "`"
         )
+
+    rejectClosureValuedConstructorField constructor (index0, fieldTy, argExpr)
+      | isClosureConvertibleFunctionType fieldTy,
+        backendExprIsClosureValue context scope argExpr =
+          Left
+            ( BackendUnsupportedCaseShape
+                ( "closure-valued constructor field `"
+                    ++ backendConstructorName constructor
+                    ++ "` argument "
+                    ++ show index0
+                    ++ " requires closure-aware ADT field lowering"
+                )
+            )
+      | otherwise = Right ()
 
     constructorResultSubstitution globalContext ownerContext typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy =
       matchConstructorResult constructorResultTy effectiveResultTy normalizedExplicitSubstitution

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -153,6 +153,10 @@ extendClosureScopeTerms :: [(String, ElabType)] -> ClosureScope -> ClosureScope
 extendClosureScopeTerms bindings scope =
   foldr (\(name, ty) acc -> extendClosureScopeTerm name ty False acc) scope bindings
 
+extendClosureScopeLambdaParams :: [(String, ElabType)] -> ClosureScope -> ClosureScope
+extendClosureScopeLambdaParams bindings scope =
+  foldr (\(name, ty) acc -> extendClosureScopeTerm name ty (isClosureConvertibleElabType ty) acc) scope bindings
+
 runConvertM :: ConvertM a -> Either BackendConversionError a
 runConvertM action =
   evalStateT
@@ -1768,7 +1772,12 @@ convertOrdinaryTerm mode context env scope term resultTy0 =
               Just canonicalTy -> canonicalTy
               Nothing -> paramTy
           bodyMode = directLambdaBodyMode bodyExpected body
-          bodyScope = extendClosureScopeTerm name paramEnvTy False scope
+          bodyScope =
+            extendClosureScopeTerm
+              name
+              paramEnvTy
+              (isClosureConvertibleFunctionType paramBackendTy)
+              scope
       bodyExpr <- convertTermExpectedMode bodyMode context (extendTermEnv name paramEnvTy env) bodyScope bodyExpected body
       pure
         BackendLam
@@ -2092,7 +2101,7 @@ convertLambdaClosure mode context env scope resultTy term = do
           )
           emptyClosureScope
           captures
-      bodyScope = extendClosureScopeTerms paramEnvBindings captureScope
+      bodyScope = extendClosureScopeLambdaParams paramEnvBindings captureScope
       bodyEnv =
         foldr
           (uncurry extendTermEnv)

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2091,8 +2091,26 @@ backendExprIsClosureValue context scope =
               }
        in backendExprIsClosureValue context bodyScope body
     BackendCase {backendAlternatives = alternatives} ->
-      all (backendExprIsClosureValue context scope . backendAltBody) (NE.toList alternatives)
+      all alternativeIsClosureValue (NE.toList alternatives)
     _ -> False
+  where
+    alternativeIsClosureValue alternative =
+      backendExprIsClosureValue
+        context
+        (scopeWithoutPatternBinders (backendAltPattern alternative))
+        (backendAltBody alternative)
+
+    scopeWithoutPatternBinders pattern0 =
+      scope
+        { closureScopeLocals =
+            closureScopeLocals scope `Set.difference` backendPatternBinders pattern0
+        }
+
+backendPatternBinders :: BackendPattern -> Set.Set String
+backendPatternBinders =
+  \case
+    BackendDefaultPattern -> Set.empty
+    BackendConstructorPattern _ binders -> Set.fromList binders
 
 isClosureHeadTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
 isClosureHeadTerm context scope term =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -126,6 +126,7 @@ type ConvertM = StateT ConvertState (Either BackendConversionError)
 
 data ClosureScope = ClosureScope
   { closureScopeTerms :: Map String ElabType,
+    closureScopeBoundTerms :: Set.Set String,
     closureScopeLocals :: Set.Set String
   }
 
@@ -137,6 +138,7 @@ emptyClosureScope :: ClosureScope
 emptyClosureScope =
   ClosureScope
     { closureScopeTerms = Map.empty,
+      closureScopeBoundTerms = Set.empty,
       closureScopeLocals = Set.empty
     }
 
@@ -144,6 +146,7 @@ extendClosureScopeTerm :: String -> ElabType -> Bool -> ClosureScope -> ClosureS
 extendClosureScopeTerm name ty isClosure scope =
   scope
     { closureScopeTerms = Map.insert name ty (closureScopeTerms scope),
+      closureScopeBoundTerms = Set.insert name (closureScopeBoundTerms scope),
       closureScopeLocals =
         if isClosure
           then Set.insert name (closureScopeLocals scope)
@@ -2068,14 +2071,14 @@ letBindingNeedsClosure context scope name bindingTy rhs body =
 isClosureAliasTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
 isClosureAliasTerm context scope term =
   case stripClosureHeadTypeInsts term of
-    EVar name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
+    EVar name -> closureScopeNameIsClosure context scope name
     _ -> False
 
 backendExprIsClosureValue :: ConvertContext -> ClosureScope -> BackendExpr -> Bool
 backendExprIsClosureValue context scope =
   \case
     BackendClosure {} -> True
-    BackendVar _ name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
+    BackendVar _ name -> closureScopeNameIsClosure context scope name
     BackendTyAbs _ _ _ body -> backendExprIsClosureValue context scope body
     BackendTyApp _ fun _ -> backendExprIsClosureValue context scope fun
     BackendLet _ name _ rhs body ->
@@ -2102,9 +2105,12 @@ backendExprIsClosureValue context scope =
 
     scopeWithoutPatternBinders pattern0 =
       scope
-        { closureScopeLocals =
-            closureScopeLocals scope `Set.difference` backendPatternBinders pattern0
+        { closureScopeBoundTerms = closureScopeBoundTerms scope <> binders,
+          closureScopeLocals =
+            closureScopeLocals scope `Set.difference` binders
         }
+      where
+        binders = backendPatternBinders pattern0
 
 backendPatternBinders :: BackendPattern -> Set.Set String
 backendPatternBinders =
@@ -2115,8 +2121,14 @@ backendPatternBinders =
 isClosureHeadTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
 isClosureHeadTerm context scope term =
   case stripClosureHeadTypeInsts term of
-    EVar name -> Set.member name (closureScopeLocals scope) || Set.member name (ccClosureGlobals context)
+    EVar name -> closureScopeNameIsClosure context scope name
     _ -> False
+
+closureScopeNameIsClosure :: ConvertContext -> ClosureScope -> String -> Bool
+closureScopeNameIsClosure context scope name
+  | Set.member name (closureScopeLocals scope) = True
+  | Set.member name (closureScopeBoundTerms scope) = False
+  | otherwise = Set.member name (ccClosureGlobals context)
 
 stripClosureHeadTypeInsts :: ElabTerm -> ElabTerm
 stripClosureHeadTypeInsts =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -902,53 +902,62 @@ firstClosureValueName (Just value : _) =
 
 backendExprCallsNameAsClosureHead :: String -> BackendExpr -> Bool
 backendExprCallsNameAsClosureHead needle =
-  go
+  go (Set.singleton needle)
   where
-    go =
+    go aliases =
       \case
         BackendVar {} ->
           False
         BackendLit {} ->
           False
         BackendLam _ name _ body
-          | name == needle -> False
-          | otherwise -> go body
+          | Set.member name aliases -> False
+          | otherwise -> go aliases body
         BackendApp _ fun arg ->
-          go fun || go arg
+          go aliases fun || go aliases arg
         BackendLet _ name _ rhs body
-          | name == needle -> go rhs
-          | otherwise -> go rhs || go body
+          | Set.member name aliases -> go aliases rhs
+          | otherwise ->
+              let aliasesForBody =
+                    if closureCallHeadReferencesAny aliases rhs
+                      then Set.insert name aliases
+                      else aliases
+               in go aliases rhs || go aliasesForBody body
         BackendTyAbs _ _ _ body ->
-          go body
+          go aliases body
         BackendTyApp _ fun _ ->
-          go fun
+          go aliases fun
         BackendConstruct _ _ args ->
-          any go args
+          any (go aliases) args
         BackendCase _ scrutinee alternatives ->
-          go scrutinee || any goAlternative (NE.toList alternatives)
+          go aliases scrutinee || any (goAlternative aliases) (NE.toList alternatives)
         BackendRoll _ payload ->
-          go payload
+          go aliases payload
         BackendUnroll _ payload ->
-          go payload
+          go aliases payload
         BackendClosure _ _ captures params body ->
-          any (go . backendClosureCaptureExpr) captures
+          any (go aliases . backendClosureCaptureExpr) captures
             || capturedNeedleFeedsClosureCall
-            || (not (Set.member needle closureBinders) && go body)
+            || (Set.disjoint aliases closureBinders && go aliases body)
           where
             closureBinders = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
             capturedNeedleFeedsClosureCall =
-              any capturesNeedle captures
-                && not (elem needle (map fst params))
-                && backendExprCallsNameAsClosureHead needle body
-            capturesNeedle capture =
-              backendClosureCaptureName capture == needle
-                && backendExprReferencesName needle (backendClosureCaptureExpr capture)
+              any capturesAlias captures
+                && Set.disjoint aliases (Set.fromList (map fst params))
+                && any (`backendExprCallsNameAsClosureHead` body) aliases
+            capturesAlias capture =
+              Set.member (backendClosureCaptureName capture) aliases
+                && any (\alias -> backendExprReferencesName alias (backendClosureCaptureExpr capture)) aliases
         BackendClosureCall _ fun args ->
-          closureCallHeadReferencesName needle fun || go fun || any go args
+          closureCallHeadReferencesAny aliases fun || go aliases fun || any (go aliases) args
 
-    goAlternative (BackendAlternative pattern0 body)
-      | Set.member needle (patternBinders pattern0) = False
-      | otherwise = go body
+    goAlternative aliases (BackendAlternative pattern0 body)
+      | not (Set.disjoint aliases (patternBinders pattern0)) = False
+      | otherwise = go aliases body
+
+closureCallHeadReferencesAny :: Set.Set String -> BackendExpr -> Bool
+closureCallHeadReferencesAny needles expr =
+  any (`closureCallHeadReferencesName` expr) needles
 
 closureCallHeadReferencesName :: String -> BackendExpr -> Bool
 closureCallHeadReferencesName needle =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -725,7 +725,7 @@ validateBackendExprWith mbContext expr =
        in unless (alphaEqBackendType resultTy expected) $
             Left (BackendLiteralTypeMismatch lit expected resultTy)
     BackendLam resultTy paramName paramTy body -> do
-      validateBackendExprWith (extendLocalMaybe mbContext paramName paramTy) body
+      validateBackendExprWith (extendFunctionParamLocalMaybe mbContext paramName paramTy body) body
       let expected = BTArrow paramTy (backendExprType body)
       unless (alphaEqBackendType resultTy expected) $
         Left (BackendLambdaTypeMismatch resultTy expected)
@@ -799,7 +799,7 @@ validateBackendExprWith mbContext expr =
               captures
           bodyParamContext =
             foldl
-              (\context0 (paramName, paramTy) -> extendLocalMaybe context0 paramName paramTy)
+              (\context0 (paramName, paramTy) -> extendFunctionParamLocalMaybe context0 paramName paramTy body)
               bodyContext
               params
       validateBackendExprWith bodyParamContext body
@@ -899,6 +899,114 @@ firstClosureValueName (Nothing : rest) =
   firstClosureValueName rest
 firstClosureValueName (Just value : _) =
   Just value
+
+backendExprCallsNameAsClosureHead :: String -> BackendExpr -> Bool
+backendExprCallsNameAsClosureHead needle =
+  go
+  where
+    go =
+      \case
+        BackendVar {} ->
+          False
+        BackendLit {} ->
+          False
+        BackendLam _ name _ body
+          | name == needle -> False
+          | otherwise -> go body
+        BackendApp _ fun arg ->
+          go fun || go arg
+        BackendLet _ name _ rhs body
+          | name == needle -> go rhs
+          | otherwise -> go rhs || go body
+        BackendTyAbs _ _ _ body ->
+          go body
+        BackendTyApp _ fun _ ->
+          go fun
+        BackendConstruct _ _ args ->
+          any go args
+        BackendCase _ scrutinee alternatives ->
+          go scrutinee || any goAlternative (NE.toList alternatives)
+        BackendRoll _ payload ->
+          go payload
+        BackendUnroll _ payload ->
+          go payload
+        BackendClosure _ _ captures params body ->
+          any (go . backendClosureCaptureExpr) captures
+            || capturedNeedleFeedsClosureCall
+            || (not (Set.member needle closureBinders) && go body)
+          where
+            closureBinders = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+            capturedNeedleFeedsClosureCall =
+              any capturesNeedle captures
+                && not (elem needle (map fst params))
+                && backendExprCallsNameAsClosureHead needle body
+            capturesNeedle capture =
+              backendClosureCaptureName capture == needle
+                && backendExprReferencesName needle (backendClosureCaptureExpr capture)
+        BackendClosureCall _ fun args ->
+          closureCallHeadReferencesName needle fun || go fun || any go args
+
+    goAlternative (BackendAlternative pattern0 body)
+      | Set.member needle (patternBinders pattern0) = False
+      | otherwise = go body
+
+closureCallHeadReferencesName :: String -> BackendExpr -> Bool
+closureCallHeadReferencesName needle =
+  \case
+    BackendVar _ name ->
+      name == needle
+    BackendTyApp _ fun _ ->
+      closureCallHeadReferencesName needle fun
+    _ ->
+      False
+
+backendExprReferencesName :: String -> BackendExpr -> Bool
+backendExprReferencesName needle =
+  go
+  where
+    go =
+      \case
+        BackendVar _ name ->
+          name == needle
+        BackendLit {} ->
+          False
+        BackendLam _ name _ body
+          | name == needle -> False
+          | otherwise -> go body
+        BackendApp _ fun arg ->
+          go fun || go arg
+        BackendLet _ name _ rhs body
+          | name == needle -> go rhs
+          | otherwise -> go rhs || go body
+        BackendTyAbs _ _ _ body ->
+          go body
+        BackendTyApp _ fun _ ->
+          go fun
+        BackendConstruct _ _ args ->
+          any go args
+        BackendCase _ scrutinee alternatives ->
+          go scrutinee || any goAlternative (NE.toList alternatives)
+        BackendRoll _ payload ->
+          go payload
+        BackendUnroll _ payload ->
+          go payload
+        BackendClosure _ _ captures params body ->
+          any (go . backendClosureCaptureExpr) captures
+            || (not (Set.member needle closureBinders) && go body)
+          where
+            closureBinders = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+        BackendClosureCall _ fun args ->
+          go fun || any go args
+
+    goAlternative (BackendAlternative pattern0 body)
+      | Set.member needle (patternBinders pattern0) = False
+      | otherwise = go body
+
+patternBinders :: BackendPattern -> Set.Set String
+patternBinders =
+  \case
+    BackendDefaultPattern -> Set.empty
+    BackendConstructorPattern _ binders -> Set.fromList binders
 
 validateBackendClosureCall :: Maybe BackendValidationContext -> BackendType -> BackendExpr -> [BackendExpr] -> Either BackendValidationError ()
 validateBackendClosureCall mbContext resultTy fun args =
@@ -1234,6 +1342,13 @@ lookupBackendVariable context0 name =
 extendLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> Maybe BackendValidationContext
 extendLocalMaybe mbContext name ty =
   fmap (\context0 -> extendLocal context0 name ty) mbContext
+
+extendFunctionParamLocalMaybe :: Maybe BackendValidationContext -> String -> BackendType -> BackendExpr -> Maybe BackendValidationContext
+extendFunctionParamLocalMaybe mbContext name ty body
+  | backendExprCallsNameAsClosureHead name body =
+      extendClosureLocalMaybe mbContext name ty
+  | otherwise =
+      extendLocalMaybe mbContext name ty
 
 extendLocal :: BackendValidationContext -> String -> BackendType -> BackendValidationContext
 extendLocal context0 name ty =

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -273,6 +273,7 @@ data BackendValidationContext = BackendValidationContext
     bvcData :: Map.Map String BackendData,
     bvcConstructors :: Map.Map String BackendConstructorInfo,
     bvcLocals :: Map.Map String BackendType,
+    bvcClosureGlobals :: Set.Set String,
     bvcClosureLocals :: Set.Set String,
     bvcPossibleClosureLocals :: Set.Set String,
     bvcTypeBounds :: Map.Map String (Maybe BackendType)
@@ -617,6 +618,7 @@ validateBackendProgram program = do
     bindings = concatMap backendModuleBindings modules0
     constructors = concatMap backendDataConstructors (concatMap backendModuleData modules0)
     closureEntryNames = concatMap (backendClosureEntryNames . backendBindingExpr) bindings
+    closureGlobals = backendClosureGlobalNames bindings
     constructorInfos =
       [ ( backendConstructorName constructor,
           BackendConstructorInfo
@@ -636,10 +638,46 @@ validateBackendProgram program = do
           bvcData = Map.fromList [(backendDataName dataDecl, dataDecl) | dataDecl <- concatMap backendModuleData modules0],
           bvcConstructors = Map.fromList constructorInfos,
           bvcLocals = Map.empty,
+          bvcClosureGlobals = closureGlobals,
           bvcClosureLocals = Set.empty,
           bvcPossibleClosureLocals = Set.empty,
           bvcTypeBounds = Map.empty
         }
+
+backendClosureGlobalNames :: [BackendBinding] -> Set.Set String
+backendClosureGlobalNames bindings =
+  go Set.empty
+  where
+    go globals =
+      let globals' =
+            Set.fromList
+              [ backendBindingName binding
+                | binding <- bindings,
+                  backendExprIsGlobalClosureValue globals Set.empty (backendBindingExpr binding)
+              ]
+       in if globals' == globals
+            then globals
+            else go globals'
+
+backendExprIsGlobalClosureValue :: Set.Set String -> Set.Set String -> BackendExpr -> Bool
+backendExprIsGlobalClosureValue globals locals =
+  \case
+    BackendClosure {} ->
+      True
+    BackendVar _ name ->
+      Set.member name locals || Set.member name globals
+    BackendTyApp _ fun _ ->
+      backendExprIsGlobalClosureValue globals locals fun
+    BackendLet _ name _ rhs body ->
+      let locals' =
+            if backendExprIsGlobalClosureValue globals locals rhs
+              then Set.insert name locals
+              else Set.delete name locals
+       in backendExprIsGlobalClosureValue globals locals' body
+    BackendCase {backendAlternatives = alternatives} ->
+      all (backendExprIsGlobalClosureValue globals locals . backendAltBody) (NE.toList alternatives)
+    _ ->
+      False
 
 backendRuntimePrimitiveTypes :: Map.Map String BackendType
 backendRuntimePrimitiveTypes =
@@ -802,7 +840,8 @@ backendClosureValueName mbContext =
       Just entryName
     BackendVar _ name
       | Just context0 <- mbContext,
-        Set.member name (bvcClosureLocals context0)
+        Set.member name (bvcClosureGlobals context0)
+          || Set.member name (bvcClosureLocals context0)
           || Set.member name (bvcPossibleClosureLocals context0) ->
           Just name
     BackendTyApp _ fun _ ->
@@ -821,7 +860,8 @@ backendDefiniteClosureValueName mbContext =
       Just entryName
     BackendVar _ name
       | Just context0 <- mbContext,
-        Set.member name (bvcClosureLocals context0) ->
+        Set.member name (bvcClosureGlobals context0)
+          || Set.member name (bvcClosureLocals context0) ->
           Just name
     BackendTyApp _ fun _ ->
       backendDefiniteClosureValueName mbContext fun

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -666,6 +666,8 @@ backendExprIsGlobalClosureValue globals locals =
       True
     BackendVar _ name ->
       Set.member name locals || Set.member name globals
+    BackendTyAbs _ _ _ body ->
+      backendExprIsGlobalClosureValue globals locals body
     BackendTyApp _ fun _ ->
       backendExprIsGlobalClosureValue globals locals fun
     BackendLet _ name _ rhs body ->
@@ -957,15 +959,22 @@ backendExprCallsNameAsClosureHead needle =
 
 closureCallHeadReferencesAny :: Set.Set String -> BackendExpr -> Bool
 closureCallHeadReferencesAny needles expr =
-  any (`closureCallHeadReferencesName` expr) needles
+  closureCallHeadReferencesAnyFrom needles expr
 
-closureCallHeadReferencesName :: String -> BackendExpr -> Bool
-closureCallHeadReferencesName needle =
+closureCallHeadReferencesAnyFrom :: Set.Set String -> BackendExpr -> Bool
+closureCallHeadReferencesAnyFrom aliases0 =
   \case
     BackendVar _ name ->
-      name == needle
+      Set.member name aliases0
     BackendTyApp _ fun _ ->
-      closureCallHeadReferencesName needle fun
+      closureCallHeadReferencesAnyFrom aliases0 fun
+    BackendLet _ name _ rhs body ->
+      let aliasesWithoutShadow = Set.delete name aliases0
+          aliasesForBody =
+            if closureCallHeadReferencesAnyFrom aliases0 rhs
+              then Set.insert name aliasesWithoutShadow
+              else aliasesWithoutShadow
+       in closureCallHeadReferencesAnyFrom aliasesForBody body
     _ ->
       False
 

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -653,33 +653,46 @@ backendClosureGlobalNames bindings =
             Set.fromList
               [ backendBindingName binding
                 | binding <- bindings,
-                  backendExprIsGlobalClosureValue globals Set.empty (backendBindingExpr binding)
+                  backendExprIsGlobalClosureValue globals (backendBindingExpr binding)
               ]
        in if globals' == globals
             then globals
             else go globals'
 
-backendExprIsGlobalClosureValue :: Set.Set String -> Set.Set String -> BackendExpr -> Bool
-backendExprIsGlobalClosureValue globals locals =
-  \case
-    BackendClosure {} ->
-      True
-    BackendVar _ name ->
-      Set.member name locals || Set.member name globals
-    BackendTyAbs _ _ _ body ->
-      backendExprIsGlobalClosureValue globals locals body
-    BackendTyApp _ fun _ ->
-      backendExprIsGlobalClosureValue globals locals fun
-    BackendLet _ name _ rhs body ->
-      let locals' =
-            if backendExprIsGlobalClosureValue globals locals rhs
-              then Set.insert name locals
-              else Set.delete name locals
-       in backendExprIsGlobalClosureValue globals locals' body
-    BackendCase {backendAlternatives = alternatives} ->
-      all (backendExprIsGlobalClosureValue globals locals . backendAltBody) (NE.toList alternatives)
-    _ ->
-      False
+backendExprIsGlobalClosureValue :: Set.Set String -> BackendExpr -> Bool
+backendExprIsGlobalClosureValue globals =
+  go Set.empty Set.empty
+  where
+    go closureLocals boundLocals =
+      \case
+        BackendClosure {} ->
+          True
+        BackendVar _ name
+          | Set.member name closureLocals -> True
+          | Set.member name boundLocals -> False
+          | otherwise -> Set.member name globals
+        BackendTyAbs _ _ _ body ->
+          go closureLocals boundLocals body
+        BackendTyApp _ fun _ ->
+          go closureLocals boundLocals fun
+        BackendLet _ name _ rhs body ->
+          let closureLocals' =
+                if go closureLocals boundLocals rhs
+                  then Set.insert name closureLocals
+                  else Set.delete name closureLocals
+              boundLocals' = Set.insert name boundLocals
+           in go closureLocals' boundLocals' body
+        BackendCase {backendAlternatives = alternatives} ->
+          all (goAlternative closureLocals boundLocals) (NE.toList alternatives)
+        _ ->
+          False
+
+    goAlternative closureLocals boundLocals (BackendAlternative pattern0 body) =
+      let binders = patternBinders pattern0
+       in go
+            (closureLocals `Set.difference` binders)
+            (boundLocals <> binders)
+            body
 
 backendRuntimePrimitiveTypes :: Map.Map String BackendType
 backendRuntimePrimitiveTypes =
@@ -842,9 +855,7 @@ backendClosureValueName mbContext =
       Just entryName
     BackendVar _ name
       | Just context0 <- mbContext,
-        Set.member name (bvcClosureGlobals context0)
-          || Set.member name (bvcClosureLocals context0)
-          || Set.member name (bvcPossibleClosureLocals context0) ->
+        backendContextNameIsClosureValue True context0 name ->
           Just name
     BackendTyApp _ fun _ ->
       backendClosureValueName mbContext fun
@@ -862,8 +873,7 @@ backendDefiniteClosureValueName mbContext =
       Just entryName
     BackendVar _ name
       | Just context0 <- mbContext,
-        Set.member name (bvcClosureGlobals context0)
-          || Set.member name (bvcClosureLocals context0) ->
+        backendContextNameIsClosureValue False context0 name ->
           Just name
     BackendTyApp _ fun _ ->
       backendDefiniteClosureValueName mbContext fun
@@ -901,6 +911,13 @@ firstClosureValueName (Nothing : rest) =
   firstClosureValueName rest
 firstClosureValueName (Just value : _) =
   Just value
+
+backendContextNameIsClosureValue :: Bool -> BackendValidationContext -> String -> Bool
+backendContextNameIsClosureValue includePossibleLocals context0 name
+  | Set.member name (bvcClosureLocals context0) = True
+  | includePossibleLocals && Set.member name (bvcPossibleClosureLocals context0) = True
+  | Map.member name (bvcLocals context0) = False
+  | otherwise = Set.member name (bvcClosureGlobals context0)
 
 backendExprCallsNameAsClosureHead :: String -> BackendExpr -> Bool
 backendExprCallsNameAsClosureHead needle =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2348,7 +2348,7 @@ lowerFunction :: ProgramEnv -> String -> Bool -> FunctionForm -> Either BackendL
 lowerFunction env name private form = do
   unless (null (ffTypeBinders form)) $
     Left (BackendLLVMUnsupportedExpression ("binding " ++ show name) "unspecialized polymorphic binding")
-  returnTy <- lowerBackendType env ("return type of " ++ name) (ffReturnType form)
+  returnTy <- lowerRuntimeValueType env ("return type of " ++ name) (ffReturnType form)
   params <- traverse lowerParam (ffParams form)
   let initialExprEnv = initialFunctionEnv name form params
   result <-
@@ -2650,7 +2650,7 @@ lowerExpr env exprEnv context expr =
     BackendLet resultTy name _ rhs body -> do
       exprEnv' <- bindLet env exprEnv context name rhs
       bodyValue <- lowerExpr env exprEnv' context body
-      expectedTy <- lowerBackendTypeM env context resultTy
+      expectedTy <- lowerRuntimeValueTypeM env context resultTy
       unless (lvLLVMType bodyValue == expectedTy) $
         liftEither (BackendLLVMInternalError ("let result type mismatch at " ++ context))
       pure bodyValue
@@ -2775,36 +2775,59 @@ lowerInstantiatedFunctionValue env exprEnv context name resultTy form = do
   unless (alphaEqBackendType resultTy (ffReturnType form)) $
     liftEither (BackendLLVMInternalError ("value type mismatch for " ++ name ++ " at " ++ context))
   value <- lowerExpr env exprEnv context (ffBody form)
-  expectedTy <- lowerBackendTypeM env context resultTy
+  expectedTy <- lowerRuntimeValueTypeM env context resultTy
   unless (lvLLVMType value == expectedTy) $
     liftEither (BackendLLVMInternalError ("value LLVM type mismatch for " ++ name ++ " at " ++ context))
   pure value
 
 bindLet :: ProgramEnv -> ExprEnv -> String -> String -> BackendExpr -> LowerM ExprEnv
 bindLet env exprEnv context name rhs =
-  case functionFormFromExpected (backendExprType rhs) rhs of
-    form
-      | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
-          pure
-            exprEnv
-              { eeLocalFunctions =
-                  Map.insert
-                    name
-                    LocalFunction
-                      { lfForm = form,
-                        lfCapturedEnv = exprEnv,
-                        lfStoredReference = Just (backendExprType rhs, rhs)
-                      }
-                    (eeLocalFunctions exprEnv),
-                eeValues = Map.delete name (eeValues exprEnv)
-              }
-    _ -> do
-      value <- lowerExpr env exprEnv (context ++ ", let " ++ show name) rhs
+  case closurePointerAliasValue exprEnv rhs of
+    Just value ->
       pure
         exprEnv
           { eeValues = Map.insert name value (eeValues exprEnv),
             eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
           }
+    Nothing ->
+      case functionFormFromExpected (backendExprType rhs) rhs of
+        form
+          | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+              pure
+                exprEnv
+                  { eeLocalFunctions =
+                      Map.insert
+                        name
+                        LocalFunction
+                          { lfForm = form,
+                            lfCapturedEnv = exprEnv,
+                            lfStoredReference = Just (backendExprType rhs, rhs)
+                          }
+                        (eeLocalFunctions exprEnv),
+                    eeValues = Map.delete name (eeValues exprEnv)
+                  }
+        _ -> do
+          value <- lowerExpr env exprEnv (context ++ ", let " ++ show name) rhs
+          pure
+            exprEnv
+              { eeValues = Map.insert name value (eeValues exprEnv),
+                eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
+              }
+
+closurePointerAliasValue :: ExprEnv -> BackendExpr -> Maybe LowerValue
+closurePointerAliasValue exprEnv =
+  \case
+    BackendVar ty name
+      | isFunctionLikeBackendType ty,
+        Just value <- Map.lookup name (eeValues exprEnv),
+        lvLLVMType value == LLVMPtr ->
+          Just value {lvBackendType = ty}
+    BackendTyApp ty fun _
+      | isFunctionLikeBackendType ty,
+        Just value <- closurePointerAliasValue exprEnv fun ->
+          Just value {lvBackendType = ty}
+    _ ->
+      Nothing
 
 lowerVar :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> LowerM LowerValue
 lowerVar env exprEnv context ty name =
@@ -2902,8 +2925,8 @@ lowerClosureCall env exprEnv context resultTy fun args = do
     liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
   unless (length paramTys == length args) $
     liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
-  resultLLVMType <- lowerBackendTypeM env context resultTy
-  returnLLVMType <- lowerBackendTypeM env context returnTy
+  resultLLVMType <- lowerRuntimeValueTypeM env context resultTy
+  returnLLVMType <- lowerRuntimeValueTypeM env context returnTy
   unless (resultLLVMType == returnLLVMType) $
     liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
   callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
@@ -2976,7 +2999,7 @@ lowerIndirectValueCall env exprEnv context name callee typeArgs args = do
     lowerIndirectPointerCall form = do
       callArgs <- zipWithM (lowerExprForIndirectArgument env exprEnv context) (ffParams form) args
       bindIndirectFunctionArguments env context name form callArgs
-      resultTy <- lowerBackendTypeM env context (ffReturnType form)
+      resultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
       result <- emitAssign "call" resultTy (LLVMCallOperand (lvOperand callee) [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
       pure (LowerValue (ffReturnType form) resultTy result)
 
@@ -3343,7 +3366,7 @@ lowerGlobalCall env exprEnv context name typeArgs args =
         else do
           callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
           bindFunctionArguments env context False name form callArgs
-          resultTy <- lowerBackendTypeM env context (ffReturnType form)
+          resultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
           functionName <- globalFunctionName env context binding resolvedTypeArgs
           result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
           pure (LowerValue (ffReturnType form) resultTy result)
@@ -3951,13 +3974,24 @@ lowerClosureStoredTypeM env context fieldTy
   | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
   | otherwise = lowerBackendTypeM env context fieldTy
 
+lowerRuntimeValueTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
+lowerRuntimeValueTypeM env context resultTy =
+  case lowerRuntimeValueType env context resultTy of
+    Right llvmTy -> pure llvmTy
+    Left err -> liftEither err
+
+lowerRuntimeValueType :: ProgramEnv -> String -> BackendType -> Either BackendLLVMError LLVMType
+lowerRuntimeValueType env context resultTy
+  | isClosureRuntimeValueType resultTy = Right LLVMPtr
+  | otherwise = lowerBackendType env context resultTy
+
 lowerCaseResultTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
 lowerCaseResultTypeM env context resultTy
-  | isCaseClosureResultType resultTy = pure LLVMPtr
+  | isClosureRuntimeValueType resultTy = pure LLVMPtr
   | otherwise = lowerBackendTypeM env context resultTy
 
-isCaseClosureResultType :: BackendType -> Bool
-isCaseClosureResultType =
+isClosureRuntimeValueType :: BackendType -> Bool
+isClosureRuntimeValueType =
   \case
     BTArrow {} -> True
     _ -> False

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2917,33 +2917,41 @@ lowerClosureValue env exprEnv context resultTy entryName captures = do
 
 lowerClosureCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> [BackendExpr] -> LowerM LowerValue
 lowerClosureCall env exprEnv context resultTy fun args = do
-  callee <- lowerExpr env exprEnv context fun
-  unless (lvLLVMType callee == LLVMPtr) $
-    liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a pointer: " ++ show (lvBackendType callee)))
-  let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
-  when (null paramTys) $
-    liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
-  unless (length paramTys == length args) $
-    liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
-  resultLLVMType <- lowerRuntimeValueTypeM env context resultTy
-  returnLLVMType <- lowerRuntimeValueTypeM env context returnTy
-  unless (resultLLVMType == returnLLVMType) $
-    liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
-  callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
-  codePtrField <- emitGep "closure.code.ptr" (lvOperand callee) 0
-  codePtr <- emitAssign "closure.code" LLVMPtr (LLVMLoad LLVMPtr codePtrField)
-  envPtrField <- emitGep "closure.env.ptr" (lvOperand callee) 8
-  closureEnv <- emitAssign "closure.env" LLVMPtr (LLVMLoad LLVMPtr envPtrField)
-  result <-
-    emitAssign
-      "closure.call"
-      resultLLVMType
-      ( LLVMCallOperand
-          codePtr
-          ((LLVMPtr, closureEnv) : [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-      )
-  pure (LowerValue resultTy resultLLVMType result)
+  case collectTyApps fun of
+    (BackendVar _ name, typeArgs)
+      | Just localFunction <- Map.lookup name (eeLocalFunctions exprEnv) ->
+          lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
+    _ ->
+      lowerClosurePointerCall
   where
+    lowerClosurePointerCall = do
+      callee <- lowerExpr env exprEnv context fun
+      unless (lvLLVMType callee == LLVMPtr) $
+        liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a pointer: " ++ show (lvBackendType callee)))
+      let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
+      when (null paramTys) $
+        liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
+      unless (length paramTys == length args) $
+        liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
+      resultLLVMType <- lowerRuntimeValueTypeM env context resultTy
+      returnLLVMType <- lowerRuntimeValueTypeM env context returnTy
+      unless (resultLLVMType == returnLLVMType) $
+        liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
+      callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
+      codePtrField <- emitGep "closure.code.ptr" (lvOperand callee) 0
+      codePtr <- emitAssign "closure.code" LLVMPtr (LLVMLoad LLVMPtr codePtrField)
+      envPtrField <- emitGep "closure.env.ptr" (lvOperand callee) 8
+      closureEnv <- emitAssign "closure.env" LLVMPtr (LLVMLoad LLVMPtr envPtrField)
+      result <-
+        emitAssign
+          "closure.call"
+          resultLLVMType
+          ( LLVMCallOperand
+              codePtr
+              ((LLVMPtr, closureEnv) : [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+          )
+      pure (LowerValue resultTy resultLLVMType result)
+
     lowerClosureArg (index0, paramTy) arg =
       lowerExprForIndirectArgument env exprEnv context ("__mlfp_closure_arg" ++ show index0, paramTy) arg
 
@@ -3547,6 +3555,14 @@ bindCallArguments env callEnv bodyEnv0 context allowNestedEvidence name form arg
   foldM bindOne bodyEnv0 (zip (ffParams form) args)
   where
     bindOne bodyEnv ((paramName, paramTy), arg)
+      | isFirstOrderFunctionPointerType paramTy,
+        Just _ <- closurePointerAliasValue callEnv arg = do
+          value <- lowerExprForArgument env callEnv context allowNestedEvidence (paramName, paramTy) arg
+          pure
+            bodyEnv
+              { eeValues = Map.insert paramName value (eeValues bodyEnv),
+                eeLocalFunctions = Map.delete paramName (eeLocalFunctions bodyEnv)
+              }
       | isInlineFunctionArgument allowNestedEvidence paramName paramTy = do
           localFunction <- lowerStaticFunctionArgument env callEnv context paramName paramTy arg
           pure

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3564,14 +3564,13 @@ bindCallArguments env callEnv bodyEnv0 context allowNestedEvidence name form arg
   foldM bindOne bodyEnv0 (zip (ffParams form) args)
   where
     bindOne bodyEnv ((paramName, paramTy), arg)
-      | isFirstOrderFunctionPointerType paramTy,
-        Just _ <- closurePointerAliasValue callEnv arg = do
-          value <- lowerExprForArgument env callEnv context allowNestedEvidence (paramName, paramTy) arg
-          pure
-            bodyEnv
-              { eeValues = Map.insert paramName value (eeValues bodyEnv),
-                eeLocalFunctions = Map.delete paramName (eeLocalFunctions bodyEnv)
-              }
+      | isFirstOrderFunctionPointerType paramTy = do
+          mbClosureValue <- lowerClosureRuntimeArgumentMaybe env callEnv context paramTy arg
+          case mbClosureValue of
+            Just value ->
+              bindValue bodyEnv paramName value
+            Nothing ->
+              bindInlineOrValue bodyEnv paramName paramTy arg
       | isInlineFunctionArgument allowNestedEvidence paramName paramTy = do
           localFunction <- lowerStaticFunctionArgument env callEnv context paramName paramTy arg
           pure
@@ -3584,12 +3583,51 @@ bindCallArguments env callEnv bodyEnv0 context allowNestedEvidence name form arg
                 eeValues = Map.delete paramName (eeValues bodyEnv)
               }
       | otherwise = do
-          value <- lowerExprForArgument env callEnv context allowNestedEvidence (paramName, paramTy) arg
+          bindValueFromExpr bodyEnv paramName paramTy arg
+
+    bindInlineOrValue bodyEnv paramName paramTy arg
+      | isInlineFunctionArgument allowNestedEvidence paramName paramTy = do
+          localFunction <- lowerStaticFunctionArgument env callEnv context paramName paramTy arg
           pure
             bodyEnv
-              { eeValues = Map.insert paramName value (eeValues bodyEnv),
-                eeLocalFunctions = Map.delete paramName (eeLocalFunctions bodyEnv)
+              { eeLocalFunctions =
+                  Map.insert
+                    paramName
+                    localFunction
+                    (eeLocalFunctions bodyEnv),
+                eeValues = Map.delete paramName (eeValues bodyEnv)
               }
+      | otherwise =
+          bindValueFromExpr bodyEnv paramName paramTy arg
+
+    bindValueFromExpr bodyEnv paramName paramTy arg = do
+      value <- lowerExprForArgument env callEnv context allowNestedEvidence (paramName, paramTy) arg
+      bindValue bodyEnv paramName value
+
+    bindValue bodyEnv paramName value =
+      pure
+        bodyEnv
+          { eeValues = Map.insert paramName value (eeValues bodyEnv),
+            eeLocalFunctions = Map.delete paramName (eeLocalFunctions bodyEnv)
+          }
+
+lowerClosureRuntimeArgumentMaybe :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM (Maybe LowerValue)
+lowerClosureRuntimeArgumentMaybe env exprEnv context expectedTy arg =
+  case closurePointerAliasValue exprEnv arg of
+    Just value ->
+      pure (Just value {lvBackendType = expectedTy})
+    Nothing ->
+      case collectTyApps arg of
+        (BackendVar _ name, typeArgs)
+          | Just binding <- Map.lookup name (pbBindings (peBase env)) -> do
+              (_, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs []
+              if null (ffParams form)
+                && alphaEqBackendType expectedTy (ffReturnType form)
+                && isClosureRuntimeValueType (ffReturnType form)
+                then Just <$> lowerGlobalValue env context expectedTy name binding typeArgs
+                else pure Nothing
+        _ ->
+          pure Nothing
 
 isInlineFunctionArgument :: Bool -> String -> BackendType -> Bool
 isInlineFunctionArgument allowNestedEvidence paramName paramTy =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2826,6 +2826,21 @@ closurePointerAliasValue exprEnv =
       | isFunctionLikeBackendType ty,
         Just value <- closurePointerAliasValue exprEnv fun ->
           Just value {lvBackendType = ty}
+    BackendLet ty name bindingTy rhs body
+      | isFunctionLikeBackendType ty ->
+          let exprEnvForBody =
+                case closurePointerAliasValue exprEnv rhs of
+                  Just value ->
+                    exprEnv
+                      { eeValues = Map.insert name value {lvBackendType = bindingTy} (eeValues exprEnv),
+                        eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
+                      }
+                  Nothing ->
+                    exprEnv
+                      { eeValues = Map.delete name (eeValues exprEnv),
+                        eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
+                      }
+           in closurePointerAliasValue exprEnvForBody body
     _ ->
       Nothing
 

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2864,7 +2864,7 @@ lowerGlobalValue env context resultTy name binding typeArgs =
         liftEither (BackendLLVMUnsupportedExpression context ("escaping function " ++ show functionContext))
       unless (alphaEqBackendType expectedTy (ffReturnType instantiated)) $
         liftEither (BackendLLVMInternalError ("global value type mismatch for " ++ functionContext ++ " at " ++ context))
-      resultLLVMType <- lowerBackendTypeM env context expectedTy
+      resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
       functionName <- globalFunctionName env context binding0 resolvedTypeArgs
       result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
       pure (LowerValue expectedTy resultLLVMType result)

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -720,6 +720,20 @@ spec = describe "MLF.Backend.Convert" $ do
     mainBinding <- requireBinding (backendProgramMain backend) backend
     closureParamCounts (backendBindingExpr mainBinding) `shouldSatisfy` elem 2
 
+  it "alpha-renames returned lambda parameters hoisted across shadowing lets" $ do
+    checked0 <- requireChecked returnedLetLambdaClosureProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding {checkedBindingTerm = returnedLetLambdaShadowingElabTerm}
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsAlphaRenamedShadowingClosure
+
   it "keeps direct first-order local calls on the direct application path" $ do
     checked <- requireChecked directLocalCallProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -1168,6 +1182,28 @@ returnedLetLambdaClosureProgram =
       "}"
     ]
 
+returnedLetLambdaShadowingElabTerm :: Elab.ElabTerm
+returnedLetLambdaShadowingElabTerm =
+  Elab.ELet
+    "captured"
+    (Elab.schemeFromType intElabTy)
+    (Elab.ELit (LInt 41))
+    ( Elab.ELet
+        "f"
+        (Elab.schemeFromType (Elab.TArrow intElabTy (Elab.TArrow intElabTy intElabTy)))
+        ( Elab.ELam
+            "x"
+            intElabTy
+            ( Elab.ELet
+                "y"
+                (Elab.schemeFromType intElabTy)
+                (Elab.ELit (LInt 1))
+                (Elab.ELam "y" intElabTy (Elab.EVar "y"))
+            )
+        )
+        (Elab.EVar "f")
+    )
+
 directLocalCallProgram :: String
 directLocalCallProgram =
   unlines
@@ -1536,6 +1572,40 @@ containsBackendClosureCall expr =
     BackendUnroll {backendUnrollPayload = body} -> containsBackendClosureCall body
     BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
       any (containsBackendClosureCall . backendClosureCaptureExpr) captures || containsBackendClosureCall body
+    _ -> False
+
+containsAlphaRenamedShadowingClosure :: BackendExpr -> Bool
+containsAlphaRenamedShadowingClosure expr =
+  case expr of
+    BackendClosure
+      { backendClosureCaptures = captures,
+        backendClosureParams = params,
+        backendClosureBody =
+          BackendLet
+            { backendLetName = "y",
+              backendLetBody = BackendVar {backendVarName = bodyName}
+            }
+      } ->
+        (bodyName /= "y" && bodyName `elem` map fst params)
+          || any (containsAlphaRenamedShadowingClosure . backendClosureCaptureExpr) captures
+    BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
+      any (containsAlphaRenamedShadowingClosure . backendClosureCaptureExpr) captures
+        || containsAlphaRenamedShadowingClosure body
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsAlphaRenamedShadowingClosure scrutinee
+        || any (containsAlphaRenamedShadowingClosure . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsAlphaRenamedShadowingClosure body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsAlphaRenamedShadowingClosure fun || containsAlphaRenamedShadowingClosure arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsAlphaRenamedShadowingClosure rhs || containsAlphaRenamedShadowingClosure body
+    BackendTyAbs {backendTyAbsBody = body} -> containsAlphaRenamedShadowingClosure body
+    BackendTyApp {backendTyFunction = fun} -> containsAlphaRenamedShadowingClosure fun
+    BackendConstruct {backendConstructArgs = args} -> any containsAlphaRenamedShadowingClosure args
+    BackendRoll {backendRollPayload = body} -> containsAlphaRenamedShadowingClosure body
+    BackendUnroll {backendUnrollPayload = body} -> containsAlphaRenamedShadowingClosure body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      containsAlphaRenamedShadowingClosure fun || any containsAlphaRenamedShadowingClosure args
     _ -> False
 
 closureParamCounts :: BackendExpr -> [Int]

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -712,6 +712,24 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
     backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendApp
 
+  it "clears shadowed closure locals when classifying let RHS values" $ do
+    checked <- requireChecked shadowedClosureLocalProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    useBinding <- requireBinding "Main__use" backend
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendApp
+    backendBindingExpr useBinding `shouldNotSatisfy` containsBackendClosureCall
+
+  it "rejects closure-valued constructor fields until ADT fields are closure-aware" $ do
+    checked <- requireChecked closureValuedConstructorFieldProgram
+
+    case convertCheckedProgram checked of
+      Left (BackendUnsupportedCaseShape message) ->
+        message `shouldSatisfy` isInfixOf "closure-valued constructor field"
+      other ->
+        expectationFailure ("expected closure-valued constructor field rejection, got " ++ show other)
+
   it "collects closure parameters through lets before returned lambdas" $ do
     checked <- requireChecked returnedLetLambdaClosureProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -1168,6 +1186,33 @@ topLevelClosureCallProgram =
     [ "module Main export (main) {",
       "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
       "  def main : Int = maker 0;",
+      "}"
+    ]
+
+shadowedClosureLocalProgram :: String
+shadowedClosureLocalProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def id : Int -> Int = \\(x : Int) x;",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int)",
+      "    let h : Int -> Int = let f : Int -> Int = id in f in",
+      "    h 0;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
+      "}"
+    ]
+
+closureValuedConstructorFieldProgram :: String
+closureValuedConstructorFieldProgram =
+  unlines
+    [ "module Main export (FnBox(..), main) {",
+      "  data FnBox = FnBox : (Int -> Int) -> FnBox;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    case FnBox f of { FnBox g -> g 0 };",
       "}"
     ]
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -712,6 +712,26 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
     backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendApp
 
+  it "closure-converts calls to type-abstracted closure-valued top-level bindings" $ do
+    checked <- requireChecked polymorphicTopLevelClosureCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    makerBinding <- requireBinding "Main__maker" backend
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr makerBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
+    backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendApp
+
+  it "closure-converts closure-valued function parameters through nested let aliases" $ do
+    checked <- requireChecked functionParameterNestedClosureAliasCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    useBinding <- requireBinding "Main__use" backend
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendClosureCall
+    backendBindingExpr useBinding `shouldNotSatisfy` containsBackendApp
+
   it "clears shadowed closure locals when classifying let RHS values" $ do
     checked <- requireChecked shadowedClosureLocalProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -1186,6 +1206,29 @@ topLevelClosureCallProgram =
     [ "module Main export (main) {",
       "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
       "  def main : Int = maker 0;",
+      "}"
+    ]
+
+polymorphicTopLevelClosureCallProgram :: String
+polymorphicTopLevelClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def maker : forall a. a -> Int = let captured : Int = 41 in \\(x : a) captured;",
+      "  def main : Int = maker 0;",
+      "}"
+    ]
+
+functionParameterNestedClosureAliasCallProgram :: String
+functionParameterNestedClosureAliasCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int)",
+      "    let g : Int -> Int = (let h : Int -> Int = f in h) in",
+      "    g 1;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
       "}"
     ]
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -2,7 +2,7 @@ module BackendConvertSpec (spec) where
 
 import Control.Applicative ((<|>))
 import Data.Foldable (toList)
-import Data.List (find, intercalate, isInfixOf)
+import Data.List (find, intercalate, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import MLF.Backend.Convert
 import MLF.Backend.IR
@@ -849,6 +849,27 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosure
     backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosureCall
 
+  it "shares closure entry names across lifted recursive helper conversion" $ do
+    checked0 <- requireChecked liftedRecursiveHelpersClosureNameProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding
+                  { checkedBindingType = intElabTy,
+                    checkedBindingSourceType = STBase "Int",
+                    checkedBindingTerm = liftedRecursiveHelpersClosureNameTerm
+                  }
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    let helperBindings = filter (isInfixOf "$letrec$" . backendBindingName) (backendBindings backend)
+        closureEntryNames = concatMap (collectBackendClosureEntryNames . backendBindingExpr) helperBindings
+    length helperBindings `shouldBe` 2
+    length closureEntryNames `shouldBe` 2
+    closureEntryNames `shouldBe` nub closureEntryNames
+
 simpleFunctionProgram :: String
 simpleFunctionProgram =
   unlines
@@ -1395,6 +1416,15 @@ directLocalCallProgram =
       "}"
     ]
 
+liftedRecursiveHelpersClosureNameProgram :: String
+liftedRecursiveHelpersClosureNameProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
+      "  def main : Int = 0;",
+      "}"
+    ]
+
 requireChecked :: String -> IO CheckedProgram
 requireChecked input = do
   program <- requireParsed input
@@ -1735,6 +1765,27 @@ containsBackendClosure expr =
     BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
       containsBackendClosure fun || any containsBackendClosure args
     _ -> False
+
+collectBackendClosureEntryNames :: BackendExpr -> [String]
+collectBackendClosureEntryNames expr =
+  case expr of
+    BackendClosure {backendClosureEntryName = entryName, backendClosureCaptures = captures, backendClosureBody = body} ->
+      entryName : concatMap (collectBackendClosureEntryNames . backendClosureCaptureExpr) captures ++ collectBackendClosureEntryNames body
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      collectBackendClosureEntryNames scrutinee ++ concatMap (collectBackendClosureEntryNames . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> collectBackendClosureEntryNames body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      collectBackendClosureEntryNames fun ++ collectBackendClosureEntryNames arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      collectBackendClosureEntryNames rhs ++ collectBackendClosureEntryNames body
+    BackendTyAbs {backendTyAbsBody = body} -> collectBackendClosureEntryNames body
+    BackendTyApp {backendTyFunction = fun} -> collectBackendClosureEntryNames fun
+    BackendConstruct {backendConstructArgs = args} -> concatMap collectBackendClosureEntryNames args
+    BackendRoll {backendRollPayload = body} -> collectBackendClosureEntryNames body
+    BackendUnroll {backendUnrollPayload = body} -> collectBackendClosureEntryNames body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      collectBackendClosureEntryNames fun ++ concatMap collectBackendClosureEntryNames args
+    _ -> []
 
 containsBackendClosureCall :: BackendExpr -> Bool
 containsBackendClosureCall expr =
@@ -2313,6 +2364,36 @@ recursiveLexicalTypeOrderHelperBackendTy =
         "a"
         Nothing
         unaryIntBackendTy
+    )
+
+liftedRecursiveHelpersClosureNameTerm :: Elab.ElabTerm
+liftedRecursiveHelpersClosureNameTerm =
+  Elab.ELet
+    "left"
+    (Elab.schemeFromType unaryIntElabTy)
+    (liftedRecursiveHelpersClosureNameRhs "left")
+    ( Elab.ELet
+        "right"
+        (Elab.schemeFromType unaryIntElabTy)
+        (liftedRecursiveHelpersClosureNameRhs "right")
+        (Elab.EApp (Elab.EVar "right") (Elab.ELit (LInt 0)))
+    )
+
+liftedRecursiveHelpersClosureNameRhs :: String -> Elab.ElabTerm
+liftedRecursiveHelpersClosureNameRhs selfName =
+  Elab.ELam
+    "n"
+    intElabTy
+    ( Elab.ELet
+        "f"
+        (Elab.schemeFromType unaryIntElabTy)
+        (Elab.ELam "x" intElabTy (Elab.EVar "x"))
+        ( Elab.ELet
+            "ignored"
+            (Elab.schemeFromType intElabTy)
+            (Elab.EApp (Elab.EVar selfName) (Elab.EVar "n"))
+            (Elab.EApp (Elab.EVar "Main__use") (Elab.EVar "f"))
+        )
     )
 
 intIdentityElabTerm :: Elab.ElabTerm

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -75,7 +75,7 @@ spec = describe "MLF.Backend.Convert" $ do
       Just other -> expectationFailure ("expected backend case, got " ++ show other)
       Nothing -> expectationFailure "expected backend case"
 
-  it "falls back to ordinary application for over-applied case-shaped terms" $ do
+  it "applies over-applied case-shaped terms through the closure-call path" $ do
     checked0 <- requireChecked functionCaseProgram
     let checked =
           mapMainBinding
@@ -92,14 +92,14 @@ spec = describe "MLF.Backend.Convert" $ do
 
     mainBinding <- requireBinding (backendProgramMain backend) backend
     case backendBindingExpr mainBinding of
-      BackendApp
+      BackendClosureCall
         { backendExprType = resultTy,
-          backendFunction = fun,
-          backendArgument = BackendLit {backendLit = LInt 1}
+          backendClosureFunction = fun,
+          backendClosureArguments = [BackendLit {backendLit = LInt 1}]
         } -> do
           resultTy `shouldBe` intTy
           fun `shouldSatisfy` containsBackendCase
-      other -> expectationFailure ("expected backend application of recovered case, got " ++ show other)
+      other -> expectationFailure ("expected backend closure call of recovered case, got " ++ show other)
 
   it "recovers backend cases with type-wrapped handler lambdas" $ do
     checked0 <- requireChecked intCaseProgram
@@ -662,6 +662,42 @@ spec = describe "MLF.Backend.Convert" $ do
     convertSourceType unsupportedVariableHeadType
       `shouldBe` Right (BTVarApp "f" (intTy :| []))
 
+  it "closure-converts a returned local function value" $ do
+    checked <- requireChecked returnedClosureProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+
+  it "closure-converts local function aliases that cross let boundaries" $ do
+    checked <- requireChecked closureAliasCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
+
+  it "closure-converts captured lambdas called through let aliases" $ do
+    checked <- requireChecked capturedClosureCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCapture "captured"
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
+
+  it "keeps direct first-order local calls on the direct application path" $ do
+    checked <- requireChecked directLocalCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendApp
+    backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosureCall
+
 simpleFunctionProgram :: String
 simpleFunctionProgram =
   unlines
@@ -1036,6 +1072,47 @@ unsupportedVariableHeadType :: SrcType
 unsupportedVariableHeadType =
   STVarApp "f" (STBase "Int" :| [])
 
+returnedClosureProgram :: String
+returnedClosureProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int -> Int =",
+      "    let captured : Int = 41 in \\(x : Int) captured;",
+      "}"
+    ]
+
+closureAliasCallProgram :: String
+closureAliasCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    let f : Int -> Int = \\(x : Int) x in",
+      "    let g : Int -> Int = f in",
+      "    g 7;",
+      "}"
+    ]
+
+capturedClosureCallProgram :: String
+capturedClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    let g : Int -> Int = f in",
+      "    g 0;",
+      "}"
+    ]
+
+directLocalCallProgram :: String
+directLocalCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    let f : Int -> Int = \\(x : Int) x in f 7;",
+      "}"
+    ]
+
 requireChecked :: String -> IO CheckedProgram
 requireChecked input = do
   program <- requireParsed input
@@ -1336,6 +1413,93 @@ containsBackendTyApp expr =
     BackendRoll {backendRollPayload = body} -> containsBackendTyApp body
     BackendUnroll {backendUnrollPayload = body} -> containsBackendTyApp body
     _ -> False
+
+containsBackendApp :: BackendExpr -> Bool
+containsBackendApp expr =
+  case expr of
+    BackendApp {} -> True
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsBackendApp scrutinee || any (containsBackendApp . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsBackendApp body
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsBackendApp rhs || containsBackendApp body
+    BackendTyAbs {backendTyAbsBody = body} -> containsBackendApp body
+    BackendTyApp {backendTyFunction = fun} -> containsBackendApp fun
+    BackendConstruct {backendConstructArgs = args} -> any containsBackendApp args
+    BackendRoll {backendRollPayload = body} -> containsBackendApp body
+    BackendUnroll {backendUnrollPayload = body} -> containsBackendApp body
+    BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
+      any (containsBackendApp . backendClosureCaptureExpr) captures || containsBackendApp body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      containsBackendApp fun || any containsBackendApp args
+    _ -> False
+
+containsBackendClosure :: BackendExpr -> Bool
+containsBackendClosure expr =
+  case expr of
+    BackendClosure {} -> True
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsBackendClosure scrutinee || any (containsBackendClosure . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsBackendClosure body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsBackendClosure fun || containsBackendClosure arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsBackendClosure rhs || containsBackendClosure body
+    BackendTyAbs {backendTyAbsBody = body} -> containsBackendClosure body
+    BackendTyApp {backendTyFunction = fun} -> containsBackendClosure fun
+    BackendConstruct {backendConstructArgs = args} -> any containsBackendClosure args
+    BackendRoll {backendRollPayload = body} -> containsBackendClosure body
+    BackendUnroll {backendUnrollPayload = body} -> containsBackendClosure body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      containsBackendClosure fun || any containsBackendClosure args
+    _ -> False
+
+containsBackendClosureCall :: BackendExpr -> Bool
+containsBackendClosureCall expr =
+  case expr of
+    BackendClosureCall {} -> True
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsBackendClosureCall scrutinee || any (containsBackendClosureCall . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsBackendClosureCall body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsBackendClosureCall fun || containsBackendClosureCall arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsBackendClosureCall rhs || containsBackendClosureCall body
+    BackendTyAbs {backendTyAbsBody = body} -> containsBackendClosureCall body
+    BackendTyApp {backendTyFunction = fun} -> containsBackendClosureCall fun
+    BackendConstruct {backendConstructArgs = args} -> any containsBackendClosureCall args
+    BackendRoll {backendRollPayload = body} -> containsBackendClosureCall body
+    BackendUnroll {backendUnrollPayload = body} -> containsBackendClosureCall body
+    BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
+      any (containsBackendClosureCall . backendClosureCaptureExpr) captures || containsBackendClosureCall body
+    _ -> False
+
+containsBackendClosureCapture :: String -> BackendExpr -> Bool
+containsBackendClosureCapture expected expr =
+  case expr of
+    BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
+      any (captureNameMatches expected . backendClosureCaptureName) captures
+        || any (containsBackendClosureCapture expected . backendClosureCaptureExpr) captures
+        || containsBackendClosureCapture expected body
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsBackendClosureCapture expected scrutinee
+        || any (containsBackendClosureCapture expected . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> containsBackendClosureCapture expected body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsBackendClosureCapture expected fun || containsBackendClosureCapture expected arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      containsBackendClosureCapture expected rhs || containsBackendClosureCapture expected body
+    BackendTyAbs {backendTyAbsBody = body} -> containsBackendClosureCapture expected body
+    BackendTyApp {backendTyFunction = fun} -> containsBackendClosureCapture expected fun
+    BackendConstruct {backendConstructArgs = args} -> any (containsBackendClosureCapture expected) args
+    BackendRoll {backendRollPayload = body} -> containsBackendClosureCapture expected body
+    BackendUnroll {backendUnrollPayload = body} -> containsBackendClosureCapture expected body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      containsBackendClosureCapture expected fun || any (containsBackendClosureCapture expected) args
+    _ -> False
+  where
+    captureNameMatches expectedName actualName =
+      expectedName == actualName || expectedName `isInfixOf` actualName
 
 containsBackendTyAppArgument :: BackendType -> BackendExpr -> Bool
 containsBackendTyAppArgument expected expr =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -688,6 +688,17 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCapture "captured"
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
 
+  it "closure-converts closure-valued function parameters at call sites" $ do
+    checked <- requireChecked functionParameterClosureCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    useBinding <- requireBinding "Main__use" backend
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendClosureCall
+    backendBindingExpr useBinding `shouldNotSatisfy` containsBackendApp
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+
   it "closure-converts calls to closure-valued top-level bindings" $ do
     checked <- requireChecked topLevelClosureCallProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -1120,6 +1131,18 @@ capturedClosureCallProgram =
       "    let f : Int -> Int = \\(x : Int) captured in",
       "    let g : Int -> Int = f in",
       "    g 0;",
+      "}"
+    ]
+
+functionParameterClosureCallProgram :: String
+functionParameterClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
       "}"
     ]
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -798,6 +798,16 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr useBinding `shouldSatisfy` containsBackendApp
     backendBindingExpr useBinding `shouldNotSatisfy` containsBackendClosureCall
 
+  it "keeps local non-closure binders from inheriting same-named closure globals" $ do
+    checked <- requireChecked shadowedGlobalClosureHeadProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendCase
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendApp
+    backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosureCall
+
   it "rejects closure-valued constructor fields until ADT fields are closure-aware" $ do
     checked <- requireChecked closureValuedConstructorFieldProgram
 
@@ -1317,6 +1327,17 @@ shadowedCaseClosureLocalProgram =
       "    let captured : Int = 41 in",
       "    let f : Int -> Int = \\(x : Int) captured in",
       "    use f;",
+      "}"
+    ]
+
+shadowedGlobalClosureHeadProgram :: String
+shadowedGlobalClosureHeadProgram =
+  unlines
+    [ "module Main export (FnBox(..), main) {",
+      "  data FnBox = FnBox : (Int -> Int) -> FnBox;",
+      "  def f : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
+      "  def id : Int -> Int = \\(x : Int) x;",
+      "  def main : Int = case FnBox id of { FnBox f -> f 0 };",
       "}"
     ]
 

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -688,6 +688,25 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCapture "captured"
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
 
+  it "closure-converts calls to closure-valued top-level bindings" $ do
+    checked <- requireChecked topLevelClosureCallProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    makerBinding <- requireBinding "Main__maker" backend
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr makerBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
+    backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendApp
+
+  it "collects closure parameters through lets before returned lambdas" $ do
+    checked <- requireChecked returnedLetLambdaClosureProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    closureParamCounts (backendBindingExpr mainBinding) `shouldSatisfy` elem 2
+
   it "keeps direct first-order local calls on the direct application path" $ do
     checked <- requireChecked directLocalCallProgram
     backend <- requireRight (convertCheckedProgram checked)
@@ -1104,6 +1123,26 @@ capturedClosureCallProgram =
       "}"
     ]
 
+topLevelClosureCallProgram :: String
+topLevelClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
+      "  def main : Int = maker 0;",
+      "}"
+    ]
+
+returnedLetLambdaClosureProgram :: String
+returnedLetLambdaClosureProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int -> Int -> Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int -> Int = \\(x : Int) let y : Int = captured in \\(z : Int) y in",
+      "    f;",
+      "}"
+    ]
+
 directLocalCallProgram :: String
 directLocalCallProgram =
   unlines
@@ -1473,6 +1512,27 @@ containsBackendClosureCall expr =
     BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
       any (containsBackendClosureCall . backendClosureCaptureExpr) captures || containsBackendClosureCall body
     _ -> False
+
+closureParamCounts :: BackendExpr -> [Int]
+closureParamCounts expr =
+  case expr of
+    BackendClosure {backendClosureCaptures = captures, backendClosureParams = params, backendClosureBody = body} ->
+      length params : concatMap (closureParamCounts . backendClosureCaptureExpr) captures ++ closureParamCounts body
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      closureParamCounts scrutinee ++ concatMap (closureParamCounts . backendAltBody) (toList alternatives)
+    BackendLam {backendBody = body} -> closureParamCounts body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      closureParamCounts fun ++ closureParamCounts arg
+    BackendLet {backendLetRhs = rhs, backendLetBody = body} ->
+      closureParamCounts rhs ++ closureParamCounts body
+    BackendTyAbs {backendTyAbsBody = body} -> closureParamCounts body
+    BackendTyApp {backendTyFunction = fun} -> closureParamCounts fun
+    BackendConstruct {backendConstructArgs = args} -> concatMap closureParamCounts args
+    BackendRoll {backendRollPayload = body} -> closureParamCounts body
+    BackendUnroll {backendUnrollPayload = body} -> closureParamCounts body
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      closureParamCounts fun ++ concatMap closureParamCounts args
+    _ -> []
 
 containsBackendClosureCapture :: String -> BackendExpr -> Bool
 containsBackendClosureCapture expected expr =

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -788,6 +788,16 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr useBinding `shouldSatisfy` containsBackendApp
     backendBindingExpr useBinding `shouldNotSatisfy` containsBackendClosureCall
 
+  it "clears shadowed closure locals when classifying case pattern results" $ do
+    checked <- requireChecked shadowedCaseClosureLocalProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    useBinding <- requireBinding "Main__use" backend
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendCase
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendApp
+    backendBindingExpr useBinding `shouldNotSatisfy` containsBackendClosureCall
+
   it "rejects closure-valued constructor fields until ADT fields are closure-aware" $ do
     checked <- requireChecked closureValuedConstructorFieldProgram
 
@@ -1287,6 +1297,22 @@ shadowedClosureLocalProgram =
       "  def use : (Int -> Int) -> Int = \\(f : Int -> Int)",
       "    let h : Int -> Int = let f : Int -> Int = id in f in",
       "    h 0;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
+      "}"
+    ]
+
+shadowedCaseClosureLocalProgram :: String
+shadowedCaseClosureLocalProgram =
+  unlines
+    [ "module Main export (FnBox(..), main) {",
+      "  data FnBox = FnBox : (Int -> Int) -> FnBox;",
+      "  def id : Int -> Int = \\(x : Int) x;",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int)",
+      "    let g : Int -> Int = case FnBox id of { FnBox f -> f } in",
+      "    g 0;",
       "  def main : Int =",
       "    let captured : Int = 41 in",
       "    let f : Int -> Int = \\(x : Int) captured in",

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -223,6 +223,45 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendExpr (BackendClosureCall boolTy structuralClosure [BackendVar structuralBoxTy "box"])
       `shouldBe` Right ()
 
+  it "lets local non-closure binders shadow closure-valued globals during validation" $ do
+    let globalClosure =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$shadowed_global",
+              backendClosureCaptures = [],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            }
+        shadowedLetCallProgram =
+          programWithBindings
+            [ binding "f" idTy globalClosure,
+              mainBinding
+                ( BackendLet
+                    intTy
+                    "f"
+                    idTy
+                    intIdentityExpr
+                    (BackendApp intTy (BackendVar idTy "f") (intLit 1))
+                )
+            ]
+        shadowedCaseClosureGlobalProgram =
+          programWithDataAndBindings
+            [fnBoxData]
+            [ binding "f" idTy globalClosure,
+              binding
+                "g"
+                idTy
+                ( BackendCase
+                    idTy
+                    (BackendConstruct fnBoxTy "FnBox" [intIdentityExpr])
+                    (BackendAlternative (BackendConstructorPattern "FnBox" ["f"]) (BackendVar idTy "f") :| [])
+                ),
+              mainBinding (BackendApp intTy (BackendVar idTy "g") (intLit 1))
+            ]
+
+    validateBackendProgram shadowedLetCallProgram `shouldBe` Right ()
+    validateBackendProgram shadowedCaseClosureGlobalProgram `shouldBe` Right ()
+
   it "rejects malformed closure IR" $ do
     let goodClosure entryName =
           BackendClosure
@@ -808,6 +847,14 @@ boxData =
       backendDataConstructors = [BackendConstructor "Box" [] [intTy] boxTy]
     }
 
+fnBoxData :: BackendData
+fnBoxData =
+  BackendData
+    { backendDataName = "FnBox",
+      backendDataParameters = [],
+      backendDataConstructors = [BackendConstructor "FnBox" [] [idTy] fnBoxTy]
+    }
+
 optionData :: BackendData
 optionData =
   BackendData
@@ -1313,6 +1360,10 @@ singleFieldStructuralBody fieldTy =
 boxTy :: BackendType
 boxTy =
   BTBase (BaseTy "Box")
+
+fnBoxTy :: BackendType
+fnBoxTy =
+  BTBase (BaseTy "FnBox")
 
 packTy :: BackendType
 packTy =

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -190,6 +190,19 @@ spec = describe "MLF.Backend.IR" $ do
             idTy
             value
             (BackendClosureCall intTy (BackendVar idTy "f") [intLit 1])
+        callClosureAlias value =
+          BackendLet
+            intTy
+            "f"
+            idTy
+            value
+            ( BackendLet
+                intTy
+                "g"
+                idTy
+                (BackendVar idTy "f")
+                (BackendClosureCall intTy (BackendVar idTy "g") [intLit 1])
+            )
         structuralClosureArgTy =
           BTMu "$Box_self" (singleFieldStructuralBody (BTVar "a"))
         structuralClosure =
@@ -204,6 +217,8 @@ spec = describe "MLF.Backend.IR" $ do
     validateBackendProgram (programWithMainExpr (callClosure closure))
       `shouldBe` Right ()
     validateBackendProgram (programWithMainExpr (callClosure capturedClosure))
+      `shouldBe` Right ()
+    validateBackendProgram (programWithMainExpr (callClosureAlias closure))
       `shouldBe` Right ()
     validateBackendExpr (BackendClosureCall boolTy structuralClosure [BackendVar structuralBoxTy "box"])
       `shouldBe` Right ()

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -622,6 +622,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "lowers closure-valued function parameters through let aliases" $ do
+    output <-
+      withTempProgram sourceFunctionParameterClosureAliasCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "BackendClosureCallExpectedClosureValue"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "lowers source-level returned closure values as pointer results" $ do
     output <-
       withTempProgram sourceReturnedClosureProgram $ \path ->
@@ -637,6 +648,16 @@ spec = describe "MLF.Backend.LLVM" $ do
         requireRight =<< emitBackendFile path
 
     output `shouldSatisfy` isInfixOf "define ptr @\"Main__maker\"()"
+    output `shouldSatisfy` isInfixOf "call ptr @\"Main__maker\"()"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "lowers top-level closure values passed as function arguments" $ do
+    output <-
+      withTempProgram sourceTopLevelClosureArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
     output `shouldSatisfy` isInfixOf "call ptr @\"Main__maker\"()"
     output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
     validateLLVMAssembly output
@@ -2952,6 +2973,18 @@ sourceFunctionParameterClosureCallProgram =
       "}"
     ]
 
+sourceFunctionParameterClosureAliasCallProgram :: String
+sourceFunctionParameterClosureAliasCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) let g : Int -> Int = f in g 1;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
+      "}"
+    ]
+
 sourceReturnedClosureProgram :: String
 sourceReturnedClosureProgram =
   unlines
@@ -2967,6 +3000,16 @@ sourceTopLevelClosureCallProgram =
     [ "module Main export (main) {",
       "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
       "  def main : Int = maker 0;",
+      "}"
+    ]
+
+sourceTopLevelClosureArgumentProgram :: String
+sourceTopLevelClosureArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
+      "  def main : Int = use maker;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -588,11 +588,31 @@ spec = describe "MLF.Backend.LLVM" $ do
 
   it "rejects partial applications until closure conversion is explicit in backend IR" $ do
     renderBackendProgramLLVM partialApplicationProgram
-      `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
+      `shouldSatisfyLeft` isInfixOf "Backend LLVM arity mismatch"
 
   it "rejects raw escaping lambdas until closure construction is explicit in backend IR" $ do
     renderBackendProgramLLVM escapingLambdaProgram
-      `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
+      `shouldSatisfyLeft` isInfixOf "escaping function"
+
+  it "lowers source-level captured closure calls through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceCapturedClosureCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "store i64 41"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "lowers source-level returned closure values as pointer results" $ do
+    output <-
+      withTempProgram sourceReturnedClosureProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define ptr @\"Main__main\"()"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$Main__main$"
+    validateLLVMAssembly output
 
   it "lowers zero-capture closures through the explicit closure ABI" $ do
     output <- requireRight (renderBackendProgramLLVM zeroCaptureClosureProgram)
@@ -2861,6 +2881,27 @@ escapingLambdaProgram =
         backendLetRhs = intIdentityExpr,
         backendLetBody = BackendVar unaryIntTy "f"
       }
+
+sourceCapturedClosureCallProgram :: String
+sourceCapturedClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    let g : Int -> Int = f in",
+      "    g 0;",
+      "}"
+    ]
+
+sourceReturnedClosureProgram :: String
+sourceReturnedClosureProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int -> Int =",
+      "    let captured : Int = 41 in \\(x : Int) captured;",
+      "}"
+    ]
 
 zeroCaptureClosureProgram :: BackendProgram
 zeroCaptureClosureProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -614,6 +614,27 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$Main__main$"
     validateLLVMAssembly output
 
+  it "lowers source-level top-level closure calls through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceTopLevelClosureCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define ptr @\"Main__maker\"()"
+    output `shouldSatisfy` isInfixOf "call ptr @\"Main__maker\"()"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "lowers returned lambdas behind lets with complete closure parameters" $ do
+    output <-
+      withTempProgram sourceReturnedLetLambdaClosureProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define ptr @\"Main__main\"()"
+    output `shouldSatisfy` isInfixOf "(ptr %\"__mlfp_env\", i64 %\""
+    output `shouldSatisfy` isInfixOf "\", i64 %\""
+    validateLLVMAssembly output
+
   it "lowers zero-capture closures through the explicit closure ABI" $ do
     output <- requireRight (renderBackendProgramLLVM zeroCaptureClosureProgram)
 
@@ -2900,6 +2921,26 @@ sourceReturnedClosureProgram =
     [ "module Main export (main) {",
       "  def main : Int -> Int =",
       "    let captured : Int = 41 in \\(x : Int) captured;",
+      "}"
+    ]
+
+sourceTopLevelClosureCallProgram :: String
+sourceTopLevelClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
+      "  def main : Int = maker 0;",
+      "}"
+    ]
+
+sourceReturnedLetLambdaClosureProgram :: String
+sourceReturnedLetLambdaClosureProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int -> Int -> Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int -> Int = \\(x : Int) let y : Int = captured in \\(z : Int) y in",
+      "    f;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -653,6 +653,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "lowers type-abstracted top-level closure calls through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourcePolymorphicTopLevelClosureCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private ptr @\"Main__maker"
+    output `shouldSatisfy` isInfixOf "call ptr @\"Main__maker"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "lowers top-level closure values passed as function arguments" $ do
     output <-
       withTempProgram sourceTopLevelClosureArgumentProgram $ \path ->
@@ -660,6 +671,17 @@ spec = describe "MLF.Backend.LLVM" $ do
 
     output `shouldSatisfy` isInfixOf "call ptr @\"Main__maker\"()"
     output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "lowers closure-valued function parameters through nested let aliases" $ do
+    output <-
+      withTempProgram sourceFunctionParameterNestedClosureAliasCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "BackendClosureCallExpectedClosureValue"
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
@@ -3015,6 +3037,15 @@ sourceTopLevelClosureCallProgram =
       "}"
     ]
 
+sourcePolymorphicTopLevelClosureCallProgram :: String
+sourcePolymorphicTopLevelClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def maker : forall a. a -> Int = let captured : Int = 41 in \\(x : a) captured;",
+      "  def main : Int = maker 0;",
+      "}"
+    ]
+
 sourceTopLevelClosureArgumentProgram :: String
 sourceTopLevelClosureArgumentProgram =
   unlines
@@ -3022,6 +3053,20 @@ sourceTopLevelClosureArgumentProgram =
       "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
       "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
       "  def main : Int = use maker;",
+      "}"
+    ]
+
+sourceFunctionParameterNestedClosureAliasCallProgram :: String
+sourceFunctionParameterNestedClosureAliasCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int)",
+      "    let g : Int -> Int = (let h : Int -> Int = f in h) in",
+      "    g 1;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -673,6 +673,9 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "\", i64 %\""
     validateLLVMAssembly output
 
+  it "preserves shadowed lambda parameters collected through lets" $
+    assertNativeProgram sourceReturnedLetLambdaShadowingProgram "7"
+
   it "lowers zero-capture closures through the explicit closure ABI" $ do
     output <- requireRight (renderBackendProgramLLVM zeroCaptureClosureProgram)
 
@@ -3021,6 +3024,15 @@ sourceReturnedLetLambdaClosureProgram =
       "    let captured : Int = 41 in",
       "    let f : Int -> Int -> Int = \\(x : Int) let y : Int = captured in \\(z : Int) y in",
       "    f;",
+      "}"
+    ]
+
+sourceReturnedLetLambdaShadowingProgram :: String
+sourceReturnedLetLambdaShadowingProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def make : Int -> Int = let y : Int = 1 in \\(y : Int) y;",
+      "  def main : Int = make 7;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -676,6 +676,15 @@ spec = describe "MLF.Backend.LLVM" $ do
   it "preserves shadowed lambda parameters collected through lets" $
     assertNativeProgram sourceReturnedLetLambdaShadowingProgram "7"
 
+  it "rejects source closure-valued constructor fields before LLVM emission" $ do
+    result <- withTempProgram sourceClosureValuedConstructorFieldProgram emitBackendFile
+
+    case result of
+      Left err ->
+        err `shouldSatisfy` isInfixOf "closure-valued constructor field"
+      Right output ->
+        expectationFailure ("expected closure-valued constructor field rejection, got output:\n" ++ output)
+
   it "lowers zero-capture closures through the explicit closure ABI" $ do
     output <- requireRight (renderBackendProgramLLVM zeroCaptureClosureProgram)
 
@@ -3033,6 +3042,18 @@ sourceReturnedLetLambdaShadowingProgram =
     [ "module Main export (main) {",
       "  def make : Int -> Int = let y : Int = 1 in \\(y : Int) y;",
       "  def main : Int = make 7;",
+      "}"
+    ]
+
+sourceClosureValuedConstructorFieldProgram :: String
+sourceClosureValuedConstructorFieldProgram =
+  unlines
+    [ "module Main export (FnBox(..), main) {",
+      "  data FnBox = FnBox : (Int -> Int) -> FnBox;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    case FnBox f of { FnBox g -> g 0 };",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -605,6 +605,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "lowers closure-valued function parameters through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceFunctionParameterClosureCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.malloc"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "lowers source-level returned closure values as pointer results" $ do
     output <-
       withTempProgram sourceReturnedClosureProgram $ \path ->
@@ -2912,6 +2923,18 @@ sourceCapturedClosureCallProgram =
       "    let f : Int -> Int = \\(x : Int) captured in",
       "    let g : Int -> Int = f in",
       "    g 0;",
+      "}"
+    ]
+
+sourceFunctionParameterClosureCallProgram :: String
+sourceFunctionParameterClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def use : (Int -> Int) -> Int = \\(f : Int -> Int) f 1;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let f : Int -> Int = \\(x : Int) captured in",
+      "    use f;",
       "}"
     ]
 

--- a/test/golden/backend-ir-adt-case.golden
+++ b/test/golden/backend-ir-adt-case.golden
@@ -29,11 +29,12 @@ backend-program
                       body:
                         lam $Succ_k2 : (mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> ((mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1) -> $a1)
                           body:
-                            app : $a1
+                            closure-call : $a1
                               function:
                                 var $Succ_k2 : (mu $Main.Nat_self. forall $$Nat_result. ($$Nat_result -> (($$Main.Nat_self -> $$Nat_result) -> $$Nat_result)) -> $a1)
-                              argument:
-                                var $Succ_arg1 : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
+                              arguments:
+                                arg 0:
+                                  var $Succ_arg1 : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
         binding Main__main : mu $Main.Nat_self. forall $$Main.Nat_result. ($$Main.Nat_result -> (($$Main.Nat_self -> $$Main.Nat_result) -> $$Main.Nat_result))
           exported-main: true
           expr:


### PR DESCRIPTION
Closes #95.

## Implementation Plan

---
issue_number: 95
pr_number: 112
branch: codex/issue-95
---

## Implementation Plan

Evidence inspected: issue #95 is open and asks for closure conversion of ordinary escaping lambdas and closure-valued calls; PR #112 is open from `codex/issue-95` to `master`; the branch is clean apart from the watcher start commit. `MLF.Backend.IR` already has `BackendClosure` and `BackendClosureCall`, and `MLF.Backend.LLVM.Lower` already lowers explicit closure IR. The missing work is in the checked-program conversion path, where `MLF.Backend.Convert` still emits ordinary `BackendLam`/`BackendApp` shapes for source lambdas and applications.

1. Reconfirm preconditions in the implementation turn: read the watcher-written issue plan, verify `git status --short --branch`, confirm PR #112 still targets `codex/issue-95`, and do not touch watcher-owned runtime files.

2. Add failing tests first. In `test/BackendConvertSpec.hs`, add source-level checked-program cases for: a function value returned across a let boundary, a local function stored/aliased in another variable, a closure-valued call through one or more lets, and a guard that direct first-order calls still produce `BackendApp`/direct function IR where they are non-escaping. In `test/BackendLLVMSpec.hs` or the ProgramSpec-to-LLVM parity matrix, add source-to-LLVM success coverage that validates with `llvm-as`; mark at least one representative closure case for the existing object-code smoke path. Keep the raw explicit-IR `BackendLam` escaping rejection as a fail-closed guard unless a source-level rejection test is found and converted.

3. Implement closure conversion in `src/MLF/Backend/Convert.hs`. Add a small conversion context/state for closure-valued locals and fresh closure entry names, using deterministic names based on the current binding plus an index and avoiding global/generated collisions. Preserve the leading lambda spine of top-level and otherwise direct first-order function bodies so existing direct calls remain direct. For lambdas in value/escaping positions, collect the leading lambda parameters, compute free lexical term captures from the conversion environment, convert capture expressions and the body with captures/params in scope, and emit `BackendClosure` with the original arrow type.

4. Add let-use escape handling. For local let RHSs that are function values, keep the existing direct local-function shape when every use is a direct first-order call. Closure-convert the RHS and mark the binder closure-valued when it is returned, aliased, stored, captured, or otherwise used as a value. Propagate closure-valued shape through simple let aliases so calls across let boundaries become `BackendClosureCall`.

5. Rewrite closure calls during conversion. When converting an application whose callee is a definite closure value or a closure-valued local, collect the full value-argument spine and emit `BackendClosureCall`; leave global/direct local/immediate lambda call heads as `BackendApp`. Continue to fail closed for out-of-scope partial-application packaging, function-valued ADT field representation requiring captured environments, and recursive higher-order flows unless they are already supported by the existing explicit IR/lowering path.

6. Adjust LLVM lowering only where explicit closure values require it. Keep `lowerBackendType` strict for ordinary arrow types, but add/use a runtime-result helper that maps arrow-valued explicit closure results to `LLVMPtr` for closure-call results and functions that return explicit closures. Do not weaken the raw escaping `BackendLam` rejection.

7. Update durable docs for the changed boundary. In `docs/architecture.md`, replace the statement that full source-to-source closure conversion is future work with the narrower current state: ordinary checked-program escaping lambdas and closure calls are converted to explicit backend closure IR, while partial application, function-valued ADT fields needing captured environments, and recursive higher-order flows remain future/fail-closed. Add a concise `CHANGELOG.md` entry because this is meaningful backend progress.

8. Validate in increasing scope: run focused BackendConvert tests for the new conversion cases, focused BackendLLVM/parity tests for closure LLVM emission, then `cabal build all && cabal test` before reporting implementation complete. If LLVM tools are missing, record which `llvm-as`/object-code validations were skipped by the test harness.

9. Publish in the implementation turn only after validation: run `gh auth status` and `gh auth setup-git`, inspect `git status --short` and relevant diffs, stage only issue-related source/test/docs files, commit as the prepared `codex-watcher` identity with an imperative message, and push `codex/issue-95` to update PR #112.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.