### PR TITLE
Implement #97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
   now also stay runtime pointer aliases during lowering instead of being
   reclassified as raw escaping local functions.
 - Fixed checked-program closure conversion to clear shadowed closure locals when
-  classifying nested `let` values, and to fail closed on closure-valued
-  constructor fields until ADT field lowering has a closure-aware representation.
+  classifying nested `let` values, and to store/project monomorphic
+  function-valued constructor fields as explicit closure values.
 - Fixed closure conversion and LLVM lowering for type-abstracted closure-valued
   globals and nested `let` aliases of closure parameters, keeping both on the
   explicit closure-call ABI instead of the raw function-pointer path.
@@ -59,10 +59,10 @@
   runs, and rejects unsupported native result shapes before execution.
 - Eliminated the final temporary LLVM unsupported classification from the
   shared `ProgramSpec` runtime-success parity matrix. Stored first-order
-  function constructor fields now lower as function pointers, closed direct
-  function fields use private wrappers, captured closure fields still fail
-  closed, and the representative `llc` subset includes the formerly unsupported
-  typed constructor-field row.
+  function constructor fields now lower through the explicit closure ABI,
+  including captured closure fields projected by case analysis, and the
+  representative `llc` subset includes the formerly unsupported typed
+  constructor-field row.
 - Extended LLVM backend parity to higher-kinded constructor fields and
   hidden-owner value-constructor imports. Backend IR now preserves applied type
   variables, conversion recovers structural higher-kinded constructor terms as

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,14 +192,15 @@ the existing direct-call path; indirect calls must be represented with
 `BackendClosureCall`.
 
 Checked-program conversion now closure-converts ordinary monomorphic escaping
-source lambdas, returned local function values, closure-valued let aliases, and
-indirect calls through those aliases into explicit closure IR. Direct
-first-order local calls remain direct backend applications. Partial application
-lowering, higher-order constructor fields that require captured environments,
-recursive higher-order flows, and final executable linking remain future
-extension points. Those diagnostics do not weaken source inference, checking,
-module visibility, or runtime semantics; they only describe the current
-IR-to-LLVM lowering surface.
+source lambdas, returned local function values, closure-valued let aliases,
+monomorphic function-valued constructor fields, and indirect calls through
+those aliases or projected fields into explicit closure IR. Direct first-order
+local calls remain direct backend applications. Partial application lowering,
+polymorphic or type-parameter-headed higher-order constructor fields, recursive
+higher-order flows, and final executable linking remain future extension
+points. Those diagnostics do not weaken source inference, checking, module
+visibility, or runtime semantics; they only describe the current IR-to-LLVM
+lowering surface.
 
 ## `Solved` boundary and thesis-exact cleanup rule
 

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,16 @@
+## 2026-04-30 - Closure-valued ADT fields
+
+- Checked-program conversion now stores monomorphic function-valued constructor
+  fields as `BackendClosure` values. Direct function references are
+  eta-expanded under the known field type when they are not already closure
+  values, while captured lambdas keep their closure environments.
+- Backend IR validation and LLVM lowering now treat constructor pattern binders
+  for arrow fields as closure-valued locals. Case-projected function fields are
+  loaded as closure pointers and must be applied with `BackendClosureCall`.
+- The shared ProgramSpec-to-LLVM parity matrix includes a runtime row that
+  stores a captured function in an ADT, projects it with case analysis, applies
+  it, and returns `41`.
+
 ## 2026-04-30 - Native execution for supported LLVM parity rows
 
 - Extended `BackendLLVMSpec` so supported shared `ProgramSpec`-to-LLVM parity
@@ -59,10 +72,10 @@
   `programSpecToLLVMParityCases` row now expects LLVM emission and `llvm-as`
   validation instead of accepting an unsupported backend diagnostic.
 - The LLVM lowerer now stores first-order function-valued constructor fields as
-  function pointers. Top-level function references are stored directly, closed
-  direct function expressions are lifted through private function wrappers, and
-  captured constructor-field functions still fail closed until closure
-  conversion exists.
+  explicit closure pointers. Checked-program conversion eta-expands direct
+  function references when needed, captured constructor-field functions carry
+  closure environments, and case-projected function fields remain
+  `BackendClosureCall` callees.
 - Representative object-code coverage now includes the former unsupported
   typed non-data constructor-field row, so the `llc -filetype=obj` smoke subset
   exercises stored function-field lowering in addition to the existing first

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -153,9 +153,14 @@ extendClosureScopeTerm name ty isClosure scope =
           else Set.delete name (closureScopeLocals scope)
     }
 
-extendClosureScopeTerms :: [(String, ElabType)] -> ClosureScope -> ClosureScope
-extendClosureScopeTerms bindings scope =
-  foldr (\(name, ty) acc -> extendClosureScopeTerm name ty False acc) scope bindings
+extendClosureScopePatternFields :: [((String, ElabType), BackendType)] -> ClosureScope -> ClosureScope
+extendClosureScopePatternFields bindings scope =
+  foldr
+    ( \((name, ty), fieldTy) acc ->
+        extendClosureScopeTerm name ty (isClosureConvertibleFunctionType fieldTy) acc
+    )
+    scope
+    bindings
 
 extendClosureScopeLambdaParams :: [(String, ElabType)] -> ClosureScope -> ClosureScope
 extendClosureScopeLambdaParams bindings scope =
@@ -2103,23 +2108,73 @@ backendExprIsClosureValue context scope =
     alternativeIsClosureValue alternative =
       backendExprIsClosureValue
         context
