### PR TITLE
Implement #98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   rows are explicitly classified with diagnostic fragments.
 
 ### Changed
+- Fixed checked-source recursive higher-order LLVM flows so monomorphic
+  top-level functions and closed lifted local helpers pass function-valued
+  arguments through the explicit closure ABI, while unspecialized polymorphic
+  runtime escapes remain structured unsupported cases.
 - Fixed higher-order checked-source partial applications so supplied
   closure-valued arguments, alias-propagated closure-demanded parameters, local
   helper demands, and non-variable partial callees stay on the explicit closure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,14 +193,17 @@ the existing direct-call path; indirect calls must be represented with
 
 Checked-program conversion now closure-converts ordinary monomorphic escaping
 source lambdas, returned local function values, closure-valued let aliases,
-partial applications that produce function values, and indirect calls through
-monomorphic function-valued constructor fields, and indirect calls through
-those closure values, aliases, or projected fields into explicit closure IR.
-Direct first-order local calls remain direct backend applications. Polymorphic
-or type-parameter-headed higher-order constructor fields, recursive higher-order
-flows, and final executable linking remain future extension points. Those
-diagnostics do not weaken source inference, checking, module visibility, or
-runtime semantics; they only describe the current IR-to-LLVM lowering surface.
+partial applications that produce function values, indirect calls through
+monomorphic function-valued constructor fields, indirect calls through those
+closure values, aliases, or projected fields, and monomorphic recursive
+higher-order top-level or closed local helper flows whose function-valued
+arguments fit the explicit closure ABI. Direct first-order local calls remain
+direct backend applications. Polymorphic runtime function values,
+type-parameter-headed higher-order constructor fields, recursive local helpers
+that capture ordinary lexical values, and final executable linking remain
+future extension points. Those diagnostics do not weaken source inference,
+checking, module visibility, or runtime semantics; they only describe the
+current IR-to-LLVM lowering surface.
 
 ## `Solved` boundary and thesis-exact cleanup rule
 

--- a/src/MLF/Backend/Convert.hs
+++ b/src/MLF/Backend/Convert.hs
@@ -108,7 +108,9 @@ data LiftedRecursiveLet = LiftedRecursiveLet
   { lrlName :: String,
     lrlElabType :: ElabType,
     lrlBackendType :: BackendType,
-    lrlTerm :: ElabTerm
+    lrlTerm :: ElabTerm,
+    lrlClosureValueArguments :: Set.Set Int,
+    lrlEvidenceValueArguments :: Set.Set Int
   }
 
 data LiftState = LiftState
@@ -411,6 +413,8 @@ convertCheckedBinding context env checkedModule binding = do
               Right (constructorBindingTy, expr, [])
       _ -> do
         (liftedTerm, liftedSpecs) <- liftRecursiveLetsInBinding bindingContext checkedBindingTermClosed
+        let bindingContextWithLifted =
+              extendContextWithLiftedRecursiveLets bindingContext liftedSpecs
         let envWithLifted =
               foldr
                 (\lifted acc -> extendTermEnv (lrlName lifted) (lrlElabType lifted) acc)
@@ -418,8 +422,8 @@ convertCheckedBinding context env checkedModule binding = do
                 liftedSpecs
         (liftedBindings, expr) <-
           runConvertM $ do
-            liftedBindings <- mapM (convertLiftedRecursiveLet bindingContext envWithLifted) liftedSpecs
-            expr <- convertTermExpectedMode DirectLambda bindingContext envWithLifted emptyClosureScope (Just bindingTy) liftedTerm
+            liftedBindings <- mapM (convertLiftedRecursiveLet bindingContextWithLifted envWithLifted) liftedSpecs
+            expr <- convertTermExpectedMode DirectLambda bindingContextWithLifted envWithLifted emptyClosureScope (Just bindingTy) liftedTerm
             pure (liftedBindings, expr)
         Right (bindingTy, expr, liftedBindings)
   let convertedBinding =
@@ -430,6 +434,24 @@ convertCheckedBinding context env checkedModule binding = do
             backendBindingExportedAsMain = checkedBindingExportedAsMain binding
           }
   Right (convertedBinding : liftedBindings)
