### PR TITLE
Implement #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@
 
 ### Changed
 - Fixed higher-order checked-source partial applications so supplied
-  closure-valued arguments and closure-demanded partial callees stay on the
-  explicit closure ABI instead of falling back to static function lowering.
+  closure-valued arguments, alias-propagated closure-demanded parameters, local
+  helper demands, and non-variable partial callees stay on the explicit closure
+  ABI instead of falling back to static function lowering.
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
   without rejecting the callee's arrow result type. Closure-valued let aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   closure-valued arguments, alias-propagated closure-demanded parameters, local
   helper demands, and non-variable partial callees stay on the explicit closure
   ABI instead of falling back to static function lowering.
+- Fixed checked-source partial applications with supplied polymorphic function
+  values so they stay on the static specialization path instead of being
+  captured into runtime closure environments.
 - Fixed packaged partial-application argument conversion so direct supplied
   functions are wrapped as closure values before capture, and direct-function
   closure wrappers capture free locals from inline function expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 - Fixed checked-source partial applications with supplied polymorphic function
   values so they stay on the static specialization path instead of being
   captured into runtime closure environments.
+- Fixed checked-source partial applications with supplied higher-rank function
+  values so non-first-order function parameters also stay on static lowering
+  instead of being captured into unsupported closure entries.
 - Fixed packaged partial-application argument conversion so direct supplied
   functions are wrapped as closure values before capture, and direct-function
   closure wrappers capture free locals from inline function expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   rows are explicitly classified with diagnostic fragments.
 
 ### Changed
+- Fixed higher-order checked-source partial applications so supplied
+  closure-valued arguments and closure-demanded partial callees stay on the
+  explicit closure ABI instead of falling back to static function lowering.
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
   without rejecting the callee's arrow result type. Closure-valued let aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   entering the closure ABI.
 - Freshened generated partial-closure capture and parameter names against
   in-scope binders so source names cannot collide with backend-generated slots.
+- Propagated closure-demanded argument indices through simple let-wrapped
+  function aliases before backend partial-application packaging.
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
   without rejecting the callee's arrow result type. Closure-valued let aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Added LLVM backend support for checked-source partial applications by
+  packaging supplied arguments into explicit closure values. Top-level and local
+  function partials now participate in the shared ProgramSpec-to-LLVM parity
+  matrix with assembly, object-code, and native execution coverage where the
+  local LLVM toolchain is available.
 - Added checked-program closure conversion for ordinary monomorphic escaping
   `.mlfp` lambdas and closure-valued let aliases. Backend conversion now emits
   explicit `BackendClosure` / `BackendClosureCall` IR for returned local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   closure-valued arguments, alias-propagated closure-demanded parameters, local
   helper demands, and non-variable partial callees stay on the explicit closure
   ABI instead of falling back to static function lowering.
+- Fixed packaged partial-application argument conversion so direct supplied
+  functions are wrapped as closure values before capture, and direct-function
+  closure wrappers capture free locals from inline function expressions.
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
   without rejecting the callee's arrow result type. Closure-valued let aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 - Fixed packaged partial-application argument conversion so direct supplied
   functions are wrapped as closure values before capture, and direct-function
   closure wrappers capture free locals from inline function expressions.
+- Fixed closure-demanded call argument conversion after hidden evidence
+  arguments so later direct function arguments are still wrapped before
+  entering the closure ABI.
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
   without rejecting the callee's arrow result type. Closure-valued let aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - Fixed closure-demanded call argument conversion after hidden evidence
   arguments so later direct function arguments are still wrapped before
   entering the closure ABI.
+- Freshened generated partial-closure capture and parameter names against
+  in-scope binders so source names cannot collide with backend-generated slots.
 - LLVM case lowering now treats closure-valued case results as closure
   pointers, so `BackendClosureCall` can use a case-selected closure callee
   without rejecting the callee's arrow result type. Closure-valued let aliases

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,14 +192,14 @@ the existing direct-call path; indirect calls must be represented with
 `BackendClosureCall`.
 
 Checked-program conversion now closure-converts ordinary monomorphic escaping
-source lambdas, returned local function values, closure-valued let aliases, and
-indirect calls through those aliases into explicit closure IR. Direct
-first-order local calls remain direct backend applications. Partial application
-lowering, higher-order constructor fields that require captured environments,
-recursive higher-order flows, and final executable linking remain future
-extension points. Those diagnostics do not weaken source inference, checking,
-module visibility, or runtime semantics; they only describe the current
-IR-to-LLVM lowering surface.
+source lambdas, returned local function values, closure-valued let aliases,
+partial applications that produce function values, and indirect calls through
+those closure values into explicit closure IR. Direct first-order local calls
+remain direct backend applications. Higher-order constructor fields that require
+captured environments, recursive higher-order flows, and final executable
+linking remain future extension points. Those diagnostics do not weaken source
+inference, checking, module visibility, or runtime semantics; they only describe
+the current IR-to-LLVM lowering surface.
 
 ## `Solved` boundary and thesis-exact cleanup rule
 

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,17 @@
+## 2026-04-30 - Partial applications lower as closure values
+
+- Checked-program conversion now packages underapplied monomorphic function
+  calls as explicit `BackendClosure` values that capture supplied arguments and
+  apply the remaining value parameters later. Saturated calls stay on the
+  existing direct or closure-call paths.
+- Local function bindings used through underapplication are closure-converted
+  so the packaged partial captures a closure pointer instead of referencing a
+  local helper from a separate closure entry. Existing typeclass/evidence
+  partial rows stay on the evidence-aware lowering path.
+- LLVM parity coverage now includes top-level and local partial application
+  rows, with `llvm-as`, object-code smoke, and native execution coverage when
+  the local LLVM toolchain is available.
+
 ## 2026-04-30 - Native execution for supported LLVM parity rows
 
 - Extended `BackendLLVMSpec` so supported shared `ProgramSpec`-to-LLVM parity

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -31,6 +31,9 @@
 - Generated partial-closure capture and parameter names are freshened against
   visible source binders and globals before packaging, preventing source
   bindings from colliding with backend-generated closure slots.
+- Closure-demand alias analysis looks through simple let-wrapped aliases such
+  as `let f = use in f`, preserving supplied-argument offsets while propagating
+  demanded closure-value parameters.
 - LLVM parity coverage now includes top-level and local partial application
   rows, with `llvm-as`, object-code smoke, and native execution coverage when
   the local LLVM toolchain is available.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -22,6 +22,9 @@
 - Supplied polymorphic function values remain on the existing static
   specialization path instead of becoming partial-closure captures, because
   runtime closure environments do not store `forall` values directly.
+- Supplied higher-rank function values follow the same boundary: only
+  first-order function-pointer shapes are wrapped and captured in partial
+  closures, matching the LLVM lowerer's stored-function representation.
 - LLVM parity coverage now includes top-level and local partial application
   rows, with `llvm-as`, object-code smoke, and native execution coverage when
   the local LLVM toolchain is available.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -8,6 +8,10 @@
   closure. When a callee parameter is later underapplied, direct function
   arguments are first wrapped as closure values so the generated partial
   closure does not mix raw function pointers with closure-record calls.
+- Closure-value argument demand is propagated through top-level aliases and
+  local let-bound helpers. Non-variable partial callees beta-normalize immediate
+  lambda heads and capture local free variables before their closure entry is
+  emitted, so generated entries do not reference out-of-scope locals.
 - Local function bindings used through underapplication are closure-converted
   so the packaged partial captures a closure pointer instead of referencing a
   local helper from a separate closure entry. Existing typeclass/evidence

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -4,6 +4,10 @@
   calls as explicit `BackendClosure` values that capture supplied arguments and
   apply the remaining value parameters later. Saturated calls stay on the
   existing direct or closure-call paths.
+- Higher-order partials keep function-typed supplied arguments in the packaged
+  closure. When a callee parameter is later underapplied, direct function
+  arguments are first wrapped as closure values so the generated partial
+  closure does not mix raw function pointers with closure-record calls.
 - Local function bindings used through underapplication are closure-converted
   so the packaged partial captures a closure pointer instead of referencing a
   local helper from a separate closure entry. Existing typeclass/evidence

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -19,6 +19,9 @@
   so the packaged partial captures a closure pointer instead of referencing a
   local helper from a separate closure entry. Existing typeclass/evidence
   partial rows stay on the evidence-aware lowering path.
+- Supplied polymorphic function values remain on the existing static
+  specialization path instead of becoming partial-closure captures, because
+  runtime closure environments do not store `forall` values directly.
 - LLVM parity coverage now includes top-level and local partial application
   rows, with `llvm-as`, object-code smoke, and native execution coverage when
   the local LLVM toolchain is available.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -25,6 +25,9 @@
 - Supplied higher-rank function values follow the same boundary: only
   first-order function-pointer shapes are wrapped and captured in partial
   closures, matching the LLVM lowerer's stored-function representation.
+- Ordinary call conversion treats hidden evidence arguments by their exact
+  argument index, so evidence already supplied in a call spine does not suppress
+  closure wrapping for a later closure-demanded function argument.
 - LLVM parity coverage now includes top-level and local partial application
   rows, with `llvm-as`, object-code smoke, and native execution coverage when
   the local LLVM toolchain is available.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -8,6 +8,9 @@
   closure. When a callee parameter is later underapplied, direct function
   arguments are first wrapped as closure values so the generated partial
   closure does not mix raw function pointers with closure-record calls.
+- Direct function wrappers created for closure-demanded arguments now capture
+  local free variables from inline function expressions, so the generated
+  closure entry does not reference names outside its closure environment.
 - Closure-value argument demand is propagated through top-level aliases and
   local let-bound helpers. Non-variable partial callees beta-normalize immediate
   lambda heads and capture local free variables before their closure entry is

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -28,6 +28,9 @@
 - Ordinary call conversion treats hidden evidence arguments by their exact
   argument index, so evidence already supplied in a call spine does not suppress
   closure wrapping for a later closure-demanded function argument.
+- Generated partial-closure capture and parameter names are freshened against
+  visible source binders and globals before packaging, preventing source
+  bindings from colliding with backend-generated closure slots.
 - LLVM parity coverage now includes top-level and local partial application
   rows, with `llvm-as`, object-code smoke, and native execution coverage when
   the local LLVM toolchain is available.

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1410,10 +1410,11 @@ aliasedClosureValueArguments context scope bindingTy term =
   case stripClosureHeadTypeInsts headTerm of
     EVar name ->
       Set.fromList