-        (scopeWithoutPatternBinders (backendAltPattern alternative))
+        (scopeForPatternBody (backendAltPattern alternative) (backendAltBody alternative))
         (backendAltBody alternative)
 
-    scopeWithoutPatternBinders pattern0 =
+    scopeForPatternBody pattern0 body =
       scope
         { closureScopeBoundTerms = closureScopeBoundTerms scope <> binders,
           closureScopeLocals =
-            closureScopeLocals scope `Set.difference` binders
+            (closureScopeLocals scope `Set.difference` binders) <> closureBinders
         }
       where
         binders = backendPatternBinders pattern0
+        closureBinders =
+          Set.filter
+            (\name -> backendExprMentionsNameWithClosureType name body)
+            binders
 
 backendPatternBinders :: BackendPattern -> Set.Set String
 backendPatternBinders =
   \case
     BackendDefaultPattern -> Set.empty
     BackendConstructorPattern _ binders -> Set.fromList binders
+
+backendExprMentionsNameWithClosureType :: String -> BackendExpr -> Bool
+backendExprMentionsNameWithClosureType needle =
+  go
+  where
+    go =
+      \case
+        BackendVar ty name ->
+          name == needle && isClosureConvertibleFunctionType ty
+        BackendLit {} ->
+          False
+        BackendLam _ name _ body
+          | name == needle -> False
+          | otherwise -> go body
+        BackendApp _ fun arg ->
+          go fun || go arg
+        BackendLet _ name _ rhs body
+          | name == needle -> go rhs
+          | otherwise -> go rhs || go body
+        BackendTyAbs _ _ _ body ->
+          go body
+        BackendTyApp ty (BackendVar _ name) _
+          | name == needle,
+            isClosureConvertibleFunctionType ty ->
+              True
+        BackendTyApp _ fun _ ->
+          go fun
+        BackendConstruct _ _ args ->
+          any go args
+        BackendCase _ scrutinee alternatives ->
+          go scrutinee || any goAlternative (NE.toList alternatives)
+        BackendRoll _ payload ->
+          go payload
+        BackendUnroll _ payload ->
+          go payload
+        BackendClosure _ _ captures params body ->
+          any (go . backendClosureCaptureExpr) captures
+            || (not (Set.member needle closureBinders) && go body)
+          where
+            closureBinders = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+        BackendClosureCall _ fun args ->
+          go fun || any go args
+
+    goAlternative (BackendAlternative pattern0 body)
+      | Set.member needle (backendPatternBinders pattern0) = False
+      | otherwise = go body
 
 isClosureHeadTerm :: ConvertContext -> ClosureScope -> ElabTerm -> Bool
 isClosureHeadTerm context scope term =
@@ -2549,8 +2604,7 @@ convertConstructorApplication _mode context env scope term resultTy =
                   )
               )
           )
-      argExprs <- zipWithM (convertTermExpectedMode DirectLambda context env scope . Just) fields args
-      liftEitherConvert (mapM_ (rejectClosureValuedConstructorField constructor) (zip3 [0 :: Int ..] fields argExprs))
+      argExprs <- zipWithM (convertConstructorFieldArgument context env scope) fields args
       liftEitherConvert (mapM_ (checkConstructorArgumentType context ownerContext typeBounds constructor) (zip [0 :: Int ..] (zip fields argExprs)))
       pure
         ( Just
@@ -2568,20 +2622,6 @@ convertConstructorApplication _mode context env scope term resultTy =
             ++ backendConstructorName constructor
             ++ "`"
         )
-
-    rejectClosureValuedConstructorField constructor (index0, fieldTy, argExpr)
-      | isClosureConvertibleFunctionType fieldTy,
-        backendExprIsClosureValue context scope argExpr =
-          Left
-            ( BackendUnsupportedCaseShape
-                ( "closure-valued constructor field `"
-                    ++ backendConstructorName constructor
-                    ++ "` argument "
-                    ++ show index0
-                    ++ " requires closure-aware ADT field lowering"
-                )
-            )
-      | otherwise = Right ()
 
     constructorResultSubstitution globalContext ownerContext typeBounds dataParameters parameters explicitSubstitution constructorResultTy effectiveResultTy =
       matchConstructorResult constructorResultTy effectiveResultTy normalizedExplicitSubstitution
@@ -2697,6 +2737,67 @@ convertConstructorApplication _mode context env scope term resultTy =
     resultTypePlaceholderBoundMatches typeBounds (Just actual) (Just expected) =
       resultTypePlaceholderMatches typeBounds actual expected
     resultTypePlaceholderBoundMatches _ _ _ = False