+
+extendContextWithLiftedRecursiveLets :: ConvertContext -> [LiftedRecursiveLet] -> ConvertContext
+extendContextWithLiftedRecursiveLets context liftedSpecs =
+  context
+    { ccClosureValueArguments =
+        mergeDemands liftedClosureValueArguments (ccClosureValueArguments context),
+      ccEvidenceValueArguments =
+        mergeDemands liftedEvidenceValueArguments (ccEvidenceValueArguments context)
+    }
+  where
+    mergeDemands build =
+      Map.unionWith Set.union (Map.filter (not . Set.null) (Map.fromList (map build liftedSpecs)))
+
+    liftedClosureValueArguments lifted =
+      (lrlName lifted, lrlClosureValueArguments lifted)
+
+    liftedEvidenceValueArguments lifted =
+      (lrlName lifted, lrlEvidenceValueArguments lifted)
 
 liftRecursiveLetsInBinding :: ConvertContext -> ElabTerm -> Either BackendConversionError (ElabTerm, [LiftedRecursiveLet])
 liftRecursiveLetsInBinding context term = do
@@ -493,12 +515,18 @@ liftRecursiveLetsInTerm context lexicalTerms lexicalTypes term =
                   wrapHelperTermCaptures termCaptures $
                     replaceFreeTermVariable name helperRef rhs'
           helperBackendType <- liftEitherConversion (canonicalizeBackendType context <$> convertElabType helperElabType)