-        [ demandedIndex - suppliedCount
+        [ paramOffset + exposedIndex
         | demandedIndex <- Set.toList (lookupClosureValueArgumentDemand context scope name),
+          let exposedIndex = demandedIndex - suppliedCount,
           demandedIndex >= suppliedCount,
-          demandedIndex - suppliedCount < exposedCount
+          exposedIndex < exposedCount
         ]
     _ ->
       Set.empty
@@ -1421,6 +1422,7 @@ aliasedClosureValueArguments context scope bindingTy term =
     (_, valueTy) = splitBackendForalls bindingTy
     (paramTys, _) = splitBackendArrows valueTy
     (params, body) = collectLeadingLams (length paramTys) term
+    paramOffset = length params
     exposedCount = length paramTys - length params
     (headTerm, suppliedArgs) = collectAliasedApps body
     suppliedCount = length suppliedArgs

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -134,6 +134,10 @@ data LambdaMode
   = DirectLambda
   | ClosureLambda (Maybe String)
 
+data PartialApplicationMode
+  = AllowPartialApplications
+  | SuppressPartialApplications
+
 emptyClosureScope :: ClosureScope
 emptyClosureScope =
   ClosureScope
@@ -1781,22 +1785,31 @@ convertTerm context env scope =
   convertTermExpectedMode DirectLambda context env scope Nothing
 
 convertTermExpectedMode :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> Maybe BackendType -> ElabTerm -> ConvertM BackendExpr
-convertTermExpectedMode mode context env scope mbExpectedTy term =
+convertTermExpectedMode =
+  convertTermExpectedModeWith AllowPartialApplications
+
+convertTermExpectedModeNoPartial :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> Maybe BackendType -> ElabTerm -> ConvertM BackendExpr
+convertTermExpectedModeNoPartial =
+  convertTermExpectedModeWith SuppressPartialApplications
+
+convertTermExpectedModeWith :: PartialApplicationMode -> LambdaMode -> ConvertContext -> Env -> ClosureScope -> Maybe BackendType -> ElabTerm -> ConvertM BackendExpr
+convertTermExpectedModeWith partialMode mode context env scope mbExpectedTy term =
   case mbExpectedTy of
     Just resultTy0 ->
       let resultTy = canonicalizeBackendType context resultTy0
-       in convertSpecialTerm mode context env scope term resultTy
+       in convertSpecialTerm partialMode mode context env scope term resultTy
             >>= \case
               Just expr -> pure expr
               Nothing -> convertOrdinaryTerm mode context env scope term resultTy
     Nothing -> do
       resultTy <- canonicalizeBackendType context <$> liftEitherConvert (inferBackendType env term)
-      convertSpecialTerm mode context env scope term resultTy
+      convertSpecialTerm partialMode mode context env scope term resultTy
         >>= \case
           Just expr -> pure expr
           Nothing -> convertOrdinaryTerm mode context env scope term resultTy
 
 convertSpecialTerm ::
+  PartialApplicationMode ->
   LambdaMode ->
   ConvertContext ->
   Env ->
@@ -1804,12 +1817,185 @@ convertSpecialTerm ::
   ElabTerm ->
   BackendType ->
   ConvertM (Maybe BackendExpr)
-convertSpecialTerm mode context env scope term resultTy =
+convertSpecialTerm partialMode mode context env scope term resultTy =
   convertCaseApplication mode context env scope term resultTy
     >>= \case
       Just expr -> pure (Just expr)
       Nothing ->
         convertConstructorApplication mode context env scope term resultTy
+          >>= \case
+            Just expr -> pure (Just expr)
+            Nothing ->
+              case partialMode of
+                AllowPartialApplications -> convertPartialApplication context env scope term resultTy
+                SuppressPartialApplications -> pure Nothing
+
+convertPartialApplication ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  ElabTerm ->
+  BackendType ->
+  ConvertM (Maybe BackendExpr)
+convertPartialApplication context env scope term resultTy =
+  case collectApps term of
+    (headTerm, suppliedArgs)
+      | not (null suppliedArgs),
+        not (isConstructorHeadTerm context headTerm),
+        not (partialApplicationMentionsEvidence term) -> do
+          headTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (inferBackendType env headTerm)
+          let (paramTys, finalTy) = splitBackendArrows headTy
+              suppliedCount = length suppliedArgs
+              suppliedParamTys = take suppliedCount paramTys
+              remainingParamTys = drop suppliedCount paramTys
+              expectedPartialTy = foldr BTArrow finalTy remainingParamTys
+          if suppliedCount < length paramTys
+            && alphaEqBackendType resultTy expectedPartialTy
+            && not (null remainingParamTys)
+            && partialApplicationCanCaptureSuppliedArgs suppliedParamTys
+            then do
+              suppliedArgExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) suppliedParamTys suppliedArgs
+              Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
+            else pure Nothing
+    _ -> pure Nothing
+
+packagePartialApplication ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  BackendType ->
+  [BackendType] ->
+  [BackendExpr] ->
+  [BackendType] ->
+  BackendType ->
+  ConvertM BackendExpr
+packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy = do
+  entryName <- freshClosureEntryName context (partialApplicationHint headTerm)
+  let suppliedCaptures =
+        [ BackendClosureCapture
+            { backendClosureCaptureName = name,
+              backendClosureCaptureType = argTy,
+              backendClosureCaptureExpr = argExpr
+            }
+        | (name, argTy, argExpr) <- zip3 suppliedCaptureNames suppliedParamTys suppliedArgExprs
+        ]
+      remainingParams =
+        [ (name, argTy)
+        | (name, argTy) <- zip remainingParamNames remainingParamTys
+        ]
+      suppliedVars =
+        [ BackendVar argTy name
+        | (name, argTy) <- zip suppliedCaptureNames suppliedParamTys
+        ]
+      remainingVars =
+        [ BackendVar argTy name
+        | (name, argTy) <- remainingParams
+        ]
+      allArgs = suppliedVars ++ remainingVars
+  (captures, body) <-
+    if isClosureHeadTerm context scope headTerm
+      then do
+        funExpr <- convertTermExpectedMode DirectLambda context env scope (Just headTy) headTerm
+        let funCapture =
+              BackendClosureCapture
+                { backendClosureCaptureName = partialFunctionCaptureName,
+                  backendClosureCaptureType = headTy,
+                  backendClosureCaptureExpr = funExpr
+                }
+            funVar = BackendVar headTy partialFunctionCaptureName
+        pure
+          ( funCapture : suppliedCaptures,
+            BackendClosureCall
+              { backendExprType = finalTy,
+                backendClosureFunction = funVar,
+                backendClosureArguments = allArgs
+              }
+          )
+      else do
+        headExpr <- convertTermExpectedMode DirectLambda context env scope (Just headTy) headTerm
+        if backendExprIsClosureValue context scope headExpr
+          then do
+            let funCapture =
+                  BackendClosureCapture
+                    { backendClosureCaptureName = partialFunctionCaptureName,
+                      backendClosureCaptureType = headTy,
+                      backendClosureCaptureExpr = headExpr
+                    }
+                funVar = BackendVar headTy partialFunctionCaptureName
+            pure
+              ( funCapture : suppliedCaptures,
+                BackendClosureCall
+                  { backendExprType = finalTy,
+                    backendClosureFunction = funVar,
+                    backendClosureArguments = allArgs
+                  }
+              )
+          else do
+            bodyExpr <- liftEitherConvert (applyPartialDirectArguments headExpr headTy allArgs)
+            pure (suppliedCaptures, bodyExpr)
+  pure
+    BackendClosure
+      { backendExprType = resultTy,
+        backendClosureEntryName = entryName,
+        backendClosureCaptures = captures,
+        backendClosureParams = remainingParams,
+        backendClosureBody = body
+      }
+  where
+    suppliedCaptureNames =
+      ["__mlfp_partial_capture" ++ show index0 | index0 <- [(0 :: Int) ..]]
+    remainingParamNames =
+      ["__mlfp_partial_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
+
+partialFunctionCaptureName :: String
+partialFunctionCaptureName =
+  "__mlfp_partial_function"
+
+applyPartialDirectArguments :: BackendExpr -> BackendType -> [BackendExpr] -> Either BackendConversionError BackendExpr
+applyPartialDirectArguments headExpr headTy args =
+  go headExpr headTy args
+  where
+    go current _ [] =
+      Right current
+    go current (BTArrow expectedArgTy resultTy) (arg : rest)
+      | alphaEqBackendType expectedArgTy (backendExprType arg) =
+          go (BackendApp resultTy current arg) resultTy rest
+      | otherwise =
+          Left
+            ( BackendUnsupportedCaseShape
+                ( "partial application argument type mismatch: expected "
+                    ++ show expectedArgTy
+                    ++ ", got "
+                    ++ show (backendExprType arg)
+                )
+            )
+    go _ otherTy (_ : _) =
+      Left
+        ( BackendUnsupportedCaseShape
+            ("partial application expected a function type, got " ++ show otherTy)
+        )
+
+partialApplicationHint :: ElabTerm -> String
+partialApplicationHint term =
+  case stripClosureHeadTypeInsts term of
+    EVar name -> name ++ "$partial"
+    _ -> "partial"
+
+isConstructorHeadTerm :: ConvertContext -> ElabTerm -> Bool
+isConstructorHeadTerm context term =
+  case stripClosureHeadTypeInsts term of
+    EVar name -> Map.member name (ccConstructors context)
+    _ -> False
+
+partialApplicationMentionsEvidence :: ElabTerm -> Bool
+partialApplicationMentionsEvidence term =
+  any isEvidenceCaptureName (Set.toList (freeTermVariables term))
+
+partialApplicationCanCaptureSuppliedArgs :: [BackendType] -> Bool
+partialApplicationCanCaptureSuppliedArgs =
+  all (not . isClosureConvertibleFunctionType)
 
 convertOrdinaryTerm :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> ElabTerm -> BackendType -> ConvertM BackendExpr
 convertOrdinaryTerm mode context env scope term resultTy0 =
@@ -1987,12 +2173,21 @@ convertApplicationFromFunction ::
   ElabTerm ->
   ConvertM BackendExpr
 convertApplicationFromFunction context env scope resultTy fun arg = do
-  funExpr <- convertTerm context env scope fun
+  funExpr <- convertTermExpectedModeNoPartial DirectLambda context env scope Nothing fun
   argExpr <-
     case backendExprType funExpr of
       BTArrow expectedArg _ -> convertTermExpectedMode DirectLambda context env scope (Just expectedArg) arg
       _ -> convertTerm context env scope arg
-  pure (backendApplication (applicationResultType resultTy funExpr) funExpr argExpr)
+  let callResultTy = applicationResultType resultTy funExpr
+  if backendExprIsClosureValue context scope funExpr
+    then
+      pure
+        BackendClosureCall
+          { backendExprType = callResultTy,
+            backendClosureFunction = funExpr,
+            backendClosureArguments = [argExpr]
+          }
+    else pure (backendApplication callResultTy funExpr argExpr)
 
 convertApplicationFromExpectedResult ::
   ConvertContext ->
@@ -2005,9 +2200,17 @@ convertApplicationFromExpectedResult ::
 convertApplicationFromExpectedResult context env scope resultTy fun arg = do
   rawArgTy <- liftEitherConvert (inferBackendType env arg)
   let argTy = canonicalizeBackendType context rawArgTy
-  funExpr <- convertTermExpectedMode DirectLambda context env scope (Just (BTArrow argTy resultTy)) fun
+  funExpr <- convertTermExpectedModeNoPartial DirectLambda context env scope (Just (BTArrow argTy resultTy)) fun
   argExpr <- convertTermExpectedMode DirectLambda context env scope (Just argTy) arg
-  pure (backendApplication resultTy funExpr argExpr)
+  if backendExprIsClosureValue context scope funExpr
+    then
+      pure
+        BackendClosureCall
+          { backendExprType = resultTy,
+            backendClosureFunction = funExpr,
+            backendClosureArguments = [argExpr]
+          }
+    else pure (backendApplication resultTy funExpr argExpr)
 
 backendApplication :: BackendType -> BackendExpr -> BackendExpr -> BackendExpr
 backendApplication resultTy funExpr argExpr =
@@ -2069,7 +2272,13 @@ isImmediateLambda =
 letBindingNeedsClosure :: ConvertContext -> ClosureScope -> String -> BackendType -> ElabTerm -> ElabTerm -> Bool
 letBindingNeedsClosure context scope name bindingTy rhs body =
   isClosureConvertibleFunctionType bindingTy
-    && (isClosureAliasTerm context scope rhs || (isFunctionValueTerm rhs && termUsesVariableAsValue name body))
+    && (isClosureAliasTerm context scope rhs || (isClosureConvertibleFunctionTerm rhs && termUsesFunctionAsValue bindingTy name body))
+
+isClosureConvertibleFunctionTerm :: ElabTerm -> Bool
+isClosureConvertibleFunctionTerm term =
+  not (null params)
+  where
+    (params, _) = collectClosureLams (stripAdministrativeTermWrappers term)
 
 isClosureAliasTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
 isClosureAliasTerm context scope term =
@@ -2139,10 +2348,13 @@ stripClosureHeadTypeInsts =
     ETyInst inner _ -> stripClosureHeadTypeInsts inner
     other -> other
 
-termUsesVariableAsValue :: String -> ElabTerm -> Bool
-termUsesVariableAsValue needle =
+termUsesFunctionAsValue :: BackendType -> String -> ElabTerm -> Bool
+termUsesFunctionAsValue bindingTy needle =
   go False
   where
+    functionArity =
+      length (fst (splitBackendArrows bindingTy))
+
     go underLambda term =
       case term of
         EVar name ->
@@ -2157,7 +2369,7 @@ termUsesVariableAsValue needle =
               headUse =
                 case stripClosureHeadTypeInsts headTerm of
                   EVar name
-                    | name == needle -> underLambda
+                    | name == needle -> underLambda || length args < functionArity
                   _ -> go underLambda headTerm
            in headUse || any (go underLambda) args
         ELet name _ rhs body

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2130,9 +2130,13 @@ packageDirectFunctionValue ::
 packageDirectFunctionValue context scope resultTy headTerm headExpr = do
   entryName <- freshClosureEntryName context (partialApplicationHint headTerm)
   let (paramTys, _) = splitBackendArrows resultTy
+      (paramNames, _) =
+        freshNamesLike
+          (closureGeneratedNameScope context scope headTerm)
+          (take (length paramTys) closureArgNameCandidates)
       params =
         [ (name, paramTy)
-        | (name, paramTy) <- zip remainingParamNames paramTys
+        | (name, paramTy) <- zip paramNames paramTys
         ]
       paramVars =
         [ BackendVar paramTy name
@@ -2162,7 +2166,7 @@ packageDirectFunctionValue context scope resultTy headTerm headExpr = do
         backendClosureBody = body
       }
   where
-    remainingParamNames =
+    closureArgNameCandidates =
       ["__mlfp_closure_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
 
 packagePartialApplication ::
@@ -2200,10 +2204,18 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
         | (name, argTy) <- remainingParams
         ]
       allArgs = suppliedVars ++ remainingVars
+      (suppliedCaptureNames, usedAfterSuppliedCaptures) =
+        freshNamesLike
+          (closureGeneratedNameScope context scope headTerm)
+          (take (length suppliedParamTys) suppliedCaptureNameCandidates)
+      (remainingParamNames, _) =
+        freshNamesLike
+          usedAfterSuppliedCaptures
+          (take (length remainingParamTys) remainingParamNameCandidates)
       functionCaptureName =
         freshNameLike
           (partialFunctionCaptureNameFor headTerm)
-          (Set.fromList (take (length suppliedParamTys) suppliedCaptureNames ++ take (length remainingParamTys) remainingParamNames))
+          (Set.fromList (suppliedCaptureNames ++ remainingParamNames))
   (captures, body) <-
     if isClosureHeadTerm context scope headTerm
       then do
@@ -2267,10 +2279,28 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
         backendClosureBody = body
       }
   where
-    suppliedCaptureNames =
+    suppliedCaptureNameCandidates =
       ["__mlfp_partial_capture" ++ show index0 | index0 <- [(0 :: Int) ..]]
-    remainingParamNames =
+    remainingParamNameCandidates =
       ["__mlfp_partial_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
+
+freshNamesLike :: Set.Set String -> [String] -> ([String], Set.Set String)
+freshNamesLike used0 =
+  go used0 []
+  where
+    go used names [] =
+      (reverse names, used)
+    go used names (candidate : rest) =
+      let name = freshNameLike candidate used
+       in go (Set.insert name used) (name : names) rest
+
+closureGeneratedNameScope :: ConvertContext -> ClosureScope -> ElabTerm -> Set.Set String
+closureGeneratedNameScope context scope term =
+  Set.unions
+    [ closureScopeBoundTerms scope,
+      ccGlobalTerms context,
+      freeTermVariables term
+    ]
 
 partialFunctionCaptureName :: String
 partialFunctionCaptureName =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2102,20 +2102,20 @@ convertCallArgument ::
   ElabTerm ->
   ConvertM BackendExpr
 convertCallArgument context env scope fun expectedArgTy arg
-  | applicationArgumentNeedsClosureValue context scope fun =
+  | applicationArgumentNeedsClosureValue context scope expectedArgTy fun =
       convertClosureValueArgument context env scope expectedArgTy arg
   | otherwise =
       convertTermExpectedMode DirectLambda context env scope (Just expectedArgTy) arg
 
-applicationArgumentNeedsClosureValue :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
-applicationArgumentNeedsClosureValue context scope fun
-  | partialApplicationMentionsEvidence fun = False
-  | otherwise =
-      case stripClosureHeadTypeInsts headTerm of
-        EVar name ->
-          Set.member suppliedCount (lookupClosureValueArgumentDemand context scope name)
-        _ ->
-          False
+applicationArgumentNeedsClosureValue :: ConvertContext -> ClosureScope -> BackendType -> ElabTerm -> Bool
+applicationArgumentNeedsClosureValue context scope expectedArgTy fun =
+  isFirstOrderFunctionCaptureType expectedArgTy
+    && case stripClosureHeadTypeInsts headTerm of
+      EVar name ->
+        Set.notMember suppliedCount (lookupEvidenceValueArguments context scope name)
+          && Set.member suppliedCount (lookupClosureValueArgumentDemand context scope name)
+      _ ->
+        False
   where
     (headTerm, suppliedArgs) = collectApps fun
     suppliedCount = length suppliedArgs

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -128,7 +128,8 @@ type ConvertM = StateT ConvertState (Either BackendConversionError)
 data ClosureScope = ClosureScope
   { closureScopeTerms :: Map String ElabType,
     closureScopeBoundTerms :: Set.Set String,
-    closureScopeLocals :: Set.Set String
+    closureScopeLocals :: Set.Set String,
+    closureScopeClosureValueArguments :: Map String (Set.Set Int)
   }
 
 data LambdaMode
@@ -144,7 +145,8 @@ emptyClosureScope =
   ClosureScope
     { closureScopeTerms = Map.empty,
       closureScopeBoundTerms = Set.empty,
-      closureScopeLocals = Set.empty
+      closureScopeLocals = Set.empty,
+      closureScopeClosureValueArguments = Map.empty
     }
 
 extendClosureScopeTerm :: String -> ElabType -> Bool -> ClosureScope -> ClosureScope
@@ -155,7 +157,18 @@ extendClosureScopeTerm name ty isClosure scope =
       closureScopeLocals =
         if isClosure
           then Set.insert name (closureScopeLocals scope)
-          else Set.delete name (closureScopeLocals scope)
+          else Set.delete name (closureScopeLocals scope),
+      closureScopeClosureValueArguments =
+        Map.delete name (closureScopeClosureValueArguments scope)
+    }
+
+extendClosureScopeValueArguments :: String -> Set.Set Int -> ClosureScope -> ClosureScope
+extendClosureScopeValueArguments name demanded scope =
+  scope
+    { closureScopeClosureValueArguments =
+        if Set.null demanded
+          then Map.delete name (closureScopeClosureValueArguments scope)
+          else Map.insert name demanded (closureScopeClosureValueArguments scope)
     }
 
 extendClosureScopePatternFields :: [((String, ElabType), BackendType)] -> ClosureScope -> ClosureScope