+
+convertConstructorFieldArgument ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  ConvertM BackendExpr
+convertConstructorFieldArgument context env scope fieldTy arg
+  | isClosureConvertibleFunctionType fieldTy = do
+      closureExpr <- convertTermExpectedMode (ClosureLambda Nothing) context env scope (Just fieldTy) arg
+      if backendExprIsClosureValue context scope closureExpr
+        then pure closureExpr
+        else convertEtaExpandedConstructorFieldClosure context env scope fieldTy arg
+  | otherwise =
+      convertTermExpectedMode DirectLambda context env scope (Just fieldTy) arg
+
+convertEtaExpandedConstructorFieldClosure ::
+  ConvertContext ->
+  Env ->
+  ClosureScope ->
+  BackendType ->
+  ElabTerm ->
+  ConvertM BackendExpr
+convertEtaExpandedConstructorFieldClosure context env scope fieldTy arg = do
+  params <- closureFieldEtaParams fieldTy arg
+  let applied = foldl EApp arg [EVar name | (name, _) <- params]
+      etaTerm = foldr (\(name, ty) body -> ELam name ty body) applied params
+  convertTermExpectedMode (ClosureLambda Nothing) context env scope (Just fieldTy) etaTerm
+
+closureFieldEtaParams :: BackendType -> ElabTerm -> ConvertM [(String, ElabType)]
+closureFieldEtaParams fieldTy arg = do
+  let (paramTys, _) = splitBackendArrows fieldTy
+  when (null paramTys) $
+    liftEitherConvert (Left (BackendUnsupportedCaseShape "closure-valued constructor field expected a function type"))
+  paramElabTys <-
+    traverse
+      ( \paramTy ->
+          case backendTypeToElabType paramTy of
+            Just elabTy -> pure elabTy
+            Nothing ->
+              liftEitherConvert
+                ( Left
+                    ( BackendUnsupportedCaseShape
+                        "closure-valued constructor field has a parameter type that cannot be eta-expanded"
+                    )
+                )
+      )
+      paramTys
+  let paramNames = freshConstructorFieldParamNames (length paramElabTys) (termVariableNames arg)
+  pure (zip paramNames paramElabTys)
+
+freshConstructorFieldParamNames :: Int -> Set.Set String -> [String]
+freshConstructorFieldParamNames count used0 =
+  go 0 used0
+  where
+    go index0 used
+      | index0 >= count = []
+      | otherwise =
+          let candidate = freshNameLike ("__mlfp_field_arg" ++ show index0) used
+           in candidate : go (index0 + 1) (Set.insert candidate used)
 
 constructorApplicationTerm :: ConvertContext -> ElabTerm -> Either BackendConversionError (Maybe ConstructorApplication)
 constructorApplicationTerm context term =
@@ -3501,7 +3602,7 @@ convertCaseAlternative mode context env scope resultTy dataMeta scrutineeTy cons
           (\(name, ty) acc -> extendTermEnv name ty acc)
           env
           fieldEnvTypes
-      scope' = extendClosureScopeTerms fieldEnvTypes scope
+      scope' = extendClosureScopePatternFields (zip fieldEnvTypes fields) scope
       bodyMode =
         if isClosureConvertibleFunctionType resultTy
           then ClosureLambda Nothing

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -618,7 +618,6 @@ validateBackendProgram program = do
     bindings = concatMap backendModuleBindings modules0
     constructors = concatMap backendDataConstructors (concatMap backendModuleData modules0)
     closureEntryNames = concatMap (backendClosureEntryNames . backendBindingExpr) bindings
