### PR TITLE
Implement #101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   tests can now discover `llc` plus a native linker, build a temporary
   executable from emitted `.ll`, run it, and capture stdout, stderr, and exit
   status while skipping explicitly when tools are unavailable.
+- Added native executable checks for supported shared `ProgramSpec`-to-LLVM
+  parity rows. The backend LLVM spec now compiles, links, runs, and compares
+  supported rows against their interpreter result text, while native-unsupported
+  rows are explicitly classified with diagnostic fragments.
 
 ### Changed
 - LLVM case lowering now treats closure-valued case results as closure

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,14 @@
+## 2026-04-30 - Native execution for supported LLVM parity rows
+
+- Extended `BackendLLVMSpec` so supported shared `ProgramSpec`-to-LLVM parity
+  rows emit native-entrypoint LLVM, validate it, compile/link/run it through the
+  native toolchain helper, and compare stdout/stderr/exit status against the
+  same runtime expectations used by `ProgramSpec`.
+- Native-unsupported parity rows are now named in one explicit map with expected
+  diagnostic fragments. The remaining predicate rows that require rendering
+  function values stay rejected before native execution instead of silently
+  remaining assembly-only.
+
 ## 2026-04-30 - Nullary local evidence for parameterized result aliases
 
 - Tightened nullary overloaded method finalization so placeholder type

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -36,6 +36,7 @@ import Parity.ProgramMatrix
     ProgramMatrixExpectation (..),
     ProgramMatrixSource (..),
     ProgramRuntimeCase (..),
+    ProgramRuntimeExpectation (..),
     emlfSurfaceParityMatrix,
     programSpecToLLVMParityCases,
     unifiedFixtureExpectations,
@@ -579,9 +580,14 @@ spec = describe "MLF.Backend.LLVM" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
           uniqueCaseNames = Set.fromList caseNames
           objectCodeNames = Set.fromList llvmObjectCodeParityCases
+          nativeUnsupportedNames = Map.keysSet llvmNativeUnsupportedParityCases
+          nativeRepresentativeNames = Set.fromList llvmNativeRepresentativeParityCases
 
       length caseNames `shouldBe` Set.size uniqueCaseNames
       objectCodeNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
+      nativeUnsupportedNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
+      nativeRepresentativeNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
+      nativeRepresentativeNames `Set.disjoint` nativeUnsupportedNames `shouldBe` True
       Map.keysSet llvmParityExpectations `shouldBe` uniqueCaseNames
 
     mapM_ runLLVMParityCase programSpecToLLVMParityCases
@@ -3597,14 +3603,40 @@ recIntTy =
   BTMu "self" intTy
 
 data LLVMParityExpectation
-  = ExpectLLVMAssembly
+  = ExpectLLVMNativeRun
+  | ExpectLLVMNativeUnsupported String
 
 llvmParityExpectations :: Map.Map String LLVMParityExpectation
 llvmParityExpectations =
   Map.fromList