@@ -1291,36 +1304,80 @@ buildConvertContext checked = do
   Right context0 {ccClosureValueArguments = closureValueArguments}
 
 checkedProgramClosureValueArguments :: ConvertContext -> CheckedProgram -> Either BackendConversionError (Map String (Set.Set Int))
-checkedProgramClosureValueArguments context checked =
-  Map.fromList . concat
-    <$> forM
+checkedProgramClosureValueArguments context checked = do
+  sources <-
+    forM
       [ (checkedModule, binding)
       | checkedModule <- checkedProgramModules checked,
         binding <- checkedModuleBindings checkedModule
       ]
       ( \(checkedModule, binding) -> do
-          demanded <- checkedBindingClosureValueArguments context checkedModule binding
-          pure
-            [ (checkedBindingName binding, Set.fromList demanded)
-            | not (null demanded)
-            ]
+          bindingTy <- checkedBindingBackendValueType context checkedModule binding
+          pure (checkedBindingName binding, bindingTy, checkedBindingTerm binding)
       )
+  pure (closureValueArgumentFixedPoint sources Map.empty)
+  where
+    closureValueArgumentFixedPoint sources demands =
+      let context' = context {ccClosureValueArguments = demands}
+          demands' =
+            Map.filter (not . Set.null) $
+              Map.fromList
+                [ (name, bindingClosureValueArguments context' emptyClosureScope bindingTy term)
+                | (name, bindingTy, term) <- sources
+                ]
+       in if demands' == demands
+            then demands
+            else closureValueArgumentFixedPoint sources demands'
 
-checkedBindingClosureValueArguments :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError [Int]
-checkedBindingClosureValueArguments context checkedModule binding = do
+checkedBindingBackendValueType :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError BackendType
+checkedBindingBackendValueType context checkedModule binding = do
   canonicalElabTyOpen <- checkedBindingCanonicalTypeOpen context checkedModule binding
   rawBindingTy <- convertElabType canonicalElabTyOpen
-  let bindingTy = canonicalizeBackendType context rawBindingTy
-      (_, valueTy) = splitBackendForalls bindingTy
-      (paramTys, _) = splitBackendArrows valueTy
-      (params, body) = collectLeadingLams (length paramTys) (checkedBindingTerm binding)
-  pure
+  pure (canonicalizeBackendType context rawBindingTy)
+
+bindingClosureValueArguments :: ConvertContext -> ClosureScope -> BackendType -> ElabTerm -> Set.Set Int
+bindingClosureValueArguments context scope bindingTy term =
+  directClosureValueArguments bindingTy term
+    `Set.union` aliasedClosureValueArguments context scope bindingTy term
+
+directClosureValueArguments :: BackendType -> ElabTerm -> Set.Set Int
+directClosureValueArguments bindingTy term =
+  Set.fromList
     [ index0
     | (index0, ((name, _), paramTy)) <- zip [0 :: Int ..] (zip params paramTys),
       not (isEvidenceCaptureName name),
       isClosureConvertibleFunctionType paramTy,
       termUsesFunctionAsValue paramTy name body
     ]
+  where
+    (_, valueTy) = splitBackendForalls bindingTy
+    (paramTys, _) = splitBackendArrows valueTy
+    (params, body) = collectLeadingLams (length paramTys) term
+
+aliasedClosureValueArguments :: ConvertContext -> ClosureScope -> BackendType -> ElabTerm -> Set.Set Int
+aliasedClosureValueArguments context scope bindingTy term =
+  case stripClosureHeadTypeInsts headTerm of
+    EVar name ->
+      Set.fromList
+        [ demandedIndex - suppliedCount
+        | demandedIndex <- Set.toList (lookupClosureValueArgumentDemand context scope name),
+          demandedIndex >= suppliedCount,
+          demandedIndex - suppliedCount < exposedCount
+        ]
+    _ ->
+      Set.empty
+  where
+    (_, valueTy) = splitBackendForalls bindingTy
+    (paramTys, _) = splitBackendArrows valueTy
+    (params, body) = collectLeadingLams (length paramTys) term
+    exposedCount = length paramTys - length params
+    (headTerm, suppliedArgs) = collectApps body
+    suppliedCount = length suppliedArgs
+
+lookupClosureValueArgumentDemand :: ConvertContext -> ClosureScope -> String -> Set.Set Int
+lookupClosureValueArgumentDemand context scope name =
+  Map.findWithDefault Set.empty name (closureScopeClosureValueArguments scope)
+    `Set.union` Map.findWithDefault Set.empty name (ccClosureValueArguments context)
 
 allDataInfos :: CheckedProgram -> [DataInfo]
 allDataInfos checked =
@@ -1881,26 +1938,41 @@ convertPartialApplication ::
   ConvertM (Maybe BackendExpr)
 convertPartialApplication context env scope term resultTy =
   case collectApps term of
-    (headTerm, suppliedArgs)
-      | not (null suppliedArgs),
-        not (isConstructorHeadTerm context headTerm),
-        not (partialApplicationMentionsEvidence term) -> do
-          headTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (inferBackendType env headTerm)
-          let (paramTys, finalTy) = splitBackendArrows headTy
-              suppliedCount = length suppliedArgs
-              suppliedParamTys = take suppliedCount paramTys
-              remainingParamTys = drop suppliedCount paramTys
-              expectedPartialTy = foldr BTArrow finalTy remainingParamTys
-          if suppliedCount < length paramTys
-            && alphaEqBackendType resultTy expectedPartialTy
-            && not (null remainingParamTys)
-            then do
-              suppliedArgExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) suppliedParamTys suppliedArgs
-              if partialApplicationCanCaptureSuppliedArgs context scope (zip suppliedParamTys suppliedArgExprs)
-                then Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
+    (rawHeadTerm, rawSuppliedArgs) ->
+      case normalizePartialApplicationSpine rawHeadTerm rawSuppliedArgs of
+        (headTerm, suppliedArgs)
+          | not (null suppliedArgs),
+            not (isConstructorHeadTerm context headTerm),
+            not (partialApplicationMentionsEvidence term) -> do
+              headTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (inferBackendType env headTerm)
+              let (paramTys, finalTy) = splitBackendArrows headTy
+                  suppliedCount = length suppliedArgs
+                  suppliedParamTys = take suppliedCount paramTys
+                  remainingParamTys = drop suppliedCount paramTys
+                  expectedPartialTy = foldr BTArrow finalTy remainingParamTys
+              if suppliedCount < length paramTys
+                && alphaEqBackendType resultTy expectedPartialTy
+                && not (null remainingParamTys)
+                then do
+                  suppliedArgExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) suppliedParamTys suppliedArgs
+                  if partialApplicationCanCaptureSuppliedArgs context scope (zip suppliedParamTys suppliedArgExprs)
+                    then Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
+                    else pure Nothing
                 else pure Nothing
-            else pure Nothing
-    _ -> pure Nothing
+        _ -> pure Nothing
+
+normalizePartialApplicationSpine :: ElabTerm -> [ElabTerm] -> (ElabTerm, [ElabTerm])
+normalizePartialApplicationSpine headTerm suppliedArgs =
+  case (headTerm, suppliedArgs) of
+    (ELam name _ body, arg : rest) ->
+      normalizePartialApplicationSpine (replaceFreeTermVariable name arg body) rest
+    _ ->
+      case collectApps headTerm of
+        (nestedHead, nestedArgs)
+          | not (null nestedArgs) ->
+              normalizePartialApplicationSpine nestedHead (nestedArgs ++ suppliedArgs)
+        _ ->
+          (headTerm, suppliedArgs)
 
 convertClosureValueArgument ::
   ConvertContext ->
@@ -1924,18 +1996,18 @@ convertCallArgument ::
   ElabTerm ->
   ConvertM BackendExpr
 convertCallArgument context env scope fun expectedArgTy arg
-  | applicationArgumentNeedsClosureValue context fun =
+  | applicationArgumentNeedsClosureValue context scope fun =
       convertClosureValueArgument context env scope expectedArgTy arg
   | otherwise =
       convertTermExpectedMode DirectLambda context env scope (Just expectedArgTy) arg
 
-applicationArgumentNeedsClosureValue :: ConvertContext -> ElabTerm -> Bool
-applicationArgumentNeedsClosureValue context fun
+applicationArgumentNeedsClosureValue :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
+applicationArgumentNeedsClosureValue context scope fun
   | partialApplicationMentionsEvidence fun = False
   | otherwise =
       case stripClosureHeadTypeInsts headTerm of
         EVar name ->
-          Set.member suppliedCount (Map.findWithDefault Set.empty name (ccClosureValueArguments context))
+          Set.member suppliedCount (lookupClosureValueArgumentDemand context scope name)
         _ ->
           False
   where
@@ -2075,8 +2147,9 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
                 bodyExpr <- liftEitherConvert (applyPartialDirectArguments funVar headTy allArgs)
                 pure (funCapture : suppliedCaptures, bodyExpr)
               Nothing -> do
+                calleeCaptures <- localClosureCapturesForTerm context scope headTerm
                 bodyExpr <- liftEitherConvert (applyPartialDirectArguments headExpr headTy allArgs)
-                pure (suppliedCaptures, bodyExpr)
+                pure (calleeCaptures ++ suppliedCaptures, bodyExpr)
   pure
     BackendClosure
       { backendExprType = resultTy,
@@ -2109,6 +2182,31 @@ directLocalCalleeCaptureName context scope expr =
         Set.notMember name (ccGlobalTerms context) ->
           Just name
     _ -> Nothing
+
+localClosureCapturesForTerm :: ConvertContext -> ClosureScope -> ElabTerm -> ConvertM [BackendClosureCapture]
+localClosureCapturesForTerm context scope term =
+  forM localNames $ \name ->
+    case Map.lookup name (closureScopeTerms scope) of
+      Just elabTy -> do
+        captureTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (convertElabType elabTy)
+        pure
+          BackendClosureCapture
+            { backendClosureCaptureName = name,
+              backendClosureCaptureType = captureTy,
+              backendClosureCaptureExpr = BackendVar captureTy name
+            }
+      Nothing ->
+        liftEitherConvert
+          ( Left
+              ( BackendUnsupportedCaseShape
+                  ("partial application callee references out-of-scope local `" ++ name ++ "`")
+              )
+          )
+  where
+    localNames =
+      Set.toAscList $
+        (freeTermVariables term `Set.intersection` closureScopeBoundTerms scope)
+          `Set.difference` ccGlobalTerms context
 
 stripBackendHeadTypeApps :: BackendExpr -> BackendExpr
 stripBackendHeadTypeApps =
@@ -2227,12 +2325,15 @@ convertOrdinaryTerm mode context env scope term resultTy0 =
             case backendTypeToElabType bindingTy of
               Just canonicalTy -> canonicalTy
               Nothing -> schemeTy
+          demandedClosureValueArguments =
+            bindingClosureValueArguments context scope bindingTy rhs
           bodyScope =
-            extendClosureScopeTerm
-              name
-              bindingEnvTy
-              (bindingClosure || backendExprIsClosureValue context scope rhsExpr)
-              scope
+            extendClosureScopeValueArguments name demandedClosureValueArguments $
+              extendClosureScopeTerm
+                name
+                bindingEnvTy
+                (bindingClosure || backendExprIsClosureValue context scope rhsExpr)
+                scope
           bodyMode =
             if isClosureConvertibleFunctionType resultTy
               then ClosureLambda Nothing

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -80,6 +80,7 @@ data ConvertContext = ConvertContext
     ccGlobalTerms :: Set.Set String,
     ccClosureGlobals :: Set.Set String,
     ccClosureValueArguments :: Map String (Set.Set Int),
+    ccEvidenceValueArguments :: Map String (Set.Set Int),
     ccCurrentModuleName :: Maybe String,
     ccCurrentBindingName :: String
   }
@@ -129,7 +130,8 @@ data ClosureScope = ClosureScope
   { closureScopeTerms :: Map String ElabType,
     closureScopeBoundTerms :: Set.Set String,
     closureScopeLocals :: Set.Set String,
-    closureScopeClosureValueArguments :: Map String (Set.Set Int)
+    closureScopeClosureValueArguments :: Map String (Set.Set Int),
+    closureScopeEvidenceValueArguments :: Map String (Set.Set Int)
   }
 
 data LambdaMode
@@ -146,7 +148,8 @@ emptyClosureScope =
     { closureScopeTerms = Map.empty,
       closureScopeBoundTerms = Set.empty,
       closureScopeLocals = Set.empty,
-      closureScopeClosureValueArguments = Map.empty
+      closureScopeClosureValueArguments = Map.empty,
+      closureScopeEvidenceValueArguments = Map.empty
     }
 
 extendClosureScopeTerm :: String -> ElabType -> Bool -> ClosureScope -> ClosureScope
@@ -159,7 +162,9 @@ extendClosureScopeTerm name ty isClosure scope =
           then Set.insert name (closureScopeLocals scope)
           else Set.delete name (closureScopeLocals scope),
       closureScopeClosureValueArguments =
-        Map.delete name (closureScopeClosureValueArguments scope)
+        Map.delete name (closureScopeClosureValueArguments scope),
+      closureScopeEvidenceValueArguments =
+        Map.delete name (closureScopeEvidenceValueArguments scope)
     }
 
 extendClosureScopeValueArguments :: String -> Set.Set Int -> ClosureScope -> ClosureScope