-    closureGlobals = backendClosureGlobalNames bindings
     constructorInfos =
       [ ( backendConstructorName constructor,
           BackendConstructorInfo
@@ -630,7 +629,7 @@ validateBackendProgram program = do
         | dataDecl <- concatMap backendModuleData modules0,
           constructor <- backendDataConstructors dataDecl
       ]
-    context0 =
+    baseContext =
       BackendValidationContext
         { bvcGlobals =
             Map.fromList [(backendBindingName binding, backendBindingType binding) | binding <- bindings]
@@ -638,14 +637,17 @@ validateBackendProgram program = do
           bvcData = Map.fromList [(backendDataName dataDecl, dataDecl) | dataDecl <- concatMap backendModuleData modules0],
           bvcConstructors = Map.fromList constructorInfos,
           bvcLocals = Map.empty,
-          bvcClosureGlobals = closureGlobals,
+          bvcClosureGlobals = Set.empty,
           bvcClosureLocals = Set.empty,
           bvcPossibleClosureLocals = Set.empty,
           bvcTypeBounds = Map.empty
         }
+    closureGlobals = backendClosureGlobalNames baseContext bindings
+    context0 =
+      baseContext {bvcClosureGlobals = closureGlobals}
 
-backendClosureGlobalNames :: [BackendBinding] -> Set.Set String
-backendClosureGlobalNames bindings =
+backendClosureGlobalNames :: BackendValidationContext -> [BackendBinding] -> Set.Set String
+backendClosureGlobalNames baseContext bindings =
   go Set.empty
   where
     go globals =
@@ -653,46 +655,11 @@ backendClosureGlobalNames bindings =
             Set.fromList
               [ backendBindingName binding
                 | binding <- bindings,
-                  backendExprIsGlobalClosureValue globals (backendBindingExpr binding)
+                  Just _ <- [backendDefiniteClosureValueName (Just (baseContext {bvcClosureGlobals = globals})) (backendBindingExpr binding)]
               ]
        in if globals' == globals
             then globals
             else go globals'
-
-backendExprIsGlobalClosureValue :: Set.Set String -> BackendExpr -> Bool
-backendExprIsGlobalClosureValue globals =
-  go Set.empty Set.empty
-  where
-    go closureLocals boundLocals =
-      \case
-        BackendClosure {} ->
-          True
-        BackendVar _ name
-          | Set.member name closureLocals -> True
-          | Set.member name boundLocals -> False
-          | otherwise -> Set.member name globals
-        BackendTyAbs _ _ _ body ->
-          go closureLocals boundLocals body
-        BackendTyApp _ fun _ ->
-          go closureLocals boundLocals fun
-        BackendLet _ name _ rhs body ->
-          let closureLocals' =
-                if go closureLocals boundLocals rhs
-                  then Set.insert name closureLocals
-                  else Set.delete name closureLocals
-              boundLocals' = Set.insert name boundLocals
-           in go closureLocals' boundLocals' body
-        BackendCase {backendAlternatives = alternatives} ->
-          all (goAlternative closureLocals boundLocals) (NE.toList alternatives)
-        _ ->
-          False
-
-    goAlternative closureLocals boundLocals (BackendAlternative pattern0 body) =
-      let binders = patternBinders pattern0
-       in go
-            (closureLocals `Set.difference` binders)
-            (boundLocals <> binders)
-            body
 
 backendRuntimePrimitiveTypes :: Map.Map String BackendType
 backendRuntimePrimitiveTypes =
@@ -857,6 +824,8 @@ backendClosureValueName mbContext =
       | Just context0 <- mbContext,
         backendContextNameIsClosureValue True context0 name ->
           Just name
+    BackendTyAbs _ _ _ body ->
+      backendClosureValueName mbContext body
     BackendTyApp _ fun _ ->
       backendClosureValueName mbContext fun
     BackendLet _ name bindingTy rhs body ->
@@ -875,6 +844,8 @@ backendDefiniteClosureValueName mbContext =
       | Just context0 <- mbContext,
         backendContextNameIsClosureValue False context0 name ->
           Just name
+    BackendTyAbs _ _ _ body ->
+      backendDefiniteClosureValueName mbContext body
     BackendTyApp _ fun _ ->
       backendDefiniteClosureValueName mbContext fun
     BackendLet _ name bindingTy rhs body ->
@@ -1449,13 +1420,19 @@ extendClosureShapeLocalMaybe sourceContext targetContext name ty rhs
   | otherwise =
       extendLocalMaybe targetContext name ty
 
-extendLocals :: BackendValidationContext -> [(String, BackendType)] -> BackendValidationContext
-extendLocals context0 bindings =
-  context0
-    { bvcLocals = foldr (uncurry Map.insert) (bvcLocals context0) bindings,
-      bvcClosureLocals = foldr (Set.delete . fst) (bvcClosureLocals context0) bindings,
-      bvcPossibleClosureLocals = foldr (Set.delete . fst) (bvcPossibleClosureLocals context0) bindings
-    }
+extendPatternLocals :: BackendValidationContext -> [(String, BackendType)] -> BackendValidationContext
+extendPatternLocals =
+  foldr extendOne
+  where
+    extendOne (name, ty) context0
+      | backendTypeIsClosureValue ty = extendClosureLocal context0 name ty
+      | otherwise = extendLocal context0 name ty
+
+backendTypeIsClosureValue :: BackendType -> Bool
+backendTypeIsClosureValue =
+  \case
+    BTArrow {} -> True
+    _ -> False
 
 dropTermLocalsMaybe :: Maybe BackendValidationContext -> Maybe BackendValidationContext
 dropTermLocalsMaybe =
@@ -1730,7 +1707,7 @@ validateBackendPattern (Just context0) scrutineeTy (BackendConstructorPattern na
             extendTypeBounds
               context0
               (constructorPatternTypeBounds substitution fresheningSubstitution constructor)
-      pure (Just (extendLocals contextForBody (zip binders instantiatedFields)))
+      pure (Just (extendPatternLocals contextForBody (zip binders instantiatedFields)))
 
 constructorPatternFresheningSubstitution ::
   BackendValidationContext ->

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -975,15 +975,16 @@ functionFormType form =
 
 backendTypeHasRuntimeRepresentation :: ProgramEnv -> BackendType -> Bool
 backendTypeHasRuntimeRepresentation env ty =
-  case lowerBackendType env "runtime representation check" ty of
-    Right _ -> True
-    Left _ -> False
+  isClosureRuntimeValueType ty
+    || case lowerBackendType env "runtime representation check" ty of
+      Right _ -> True
+      Left _ -> False
 
 backendTypeRequiresStaticSpecialization :: BackendType -> Bool
 backendTypeRequiresStaticSpecialization =
   \case
     BTVar {} -> False
-    BTArrow {} -> True
+    BTArrow {} -> False
     BTBase {} -> False
     BTCon {} -> False
     BTVarApp {} -> True
@@ -1642,6 +1643,7 @@ collectFunctionWrappersInExpr base substitution localFunctions bound expr =
                 let fieldTy' = substituteBackendTypes substitution fieldTy,
                 let arg' = substituteExprTypes substitution arg,
                 isFirstOrderFunctionPointerType fieldTy',
+                not (isClosureRuntimeValueType fieldTy'),
                 Just request <- [functionWrapperRequest fieldTy' arg']
               ]
             Nothing -> []
@@ -3914,6 +3916,11 @@ lowerConstruct env exprEnv context resultTy name args =
 
 lowerConstructField :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
 lowerConstructField env exprEnv context fieldTy arg
+  | isClosureRuntimeValueType fieldTy = do
+      value <- lowerExpr env exprEnv context arg
+      expectedTy <- lowerRuntimeValueTypeM env context fieldTy
+      requireLLVMType context "constructor field" expectedTy value
+      pure value {lvBackendType = fieldTy}
   | isFirstOrderFunctionPointerType fieldTy =
       lowerStoredFunctionArgument env exprEnv context fieldTy arg
   | otherwise =
@@ -4044,11 +4051,13 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
 
 lowerStoredFieldTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
 lowerStoredFieldTypeM env context fieldTy
+  | isClosureRuntimeValueType fieldTy = pure LLVMPtr
   | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
   | otherwise = lowerBackendTypeM env context fieldTy
 
 lowerClosureStoredTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
 lowerClosureStoredTypeM env context fieldTy
+  | isClosureRuntimeValueType fieldTy = pure LLVMPtr
   | isFirstOrderFunctionPointerType fieldTy = pure LLVMPtr
   | otherwise = lowerBackendTypeM env context fieldTy
 
@@ -4164,8 +4173,8 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
             then pure acc {eeLocalFunctions = Map.insert binder localFunction (eeLocalFunctions acc)}
             else pure acc
       | backendTypeHasRuntimeRepresentation env fieldTy = do
-          value <- lowerExpr env exprEnv context arg
-          expectedTy <- lowerBackendTypeM env context fieldTy
+          value <- lowerConstructField env exprEnv context fieldTy arg
+          expectedTy <- lowerRuntimeValueTypeM env context fieldTy
           requireLLVMType context constructorName expectedTy value
           if Set.member binder usedBinders
             then pure acc {eeValues = Map.insert binder value (eeValues acc)}
@@ -4178,8 +4187,8 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
           _ <- lowerStaticFunctionArgument env exprEnv context "_" fieldTy arg
           pure ()
       | backendTypeHasRuntimeRepresentation env fieldTy = do
-          value <- lowerExpr env exprEnv context arg
-          expectedTy <- lowerBackendTypeM env context fieldTy
+          value <- lowerConstructField env exprEnv context fieldTy arg
+          expectedTy <- lowerRuntimeValueTypeM env context fieldTy
           requireLLVMType context constructorName expectedTy value
       | otherwise =
           liftEither (BackendLLVMUnsupportedType ("field at " ++ context) fieldTy)

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -788,34 +788,36 @@ spec = describe "MLF.Backend.Convert" $ do
     backendBindingExpr useBinding `shouldSatisfy` containsBackendApp
     backendBindingExpr useBinding `shouldNotSatisfy` containsBackendClosureCall
 
-  it "clears shadowed closure locals when classifying case pattern results" $ do
+  it "classifies function-valued case pattern fields as closure locals" $ do
     checked <- requireChecked shadowedCaseClosureLocalProgram
     backend <- requireRight (convertCheckedProgram checked)
 
     validateBackendProgram backend `shouldBe` Right ()
     useBinding <- requireBinding "Main__use" backend
     backendBindingExpr useBinding `shouldSatisfy` containsBackendCase
-    backendBindingExpr useBinding `shouldSatisfy` containsBackendApp
-    backendBindingExpr useBinding `shouldNotSatisfy` containsBackendClosureCall
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr useBinding `shouldSatisfy` containsBackendClosureCall
 
-  it "keeps local non-closure binders from inheriting same-named closure globals" $ do
+  it "lets function-valued case fields shadow same-named closure globals" $ do
     checked <- requireChecked shadowedGlobalClosureHeadProgram
     backend <- requireRight (convertCheckedProgram checked)
 
     validateBackendProgram backend `shouldBe` Right ()
     mainBinding <- requireBinding (backendProgramMain backend) backend
     backendBindingExpr mainBinding `shouldSatisfy` containsBackendCase
-    backendBindingExpr mainBinding `shouldSatisfy` containsBackendApp
-    backendBindingExpr mainBinding `shouldNotSatisfy` containsBackendClosureCall
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
 
-  it "rejects closure-valued constructor fields until ADT fields are closure-aware" $ do
+  it "stores and projects closure-valued constructor fields as closure values" $ do
     checked <- requireChecked closureValuedConstructorFieldProgram
+    backend <- requireRight (convertCheckedProgram checked)
 
-    case convertCheckedProgram checked of
-      Left (BackendUnsupportedCaseShape message) ->
-        message `shouldSatisfy` isInfixOf "closure-valued constructor field"
-      other ->
-        expectationFailure ("expected closure-valued constructor field rejection, got " ++ show other)
+    validateBackendProgram backend `shouldBe` Right ()
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendCase
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCapture "captured"
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosureCall
 
   it "collects closure parameters through lets before returned lambdas" $ do
     checked <- requireChecked returnedLetLambdaClosureProgram

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -246,21 +246,44 @@ spec = describe "MLF.Backend.IR" $ do
             ]
         shadowedCaseClosureGlobalProgram =
           programWithDataAndBindings
-            [fnBoxData]
+            [boxData]
             [ binding "f" idTy globalClosure,
-              binding
-                "g"
-                idTy
+              mainBinding
                 ( BackendCase
-                    idTy
-                    (BackendConstruct fnBoxTy "FnBox" [intIdentityExpr])
-                    (BackendAlternative (BackendConstructorPattern "FnBox" ["f"]) (BackendVar idTy "f") :| [])
-                ),
-              mainBinding (BackendApp intTy (BackendVar idTy "g") (intLit 1))
+                    intTy
+                    (BackendConstruct boxTy "Box" [intLit 1])
+                    (BackendAlternative (BackendConstructorPattern "Box" ["f"]) (BackendVar intTy "f") :| [])
+                )
             ]
 
     validateBackendProgram shadowedLetCallProgram `shouldBe` Right ()
     validateBackendProgram shadowedCaseClosureGlobalProgram `shouldBe` Right ()
