### PR TITLE
Implement #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   explicit `BackendClosure` / `BackendClosureCall` IR for returned local
   functions and indirect calls through aliases while preserving direct
   first-order local calls on the direct application path.
+- Added an explicit `emit-backend` IO contract: checked IO entrypoints,
+  direct `__io_*` primitive use, and pure entrypoints with reachable IO
+  dependencies now fail closed with stable unsupported backend diagnostics,
+  while unused IO-typed bindings remain outside the emitted LLVM subset.
 - Added the checked `.mlfp` source surface for `Unit`, opaque `IO`, initial IO
   primitives, and the built-in `Monad IO` Prelude instance; backend conversion
   remains fail-closed for IO entrypoints until concrete IO lowering is added.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ cabal run mlf2 -- emit-native test/programs/unified/authoritative-let-polymorphi
 ```
 
 `emit-backend` keeps the raw backend contract: the checked `.mlfp` `main`
-binding remains a module-qualified LLVM function such as `Main__main`.
+binding remains a module-qualified LLVM function such as `Main__main`. It is a
+pure LLVM subset contract today: checked `main : IO Unit`, direct `__io_*`
+primitive calls, and pure entrypoints with reachable IO-typed dependencies are
+rejected with an unsupported backend diagnostic before LLVM is emitted.
 `emit-native` adds the process contract used by native execution tests. It emits
 a C ABI `i32 @main()` wrapper that calls the checked zero-argument `.mlfp`
 `main`, renders supported pure results to stdout with the same value text used
@@ -148,7 +151,8 @@ first-order ADT results whose fields are recursively renderable. Function,
 polymorphic, `String`, unknown, and IO-like results are rejected before native
 run assertions use them. Native mode declares libc `malloc` and vararg `printf`
 and defines the backend-owned `__mlfp_and` primitive when no program binding owns
-that runtime name; broader IO behavior remains outside this pure contract.
+that runtime name; broader IO runtime linking remains outside this pure
+contract.
 
 Backend LLVM validation tests use LLVM command-line tools with opaque pointer
 support when available. The test suite looks for `llvm-as` and `llc` on `PATH`,

--- a/docs/mlfp-language-reference.md
+++ b/docs/mlfp-language-reference.md
@@ -342,10 +342,12 @@ stdout, and successful `IO Unit` programs do not render a `Unit` result value.
 The initial runtime contract rejects `main : IO a` for non-`Unit` `a`.
 
 The backend contract is fail-closed for the first IO slice. `emit-backend`
-should reject checked IO programs with a structured unsupported diagnostic until
-the backend IO issue adds a concrete lowering plan for the selected primitives.
-That rejection does not change source typing, pure runtime rendering, or the
-existing first-order LLVM subset.
+rejects checked IO entrypoints with a structured unsupported diagnostic until a
+later backend/runtime issue adds a concrete lowering plan for the selected
+primitives. It also rejects pure entrypoints that depend on IO-typed helpers or
+direct opaque primitives. The backend does not lower `__io_pure`, `__io_bind`,
+or `__io_putStrLn` yet. That rejection does not change source typing, pure
+runtime rendering, or the existing first-order LLVM subset.
 
 ## Backend Boundary
 
@@ -370,10 +372,13 @@ cabal run mlf2 -- emit-backend path/to/file.mlfp
 Like `run-program`, `emit-backend` parses one source file and prepends the
 built-in Prelude as an explicit module before checking. The emitted text is
 LLVM IR for the supported backend subset, not a stable ABI or a promise of
-final executable linking. The source-facing surface remains primarily
-first-order: checked first-order function bindings, saturated direct calls,
-literals, variables, SSA-style lets, type abstraction/application after
-specialization, ADT construction, and ADT case analysis.
+final executable linking. IO values remain outside the LLVM contract: checked
+`main : IO Unit`, direct `__io_*` primitive calls, and pure `main` bindings
+whose reachable dependencies mention IO fail before LLVM is emitted. The
+source-facing surface remains primarily first-order: checked first-order
+function bindings, saturated direct calls, literals, variables, SSA-style lets,
+type abstraction/application after specialization, ADT construction, and ADT
+case analysis.
 
 The typed backend IR can also represent data metadata, constructor nodes, case
 nodes, recursive roll/unroll nodes, and explicit closure construction plus

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -16,6 +16,7 @@ module MLF.Backend.Convert
     convertCheckedProgram,
     convertElabType,
     convertSourceType,
+    renderBackendConversionError,
   )
 where
 
@@ -71,6 +72,22 @@ data BackendConversionError
   | BackendTypeCheckFailed ElabTerm TypeCheckError
   | BackendValidationFailed BackendValidationError
   deriving (Eq, Show)
+
+renderBackendConversionError :: BackendConversionError -> String
+renderBackendConversionError err =
+  case err of
+    BackendUnsupportedSourceType ty ->
+      "Unsupported backend source type: " ++ show ty
+    BackendUnsupportedInstantiation inst ->
+      "Unsupported backend instantiation: " ++ show inst
+    BackendUnsupportedRecursiveLet detail ->
+      "Unsupported backend recursive let: " ++ detail
+    BackendUnsupportedCaseShape detail ->
+      "Unsupported backend conversion shape: " ++ detail
+    BackendTypeCheckFailed term typeErr ->
+      "Backend typecheck failed for converted term " ++ show term ++ ": " ++ show typeErr
+    BackendValidationFailed validationErr ->
+      "Backend IR validation failed: " ++ show validationErr
 
 data ConvertContext = ConvertContext
   { ccModuleScopes :: Map String ElaborateScope,

--- a/src/MLF/Backend/LLVM.hs
+++ b/src/MLF/Backend/LLVM.hs
@@ -17,6 +17,7 @@ import Data.Bifunctor (first)
 import MLF.Backend.Convert
   ( BackendConversionError,
     convertCheckedProgram,
+    renderBackendConversionError,
   )
 import MLF.Backend.IR (BackendProgram)
 import qualified MLF.Backend.LLVM.Lower as Lower
@@ -50,6 +51,6 @@ renderBackendLLVMError :: BackendLLVMError -> String
 renderBackendLLVMError err =
   case err of
     BackendLLVMConversionFailed conversionErr ->
-      "Backend LLVM conversion failed: " ++ show conversionErr
+      "Backend LLVM conversion failed: " ++ renderBackendConversionError conversionErr
     BackendLLVMLoweringFailed loweringErr ->
       Lower.renderBackendLLVMError loweringErr

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -2,7 +2,7 @@
 
 module BackendLLVMSpec (spec) where
 
-import Control.Monad (when)
+import Control.Monad (forM_, when)
 import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
@@ -57,6 +57,45 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "; mlf2 LLVM backend v0"
     output `shouldSatisfy` isInfixOf "define i64 @\"Main__main\"()"
     validateLLVMAssembly output
+
+  describe "IO backend contract" $ do
+    it "rejects checked main : IO Unit before LLVM lowering" $ do
+      result <- emitBackendSource ioPureUnitMainProgram
+
+      result `shouldFailWithAll` backendIOUnsupportedFragments
+
+    it "rejects primitive IO operations without emitting LLVM" $
+      forM_
+        [ ("putStrLn", ioPutStrLnMainProgram),
+          ("direct __io_pure/__io_bind", ioDirectPrimitiveMainProgram)
+        ]
+        ( \(_label, programText) -> do
+            result <- emitBackendSource programText
+            result `shouldFailWithAll` backendIOUnsupportedFragments
+        )
+
+    it "rejects pure mains that depend on IO-typed helpers" $ do
+      result <- emitBackendSource pureMainIODependencyProgram
+
+      result
+        `shouldFailWithAll` [ "IO dependencies are not supported by backend conversion yet",
+                              "Main__main -> Main__discard"
+                            ]
+
+    it "rejects pure mains that directly reference opaque IO primitives" $ do
+      result <- emitBackendSource pureMainDirectIOPrimitiveProgram
+
+      result
+        `shouldFailWithAll` [ "IO dependencies are not supported by backend conversion yet",
+                              "Main__main -> __io_pure"
+                            ]
+
+    it "accepts pure mains when IO-typed bindings are unused" $ do
+      output <- requireRight =<< emitBackendSource pureMainUnusedIOProgram
+
+      output `shouldSatisfy` isInfixOf "define i1 @\"Main__main\"()"
+      output `shouldNotSatisfy` isInfixOf "__io_"
+      validateLLVMAssembly output
 
   describe "native process entrypoint" $ do
     it "prints an Int main value to stdout and exits successfully" $
@@ -1154,6 +1193,25 @@ emitNativeSource :: String -> IO (Either String String)
 emitNativeSource programText =
   withTempProgram programText emitNativeFile
 
+emitBackendSource :: String -> IO (Either String String)
+emitBackendSource programText =
+  withTempProgram programText emitBackendFile
+
+shouldFailWithAll :: Either String String -> [String] -> Expectation
+shouldFailWithAll result fragments =
+  case result of
+    Left message ->
+      mapM_ (\fragment -> message `shouldSatisfy` isInfixOf fragment) fragments
+    Right output ->
+      expectationFailure ("expected backend failure, got output:\n" ++ output)
+
+backendIOUnsupportedFragments :: [String]
+backendIOUnsupportedFragments =
+  [ "Backend LLVM conversion failed",
+    "Unsupported backend conversion shape",
+    "IO programs are not supported by backend conversion yet"
+  ]
+
 renderProgramMatrixSourceLLVM :: ProgramMatrixSource -> IO String
 renderProgramMatrixSourceLLVM source =
   case source of
@@ -1168,6 +1226,62 @@ simpleFunctionProgram =
     [ "module Main export (id, main) {",
       "  def id : Int -> Int = \\x x;",
       "  def main : Int = id 1;",
+      "}"
+    ]
+
+ioPureUnitMainProgram :: String
+ioPureUnitMainProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  import Prelude exposing (Unit(..), IO, pure);",
+      "  def main : IO Unit = pure Unit;",
+      "}"
+    ]
+
+ioPutStrLnMainProgram :: String
+ioPutStrLnMainProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  import Prelude exposing (Unit(..), IO, putStrLn);",
+      "  def main : IO Unit = putStrLn \"hello\";",
+      "}"
+    ]
+
+ioDirectPrimitiveMainProgram :: String
+ioDirectPrimitiveMainProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  import Prelude exposing (Unit(..), IO);",
+      "  def main : IO Unit = __io_bind (__io_pure Unit) (\\(_done : Unit) __io_putStrLn \"world\");",
+      "}"
+    ]
+
+pureMainIODependencyProgram :: String
+pureMainIODependencyProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  import Prelude exposing (Unit(..), IO, pure);",
+      "  def discard : IO Unit -> Unit = \\(_action : IO Unit) Unit;",
+      "  def main : Unit = discard (pure Unit);",
+      "}"
+    ]
+
+pureMainDirectIOPrimitiveProgram :: String
+pureMainDirectIOPrimitiveProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  import Prelude exposing (Unit(..), IO);",
+      "  def main : Unit = (\\(_action : IO Unit) Unit) (__io_pure Unit);",
+      "}"
+    ]
+
+pureMainUnusedIOProgram :: String
+pureMainUnusedIOProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  import Prelude exposing (Unit(..), IO, pure);",
+      "  def unused : IO Unit = pure Unit;",
+      "  def main : Bool = true;",
       "}"
     ]
 


### PR DESCRIPTION
Closes #93.

## Implementation Plan

---
issue_number: 93
pr_number: 118
branch: codex/issue-93
---

## Implementation Plan

1. Use the fail-closed route for #93: do not lower IO primitives or add LLVM/runtime calls in this issue. The inspected docs already choose this contract, and native IO linking is explicitly outside this issue.

2. Tighten the user-facing backend diagnostic path if needed by adding a renderer for `BackendConversionError` and using it from `MLF.Backend.LLVM.renderBackendLLVMError`, so IO rejection is stable text such as unsupported backend conversion rather than an internal error or raw Haskell constructor.

3. Add an `IO backend contract` group to `test/BackendLLVMSpec.hs` using a small `emitBackendSource` helper around `withTempProgram ... emitBackendFile`. Cover:
- `main : IO Unit` through `pure Unit` is rejected by `emit-backend` with the stable unsupported IO diagnostic.
- primitive IO operations, including `putStrLn` and direct `__io_pure`/`__io_bind` use, are rejected without emitting LLVM.
- pure `main` programs that depend on IO-typed helpers or direct opaque IO primitives are rejected with dependency details like `Main__main -> Main__discard` or `Main__main -> __io_pure`.
- a pure `main` with an unused IO-typed binding remains accepted, emits valid LLVM for `Main__main`, and does not emit `__io_*` runtime calls.

4. Keep or extend the existing lower-level conversion coverage in `test/BackendConvertSpec.hs` only if the new facade tests need a shared helper or a missing constructor-level assertion; avoid duplicating coverage unnecessarily.

5. Update backend-facing docs to state the exact #93 contract:
- `docs/mlfp-language-reference.md`: `emit-backend` rejects checked IO entrypoints and pure bindings that depend on opaque IO helpers; it does not lower `__io_pure`, `__io_bind`, or `__io_putStrLn` yet.
- `README.md`: note that `emit-backend`/`emit-native` remain pure LLVM contracts and broader IO runtime linking is deferred.
- `CHANGELOG.md`: add a concise Unreleased entry for explicit backend IO rejection diagnostics and tests.

6. Validate with focused and full gates: run the Backend LLVM/Convert test slice while iterating, then run `cabal build all && cabal test` before handoff. If LLVM tools are unavailable, accept the suite's pending LLVM assertions but report that condition.

7. Before publishing in the implementation turn, run `git status --short` and inspect relevant diffs, stage only issue-related files, commit as the configured `codex-watcher`, run `gh auth status` and `gh auth setup-git`, push `codex/issue-93`, and leave PR #118 for watcher/review handoff.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.