@@ -169,6 +174,15 @@ extendClosureScopeValueArguments name demanded scope =
         if Set.null demanded
           then Map.delete name (closureScopeClosureValueArguments scope)
           else Map.insert name demanded (closureScopeClosureValueArguments scope)
+    }
+
+extendClosureScopeEvidenceArguments :: String -> Set.Set Int -> ClosureScope -> ClosureScope
+extendClosureScopeEvidenceArguments name evidence scope =
+  scope
+    { closureScopeEvidenceValueArguments =
+        if Set.null evidence
+          then Map.delete name (closureScopeEvidenceValueArguments scope)
+          else Map.insert name evidence (closureScopeEvidenceValueArguments scope)
     }
 
 extendClosureScopePatternFields :: [((String, ElabType), BackendType)] -> ClosureScope -> ClosureScope
@@ -1297,11 +1311,36 @@ buildConvertContext checked = do
             ccGlobalTerms = checkedProgramGlobalTerms checked,
             ccClosureGlobals = Set.empty,
             ccClosureValueArguments = Map.empty,
+            ccEvidenceValueArguments = Map.empty,
             ccCurrentModuleName = Nothing,
             ccCurrentBindingName = ""
           }
+  evidenceValueArguments <- checkedProgramEvidenceValueArguments context0 checked
   closureValueArguments <- checkedProgramClosureValueArguments context0 checked
-  Right context0 {ccClosureValueArguments = closureValueArguments}
+  Right
+    context0
+      { ccClosureValueArguments = closureValueArguments,
+        ccEvidenceValueArguments = evidenceValueArguments
+      }
+
+checkedProgramEvidenceValueArguments :: ConvertContext -> CheckedProgram -> Either BackendConversionError (Map String (Set.Set Int))
+checkedProgramEvidenceValueArguments context checked = do
+  sources <-
+    forM
+      [ (checkedModule, binding)
+      | checkedModule <- checkedProgramModules checked,
+        binding <- checkedModuleBindings checkedModule
+      ]
+      ( \(checkedModule, binding) -> do
+          bindingTy <- checkedBindingBackendValueType context checkedModule binding
+          pure (checkedBindingName binding, bindingTy, checkedBindingTerm binding)
+      )
+  pure $
+    Map.filter (not . Set.null) $
+      Map.fromList
+        [ (name, bindingEvidenceValueArguments bindingTy term)
+        | (name, bindingTy, term) <- sources
+        ]
 
 checkedProgramClosureValueArguments :: ConvertContext -> CheckedProgram -> Either BackendConversionError (Map String (Set.Set Int))
 checkedProgramClosureValueArguments context checked = do
@@ -1339,6 +1378,18 @@ bindingClosureValueArguments :: ConvertContext -> ClosureScope -> BackendType ->
 bindingClosureValueArguments context scope bindingTy term =
   directClosureValueArguments bindingTy term
     `Set.union` aliasedClosureValueArguments context scope bindingTy term
+
+bindingEvidenceValueArguments :: BackendType -> ElabTerm -> Set.Set Int
+bindingEvidenceValueArguments bindingTy term =
+  Set.fromList
+    [ index0
+    | (index0, (name, _)) <- zip [0 :: Int ..] params,
+      isEvidenceCaptureName name
+    ]
+  where
+    (_, valueTy) = splitBackendForalls bindingTy
+    (paramTys, _) = splitBackendArrows valueTy
+    (params, _) = collectLeadingLams (length paramTys) term
 
 directClosureValueArguments :: BackendType -> ElabTerm -> Set.Set Int
 directClosureValueArguments bindingTy term =
@@ -1378,6 +1429,11 @@ lookupClosureValueArgumentDemand :: ConvertContext -> ClosureScope -> String -> 
 lookupClosureValueArgumentDemand context scope name =
   Map.findWithDefault Set.empty name (closureScopeClosureValueArguments scope)
     `Set.union` Map.findWithDefault Set.empty name (ccClosureValueArguments context)
+
+lookupEvidenceValueArguments :: ConvertContext -> ClosureScope -> String -> Set.Set Int
+lookupEvidenceValueArguments context scope name =
+  Map.findWithDefault Set.empty name (closureScopeEvidenceValueArguments scope)
+    `Set.union` Map.findWithDefault Set.empty name (ccEvidenceValueArguments context)
 
 allDataInfos :: CheckedProgram -> [DataInfo]
 allDataInfos checked =
@@ -1587,6 +1643,7 @@ buildDataMeta scope info = do
             ccGlobalTerms = Set.empty,
             ccClosureGlobals = Set.empty,
             ccClosureValueArguments = Map.empty,
+            ccEvidenceValueArguments = Map.empty,
             ccCurrentModuleName = Just (dataModule info),
             ccCurrentBindingName = ""
           }
@@ -1954,7 +2011,13 @@ convertPartialApplication context env scope term resultTy =
                 && alphaEqBackendType resultTy expectedPartialTy
                 && not (null remainingParamTys)
                 then do
-                  suppliedArgExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) suppliedParamTys suppliedArgs
+                  suppliedArgExprs <-
+                    zipWithM
+                      ( \index0 (paramTy, arg) ->
+                          convertPartialApplicationArgument context env scope headTerm index0 paramTy arg
+                      )
+                      [0 :: Int ..]
+                      (zip suppliedParamTys suppliedArgs)
                   if partialApplicationCanCaptureSuppliedArgs context scope (zip suppliedParamTys suppliedArgExprs)
                     then Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
                     else pure Nothing
@@ -1973,6 +2036,46 @@ normalizePartialApplicationSpine headTerm suppliedArgs =
               normalizePartialApplicationSpine nestedHead (nestedArgs ++ suppliedArgs)
         _ ->
           (headTerm, suppliedArgs)
+
+convertPartialApplicationArgument ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  ElabTerm ->
+  Int ->
+  BackendType ->
+  ElabTerm ->
+  ConvertM BackendExpr
+convertPartialApplicationArgument context env scope headTerm index0 expectedTy arg
+  | partialApplicationArgumentNeedsClosureValue context scope headTerm index0 expectedTy =
+      convertClosureValueArgument context env scope expectedTy arg
+  | otherwise =
+      convertTermExpectedMode DirectLambda context env scope (Just expectedTy) arg
+
+partialApplicationArgumentNeedsClosureValue ::
+  ConvertContext ->
+  ClosureScope ->
+  ElabTerm ->
+  Int ->
+  BackendType ->
+  Bool
+partialApplicationArgumentNeedsClosureValue context scope headTerm index0 expectedTy =
+  capturedFunctionArgument || demandedByCallee
+  where
+    capturedFunctionArgument =
+      isClosureConvertibleFunctionType expectedTy && not evidenceArgument
+    evidenceArgument =
+      case stripClosureHeadTypeInsts headTerm of
+        EVar name ->
+          Set.member index0 (lookupEvidenceValueArguments context scope name)
+        _ ->
+          False
+    demandedByCallee =
+      case stripClosureHeadTypeInsts headTerm of
+        EVar name ->
+          Set.member index0 (lookupClosureValueArgumentDemand context scope name)
+        _ ->
+          False
 
 convertClosureValueArgument ::
   ConvertContext ->
@@ -2043,7 +2146,9 @@ packageDirectFunctionValue context scope resultTy headTerm headExpr = do
                 }
         pure ([funCapture], BackendVar resultTy captureName)
       Nothing ->
-        pure ([], headExpr)
+        do
+          calleeCaptures <- localClosureCapturesForTerm context scope headTerm
+          pure (calleeCaptures, headExpr)
   body <- liftEitherConvert (applyPartialDirectArguments functionExpr resultTy paramVars)
   pure
     BackendClosure
@@ -2327,13 +2432,16 @@ convertOrdinaryTerm mode context env scope term resultTy0 =
               Nothing -> schemeTy
           demandedClosureValueArguments =
             bindingClosureValueArguments context scope bindingTy rhs
+          evidenceValueArguments =
+            bindingEvidenceValueArguments bindingTy rhs
           bodyScope =
-            extendClosureScopeValueArguments name demandedClosureValueArguments $
-              extendClosureScopeTerm
-                name
-                bindingEnvTy
-                (bindingClosure || backendExprIsClosureValue context scope rhsExpr)
-                scope
+            extendClosureScopeEvidenceArguments name evidenceValueArguments $
+              extendClosureScopeValueArguments name demandedClosureValueArguments $
+                extendClosureScopeTerm
+                  name
+                  bindingEnvTy
+                  (bindingClosure || backendExprIsClosureValue context scope rhsExpr)
+                  scope
           bodyMode =
             if isClosureConvertibleFunctionType resultTy
               then ClosureLambda Nothing

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2063,7 +2063,7 @@ partialApplicationArgumentNeedsClosureValue context scope headTerm index0 expect
   capturedFunctionArgument || demandedByCallee
   where
     capturedFunctionArgument =
-      isClosureConvertibleFunctionType expectedTy && not evidenceArgument
+      isFirstOrderFunctionCaptureType expectedTy && not evidenceArgument
     evidenceArgument =
       case stripClosureHeadTypeInsts headTerm of
         EVar name ->
@@ -2071,6 +2071,9 @@ partialApplicationArgumentNeedsClosureValue context scope headTerm index0 expect
         _ ->
           False
     demandedByCallee =
+      isFirstOrderFunctionCaptureType expectedTy
+        && demandedByCalleeName
+    demandedByCalleeName =
       case stripClosureHeadTypeInsts headTerm of
         EVar name ->
           Set.member index0 (lookupClosureValueArgumentDemand context scope name)
@@ -2365,18 +2368,50 @@ partialApplicationCanCaptureSuppliedArgs context scope =
   where
     canCapture (argTy, argExpr)
       | isClosureConvertibleFunctionType argTy =
-          backendExprIsClosureValue context scope argExpr
-      | isPolymorphicFunctionCaptureType argTy =
+          isFirstOrderFunctionCaptureType argTy
+            && backendExprIsClosureValue context scope argExpr
+      | isFunctionLikeBackendType argTy =
           False
       | otherwise =
           True
 
-isPolymorphicFunctionCaptureType :: BackendType -> Bool
-isPolymorphicFunctionCaptureType =
+isFunctionLikeBackendType :: BackendType -> Bool
+isFunctionLikeBackendType =
   \case
     BTForall _ _ body ->
-      isClosureConvertibleFunctionType body || isPolymorphicFunctionCaptureType body
+      isFunctionLikeBackendType body
+    BTArrow {} ->
+      True
     _ ->
+      False
+
+isFirstOrderFunctionCaptureType :: BackendType -> Bool
+isFirstOrderFunctionCaptureType ty =
+  case ty of
+    BTArrow {} ->
+      let (paramTys, returnTy) = splitBackendArrows ty
+       in all isFirstOrderCaptureValueType (returnTy : paramTys)
+    _ ->
+      False
+
+isFirstOrderCaptureValueType :: BackendType -> Bool
+isFirstOrderCaptureValueType =
+  \case
+    BTVar {} ->
+      False
+    BTArrow {} ->
+      False
+    BTBase {} ->
+      True
+    BTCon _ args ->
+      all isFirstOrderCaptureValueType args
+    BTVarApp {} ->
+      False
+    BTForall {} ->
+      False
+    BTMu {} ->
+      True
+    BTBottom ->
       False
 
 convertOrdinaryTerm :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> ElabTerm -> BackendType -> ConvertM BackendExpr

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1333,14 +1333,23 @@ checkedProgramEvidenceValueArguments context checked = do
       ]
       ( \(checkedModule, binding) -> do
           bindingTy <- checkedBindingBackendValueType context checkedModule binding
-          pure (checkedBindingName binding, bindingTy, checkedBindingTerm binding)
+          pure (checkedBindingName binding, checkedBindingSourceType binding, bindingTy, checkedBindingTerm binding)
       )
   pure $