+
+  it "treats function-valued case pattern binders as closure values during validation" $ do
+    let fieldClosure =
+          BackendClosure
+            { backendExprType = idTy,
+              backendClosureEntryName = "__mlfp_closure$field",
+              backendClosureCaptures = [],
+              backendClosureParams = [("x", intTy)],
+              backendClosureBody = BackendVar intTy "x"
+            }
+        program =
+          programWithDataAndBindings
+            [fnBoxData]
+            [ mainBinding
+                ( BackendClosureCall
+                    intTy
+                    ( BackendCase
+                        idTy
+                        (BackendConstruct fnBoxTy "FnBox" [fieldClosure])
+                        (BackendAlternative (BackendConstructorPattern "FnBox" ["f"]) (BackendVar idTy "f") :| [])
+                    )
+                    [intLit 1]
+                )
+            ]
+
+    validateBackendProgram program `shouldBe` Right ()
 
   it "rejects malformed closure IR" $ do
     let goodClosure entryName =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -550,10 +550,10 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "evidence function type mismatch"
     validateLLVMAssembly output
 
-  it "preserves inline function argument shadowing for bare references" $ do
+  it "preserves inline function argument shadowing beside closure-valued fields" $ do
     output <- requireRight (renderBackendProgramLLVM inlineFunctionArgumentShadowsValueProgram)
 