+          let helperClosureValueArguments =
+                bindingClosureValueArguments context emptyClosureScope helperBackendType helperTerm
+              helperEvidenceValueArguments =
+                bindingEvidenceValueArguments context emptyClosureScope helperBackendType helperTerm
           emitLiftedRecursiveLet
             LiftedRecursiveLet
               { lrlName = helperName,
                 lrlElabType = helperElabType,
                 lrlBackendType = helperBackendType,
-                lrlTerm = helperTerm
+                lrlTerm = helperTerm,
+                lrlClosureValueArguments = helperClosureValueArguments,
+                lrlEvidenceValueArguments = helperEvidenceValueArguments
               }
           body' <- liftRecursiveLetsInTerm context bodyTerms lexicalTypes body
           pure (ELet name scheme helperRef body')
@@ -590,8 +618,8 @@ ensureLiftableRecursiveLet name bindingTy captures rhs = do
       ( unsupported
           ("captures lexical bindings: " ++ intercalate ", " (map fst captures))
       )
-  unless (isMonomorphicFirstOrderFunctionType bindingTy) $
-    throwLiftError (unsupported "expected a monomorphic first-order function type")
+  unless (isLiftableRecursiveFunctionType bindingTy) $
+    throwLiftError (unsupported "expected a monomorphic runtime-representable function type")
   unless (isFunctionValueTerm rhs) $
     throwLiftError (unsupported "expected a function-valued recursive right-hand side")
 
@@ -647,28 +675,28 @@ throwLiftError :: BackendConversionError -> LiftM a
 throwLiftError err =
   StateT (const (Left err))
 
-isMonomorphicFirstOrderFunctionType :: BackendType -> Bool
-isMonomorphicFirstOrderFunctionType ty =
+isLiftableRecursiveFunctionType :: BackendType -> Bool
+isLiftableRecursiveFunctionType ty =
   case ty of
     BTForall {} ->
       False
     _ ->
       let (args, resultTy) = splitBackendArrows ty
-       in not (null args) && all (isFirstOrderValueType Set.empty) (resultTy : args)
+       in not (null args) && all isLiftableRecursiveValueType (resultTy : args)
 
-isFirstOrderValueType :: Set.Set String -> BackendType -> Bool
-isFirstOrderValueType bound =
+isLiftableRecursiveValueType :: BackendType -> Bool
+isLiftableRecursiveValueType =
   \case
-    BTVar name ->
-      Set.member name bound
-    BTArrow {} ->
+    BTVar {} ->
       False
+    ty@BTArrow {} ->
+      isFirstOrderFunctionCaptureType ty
     BTBase {} ->
       True
     BTCon _ args ->
-      all (isFirstOrderValueType bound) args
-    BTVarApp name args ->
-      Set.member name bound && all (isFirstOrderValueType bound) args
+      all isLiftableRecursiveValueType args
+    BTVarApp {} ->
+      False
     BTForall {} ->
       False
     BTMu {} ->

--- a/test/BackendConvertSpec.hs
+++ b/test/BackendConvertSpec.hs
@@ -2,7 +2,7 @@ module BackendConvertSpec (spec) where
 
 import Control.Applicative ((<|>))
 import Data.Foldable (toList)
-import Data.List (find, intercalate, isInfixOf, nub)
+import Data.List (find, intercalate, isInfixOf, isPrefixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import MLF.Backend.Convert
 import MLF.Backend.IR
@@ -385,6 +385,27 @@ spec = describe "MLF.Backend.Convert" $ do
 
     validateBackendProgram backend `shouldBe` Right ()
     map backendBindingName (backendBindings backend) `shouldSatisfy` any (isInfixOf "$letrec$")
+
+  it "closure-converts top-level recursive higher-order function parameters" $ do
+    checked <- requireChecked topLevelRecursiveHigherOrderProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    loopBinding <- requireBinding "Main__loop" backend
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingExpr loopBinding `shouldSatisfy` containsBackendClosureCallFunction "f"
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
+
+  it "lifts closed local recursive higher-order helpers with closure-demanded arguments" $ do
+    checked <- requireChecked localRecursiveHigherOrderProgram
+    backend <- requireRight (convertCheckedProgram checked)
+
+    validateBackendProgram backend `shouldBe` Right ()
+    helper <- requireSingleLiftedHelper backend
+    mainBinding <- requireBinding (backendProgramMain backend) backend
+    backendBindingType helper `shouldSatisfy` isBackendFunctionType
+    backendBindingExpr helper `shouldSatisfy` containsBackendClosureCallFunction "f"
+    backendBindingExpr mainBinding `shouldSatisfy` containsBackendClosure
 
   it "rejects constructor head type instantiations with no matching constructor parameter" $ do
     checked0 <- requireChecked constructorForallApplicationProgram
@@ -1110,6 +1131,41 @@ recursiveListDerivingEqProgram =
       "    deriving Eq;",
       "",
       "  def main : Bool = eq (Cons Zero Nil) (Cons Zero Nil);",
+      "}"
+    ]
+
+topLevelRecursiveHigherOrderProgram :: String
+topLevelRecursiveHigherOrderProgram =
+  unlines
+    [ "module Main export (Nat(..), loop, idInt, main) {",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat;",
+      "",
+      "  def idInt : Int -> Int = \\(x : Int) x;",
+      "  def loop : (Int -> Int) -> Nat -> Int = \\(f : Int -> Int) \\(n : Nat) case n of {",
+      "    Zero -> f 1;",
+      "    Succ inner -> loop f inner",
+      "  };",
+      "  def main : Int = loop idInt (Succ Zero);",
+      "}"
+    ]
+
+localRecursiveHigherOrderProgram :: String
+localRecursiveHigherOrderProgram =
+  unlines
+    [ "module Main export (Nat(..), main) {",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat;",
+      "",
+      "  def main : Int =",
+      "    let idInt : Int -> Int = \\(x : Int) x in",
+      "    let loop : (Int -> Int) -> Nat -> Int = \\(f : Int -> Int) \\(n : Nat) case n of {",
+      "      Zero -> f 1;",
+      "      Succ inner -> loop f inner",
+      "    } in",
+      "    loop idInt (Succ Zero);",
       "}"
     ]
 
@@ -1844,6 +1900,45 @@ containsBackendClosureCall expr =
     BackendClosure {backendClosureCaptures = captures, backendClosureBody = body} ->
       any (containsBackendClosureCall . backendClosureCaptureExpr) captures || containsBackendClosureCall body
     _ -> False
+
+containsBackendClosureCallFunction :: String -> BackendExpr -> Bool
+containsBackendClosureCallFunction expected expr =
+  case expr of
+    BackendClosureCall {backendClosureFunction = fun, backendClosureArguments = args} ->
+      closureFunctionMatches fun || any (containsBackendClosureCallFunction expected) args
+    BackendCase {backendScrutinee = scrutinee, backendAlternatives = alternatives} ->
+      containsBackendClosureCallFunction expected scrutinee
+        || any (containsBackendClosureCallFunction expected . backendAltBody) (toList alternatives)
+    BackendLam {backendParamName = name, backendBody = body}
+      | name == expected -> False
+      | otherwise -> containsBackendClosureCallFunction expected body
+    BackendApp {backendFunction = fun, backendArgument = arg} ->
+      containsBackendClosureCallFunction expected fun || containsBackendClosureCallFunction expected arg
+    BackendLet {backendLetName = name, backendLetRhs = rhs, backendLetBody = body}
+      | name == expected -> containsBackendClosureCallFunction expected rhs
+      | otherwise ->
+          containsBackendClosureCallFunction expected rhs || containsBackendClosureCallFunction expected body
+    BackendTyAbs {backendTyAbsBody = body} -> containsBackendClosureCallFunction expected body
+    BackendTyApp {backendTyFunction = fun} -> containsBackendClosureCallFunction expected fun
+    BackendConstruct {backendConstructArgs = args} -> any (containsBackendClosureCallFunction expected) args
+    BackendRoll {backendRollPayload = body} -> containsBackendClosureCallFunction expected body
+    BackendUnroll {backendUnrollPayload = body} -> containsBackendClosureCallFunction expected body
+    BackendClosure {backendClosureCaptures = captures, backendClosureParams = params, backendClosureBody = body}
+      | expected `elem` map fst params || expected `elem` map backendClosureCaptureName captures ->
+          any (containsBackendClosureCallFunction expected . backendClosureCaptureExpr) captures
+      | otherwise ->
+          any (containsBackendClosureCallFunction expected . backendClosureCaptureExpr) captures
+            || containsBackendClosureCallFunction expected body
+    _ -> False
+  where
+    closureFunctionMatches fun =
+      case fun of
+        BackendVar {backendVarName = name} -> generatedBackendNameMatches expected name
+        BackendTyApp {backendTyFunction = inner} -> closureFunctionMatches inner
+        _ -> containsBackendClosureCallFunction expected fun
+
+    generatedBackendNameMatches plain name =
+      name == plain || ("$" ++ plain ++ "#") `isPrefixOf` name
 
 containsAlphaRenamedShadowingClosure :: BackendExpr -> Bool
 containsAlphaRenamedShadowingClosure expr =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -273,6 +273,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM type"
     validateLLVMAssembly output
 
+  it "rejects source-level escaping polymorphic main values with a stable diagnostic" $ do
+    result <- withTempProgram sourceEscapingPolymorphicMainProgram emitBackendFile
+
+    result
+      `shouldSatisfy` either
+        (isInfixOf "polymorphic main binding")
+        (const False)
+
   it "statically lowers first-class function-typed arguments" $ do
     output <-
       withTempProgram firstClassFunctionArgumentProgram $ \path ->
@@ -391,6 +399,29 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldSatisfy` isInfixOf "phi ptr"
     validateLLVMAssembly output
     validateLLVMObjectCode output
+
+  it "lowers top-level recursive higher-order functions through closure arguments" $ do
+    output <-
+      withTempProgram sourceTopLevelRecursiveHigherOrderProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"Main__loop\"(ptr %\"$f#"
+    output `shouldSatisfy` isInfixOf "ptr %\"$n#"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceTopLevelRecursiveHigherOrderProgram "1"
+
+  it "lowers local recursive higher-order helpers through closure arguments" $ do
+    output <-
+      withTempProgram sourceLocalRecursiveHigherOrderProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "Main__main$letrec$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceLocalRecursiveHigherOrderProgram "1"
 
   it "emits first-order recursive ADT parity fixtures through LLVM" $ do
     mapM_
@@ -1271,6 +1302,14 @@ localFirstClassPolymorphismProgram =
       "}"
     ]
 
+sourceEscapingPolymorphicMainProgram :: String
+sourceEscapingPolymorphicMainProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : forall a. a -> a = \\x x;",
+      "}"
+    ]
+
 firstClassFunctionArgumentProgram :: String
 firstClassFunctionArgumentProgram =
   unlines
@@ -1353,6 +1392,41 @@ ordinaryFunctionEvidenceMethodProgram =
       "  def idInt : Int -> Int = \\x x;",
       "  def use : C a => (a -> a) -> a -> a = \\f \\x apply f x;",
       "  def main : Int = use idInt 1;",
+      "}"
+    ]
+
+sourceTopLevelRecursiveHigherOrderProgram :: String
+sourceTopLevelRecursiveHigherOrderProgram =
+  unlines
+    [ "module Main export (Nat(..), loop, idInt, main) {",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat;",
+      "",
+      "  def idInt : Int -> Int = \\(x : Int) x;",
+      "  def loop : (Int -> Int) -> Nat -> Int = \\(f : Int -> Int) \\(n : Nat) case n of {",
+      "    Zero -> f 1;",
+      "    Succ inner -> loop f inner",
+      "  };",
+      "  def main : Int = loop idInt (Succ Zero);",
+      "}"
+    ]
+
+sourceLocalRecursiveHigherOrderProgram :: String
+sourceLocalRecursiveHigherOrderProgram =
+  unlines
+    [ "module Main export (Nat(..), main) {",
+      "  data Nat =",
+      "      Zero : Nat",
+      "    | Succ : Nat -> Nat;",
+      "",
+      "  def main : Int =",
+      "    let idInt : Int -> Int = \\(x : Int) x in",
+      "    let loop : (Int -> Int) -> Nat -> Int = \\(f : Int -> Int) \\(n : Nat) case n of {",
+      "      Zero -> f 1;",
+      "      Succ inner -> loop f inner",
+      "    } in",
+      "    loop idInt (Succ Zero);",
       "}"
     ]
 


### PR DESCRIPTION
Closes #98.

## Implementation Plan

---
issue_number: 98
pr_number: 119
branch: codex/issue-98
---

## Implementation Plan

1. Start from the verified branch/PR state: keep work on `codex/issue-98`, do not create another PR, and confirm the worktree is clean before edits.

2. Add RED coverage first in existing test modules, avoiding new Cabal stanzas unless a new spec module becomes necessary:
   - In `test/BackendConvertSpec.hs`, add checked-source tests for a top-level recursive higher-order function and a closed local recursive higher-order helper lifted to `$letrec$`; assert validated IR, helper lifting for the local case, `BackendClosureCall` where the function parameter is invoked, and no raw direct call for closure-demanded arguments.
   - In `test/BackendLLVMSpec.hs`, add matching `.mlfp` source-level LLVM tests using `emitBackendFile`/`withTempProgram`, `validateLLVMAssembly`, representative `validateLLVMObjectCode`, and native smoke output for at least one top-level and one local recursive higher-order case.
   - Add or preserve a stable unsupported diagnostic test for a checker-accepted escaping polymorphic function value that is not soundly representable at runtime; keep existing first-class-polymorphism success coverage intact.

3. Implement recursive higher-order conversion in `src/MLF/Backend/Convert.hs`:
   - Extend lifted recursive-let metadata or conversion setup so generated helper names get closure/evidence argument-demand entries, computed from each lifted helper type/body with the existing `bindingClosureValueArguments` and `bindingEvidenceValueArguments` logic.
   - Use the extended context when converting both lifted helper bindings and the rewritten enclosing term, so calls to lifted helpers wrap demanded function arguments as closure values before LLVM lowering.
   - Replace the current local recursive-let `isMonomorphicFirstOrderFunctionType` gate with a narrower `isLiftableRecursiveFunctionType` that permits monomorphic runtime-representable higher-order arrows but still rejects `BTForall`, `BTVarApp`, `BTBottom`, and non-evidence lexical captures.
   - Preserve existing capture-safety behavior: recursive local functions that capture ordinary lexical values should continue to fail with `BackendUnsupportedRecursiveLet`.

4. Adjust `src/MLF/Backend/LLVM/Lower.hs` only if the new tests expose a lowering-side representation gap:
   - Keep the closure ABI unchanged: closure values remain pointers to `{ code pointer, env pointer }` records and calls go through `BackendClosureCall`.
   - If needed, treat closure-runtime `BTArrow` parameters/results consistently as `LLVMPtr` while preserving the existing static function/evidence wrapper paths.
   - Do not add a runtime representation for unspecialized `BTForall`; support remains static specialization when type applications are known, otherwise a structured unsupported diagnostic.

5. Update durable guidance for changed behavior:
   - Amend `docs/architecture.md` where it currently calls recursive higher-order flows a future extension point, documenting the newly supported monomorphic recursive higher-order subset and the explicit polymorphic boundary.
   - Update `CHANGELOG.md` because this is meaningful backend progress.

6. Validate in increasing scope:
   - Run targeted matches for the new recursive higher-order and polymorphic diagnostic tests.
   - Run `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.Convert"'`.
   - Run `cabal test mlf2-test --test-show-details=direct --test-options='--match "MLF.Backend.LLVM"'`.
   - Before publishing completion, run `cabal build all && cabal test`.

7. Publish in the implementation turn only after validation: inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, then push `codex/issue-98` to PR #119.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.