-    Map.filter (not . Set.null) $
-      Map.fromList
-        [ (name, bindingEvidenceValueArguments bindingTy term)
-        | (name, bindingTy, term) <- sources
-        ]
+    evidenceValueArgumentFixedPoint context sources Map.empty
+
+evidenceValueArgumentFixedPoint :: ConvertContext -> [(String, SrcType, BackendType, ElabTerm)] -> Map String (Set.Set Int) -> Map String (Set.Set Int)
+evidenceValueArgumentFixedPoint context sources demands =
+  let context' = context {ccEvidenceValueArguments = demands}
+      demands' =
+        Map.filter (not . Set.null) $
+          Map.fromList
+            [ (name, checkedBindingEvidenceValueArguments context' emptyClosureScope sourceTy bindingTy term)
+            | (name, sourceTy, bindingTy, term) <- sources
+            ]
+   in if demands' == demands
+        then demands
+        else evidenceValueArgumentFixedPoint context sources demands'
 
 checkedProgramClosureValueArguments :: ConvertContext -> CheckedProgram -> Either BackendConversionError (Map String (Set.Set Int))
 checkedProgramClosureValueArguments context checked = do
@@ -1379,8 +1388,40 @@ bindingClosureValueArguments context scope bindingTy term =
   directClosureValueArguments bindingTy term
     `Set.union` aliasedClosureValueArguments context scope bindingTy term
 
-bindingEvidenceValueArguments :: BackendType -> ElabTerm -> Set.Set Int
-bindingEvidenceValueArguments bindingTy term =
+checkedBindingEvidenceValueArguments :: ConvertContext -> ClosureScope -> SrcType -> BackendType -> ElabTerm -> Set.Set Int
+checkedBindingEvidenceValueArguments context scope sourceTy bindingTy term =
+  declaredEvidenceValueArguments sourceTy bindingTy
+    `Set.union` bindingEvidenceValueArguments context scope bindingTy term
+
+bindingEvidenceValueArguments :: ConvertContext -> ClosureScope -> BackendType -> ElabTerm -> Set.Set Int
+bindingEvidenceValueArguments context scope bindingTy term =
+  directEvidenceValueArguments bindingTy term
+    `Set.union` aliasedEvidenceValueArguments context scope bindingTy term
+
+declaredEvidenceValueArguments :: SrcType -> BackendType -> Set.Set Int
+declaredEvidenceValueArguments sourceTy bindingTy =
+  Set.fromList [0 .. evidenceCount - 1]
+  where
+    evidenceCount =
+      max 0 (runtimeArity - visibleArity)
+    runtimeArity =
+      length runtimeParamTys
+    visibleArity =
+      sourceValueArity sourceTy
+    (_, runtimeValueTy) =
+      splitBackendForalls bindingTy
+    (runtimeParamTys, _) =
+      splitBackendArrows runtimeValueTy
+
+sourceValueArity :: SrcType -> Int
+sourceValueArity sourceTy =
+  length paramTys
+  where
+    (paramTys, _) =
+      splitSourceArrows (dropSourceForalls sourceTy)
+
+directEvidenceValueArguments :: BackendType -> ElabTerm -> Set.Set Int
+directEvidenceValueArguments bindingTy term =
   Set.fromList
     [ index0
     | (index0, (name, _)) <- zip [0 :: Int ..] params,
@@ -1407,11 +1448,25 @@ directClosureValueArguments bindingTy term =
 
 aliasedClosureValueArguments :: ConvertContext -> ClosureScope -> BackendType -> ElabTerm -> Set.Set Int
 aliasedClosureValueArguments context scope bindingTy term =
+  aliasedValueArgumentIndices lookupClosureValueArgumentDemand context scope bindingTy term
+
+aliasedEvidenceValueArguments :: ConvertContext -> ClosureScope -> BackendType -> ElabTerm -> Set.Set Int
+aliasedEvidenceValueArguments context scope bindingTy term =
+  aliasedValueArgumentIndices lookupEvidenceValueArguments context scope bindingTy term
+
+aliasedValueArgumentIndices ::
+  (ConvertContext -> ClosureScope -> String -> Set.Set Int) ->
+  ConvertContext ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  Set.Set Int
+aliasedValueArgumentIndices lookupDemand context scope bindingTy term =
   case stripClosureHeadTypeInsts headTerm of
     EVar name ->
       Set.fromList
         [ paramOffset + exposedIndex
-        | demandedIndex <- Set.toList (lookupClosureValueArgumentDemand context scope name),
+        | demandedIndex <- Set.toList (lookupDemand context scope name),
           let exposedIndex = demandedIndex - suppliedCount,
           demandedIndex >= suppliedCount,
           exposedIndex < exposedCount
@@ -2011,6 +2066,7 @@ convertPartialApplication context env scope term resultTy =
               if suppliedCount < length paramTys
                 && alphaEqBackendType resultTy expectedPartialTy
                 && not (null remainingParamTys)
+                && partialApplicationSuppliesValueArgument context scope headTerm suppliedCount
                 then do
                   suppliedArgExprs <-
                     zipWithM
@@ -2081,6 +2137,12 @@ partialApplicationArgumentNeedsClosureValue context scope headTerm index0 expect
         _ ->
           False
 
+partialApplicationSuppliesValueArgument :: ConvertContext -> ClosureScope -> ElabTerm -> Int -> Bool
+partialApplicationSuppliesValueArgument context scope headTerm suppliedCount =
+  any
+    (not . partialApplicationArgumentIsEvidence context scope headTerm)
+    [0 .. suppliedCount - 1]
+
 convertClosureValueArgument ::
   ConvertContext ->
   Env ->
@@ -2118,7 +2180,7 @@ applicationArgumentNeedsClosureValue context scope expectedArgTy fun =
       _ ->
         False
   where
-    (headTerm, suppliedArgs) = collectApps fun
+    (headTerm, suppliedArgs) = collectAliasedApps fun
     suppliedCount = length suppliedArgs
 
 packageDirectFunctionValue ::
@@ -2529,7 +2591,7 @@ convertOrdinaryTerm mode context env scope term resultTy0 =
           demandedClosureValueArguments =
             bindingClosureValueArguments context scope bindingTy rhs
           evidenceValueArguments =
-            bindingEvidenceValueArguments bindingTy rhs
+            bindingEvidenceValueArguments context scope bindingTy rhs
           bodyScope =
             extendClosureScopeEvidenceArguments name evidenceValueArguments $
               extendClosureScopeValueArguments name demandedClosureValueArguments $
@@ -4365,8 +4427,32 @@ collectAliasedApps =
                            in (rhsHead, rhsArgs ++ bodyArgs)
                     _ ->
                       (term, [])
+        other
+          | Just etaHead <- etaAliasHead other ->
+              resolveHead seen etaHead
         other ->
           (other, [])
+
+    etaAliasHead term =
+      let (params, body) = collectEtaLams [] term
+          (bodyHead, bodyArgs) = collectApps (stripAdministrativeTermWrappers body)
+       in if not (null params) && etaArgsMatch params bodyArgs
+            then Just bodyHead
+            else Nothing
+
+    collectEtaLams params term =
+      case stripAdministrativeTermWrappers term of
+        ELam name _ body -> collectEtaLams (params ++ [name]) body
+        other -> (params, other)
+
+    etaArgsMatch params args =
+      length params == length args
+        && and
+          [ case stripAdministrativeTermWrappers arg of
+              EVar argName -> argName == param
+              _ -> False
+          | (param, arg) <- zip params args
+          ]
 
 inferBackendType :: Env -> ElabTerm -> Either BackendConversionError BackendType
 inferBackendType env term =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1999,8 +1999,7 @@ convertPartialApplication context env scope term resultTy =
       case normalizePartialApplicationSpine rawHeadTerm rawSuppliedArgs of
         (headTerm, suppliedArgs)
           | not (null suppliedArgs),
-            not (isConstructorHeadTerm context headTerm),
-            not (partialApplicationMentionsEvidence term) -> do
+            not (isConstructorHeadTerm context headTerm) -> do
               headTy <- normalizeBackendTypeForContext context <$> liftEitherConvert (inferBackendType env headTerm)
               let (paramTys, finalTy) = splitBackendArrows headTy
                   suppliedCount = length suppliedArgs
@@ -2018,7 +2017,7 @@ convertPartialApplication context env scope term resultTy =
                       )
                       [0 :: Int ..]
                       (zip suppliedParamTys suppliedArgs)
-                  if partialApplicationCanCaptureSuppliedArgs context scope (zip suppliedParamTys suppliedArgExprs)
+                  if partialApplicationCanCaptureSuppliedArgs context scope headTerm (zip3 [0 :: Int ..] suppliedParamTys suppliedArgExprs)
                     then Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
                     else pure Nothing
                 else pure Nothing
@@ -2388,15 +2387,13 @@ isConstructorHeadTerm context term =
     EVar name -> Map.member name (ccConstructors context)
     _ -> False
 
-partialApplicationMentionsEvidence :: ElabTerm -> Bool
-partialApplicationMentionsEvidence term =
-  any isEvidenceCaptureName (Set.toList (freeTermVariables term))
-
-partialApplicationCanCaptureSuppliedArgs :: ConvertContext -> ClosureScope -> [(BackendType, BackendExpr)] -> Bool
-partialApplicationCanCaptureSuppliedArgs context scope =
+partialApplicationCanCaptureSuppliedArgs :: ConvertContext -> ClosureScope -> ElabTerm -> [(Int, BackendType, BackendExpr)] -> Bool
+partialApplicationCanCaptureSuppliedArgs context scope headTerm =
   all canCapture
   where
-    canCapture (argTy, argExpr)
+    canCapture (index0, argTy, argExpr)
+      | partialApplicationArgumentIsEvidence context scope headTerm index0 =
+          canCaptureEvidence argTy argExpr
       | isClosureConvertibleFunctionType argTy =
           isFirstOrderFunctionCaptureType argTy
             && backendExprIsClosureValue context scope argExpr
@@ -2404,6 +2401,28 @@ partialApplicationCanCaptureSuppliedArgs context scope =
           False
       | otherwise =
           True
+
+    canCaptureEvidence argTy argExpr
+      | isFunctionLikeBackendType argTy =
+          isFirstOrderFunctionCaptureType argTy
+            && backendExprCanStoreFunctionReference context scope argExpr
+      | otherwise =
+          True
+
+partialApplicationArgumentIsEvidence :: ConvertContext -> ClosureScope -> ElabTerm -> Int -> Bool
+partialApplicationArgumentIsEvidence context scope headTerm index0 =
+  case stripClosureHeadTypeInsts headTerm of
+    EVar name ->
+      Set.member index0 (lookupEvidenceValueArguments context scope name)
+    _ ->
+      False
+
+backendExprCanStoreFunctionReference :: ConvertContext -> ClosureScope -> BackendExpr -> Bool
+backendExprCanStoreFunctionReference context scope expr =
+  backendExprIsClosureValue context scope expr
+    || case stripBackendHeadTypeApps expr of
+      BackendVar {} -> True
+      _ -> False
 
 isFunctionLikeBackendType :: BackendType -> Bool
 isFunctionLikeBackendType =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -79,6 +79,7 @@ data ConvertContext = ConvertContext
     ccData :: [DataMeta],
     ccGlobalTerms :: Set.Set String,
     ccClosureGlobals :: Set.Set String,
+    ccClosureValueArguments :: Map String (Set.Set Int),
     ccCurrentModuleName :: Maybe String,
     ccCurrentBindingName :: String
   }
@@ -1269,17 +1270,52 @@ buildConvertContext checked = do
             constructorMeta <- constructorMetasForData dataMeta
         ]
       bindingData = bindingDataHints dataMetas checked
-  Right
-    ConvertContext
-      { ccModuleScopes = moduleScopes,
-        ccConstructors = Map.fromList constructorMetas,
-        ccBindingData = bindingData,
-        ccData = dataMetas,
-        ccGlobalTerms = checkedProgramGlobalTerms checked,
-        ccClosureGlobals = Set.empty,
-        ccCurrentModuleName = Nothing,
-        ccCurrentBindingName = ""
-      }
+  let context0 =
+        ConvertContext
+          { ccModuleScopes = moduleScopes,
+            ccConstructors = Map.fromList constructorMetas,
+            ccBindingData = bindingData,
+            ccData = dataMetas,
+            ccGlobalTerms = checkedProgramGlobalTerms checked,
+            ccClosureGlobals = Set.empty,
+            ccClosureValueArguments = Map.empty,
+            ccCurrentModuleName = Nothing,
+            ccCurrentBindingName = ""
+          }
+  closureValueArguments <- checkedProgramClosureValueArguments context0 checked
+  Right context0 {ccClosureValueArguments = closureValueArguments}
+
+checkedProgramClosureValueArguments :: ConvertContext -> CheckedProgram -> Either BackendConversionError (Map String (Set.Set Int))
+checkedProgramClosureValueArguments context checked =
+  Map.fromList . concat
+    <$> forM
+      [ (checkedModule, binding)
+      | checkedModule <- checkedProgramModules checked,
+        binding <- checkedModuleBindings checkedModule
+      ]
+      ( \(checkedModule, binding) -> do
+          demanded <- checkedBindingClosureValueArguments context checkedModule binding
+          pure
+            [ (checkedBindingName binding, Set.fromList demanded)
+            | not (null demanded)
+            ]
+      )
+
+checkedBindingClosureValueArguments :: ConvertContext -> CheckedModule -> CheckedBinding -> Either BackendConversionError [Int]
+checkedBindingClosureValueArguments context checkedModule binding = do
+  canonicalElabTyOpen <- checkedBindingCanonicalTypeOpen context checkedModule binding
+  rawBindingTy <- convertElabType canonicalElabTyOpen
+  let bindingTy = canonicalizeBackendType context rawBindingTy
+      (_, valueTy) = splitBackendForalls bindingTy
+      (paramTys, _) = splitBackendArrows valueTy
+      (params, body) = collectLeadingLams (length paramTys) (checkedBindingTerm binding)
+  pure
+    [ index0
+    | (index0, ((name, _), paramTy)) <- zip [0 :: Int ..] (zip params paramTys),
+      not (isEvidenceCaptureName name),
+      isClosureConvertibleFunctionType paramTy,
+      termUsesFunctionAsValue paramTy name body
+    ]
 
 allDataInfos :: CheckedProgram -> [DataInfo]
 allDataInfos checked =
@@ -1488,6 +1524,7 @@ buildDataMeta scope info = do
             ccData = [rawMeta],
             ccGlobalTerms = Set.empty,
             ccClosureGlobals = Set.empty,
+            ccClosureValueArguments = Map.empty,
             ccCurrentModuleName = Just (dataModule info),
             ccCurrentBindingName = ""
           }
@@ -1852,12 +1889,96 @@ convertPartialApplication context env scope term resultTy =
           if suppliedCount < length paramTys
             && alphaEqBackendType resultTy expectedPartialTy
             && not (null remainingParamTys)
-            && partialApplicationCanCaptureSuppliedArgs suppliedParamTys
             then do
               suppliedArgExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) suppliedParamTys suppliedArgs
-              Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
+              if partialApplicationCanCaptureSuppliedArgs context scope (zip suppliedParamTys suppliedArgExprs)
+                then Just <$> packagePartialApplication context env scope resultTy headTerm headTy suppliedParamTys suppliedArgExprs remainingParamTys finalTy
+                else pure Nothing
             else pure Nothing
     _ -> pure Nothing
+
+convertClosureValueArgument ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  ConvertM BackendExpr
+convertClosureValueArgument context env scope expectedTy arg = do
+  argExpr <- convertTermExpectedMode DirectLambda context env scope (Just expectedTy) arg
+  if backendExprIsClosureValue context scope argExpr
+    then pure argExpr
+    else packageDirectFunctionValue context scope expectedTy arg argExpr
+
+convertCallArgument ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  ElabTerm ->
+  BackendType ->
+  ElabTerm ->
+  ConvertM BackendExpr
+convertCallArgument context env scope fun expectedArgTy arg
+  | applicationArgumentNeedsClosureValue context fun =
+      convertClosureValueArgument context env scope expectedArgTy arg
+  | otherwise =
+      convertTermExpectedMode DirectLambda context env scope (Just expectedArgTy) arg
+
+applicationArgumentNeedsClosureValue :: ConvertContext -> ElabTerm -> Bool
+applicationArgumentNeedsClosureValue context fun
+  | partialApplicationMentionsEvidence fun = False
+  | otherwise =
+      case stripClosureHeadTypeInsts headTerm of
+        EVar name ->
+          Set.member suppliedCount (Map.findWithDefault Set.empty name (ccClosureValueArguments context))
+        _ ->
+          False
+  where
+    (headTerm, suppliedArgs) = collectApps fun
+    suppliedCount = length suppliedArgs
+
+packageDirectFunctionValue ::
+  ConvertContext ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  BackendExpr ->
+  ConvertM BackendExpr
+packageDirectFunctionValue context scope resultTy headTerm headExpr = do
+  entryName <- freshClosureEntryName context (partialApplicationHint headTerm)
+  let (paramTys, _) = splitBackendArrows resultTy
+      params =
+        [ (name, paramTy)
+        | (name, paramTy) <- zip remainingParamNames paramTys
+        ]
+      paramVars =
+        [ BackendVar paramTy name
+        | (name, paramTy) <- params
+        ]
+  (captures, functionExpr) <-
+    case directLocalCalleeCaptureName context scope headExpr of
+      Just captureName -> do
+        let funCapture =
+              BackendClosureCapture
+                { backendClosureCaptureName = captureName,
+                  backendClosureCaptureType = resultTy,
+                  backendClosureCaptureExpr = headExpr
+                }
+        pure ([funCapture], BackendVar resultTy captureName)
+      Nothing ->
+        pure ([], headExpr)
+  body <- liftEitherConvert (applyPartialDirectArguments functionExpr resultTy paramVars)
+  pure
+    BackendClosure
+      { backendExprType = resultTy,
+        backendClosureEntryName = entryName,
+        backendClosureCaptures = captures,
+        backendClosureParams = params,
+        backendClosureBody = body
+      }
+  where
+    remainingParamNames =
+      ["__mlfp_closure_arg" ++ show index0 | index0 <- [(0 :: Int) ..]]
 
 packagePartialApplication ::
   ConvertContext ->