-    output `shouldSatisfy` isInfixOf "store ptr @\"idInt\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_shadow\""
     output `shouldNotSatisfy` isInfixOf "escaping function \"f\""
     validateLLVMAssembly output
 
@@ -698,14 +698,18 @@ spec = describe "MLF.Backend.LLVM" $ do
   it "preserves shadowed lambda parameters collected through lets" $
     assertNativeProgram sourceReturnedLetLambdaShadowingProgram "7"
 
-  it "rejects source closure-valued constructor fields before LLVM emission" $ do
-    result <- withTempProgram sourceClosureValuedConstructorFieldProgram emitBackendFile
+  it "lowers source closure-valued constructor fields through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceClosureValuedConstructorFieldProgram $ \path ->
+        requireRight =<< emitBackendFile path
 
-    case result of
-      Left err ->
-        err `shouldSatisfy` isInfixOf "closure-valued constructor field"
-      Right output ->
-        expectationFailure ("expected closure-valued constructor field rejection, got output:\n" ++ output)
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "store i64 41"
+    output `shouldSatisfy` isInfixOf "load ptr"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "closure-valued constructor field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
 
   it "lowers zero-capture closures through the explicit closure ABI" $ do
     output <- requireRight (renderBackendProgramLLVM zeroCaptureClosureProgram)
@@ -754,16 +758,11 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$poly\""
     validateLLVMAssembly output
 
-  it "keys function wrappers from qualified specialization forms" $ do
+  it "keeps closure-valued constructor fields on the closure ABI across specializations" $ do
     output <- requireRight (renderBackendProgramLLVM polymorphicClosureFunctionWrapperProgram)
 
-    let wrapperDefinitions =
-          filter
-            (\line -> "define private i64 @\"__mlfp_function_wrapper$" `isInfixOf` line)
-            (lines output)
-    length wrapperDefinitions `shouldSatisfy` (>= 2)
     output `shouldSatisfy` isInfixOf "$__mlfp_closure$wrapper_key"
-    output `shouldNotSatisfy` isInfixOf "unsupported function argument"
+    output `shouldNotSatisfy` isInfixOf "__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
   it "qualifies closure entries in inlined polymorphic global calls" $ do
@@ -777,53 +776,66 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "store ptr @\"__mlfp_closure$inline\""
     validateLLVMAssembly output
 
