### PR TITLE
Implement #94

### DIFF
--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2894,7 +2894,7 @@ lowerClosureValue env exprEnv context resultTy entryName captures = do
 
 lowerClosureCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> [BackendExpr] -> LowerM LowerValue
 lowerClosureCall env exprEnv context resultTy fun args = do
-  callee <- lowerExpr env exprEnv context fun
+  callee <- lowerClosureCallee env exprEnv context fun
   unless (lvLLVMType callee == LLVMPtr) $
     liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a pointer: " ++ show (lvBackendType callee)))
   let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
@@ -2923,6 +2923,15 @@ lowerClosureCall env exprEnv context resultTy fun args = do
   where
     lowerClosureArg (index0, paramTy) arg =
       lowerExprForIndirectArgument env exprEnv context ("__mlfp_closure_arg" ++ show index0, paramTy) arg
+
+lowerClosureCallee :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
+lowerClosureCallee env exprEnv context =
+  \case
+    BackendLet _ name _ rhs body -> do
+      exprEnv' <- bindLet env exprEnv context name rhs
+      lowerClosureCallee env exprEnv' context body
+    expr ->
+      lowerExpr env exprEnv context expr
 
 lowerCall :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
 lowerCall env exprEnv context expr =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -621,6 +621,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
     validateLLVMAssembly output
 
+  it "lowers let-selected closure callees through the explicit closure ABI" $ do
+    output <- requireRight (renderBackendProgramLLVM letSelectedClosureCalleeProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$let_callee\"(ptr %\"__mlfp_env\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$let_callee\""
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+
   it "qualifies closure entry names emitted from type specializations" $ do
     output <- requireRight (renderBackendProgramLLVM polymorphicClosureSpecializationProgram)
 
@@ -2948,6 +2956,27 @@ caseSelectedClosureCalleeProgram =
           backendClosureParams = [("x", intTy)],
           backendClosureBody = body
         }
+
+letSelectedClosureCalleeProgram :: BackendProgram
+letSelectedClosureCalleeProgram =
+  programWithMainExpr intTy $
+    BackendClosureCall
+      intTy
+      ( BackendLet
+          unaryIntTy
+          "f"
+          unaryIntTy
+          ( BackendClosure
+              { backendExprType = unaryIntTy,
+                backendClosureEntryName = "__mlfp_closure$let_callee",
+                backendClosureCaptures = [],
+                backendClosureParams = [("x", intTy)],
+                backendClosureBody = BackendVar intTy "x"
+              }
+          )
+          (BackendVar unaryIntTy "f")
+      )
+      [intLit 7]
 
 polymorphicClosureSpecializationProgram :: BackendProgram
 polymorphicClosureSpecializationProgram =


### PR DESCRIPTION
Closes #94.

## Implementation Plan

---
issue_number: 94
pr_number: 114
branch: codex/issue-94-3
---

## Implementation Plan

Context verified: issue #94 is open, PR #114 is open against `master`, and the local branch is `codex/issue-94-3` at `origin/codex/issue-94-3` with no local file changes. The reopened finding is specifically a validation/lowering mismatch for `BackendClosureCall` where the callee is a `BackendLet` returning an arrow-typed closure value.

1. Before editing in the implementation turn, read `/workspace/artifacts/issue-implementers/soulomoon_mlf2__issue94/issue-plan.md`, confirm `git status --short --branch` is clean enough to stage safely, and keep using the existing PR branch `codex/issue-94-3`.
2. Add a regression in `test/BackendLLVMSpec.hs` near the existing closure ABI tests. The test should construct a `BackendClosureCall intTy` whose callee expression is itself `BackendLet unaryIntTy "f" unaryIntTy <BackendClosure ...> (BackendVar unaryIntTy "f")`, assert `renderBackendProgramLLVM` succeeds, check for the closure entry/store/indirect call shape, and validate the generated LLVM assembly.
3. Implement the lowering fix in `src/MLF/Backend/LLVM/Lower.hs` by routing `lowerClosureCall` through a closure-callee-specific helper instead of directly calling generic `lowerExpr` on the callee.
4. The helper should handle `BackendLet _ name _ rhs body` by calling `bindLet` for the RHS and then recursively lowering the let body as a closure callee. This avoids the generic `BackendLet` path calling `lowerBackendTypeM` on an arrow result while preserving existing let binding semantics.
5. Delegate non-let callees to existing lowering paths, so case-shaped closure callees keep using `lowerCaseResultTypeM`, direct closure values/vars behave as before, and generic arrow-valued lets outside closure-callee context remain rejected by the existing partial-application and escaping-lambda tests.
6. Keep the existing pointer/type checks in `lowerClosureCall` after callee lowering: require `LLVMPtr`, collect arrow parameter/result types from `lvBackendType`, lower arguments with `lowerExprForIndirectArgument`, and emit the same closure ABI loads/call.
7. Run focused validation first: `cabal test mlf2-test --test-options='--match "let-selected closure callees"'` or the exact new test name. Then run the surrounding backend LLVM slice with an Hspec match for `MLF.Backend.LLVM` or the closure-related examples.
8. Run the full required gate before completion: `cabal build all && cabal test`.
9. Inspect `git status --short` and relevant diffs, stage only `src/MLF/Backend/LLVM/Lower.hs` and `test/BackendLLVMSpec.hs`, commit as `codex-watcher <codex-watcher@users.noreply.github.com>` with an imperative message such as `Lower let-selected closure callees`, then run `gh auth status`, `gh auth setup-git`, and push `codex/issue-94-3` to the existing PR #114 without creating a duplicate PR.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.