@@ -1894,17 +2015,21 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
         | (name, argTy) <- remainingParams
         ]
       allArgs = suppliedVars ++ remainingVars
+      functionCaptureName =
+        freshNameLike
+          (partialFunctionCaptureNameFor headTerm)
+          (Set.fromList (take (length suppliedParamTys) suppliedCaptureNames ++ take (length remainingParamTys) remainingParamNames))
   (captures, body) <-
     if isClosureHeadTerm context scope headTerm
       then do
         funExpr <- convertTermExpectedMode DirectLambda context env scope (Just headTy) headTerm
         let funCapture =
               BackendClosureCapture
-                { backendClosureCaptureName = partialFunctionCaptureName,
+                { backendClosureCaptureName = functionCaptureName,
                   backendClosureCaptureType = headTy,
                   backendClosureCaptureExpr = funExpr
                 }
-            funVar = BackendVar headTy partialFunctionCaptureName
+            funVar = BackendVar headTy functionCaptureName
         pure
           ( funCapture : suppliedCaptures,
             BackendClosureCall
@@ -1919,11 +2044,11 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
           then do
             let funCapture =
                   BackendClosureCapture
-                    { backendClosureCaptureName = partialFunctionCaptureName,
+                    { backendClosureCaptureName = functionCaptureName,
                       backendClosureCaptureType = headTy,
                       backendClosureCaptureExpr = headExpr
                     }
-                funVar = BackendVar headTy partialFunctionCaptureName
+                funVar = BackendVar headTy functionCaptureName
             pure
               ( funCapture : suppliedCaptures,
                 BackendClosureCall
@@ -1933,8 +2058,20 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
                   }
               )
           else do
-            bodyExpr <- liftEitherConvert (applyPartialDirectArguments headExpr headTy allArgs)
-            pure (suppliedCaptures, bodyExpr)
+            case directLocalCalleeCaptureName context scope headExpr of
+              Just captureName -> do
+                let funCapture =
+                      BackendClosureCapture
+                        { backendClosureCaptureName = captureName,
+                          backendClosureCaptureType = headTy,
+                          backendClosureCaptureExpr = headExpr
+                        }
+                    funVar = BackendVar headTy captureName
+                bodyExpr <- liftEitherConvert (applyPartialDirectArguments funVar headTy allArgs)
+                pure (funCapture : suppliedCaptures, bodyExpr)
+              Nothing -> do
+                bodyExpr <- liftEitherConvert (applyPartialDirectArguments headExpr headTy allArgs)
+                pure (suppliedCaptures, bodyExpr)
   pure
     BackendClosure
       { backendExprType = resultTy,
@@ -1952,6 +2089,27 @@ packagePartialApplication context env scope resultTy headTerm headTy suppliedPar
 partialFunctionCaptureName :: String
 partialFunctionCaptureName =
   "__mlfp_partial_function"
+
+partialFunctionCaptureNameFor :: ElabTerm -> String
+partialFunctionCaptureNameFor term =
+  case stripClosureHeadTypeInsts term of
+    EVar name -> name
+    _ -> partialFunctionCaptureName
+
+directLocalCalleeCaptureName :: ConvertContext -> ClosureScope -> BackendExpr -> Maybe String
+directLocalCalleeCaptureName context scope expr =
+  case stripBackendHeadTypeApps expr of
+    BackendVar _ name
+      | Set.member name (closureScopeBoundTerms scope),
+        Set.notMember name (ccGlobalTerms context) ->
+          Just name
+    _ -> Nothing
+
+stripBackendHeadTypeApps :: BackendExpr -> BackendExpr
+stripBackendHeadTypeApps =
+  \case
+    BackendTyApp _ fun _ -> stripBackendHeadTypeApps fun
+    other -> other
 
 applyPartialDirectArguments :: BackendExpr -> BackendType -> [BackendExpr] -> Either BackendConversionError BackendExpr
 applyPartialDirectArguments headExpr headTy args =
@@ -1993,9 +2151,15 @@ partialApplicationMentionsEvidence :: ElabTerm -> Bool
 partialApplicationMentionsEvidence term =
   any isEvidenceCaptureName (Set.toList (freeTermVariables term))
 
-partialApplicationCanCaptureSuppliedArgs :: [BackendType] -> Bool
-partialApplicationCanCaptureSuppliedArgs =
-  all (not . isClosureConvertibleFunctionType)
+partialApplicationCanCaptureSuppliedArgs :: ConvertContext -> ClosureScope -> [(BackendType, BackendExpr)] -> Bool
+partialApplicationCanCaptureSuppliedArgs context scope =
+  all canCapture
+  where
+    canCapture (argTy, argExpr)
+      | isClosureConvertibleFunctionType argTy =
+          backendExprIsClosureValue context scope argExpr
+      | otherwise =
+          True
 
 convertOrdinaryTerm :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> ElabTerm -> BackendType -> ConvertM BackendExpr
 convertOrdinaryTerm mode context env scope term resultTy0 =
@@ -2176,7 +2340,7 @@ convertApplicationFromFunction context env scope resultTy fun arg = do
   funExpr <- convertTermExpectedModeNoPartial DirectLambda context env scope Nothing fun
   argExpr <-
     case backendExprType funExpr of
-      BTArrow expectedArg _ -> convertTermExpectedMode DirectLambda context env scope (Just expectedArg) arg
+      BTArrow expectedArg _ -> convertCallArgument context env scope fun expectedArg arg
       _ -> convertTerm context env scope arg
   let callResultTy = applicationResultType resultTy funExpr
   if backendExprIsClosureValue context scope funExpr
@@ -2201,7 +2365,7 @@ convertApplicationFromExpectedResult context env scope resultTy fun arg = do
   rawArgTy <- liftEitherConvert (inferBackendType env arg)
   let argTy = canonicalizeBackendType context rawArgTy
   funExpr <- convertTermExpectedModeNoPartial DirectLambda context env scope (Just (BTArrow argTy resultTy)) fun
-  argExpr <- convertTermExpectedMode DirectLambda context env scope (Just argTy) arg
+  argExpr <- convertCallArgument context env scope fun argTy arg
   if backendExprIsClosureValue context scope funExpr
     then
       pure

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -1422,7 +1422,7 @@ aliasedClosureValueArguments context scope bindingTy term =
     (paramTys, _) = splitBackendArrows valueTy
     (params, body) = collectLeadingLams (length paramTys) term
     exposedCount = length paramTys - length params
-    (headTerm, suppliedArgs) = collectApps body
+    (headTerm, suppliedArgs) = collectAliasedApps body
     suppliedCount = length suppliedArgs
 
 lookupClosureValueArgumentDemand :: ConvertContext -> ClosureScope -> String -> Set.Set Int
@@ -4322,6 +4322,30 @@ collectApps =
       case term of
         EApp fun arg -> go (arg : args) fun
         other -> (other, args)
+
+collectAliasedApps :: ElabTerm -> (ElabTerm, [ElabTerm])
+collectAliasedApps =
+  go Set.empty
+  where
+    go seen term =
+      let (headTerm, args) = collectApps (stripAdministrativeTermWrappers term)
+          (resolvedHead, aliasArgs) = resolveHead seen headTerm
+       in (resolvedHead, aliasArgs ++ args)
+
+    resolveHead seen term =
+      case stripAdministrativeTermWrappers term of
+        ELet name _ rhs body
+          | Set.notMember name seen ->
+              let (bodyHead, bodyArgs) = go (Set.insert name seen) body
+               in case stripClosureHeadTypeInsts bodyHead of
+                    EVar bodyName
+                      | bodyName == name ->
+                          let (rhsHead, rhsArgs) = go (Set.insert name seen) rhs
+                           in (rhsHead, rhsArgs ++ bodyArgs)
+                    _ ->
+                      (term, [])
+        other ->
+          (other, [])
 
 inferBackendType :: Env -> ElabTerm -> Either BackendConversionError BackendType
 inferBackendType env term =

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -2366,8 +2366,18 @@ partialApplicationCanCaptureSuppliedArgs context scope =
     canCapture (argTy, argExpr)
       | isClosureConvertibleFunctionType argTy =
           backendExprIsClosureValue context scope argExpr
+      | isPolymorphicFunctionCaptureType argTy =
+          False
       | otherwise =
           True
+
+isPolymorphicFunctionCaptureType :: BackendType -> Bool
+isPolymorphicFunctionCaptureType =
+  \case
+    BTForall _ _ body ->
+      isClosureConvertibleFunctionType body || isPolymorphicFunctionCaptureType body
+    _ ->
+      False
 
 convertOrdinaryTerm :: LambdaMode -> ConvertContext -> Env -> ClosureScope -> ElabTerm -> BackendType -> ConvertM BackendExpr
 convertOrdinaryTerm mode context env scope term resultTy0 =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2914,10 +2914,30 @@ lowerClosureValue env exprEnv context resultTy entryName captures = do
   pure (LowerValue resultTy LLVMPtr closurePointer)
   where
     lowerCapture capture = do
-      value <- lowerExpr env exprEnv (context ++ ", closure capture " ++ show (backendClosureCaptureName capture)) (backendClosureCaptureExpr capture)
+      value <-
+        if shouldLowerStoredFunctionCapture capture
+          then
+            lowerStoredFunctionArgument
+              env
+              exprEnv
+              (context ++ ", closure capture " ++ show (backendClosureCaptureName capture))
+              (backendClosureCaptureType capture)
+              (backendClosureCaptureExpr capture)
+          else
+            lowerExpr env exprEnv (context ++ ", closure capture " ++ show (backendClosureCaptureName capture)) (backendClosureCaptureExpr capture)
       expectedTy <- lowerClosureStoredTypeM env context (backendClosureCaptureType capture)
       requireLLVMType context (backendClosureCaptureName capture) expectedTy value
       pure (expectedTy, value)
+
+    shouldLowerStoredFunctionCapture capture =
+      isFirstOrderFunctionPointerType (backendClosureCaptureType capture)
+        && not (isEvidenceArgument True (backendClosureCaptureName capture) (backendClosureCaptureType capture))
+        && case closurePointerAliasValue exprEnv (backendClosureCaptureExpr capture) of
+          Just _ -> False
+          Nothing ->
+            case collectTyApps (backendClosureCaptureExpr capture) of
+              (BackendVar {}, _) -> True
+              _ -> False
 
     lowerClosureEnvironment [] =
       pure LLVMNull

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3632,17 +3632,22 @@ lowerClosureRuntimeArgumentMaybe env exprEnv context expectedTy arg =
     Just value ->
       pure (Just value {lvBackendType = expectedTy})
     Nothing ->
-      case collectTyApps arg of
-        (BackendVar _ name, typeArgs)
-          | Just binding <- Map.lookup name (pbBindings (peBase env)) -> do
-              (_, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs []
-              if null (ffParams form)
-                && alphaEqBackendType expectedTy (ffReturnType form)
-                && isClosureRuntimeValueType (ffReturnType form)
-                then Just <$> lowerGlobalValue env context expectedTy name binding typeArgs
-                else pure Nothing
+      case arg of
+        BackendClosure {}
+          | alphaEqBackendType expectedTy (backendExprType arg) ->
+              Just <$> lowerExpr env exprEnv context arg
         _ ->
-          pure Nothing
+          case collectTyApps arg of
+            (BackendVar _ name, typeArgs)
+              | Just binding <- Map.lookup name (pbBindings (peBase env)) -> do
+                  (_, form) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs []
+                  if null (ffParams form)
+                    && alphaEqBackendType expectedTy (ffReturnType form)
+                    && isClosureRuntimeValueType (ffReturnType form)
+                    then Just <$> lowerGlobalValue env context expectedTy name binding typeArgs
+                    else pure Nothing
+            _ ->
+              pure Nothing
 
 isInlineFunctionArgument :: Bool -> String -> BackendType -> Bool
 isInlineFunctionArgument allowNestedEvidence paramName paramTy =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2934,12 +2934,29 @@ lowerClosureValue env exprEnv context resultTy entryName captures = do
     shouldLowerStoredFunctionCapture capture =
       isFirstOrderFunctionPointerType (backendClosureCaptureType capture)
         && not (isEvidenceArgument True (backendClosureCaptureName capture) (backendClosureCaptureType capture))
-        && case closurePointerAliasValue exprEnv (backendClosureCaptureExpr capture) of
-          Just _ -> False
-          Nothing ->
-            case collectTyApps (backendClosureCaptureExpr capture) of
-              (BackendVar {}, _) -> True
-              _ -> False
+        && not (captureExprIsRuntimeClosureValue capture)
+        && case collectTyApps (backendClosureCaptureExpr capture) of
+          (BackendVar {}, _) -> True
+          _ -> False
+
+    captureExprIsRuntimeClosureValue capture =
+      case closurePointerAliasValue exprEnv (backendClosureCaptureExpr capture) of
+        Just _ ->
+          True
+        Nothing ->
+          captureExprNamesGlobalClosureValue capture
+
+    captureExprNamesGlobalClosureValue capture =
+      case collectTyApps (backendClosureCaptureExpr capture) of
+        (BackendVar _ name, typeArgs)
+          | Just binding <- Map.lookup name (pbBindings (peBase env)),
+            Right (_, form) <- instantiateFunctionFormWithTypeArgs context (biForm binding) typeArgs [],
+            null (ffParams form),
+            alphaEqBackendType (backendClosureCaptureType capture) (ffReturnType form),
+            isClosureRuntimeValueType (ffReturnType form) ->
+              True
+        _ ->
+          False
 
     lowerClosureEnvironment [] =
       pure LLVMNull

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2339,12 +2339,28 @@ functionWrapperForm wrapper =
 applyEvidenceWrapperArgs :: BackendExpr -> BackendType -> [BackendExpr] -> BackendExpr
 applyEvidenceWrapperArgs expr _ [] =
   expr
+applyEvidenceWrapperArgs expr ty args
+  | backendExprIsExplicitClosure expr =
+      BackendClosureCall
+        { backendExprType = returnTy,
+          backendClosureFunction = expr,
+          backendClosureArguments = args
+        }
+  where
+    (_, returnTy) = collectArrowsType ty
 applyEvidenceWrapperArgs expr ty (arg : rest) =
   case ty of
     BTArrow _ resultTy ->
       applyEvidenceWrapperArgs (BackendApp resultTy expr arg) resultTy rest
     _ ->
       expr
+
+backendExprIsExplicitClosure :: BackendExpr -> Bool
+backendExprIsExplicitClosure =
+  \case
+    BackendClosure {} -> True
+    BackendLet _ _ _ _ body -> backendExprIsExplicitClosure body
+    _ -> False
 
 lowerFunction :: ProgramEnv -> String -> Bool -> FunctionForm -> Either BackendLLVMError LLVMFunction
 lowerFunction env name private form = do

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -849,6 +849,21 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosure
     backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosureCall
 
+  it "captures local direct callees when packaging partial applications" $ do
+    checked0 <- requireChecked localDirectAliasPartialApplicationBaseProgram
+    let checked =
+          mapMainBinding
+            ( \binding ->
+                binding {checkedBindingTerm = localDirectAliasPartialApplicationTerm}
+            )
+            checked0
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCapture "keep"
+
   it "shares closure entry names across lifted recursive helper conversion" $ do
     checked0 <- requireChecked liftedRecursiveHelpersClosureNameProgram
     let checked =
@@ -1415,6 +1430,27 @@ directLocalCallProgram =
       "    let f : Int -> Int = \\(x : Int) x in f 7;",
       "}"
     ]
+
+localDirectAliasPartialApplicationBaseProgram :: String
+localDirectAliasPartialApplicationBaseProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def main : Int = apply (keepLeft 1);",
+      "}"
+    ]
+
+localDirectAliasPartialApplicationTerm :: Elab.ElabTerm
+localDirectAliasPartialApplicationTerm =
+  Elab.ELet
+    "keep"
+    (Elab.schemeFromType binaryIntElabTy)
+    (Elab.EVar "Main__keepLeft")
+    ( Elab.EApp
+        (Elab.EVar "Main__apply")
+        (Elab.EApp (Elab.EVar "keep") (Elab.ELit (LInt 1)))
+    )
 
 liftedRecursiveHelpersClosureNameProgram :: String
 liftedRecursiveHelpersClosureNameProgram =
@@ -2116,6 +2152,10 @@ staleSomeInPolymorphicOptionTerm =
 unaryIntElabTy :: Elab.ElabType
 unaryIntElabTy =
   Elab.TArrow intElabTy intElabTy
+
+binaryIntElabTy :: Elab.ElabType
+binaryIntElabTy =
+  Elab.TArrow intElabTy (Elab.TArrow intElabTy intElabTy)
 
 recursiveCaptureAvoidingElabTy :: Elab.ElabType
 recursiveCaptureAvoidingElabTy =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -711,6 +711,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourceClosureDemandAfterEvidenceProgram "1"
 
+  it "packages constrained partial applications after hidden evidence" $ do
+    output <-
+      withTempProgram sourceConstrainedPartialApplicationProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldNotSatisfy` isInfixOf "unsupported static function argument"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceConstrainedPartialApplicationProgram "1"
+
   it "freshens generated partial capture names against local binders" $ do
     output <-
       withTempProgram sourcePartialApplicationGeneratedNameCollisionProgram $ \path ->
@@ -3360,6 +3371,22 @@ sourceClosureDemandAfterEvidenceProgram =
       "  def apply : (Int -> Int) -> Int = \\f f 2;",
       "  def use : Marker Bool => (Int -> Int -> Int) -> Int = \\f apply (f 1);",
       "  def main : Int = use keepLeft;",
+      "}"
+    ]
+
+sourceConstrainedPartialApplicationProgram :: String
+sourceConstrainedPartialApplicationProgram =
+  unlines
+    [ "module Main export (Pick, main) {",
+      "  class Pick a {",
+      "    pick : a -> a -> a;",
+      "  }",
+      "  instance Pick Int {",
+      "    pick = \\x \\y x;",
+      "  }",
+      "  def keep : Pick Int => Int -> Int -> Int = \\x \\y pick x y;",
+      "  def apply : (Int -> Int) -> Int = \\f f 1;",
+      "  def main : Int = apply (keep 1);",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -734,6 +734,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourceConstrainedPartialApplicationProgram "1"
 
+  it "packages constrained partial applications through constrained aliases" $ do
+    output <-
+      withTempProgram sourceConstrainedPartialApplicationAliasProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldNotSatisfy` isInfixOf "Backend LLVM arity mismatch"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceConstrainedPartialApplicationAliasProgram "1"
+
   it "freshens generated partial capture names against local binders" $ do
     output <-
       withTempProgram sourcePartialApplicationGeneratedNameCollisionProgram $ \path ->
@@ -756,6 +767,26 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationDirectFunctionArgumentProgram "4"
+
+  it "wraps closure-demanded arguments for let-headed call aliases" $ do
+    output <-
+      withTempProgram sourceClosureDemandLetHeadedCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceClosureDemandLetHeadedCallProgram "1"
+
+  it "wraps closure-demanded arguments for eta-expanded call heads" $ do
+    output <-
+      withTempProgram sourceClosureDemandEtaCallHeadProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceClosureDemandEtaCallHeadProgram "1"
 
   it "keeps polymorphic supplied partial arguments on the static specialization path" $ do
     output <-
@@ -3414,6 +3445,23 @@ sourceConstrainedPartialApplicationProgram =
       "}"
     ]
 
+sourceConstrainedPartialApplicationAliasProgram :: String
+sourceConstrainedPartialApplicationAliasProgram =
+  unlines
+    [ "module Main export (Pick, main) {",
+      "  class Pick a {",
+      "    pick : a -> a -> a;",
+      "  }",
+      "  instance Pick Int {",
+      "    pick = \\x \\y x;",
+      "  }",
+      "  def keep : Pick Int => Int -> Int -> Int = \\x \\y pick x y;",
+      "  def keepAlias : Pick Int => Int -> Int -> Int = keep;",
+      "  def apply : (Int -> Int) -> Int = \\f f 1;",
+      "  def main : Int = apply (keepAlias 1);",
+      "}"
+    ]
+
 sourcePartialApplicationGeneratedNameCollisionProgram :: String
 sourcePartialApplicationGeneratedNameCollisionProgram =
   unlines
@@ -3433,6 +3481,29 @@ sourcePartialApplicationDirectFunctionArgumentProgram =
       "  def choose : (Int -> Int -> Int) -> Int -> Int -> Int = \\f \\ignored \\x f x ignored;",
       "  def apply : (Int -> Int) -> Int = \\f f 4;",
       "  def main : Int = apply (choose keepLeft 0);",
+      "}"
+    ]
+
+sourceClosureDemandLetHeadedCallProgram :: String
+sourceClosureDemandLetHeadedCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def main : Int =",
+      "    (let f : (Int -> Int -> Int) -> Int = use in f) keepLeft;",
+      "}"
+    ]
+
+sourceClosureDemandEtaCallHeadProgram :: String
+sourceClosureDemandEtaCallHeadProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def main : Int = (\\(u : Int -> Int -> Int) use u) keepLeft;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -688,6 +688,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationClosureDemandWrappedAliasProgram "1"
 