-  it "rejects closure entry names that collide with generated wrapper functions" $
-    renderBackendProgramLLVM closureEntryFunctionWrapperCollisionProgram
-      `shouldSatisfyLeft` isInfixOf "Duplicate backend LLVM symbol: \"__mlfp_function_wrapper$0\""
+  it "does not reserve retired stored-function wrapper names without generated wrappers" $ do
+    output <- requireRight (renderBackendProgramLLVM closureEntryFunctionWrapperCollisionProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$0\""
+    output `shouldNotSatisfy` isInfixOf "Duplicate backend LLVM symbol"
+    validateLLVMAssembly output
 
   it "rejects closure entry names that collide with runtime declarations" $
     renderBackendProgramLLVM closureEntryRuntimeDeclarationCollisionProgram
       `shouldSatisfyLeft` isInfixOf "Duplicate backend LLVM symbol: \"malloc\""
 
-  it "lowers stored top-level function constructor fields" $ do
+  it "lowers stored explicit closure constructor fields" $ do
     output <- requireRight (renderBackendProgramLLVM functionFieldProgram)
 
-    output `shouldSatisfy` isInfixOf "define i64 @\"helper\""
-    output `shouldSatisfy` isInfixOf "store ptr @\"helper\""
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$field_top\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_top\""
+    output `shouldNotSatisfy` isInfixOf "__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
-  it "lowers stored direct function constructor fields through private wrappers" $ do
+  it "lowers stored direct closure constructor fields through closure records" $ do
     output <- requireRight (renderBackendProgramLLVM directFunctionFieldProgram)
 
-    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
-    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$field_direct\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_direct\""
+    output `shouldNotSatisfy` isInfixOf "__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
-  it "lowers stored local function constructor fields through private wrappers" $ do
+  it "lowers stored local closure constructor fields through pointer aliases" $ do
     output <- requireRight (renderBackendProgramLLVM localFunctionFieldProgram)
 
-    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
-    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$field_local\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_local\""
+    output `shouldNotSatisfy` isInfixOf "__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
-  it "lowers stored transitive local function aliases through private wrappers" $ do
+  it "lowers stored transitive local closure aliases through pointer aliases" $ do
     output <- requireRight (renderBackendProgramLLVM transitiveLocalFunctionFieldProgram)
 
-    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
-    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$field_transitive\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_transitive\""
+    output `shouldNotSatisfy` isInfixOf "__mlfp_function_wrapper$"
     validateLLVMAssembly output
 
-  it "re-stores immediate constructor fields carrying closed direct functions" $ do
+  it "re-stores case-projected constructor fields carrying closures" $ do
     output <- requireRight (renderBackendProgramLLVM immediateRestoredFunctionFieldProgram)
 
-    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_function_wrapper$"
-    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_function_wrapper$"
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$field_restored\""
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_restored\""
+    output `shouldSatisfy` isInfixOf "load ptr"
     output `shouldNotSatisfy` isInfixOf "unsupported function argument"
     validateLLVMAssembly output
 
-  it "rejects captured function constructor fields until closure conversion exists" $ do
-    renderBackendProgramLLVM capturedFunctionFieldProgram
-      `shouldSatisfyLeft` isInfixOf "unsupported function argument"
+  it "lowers captured function constructor fields through closure environments" $ do
+    output <- requireRight (renderBackendProgramLLVM capturedFunctionFieldProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$field_captured\""
+    output `shouldSatisfy` isInfixOf "store i64 1"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_closure$field_captured\""
+    output `shouldNotSatisfy` isInfixOf "unsupported function argument"
+    validateLLVMAssembly output
 
   it "rejects unknown base types" $ do
     renderBackendProgramLLVM unknownBaseProgram
@@ -1875,7 +1887,7 @@ inlineFunctionArgumentShadowsValueProgram =
                           (BTArrow unaryIntTy fnBoxTy)
                           "f"
                           unaryIntTy
-                          (BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"]),
+                          (BackendConstruct fnBoxTy "FnBox" [closureWithEntry "__mlfp_closure$field_shadow"]),
                       backendBindingExportedAsMain = False
                     },
                   BackendBinding
@@ -3342,19 +3354,7 @@ polymorphicClosureFunctionWrapperExpr =
 
 closureContainingFunctionExpr :: BackendExpr
 closureContainingFunctionExpr =
-  BackendLet
-    unaryIntTy
-    "unusedClosure"
-    unaryIntTy
-    ( BackendClosure
-        { backendExprType = unaryIntTy,
-          backendClosureEntryName = "__mlfp_closure$wrapper_key",
-          backendClosureCaptures = [],
-          backendClosureParams = [("x", intTy)],
-          backendClosureBody = BackendVar intTy "x"
-        }
-    )
-    intIdentityExpr
+  closureWithEntry "__mlfp_closure$wrapper_key"
 
 polymorphicClosureFunctionWrapperCall :: BackendType -> BackendExpr -> BackendExpr
 polymorphicClosureFunctionWrapperCall argTy arg =
@@ -3434,13 +3434,7 @@ closureEntryFunctionWrapperCollisionProgram =
     BackendConstruct
       fnBoxTy
       "FnBox"
-      [ BackendLet
-          unaryIntTy
-          "unusedClosure"
-          unaryIntTy
-          (closureWithEntry "__mlfp_function_wrapper$0")
-          intIdentityExpr
-      ]
+      [closureWithEntry "__mlfp_function_wrapper$0"]
 
 closureEntryRuntimeDeclarationCollisionProgram :: BackendProgram
 closureEntryRuntimeDeclarationCollisionProgram =
@@ -3474,7 +3468,7 @@ functionFieldProgram =
                   BackendBinding
                     { backendBindingName = "main",
                       backendBindingType = fnBoxTy,
-                      backendBindingExpr = BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "helper"],
+                      backendBindingExpr = BackendConstruct fnBoxTy "FnBox" [closureWithEntry "__mlfp_closure$field_top"],
                       backendBindingExportedAsMain = True
                     }
                 ]
@@ -3494,7 +3488,7 @@ directFunctionFieldProgram =
                 [ BackendBinding
                     { backendBindingName = "main",
                       backendBindingType = fnBoxTy,
-                      backendBindingExpr = BackendConstruct fnBoxTy "FnBox" [intIdentityExpr],
+                      backendBindingExpr = BackendConstruct fnBoxTy "FnBox" [closureWithEntry "__mlfp_closure$field_direct"],
                       backendBindingExportedAsMain = True
                     }
                 ]
@@ -3510,7 +3504,7 @@ localFunctionFieldProgram =
       { backendExprType = fnBoxTy,
         backendLetName = "f",
         backendLetType = unaryIntTy,
-        backendLetRhs = intIdentityExpr,
+        backendLetRhs = closureWithEntry "__mlfp_closure$field_local",
         backendLetBody = BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"]
       }
 