-    [ (runtimeCaseName runtimeCase, ExpectLLVMAssembly)
+    [ ( runtimeCaseName runtimeCase,
+        case Map.lookup (runtimeCaseName runtimeCase) llvmNativeUnsupportedParityCases of
+          Just reason -> ExpectLLVMNativeUnsupported reason
+          Nothing -> ExpectLLVMNativeRun
+      )
     | runtimeCase <- programSpecToLLVMParityCases
     ]
+
+llvmNativeUnsupportedParityCases :: Map.Map String String
+llvmNativeUnsupportedParityCases =
+  Map.fromList
+    [ ( "standalone: does not decode non-data main values through fallback ADT decoding",
+        "main must be a zero-argument pure value"
+      ),
+      ( "standalone: does not decode typed non-data constructor fields through fallback ADT decoding",
+        "function main values are not native-renderable"
+      )
+    ]
+
+llvmNativeRepresentativeParityCases :: [String]
+llvmNativeRepresentativeParityCases =
+  [ "surface: runs lambda/application",
+    "surface: runs let polymorphism at Int and Bool",
+    "unified fixture: test/programs/unified/authoritative-case-analysis.mlfp",
+    "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp",
+    "unified fixture: test/programs/unified/authoritative-overloaded-method.mlfp",
+    "unified fixture: test/programs/unified/first-class-polymorphism.mlfp"
+  ]
 
 llvmObjectCodeParityCases :: [String]
 llvmObjectCodeParityCases =
@@ -3629,11 +3661,33 @@ runLLVMParityCase runtimeCase =
     case Map.lookup (runtimeCaseName runtimeCase) llvmParityExpectations of
       Nothing ->
         expectationFailure ("missing LLVM parity expectation for " ++ runtimeCaseName runtimeCase)
-      Just ExpectLLVMAssembly -> do
+      Just ExpectLLVMNativeRun -> do
         output <- requireRight result
         validateLLVMAssembly output
         when (runtimeCaseName runtimeCase `Set.member` llvmObjectCodeParityCaseNames) $
           validateLLVMObjectCode output
+        nativeOutput <- requireRight =<< emitProgramRuntimeNativeLLVM (runtimeCaseSource runtimeCase)
+        validateLLVMAssembly nativeOutput
+        validateLLVMObjectCode nativeOutput
+        nativeResult <- runLLVMNativeExecutable nativeOutput
+        assertNativeRuntimeResult (runtimeCaseExpectation runtimeCase) nativeResult
+      Just (ExpectLLVMNativeUnsupported fragment) -> do
+        output <- requireRight result
+        validateLLVMAssembly output
+        when (runtimeCaseName runtimeCase `Set.member` llvmObjectCodeParityCaseNames) $
+          validateLLVMObjectCode output
+        nativeResult <- emitProgramRuntimeNativeLLVM (runtimeCaseSource runtimeCase)
+        case nativeResult of
+          Left err ->
+            err `shouldSatisfy` isInfixOf fragment
+          Right nativeOutput ->
+            expectationFailure $
+              "expected native LLVM emission to reject "
+                ++ runtimeCaseName runtimeCase
+                ++ " with "
+                ++ show fragment
+                ++ ", but it emitted:\n"
+                ++ nativeOutput
 
 emitProgramRuntimeLLVM :: ProgramMatrixSource -> IO (Either String String)
 emitProgramRuntimeLLVM source =
@@ -3642,6 +3696,69 @@ emitProgramRuntimeLLVM source =
       withTempProgram programText emitBackendFile
     ProgramFile path ->
       emitBackendFile path
+
+emitProgramRuntimeNativeLLVM :: ProgramMatrixSource -> IO (Either String String)
+emitProgramRuntimeNativeLLVM source =
+  case source of
+    InlineProgram programText ->
+      withTempProgram programText emitNativeFile
+    ProgramFile path ->
+      emitNativeFile path
+
+assertNativeRuntimeResult :: ProgramRuntimeExpectation -> NativeRunResult -> Expectation
+assertNativeRuntimeResult expectation result =
+  case expectation of
+    ExpectRuntimeValue expectedValue -> do
+      when (nativeRunExitCode result /= ExitSuccess) $
+        expectationFailure $
+          nativeRunMismatch
+            ("expected native process exit success for value " ++ show expectedValue)
+            result
+      when (nativeRunStdout result /= expectedValue ++ "\n") $
+        expectationFailure $
+          nativeRunMismatch
+            ("expected stdout " ++ show (expectedValue ++ "\n"))
+            result
+      when (nativeRunStderr result /= "") $
+        expectationFailure $
+          nativeRunMismatch "expected empty stderr" result
+    ExpectRuntimePredicate label predicate -> do
+      when (nativeRunExitCode result /= ExitSuccess) $
+        expectationFailure $
+          nativeRunMismatch
+            ("expected native process exit success for predicate " ++ label)
+            result
+      when (nativeRunStderr result /= "") $
+        expectationFailure $
+          nativeRunMismatch "expected empty stderr" result
+      case stripSingleTrailingNewline (nativeRunStdout result) of
+        Nothing ->
+          expectationFailure $
+            nativeRunMismatch "expected stdout with one trailing newline" result
+        Just rendered
+          | predicate rendered -> pure ()
+          | otherwise ->
+              expectationFailure $
+                nativeRunMismatch
+                  ("expected " ++ label ++ ", got " ++ show rendered)
+                  result
+
+stripSingleTrailingNewline :: String -> Maybe String
+stripSingleTrailingNewline output =
+  case reverse output of
+    '\n' : rest -> Just (reverse rest)
+    _ -> Nothing
+
+nativeRunMismatch :: String -> NativeRunResult -> String
+nativeRunMismatch label result =
+  unlines
+    [ label,
+      "exit code: " ++ show (nativeRunExitCode result),
+      "stdout:",
+      nativeRunStdout result,
+      "stderr:",
+      nativeRunStderr result
+    ]
 
 requireChecked :: String -> IO CheckedProgram
 requireChecked input =


### PR DESCRIPTION
Closes #101.

## Implementation Plan

---
issue_number: 101
pr_number: 113
branch: codex/issue-101
---

## Implementation Plan

1. Confirm the implementation turn starts on `codex/issue-101` with PR #113 open, a clean worktree, and `origin/HEAD` as the base. Before publishing, run `gh auth status` and `gh auth setup-git`.

2. In `test/BackendLLVMSpec.hs`, extend the `ProgramSpec-to-LLVM parity matrix` so each `programSpecToLLVMParityCases` row still emits raw LLVM, validates with `llvm-as`, and keeps the existing selected `llc` object-code checks.

3. Replace the current all-assembly-only `LLVMParityExpectation` with an explicit native policy: default every parity case to native-run unless its name appears in a small `llvmNativeUnsupportedParityCases :: Map String String` with a reason/error fragment. Keep a guard that the unsupported map is a subset of the parity case names, and that every parity case is classified exactly once.

4. Add native helpers in `BackendLLVMSpec`: `emitProgramRuntimeNativeLLVM` using `emitNativeFile`; `assertNativeRuntimeResult` comparing `NativeRunResult` against `ProgramRuntimeExpectation`; and mismatch messages that include exit code, stdout, and stderr. For `ExpectRuntimeValue expected`, require `ExitSuccess`, stdout `expected ++ "\n"`, and empty stderr. For predicate expectations, either classify unsupported or apply the predicate to stdout with the single trailing newline removed.

5. In `runLLVMParityCase`, after raw LLVM validation, branch on the native policy. Native-supported rows should emit native LLVM, validate assembly/object, run via `runLLVMNativeExecutable`, and compare against the shared ProgramSpec expectation. Native-unsupported rows should assert `emitNativeFile` fails with the recorded fragment rather than silently skipping native execution.

6. Seed the native-unsupported map with the current ProgramSpec predicate rows that the native renderer deliberately rejects: `standalone: does not decode non-data main values through fallback ADT decoding` and `standalone: does not decode typed non-data constructor fields through fallback ADT decoding`, using the existing fragment `function main values are not native-renderable` unless implementation inspection shows a more exact emitted diagnostic.

7. Add a focused representative guard list for the issue acceptance surface, ensuring native-run policy covers at least integer, boolean, constructor/case ADT, recursive ADT, typeclass/evidence, and first-class-polymorphism rows. Good candidate names include `surface: runs lambda/application`, `surface: runs let polymorphism at Int and Bool`, `unified fixture: test/programs/unified/authoritative-case-analysis.mlfp`, `unified fixture: test/programs/unified/authoritative-recursive-let.mlfp`, `unified fixture: test/programs/unified/authoritative-overloaded-method.mlfp`, and `unified fixture: test/programs/unified/first-class-polymorphism.mlfp`.

8. Update `CHANGELOG.md` and `implementation_notes.md` with a short note that supported ProgramSpec-to-LLVM parity rows now native-run through linked executables, while unsupported native rows are explicitly classified.

9. Validate with a focused test first, for example `cabal test mlf2-test --test-options='--match "ProgramSpec-to-LLVM parity matrix"'`, then run the required full gate `cabal build all && cabal test`. If native LLVM tools or a C linker are missing, confirm tests are marked pending rather than failing.

10. Inspect `git status --short` and relevant diffs, stage only issue-related files, commit with the prepared `codex-watcher` identity, push `codex/issue-101`, and leave PR #113 ready for watcher handoff. Do not create a duplicate PR or resolve review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.