+  it "offsets propagated closure-demand indices through eta-expanded aliases" $ do
+    output <-
+      withTempProgram sourcePartialApplicationClosureDemandEtaAliasProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationClosureDemandEtaAliasProgram "1"
+
   it "tracks partial closure-valued argument demand for local helpers" $ do
     output <-
       withTempProgram sourcePartialApplicationLocalClosureDemandProgram $ \path ->
@@ -3344,6 +3356,18 @@ sourcePartialApplicationClosureDemandWrappedAliasProgram =
       "  def useWrapped : (Int -> Int -> Int) -> Int =",
       "    let f : (Int -> Int -> Int) -> Int = use in f;",
       "  def main : Int = useWrapped keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationClosureDemandEtaAliasProgram :: String
+sourcePartialApplicationClosureDemandEtaAliasProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def useAfter : Int -> (Int -> Int -> Int) -> Int = \\n use;",
+      "  def main : Int = useAfter 0 keepLeft;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -712,6 +712,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationPolymorphicArgumentProgram "true"
 
+  it "keeps higher-rank supplied partial functions on the static specialization path" $ do
+    output <-
+      withTempProgram sourcePartialApplicationHigherRankFunctionArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldNotSatisfy` isInfixOf "escaping function value"
+    output `shouldNotSatisfy` isInfixOf "Main__useHigher$partial"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationHigherRankFunctionArgumentProgram "1"
+
   it "captures locals when wrapping demanded inline function arguments" $ do
     output <-
       withTempProgram sourceClosureDemandedInlineFunctionArgumentProgram $ \path ->
@@ -3311,6 +3322,19 @@ sourcePartialApplicationPolymorphicArgumentProgram =
       "    \\poly \\ignored let keepInt : Int = poly 1 in poly true;",
       "  def apply : (Int -> Bool) -> Bool = \\f f 0;",
       "  def main : Bool = apply (usePoly id);",
+      "}"
+    ]
+
+sourcePartialApplicationHigherRankFunctionArgumentProgram :: String
+sourcePartialApplicationHigherRankFunctionArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def id : forall a. a -> a = \\x x;",
+      "  def idScore : (forall a. a -> a) -> Int = \\poly poly 1;",
+      "  def useHigher : ((forall a. a -> a) -> Int) -> Int -> Int =",
+      "    \\score \\ignored score id;",
+      "  def apply : (Int -> Int) -> Int = \\f f 0;",
+      "  def main : Int = apply (useHigher idScore);",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -688,6 +688,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationLocalClosureDemandProgram "1"
 
+  it "wraps closure-demanded arguments after evidence arguments" $ do
+    output <-
+      withTempProgram sourceClosureDemandAfterEvidenceProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    output `shouldNotSatisfy` isInfixOf "BackendClosureCallExpectedClosureValue"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceClosureDemandAfterEvidenceProgram "1"
+
   it "wraps direct function arguments before packaging partial applications" $ do
     output <-
       withTempProgram sourcePartialApplicationDirectFunctionArgumentProgram $ \path ->
@@ -3299,6 +3310,21 @@ sourcePartialApplicationLocalClosureDemandProgram =
       "  def main : Int =",
       "    let use : (Int -> Int -> Int) -> Int = \\f apply (f 1)",
       "    in use keepLeft;",
+      "}"
+    ]
+
+sourceClosureDemandAfterEvidenceProgram :: String
+sourceClosureDemandAfterEvidenceProgram =
+  unlines
+    [ "module Main export (Marker, main) {",
+      "  class Marker a {",
+      "  }",
+      "  instance Marker Bool {",
+      "  }",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : Marker Bool => (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def main : Int = use keepLeft;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -640,6 +640,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationClosureArgumentProgram "41"
 
+  it "packages partial applications with global closure-valued supplied arguments" $ do
+    output <-
+      withTempProgram sourcePartialApplicationGlobalClosureArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "unsupported static function argument"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationGlobalClosureArgumentProgram "41"
+
   it "packages partial applications headed by closure-valued parameters" $ do
     output <-
       withTempProgram sourcePartialApplicationClosureParameterProgram $ \path ->
@@ -3156,6 +3168,19 @@ sourcePartialApplicationClosureArgumentProgram =
       "    let captured : Int = 41 in",
       "    let inc : Int -> Int = \\(x : Int) captured in",
       "    apply (choose inc 0);",
+      "}"
+    ]
+
+sourcePartialApplicationGlobalClosureArgumentProgram :: String
+sourcePartialApplicationGlobalClosureArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def choose : (Int -> Int) -> Int -> Int -> Int = \\f \\ignored \\x f x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 4;",
+      "  def globalInc : Int -> Int =",
+      "    let captured : Int = 41 in",
+      "    \\(x : Int) captured;",
+      "  def main : Int = apply (choose globalInc 0);",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -628,6 +628,30 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourceLocalPartialApplicationProgram "1"
 
+  it "packages partial applications with closure-valued supplied arguments" $ do
+    output <-
+      withTempProgram sourcePartialApplicationClosureArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "unsupported static function argument"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationClosureArgumentProgram "41"
+
+  it "packages partial applications headed by closure-valued parameters" $ do
+    output <-
+      withTempProgram sourcePartialApplicationClosureParameterProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "BackendClosureCallExpectedClosureValue"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationClosureParameterProgram "1"
+
   it "lowers source-level captured closure calls through the explicit closure ABI" $ do
     output <-
       withTempProgram sourceCapturedClosureCallProgram $ \path ->
@@ -3107,6 +3131,30 @@ sourceLocalPartialApplicationProgram =
       "  def main : Int =",
       "    let keepLeft : Int -> Int -> Int = \\x \\y x",
       "    in apply (keepLeft 1);",
+      "}"
+    ]
+
+sourcePartialApplicationClosureArgumentProgram :: String
+sourcePartialApplicationClosureArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def choose : (Int -> Int) -> Int -> Int -> Int = \\f \\ignored \\x f x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 4;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let inc : Int -> Int = \\(x : Int) captured in",
+      "    apply (choose inc 0);",
+      "}"
+    ]
+
+sourcePartialApplicationClosureParameterProgram :: String
+sourcePartialApplicationClosureParameterProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def main : Int = use keepLeft;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -592,13 +592,41 @@ spec = describe "MLF.Backend.LLVM" $ do
 
     mapM_ runLLVMParityCase programSpecToLLVMParityCases
 
-  it "rejects partial applications until closure conversion is explicit in backend IR" $ do
-    renderBackendProgramLLVM partialApplicationProgram
-      `shouldSatisfyLeft` isInfixOf "Backend LLVM arity mismatch"
+  it "lowers packaged partial applications through the explicit closure ABI" $ do
+    output <- requireRight (renderBackendProgramLLVM partialApplicationProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$addOne\""
+    output `shouldSatisfy` isInfixOf "store i64 1"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
 
   it "rejects raw escaping lambdas until closure construction is explicit in backend IR" $ do
     renderBackendProgramLLVM escapingLambdaProgram
       `shouldSatisfyLeft` isInfixOf "escaping function"
+
+  it "packages source-level top-level partial applications as closure values" $ do
+    output <-
+      withTempProgram sourceTopLevelPartialApplicationProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "__mlfp_closure$Main__main$Main__keepLeft$partial"
+    output `shouldSatisfy` isInfixOf "store i64 1"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceTopLevelPartialApplicationProgram "1"
+
+  it "packages source-level local partial applications as closure values" $ do
+    output <-
+      withTempProgram sourceLocalPartialApplicationProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceLocalPartialApplicationProgram "1"
 
   it "lowers source-level captured closure calls through the explicit closure ABI" $ do
     output <-
@@ -2927,12 +2955,36 @@ partialApplicationProgram =
     [ addBinding,
       BackendBinding
         { backendBindingName = "main",
-          backendBindingType = unaryIntTy,
+          backendBindingType = intTy,
           backendBindingExpr =
-            BackendApp
-              { backendExprType = unaryIntTy,
-                backendFunction = BackendVar binaryIntTy "add",
-                backendArgument = intLit 1
+            BackendLet
+              { backendExprType = intTy,
+                backendLetName = "addOne",
+                backendLetType = unaryIntTy,
+                backendLetRhs =
+                  BackendClosure
+                    { backendExprType = unaryIntTy,
+                      backendClosureEntryName = "__mlfp_closure$addOne",
+                      backendClosureCaptures = [BackendClosureCapture "__mlfp_partial_capture0" intTy (intLit 1)],
+                      backendClosureParams = [("__mlfp_partial_arg0", intTy)],
+                      backendClosureBody =
+                        BackendApp
+                          { backendExprType = intTy,
+                            backendFunction =
+                              BackendApp
+                                { backendExprType = unaryIntTy,
+                                  backendFunction = BackendVar binaryIntTy "add",
+                                  backendArgument = BackendVar intTy "__mlfp_partial_capture0"
+                                },
+                            backendArgument = BackendVar intTy "__mlfp_partial_arg0"
+                          }
+                    },
+                backendLetBody =
+                  BackendClosureCall
+                    { backendExprType = intTy,
+                      backendClosureFunction = BackendVar unaryIntTy "addOne",
+                      backendClosureArguments = [intLit 2]
+                    }
               },
           backendBindingExportedAsMain = True
         }
@@ -3034,6 +3086,27 @@ sourceTopLevelClosureCallProgram =
     [ "module Main export (main) {",
       "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
       "  def main : Int = maker 0;",
+      "}"
+    ]
+
+sourceTopLevelPartialApplicationProgram :: String
+sourceTopLevelPartialApplicationProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def main : Int = apply (keepLeft 1);",
+      "}"
+    ]
+
+sourceLocalPartialApplicationProgram :: String
+sourceLocalPartialApplicationProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def main : Int =",
+      "    let keepLeft : Int -> Int -> Int = \\x \\y x",
+      "    in apply (keepLeft 1);",
       "}"
     ]
 
@@ -3896,6 +3969,7 @@ llvmNativeRepresentativeParityCases =
 llvmObjectCodeParityCases :: [String]
 llvmObjectCodeParityCases =
     [ "surface: runs lambda/application",
+      "surface: runs top-level partial application",
       "unified fixture: test/programs/unified/authoritative-case-analysis.mlfp",
       "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp",
       "boundary: runs value-exported constructor when owner type is not exported",

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -699,6 +699,16 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourceClosureDemandAfterEvidenceProgram "1"
 
+  it "freshens generated partial capture names against local binders" $ do
+    output <-
+      withTempProgram sourcePartialApplicationGeneratedNameCollisionProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldNotSatisfy` isInfixOf "BackendDuplicateClosureCapture"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationGeneratedNameCollisionProgram "1"
+
   it "wraps direct function arguments before packaging partial applications" $ do
     output <-
       withTempProgram sourcePartialApplicationDirectFunctionArgumentProgram $ \path ->