@@ -3521,7 +3515,7 @@ transitiveLocalFunctionFieldProgram =
       { backendExprType = fnBoxTy,
         backendLetName = "f",
         backendLetType = unaryIntTy,
-        backendLetRhs = intIdentityExpr,
+        backendLetRhs = closureWithEntry "__mlfp_closure$field_transitive",
         backendLetBody =
           BackendLet
             { backendExprType = fnBoxTy,
@@ -3546,7 +3540,7 @@ immediateRestoredFunctionFieldProgram =
                       backendBindingExpr =
                         BackendCase
                           fnBoxTy
-                          (BackendConstruct fnBoxTy "FnBox" [intIdentityExpr])
+                          (BackendConstruct fnBoxTy "FnBox" [closureWithEntry "__mlfp_closure$field_restored"])
                           ( BackendAlternative
                               (BackendConstructorPattern "FnBox" ["f"])
                               (BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"])
@@ -3580,11 +3574,13 @@ capturedFunctionFieldProgram =
                           ( BackendConstruct
                               fnBoxTy
                               "FnBox"
-                              [ BackendLam
-                                  unaryIntTy
-                                  "x"
-                                  intTy
-                                  (BackendVar intTy "captured")
+                              [ BackendClosure
+                                  { backendExprType = unaryIntTy,
+                                    backendClosureEntryName = "__mlfp_closure$field_captured",
+                                    backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                    backendClosureParams = [("x", intTy)],
+                                    backendClosureBody = BackendVar intTy "captured"
+                                  }
                               ]
                           ),
                       backendBindingExportedAsMain = True
@@ -3902,7 +3898,8 @@ llvmObjectCodeParityCases =
       "boundary: runs aliased bulk-imported hidden-owner constructors in one case",
       "boundary: runs exposed constructor with qualified alias type identity",
       "unified fixture: test/programs/unified/first-class-polymorphism.mlfp",
-      "standalone: does not decode typed non-data constructor fields through fallback ADT decoding"
+      "standalone: does not decode typed non-data constructor fields through fallback ADT decoding",
+      "standalone: applies captured function-valued constructor fields"
     ]
 
 llvmObjectCodeParityCaseNames :: Set.Set String

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -2954,6 +2954,22 @@ programSpecStandaloneRuntimeSuccessCases =
         )
         (ExpectRuntimePredicate "rendered value is not Holder Token" (/= "Holder Token"))
     , ProgramRuntimeCase
+        "standalone: applies captured function-valued constructor fields"
+        ( InlineProgram $
+            unlines
+                [ "module Main export (FnBox(..), main) {"
+                , "  data FnBox ="
+                , "      FnBox : (Int -> Int) -> FnBox;"
+                , ""
+                , "  def main : Int ="
+                , "    let captured : Int = 41 in"
+                , "    let f : Int -> Int = \\(x : Int) captured in"
+                , "    case FnBox f of { FnBox g -> g 0 };"
+                , "}"
+                ]
+        )
+        (ExpectRuntimeValue "41")
+    , ProgramRuntimeCase
         "standalone: evaluates a recursive Nat equality example at representative depth"
         (InlineProgram (recursiveNatEqualityProgram 24))
         (ExpectRuntimeValue "true")


### PR DESCRIPTION
Closes #97.

## Implementation Plan

---
issue_number: 97
pr_number: 117
branch: codex/issue-97
---

## Planning Evidence
- Issue #97 asks for function-valued ADT fields to store/project closure values, including captured constructor-field functions and pattern-bound fields applied after projection.
- PR #117 is open on `codex/issue-97` against `master`; the branch currently only has the starter commit and no local file changes.
- The current fail-closed source path is `src/MLF/Backend/Convert.hs` in `rejectClosureValuedConstructorField`; LLVM lowering still treats monomorphic function fields as raw first-order function pointers/static fields in `src/MLF/Backend/LLVM/Lower.hs`.

## Implementation Plan
1. Before editing, read the watcher-written `issue-plan.md`, confirm `git status --short --branch`, and verify PR #117/head branch still match `codex/issue-97`.
2. Update backend conversion in `MLF.Backend.Convert`:
   - Remove the closure-valued constructor-field rejection.
   - Convert monomorphic arrow constructor arguments as closure values. Prefer direct closure conversion for lambdas/closure aliases; for plain function references, eta-expand under the known field type so conversion emits explicit `BackendClosure` IR.
   - Mark constructor pattern binders for monomorphic arrow fields as closure-valued in the `ClosureScope`, while still letting non-function binders shadow outer closure globals normally.
3. Update LLVM lowering in `MLF.Backend.LLVM.Lower`:
   - Treat ordinary `BTArrow` ADT fields as closure-runtime pointers, not static/raw function-pointer fields.
   - Keep `BTForall`/`BTVarApp` static-specialization behavior intact.
   - Store constructor function fields by lowering explicit closure values, load projected fields as closure pointers, and ensure projected applications use `BackendClosureCall`/the hidden-env closure ABI.
   - Preserve existing evidence/raw first-order function argument behavior outside ADT field storage.
4. Update tests:
   - Change `BackendConvertSpec` closure-valued constructor-field rejection into a success assertion that validates IR and contains both `BackendClosure` and `BackendClosureCall` through the case projection path.
   - Change `BackendLLVMSpec` source-level rejection into a success test checking the closure entry, closure record store/load, closure-code call, `llvm-as`, and object-code smoke where available.
   - Update lowerer unit tests for stored function constructor fields so ADT fields assert closure ABI behavior instead of raw `__mlfp_function_wrapper` storage.
   - Add or promote a `ProgramMatrix` runtime parity row that stores a captured closure in an ADT, pattern matches it out, applies it, and returns an `Int` such as `41`; include it in object-code representative coverage if appropriate.
5. Update durable docs for the behavior change: `CHANGELOG.md`, `implementation_notes.md`, and the backend closure/LLVM boundary text in `docs/architecture.md` so captured function-valued ADT fields are no longer described as unsupported.
6. Validate in this order:
   - Targeted conversion tests for `MLF.Backend.Convert`.
   - Targeted LLVM backend tests for `MLF.Backend.LLVM` and the ProgramSpec-to-LLVM parity matrix.
   - Full gate: `cabal build all && cabal test`.
7. Publish only after validation: inspect `git status --short` and relevant diffs, stage only issue-related files, run `gh auth status` and `gh auth setup-git`, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, push `codex/issue-97`, and leave PR #117 as the existing handoff PR without creating another PR.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.