@@ -3325,6 +3335,17 @@ sourceClosureDemandAfterEvidenceProgram =
       "  def apply : (Int -> Int) -> Int = \\f f 2;",
       "  def use : Marker Bool => (Int -> Int -> Int) -> Int = \\f apply (f 1);",
       "  def main : Int = use keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationGeneratedNameCollisionProgram :: String
+sourcePartialApplicationGeneratedNameCollisionProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def main : Int =",
+      "    let __mlfp_partial_capture0 : Int -> Int -> Int = \\x \\y x in",
+      "    apply (__mlfp_partial_capture0 1);",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -664,6 +664,42 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationClosureParameterProgram "1"
 
+  it "tracks partial closure-valued argument demand through top-level aliases" $ do
+    output <-
+      withTempProgram sourcePartialApplicationClosureDemandAliasProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationClosureDemandAliasProgram "1"
+
+  it "tracks partial closure-valued argument demand for local helpers" $ do
+    output <-
+      withTempProgram sourcePartialApplicationLocalClosureDemandProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationLocalClosureDemandProgram "1"
+
+  it "captures locals for non-variable partial callees" $ do
+    output <-
+      withTempProgram sourcePartialApplicationNonVariableCalleeProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "Backend LLVM arity mismatch"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationNonVariableCalleeProgram "1"
+
   it "lowers source-level captured closure calls through the explicit closure ABI" $ do
     output <-
       withTempProgram sourceCapturedClosureCallProgram $ \path ->
@@ -3192,6 +3228,42 @@ sourcePartialApplicationClosureParameterProgram =
       "  def apply : (Int -> Int) -> Int = \\f f 2;",
       "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
       "  def main : Int = use keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationClosureDemandAliasProgram :: String
+sourcePartialApplicationClosureDemandAliasProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def useAlias : (Int -> Int -> Int) -> Int = use;",
+      "  def main : Int = useAlias keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationLocalClosureDemandProgram :: String
+sourcePartialApplicationLocalClosureDemandProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def main : Int =",
+      "    let use : (Int -> Int -> Int) -> Int = \\f apply (f 1)",
+      "    in use keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationNonVariableCalleeProgram :: String
+sourcePartialApplicationNonVariableCalleeProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def make : Int -> Int -> Int -> Int = \\base \\ignored \\x base;",
+      "  def apply : (Int -> Int) -> Int = \\f f 4;",
+      "  def main : Int =",
+      "    let base : Int = 1 in",
+      "    apply (((\\z make z) base) 2);",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -676,6 +676,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationClosureDemandAliasProgram "1"
 
+  it "tracks partial closure-valued argument demand through wrapped aliases" $ do
+    output <-
+      withTempProgram sourcePartialApplicationClosureDemandWrappedAliasProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationClosureDemandWrappedAliasProgram "1"
+
   it "tracks partial closure-valued argument demand for local helpers" $ do
     output <-
       withTempProgram sourcePartialApplicationLocalClosureDemandProgram $ \path ->
@@ -3308,6 +3320,19 @@ sourcePartialApplicationClosureDemandAliasProgram =
       "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
       "  def useAlias : (Int -> Int -> Int) -> Int = use;",
       "  def main : Int = useAlias keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationClosureDemandWrappedAliasProgram :: String
+sourcePartialApplicationClosureDemandWrappedAliasProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def apply : (Int -> Int) -> Int = \\f f 2;",
+      "  def use : (Int -> Int -> Int) -> Int = \\f apply (f 1);",
+      "  def useWrapped : (Int -> Int -> Int) -> Int =",
+      "    let f : (Int -> Int -> Int) -> Int = use in f;",
+      "  def main : Int = useWrapped keepLeft;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -701,6 +701,17 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationDirectFunctionArgumentProgram "4"
 
+  it "keeps polymorphic supplied partial arguments on the static specialization path" $ do
+    output <-
+      withTempProgram sourcePartialApplicationPolymorphicArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldNotSatisfy` isInfixOf "escaping polymorphic binding"
+    output `shouldNotSatisfy` isInfixOf "Main__usePoly$partial"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationPolymorphicArgumentProgram "true"
+
   it "captures locals when wrapping demanded inline function arguments" $ do
     output <-
       withTempProgram sourceClosureDemandedInlineFunctionArgumentProgram $ \path ->
@@ -3288,6 +3299,18 @@ sourcePartialApplicationDirectFunctionArgumentProgram =
       "  def choose : (Int -> Int -> Int) -> Int -> Int -> Int = \\f \\ignored \\x f x ignored;",
       "  def apply : (Int -> Int) -> Int = \\f f 4;",
       "  def main : Int = apply (choose keepLeft 0);",
+      "}"
+    ]
+
+sourcePartialApplicationPolymorphicArgumentProgram :: String
+sourcePartialApplicationPolymorphicArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def id : forall a. a -> a = \\x x;",
+      "  def usePoly : (forall a. a -> a) -> Int -> Bool =",
+      "    \\poly \\ignored let keepInt : Int = poly 1 in poly true;",
+      "  def apply : (Int -> Bool) -> Bool = \\f f 0;",
+      "  def main : Bool = apply (usePoly id);",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -688,6 +688,31 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourcePartialApplicationLocalClosureDemandProgram "1"
 
+  it "wraps direct function arguments before packaging partial applications" $ do
+    output <-
+      withTempProgram sourcePartialApplicationDirectFunctionArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "unsupported static function argument"
+    output `shouldNotSatisfy` isInfixOf "store ptr @\"Main__keepLeft\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourcePartialApplicationDirectFunctionArgumentProgram "4"
+
+  it "captures locals when wrapping demanded inline function arguments" $ do
+    output <-
+      withTempProgram sourceClosureDemandedInlineFunctionArgumentProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "$partial"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "unsupported static function argument"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceClosureDemandedInlineFunctionArgumentProgram "41"
+
   it "captures locals for non-variable partial callees" $ do
     output <-
       withTempProgram sourcePartialApplicationNonVariableCalleeProgram $ \path ->
@@ -3252,6 +3277,30 @@ sourcePartialApplicationLocalClosureDemandProgram =
       "  def main : Int =",
       "    let use : (Int -> Int -> Int) -> Int = \\f apply (f 1)",
       "    in use keepLeft;",
+      "}"
+    ]
+
+sourcePartialApplicationDirectFunctionArgumentProgram :: String
+sourcePartialApplicationDirectFunctionArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def keepLeft : Int -> Int -> Int = \\x \\y x;",
+      "  def choose : (Int -> Int -> Int) -> Int -> Int -> Int = \\f \\ignored \\x f x ignored;",
+      "  def apply : (Int -> Int) -> Int = \\f f 4;",
+      "  def main : Int = apply (choose keepLeft 0);",
+      "}"
+    ]
+
+sourceClosureDemandedInlineFunctionArgumentProgram :: String
+sourceClosureDemandedInlineFunctionArgumentProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def choose : (Int -> Int -> Int) -> Int -> Int -> Int = \\f \\ignored \\x f x ignored;",
+      "  def apply : (Int -> Int) -> Int = \\f f 4;",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let use : (Int -> Int -> Int) -> Int = \\fn apply (choose fn 0) in",
+      "    use (\\x \\y captured);",
       "}"
     ]
 

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -67,6 +67,31 @@ emlfSurfaceParityMatrix =
         )
         (ExpectRunValue "1")
     , ProgramMatrixCase
+        "runs top-level partial application"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (main) {"
+                , "  def keepLeft : Int -> Int -> Int = \\x \\y x;"
+                , "  def apply : (Int -> Int) -> Int = \\f f 2;"
+                , "  def main : Int = apply (keepLeft 1);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "1")
+    , ProgramMatrixCase
+        "runs local partial application"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (main) {"
+                , "  def apply : (Int -> Int) -> Int = \\f f 2;"
+                , "  def main : Int ="
+                , "    let keepLeft : Int -> Int -> Int = \\x \\y x"
+                , "    in apply (keepLeft 1);"
+                , "}"
+                ]
+        )
+        (ExpectRunValue "1")
+    , ProgramMatrixCase
         "runs let polymorphism at Int and Bool"
         ( InlineProgram $
             unlines


### PR DESCRIPTION
Closes #96.

## Implementation Plan

---
issue_number: 96
pr_number: 116
branch: codex/issue-96
---

## Implementation Plan

1. Reconfirm branch/worktree before editing: stay on `codex/issue-96`, confirm PR #116 is the existing PR, and keep watcher-owned files untouched.

2. Add focused failing coverage first in `test/BackendLLVMSpec.hs` and/or `test/Parity/ProgramMatrix.hs` for checked-source partial applications that currently should lower through LLVM:
   - top-level known function partial application, then later closure call;
   - local let-bound function partial application, then later closure call;
   - keep the existing overloaded/typeclass partial rows green, and add representative object-code smoke coverage for at least one partial-application row.
   Convert the current raw partial-application rejection expectation into a success fixture using the explicit closure shape or checked-source path; avoid inventing a second raw underapplied-`BackendApp` ABI.

3. Implement partial-application packaging in `src/MLF/Backend/Convert.hs` using the existing closure IR:
   - recognize `collectApps` shapes where the checked head type has more value parameters than supplied arguments and the remaining type matches the expected result function type;
   - leave saturated calls on the existing direct/closure-call paths and leave overapplication/frontend ambiguity to existing checker diagnostics;
   - generate a `BackendClosure` with captures for supplied arguments and, when needed, the closure-valued callee, plus fresh remaining value parameters;
   - make the closure body apply captured supplied arguments followed by remaining parameters, using `BackendClosureCall` for closure-valued heads and direct backend applications for known direct global calls.

4. Make local-function underapplication work without weakening saturated local calls:
   - extend the local let closure-demand analysis so a let-bound function is closure-converted when it is used bare, passed/returned as a value, or underapplied;
   - keep fully saturated local calls as direct local calls.

5. Touch `src/MLF/Backend/LLVM/Lower.hs` only if tests expose a lowering gap for direct `BackendClosure` values used as first-order function arguments or for closure-entry collection/qualification through the new shapes. Reuse the existing closure ABI and validation instead of adding a new runtime representation.

6. Update durable docs for the behavior change: `docs/architecture.md`, `implementation_notes.md`, and `CHANGELOG.md` if the completed change records meaningful project progress.

7. Validate in increasing scope:
   - targeted partial/LLVM specs, for example `cabal test mlf2-test --test-show-details=direct --test-options='--match "partial"'` and an `MLF.Backend.LLVM` slice;
   - ensure generated LLVM validates with the existing `llvm-as` helpers and object-code smoke cases where tools are available;
   - final gate before completion: `cabal build all && cabal test`.

8. Publish only after validation: run `gh auth status` and `gh auth setup-git`, inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, and push `codex/issue-96` to the existing PR #116 without creating another PR.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.