### PR TITLE
Implement #88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   parity rows. The backend LLVM spec now compiles, links, runs, and compares
   supported rows against their interpreter result text, while native-unsupported
   rows are explicitly classified with diagnostic fragments.
+- Added unified `.mlfp` fixtures for higher-order LLVM backend coverage:
+  local function flows, returned closures, function-valued ADT fields, and
+  partial applications now run through shared backend parity.
 
 ### Changed
 - Fixed checked-source recursive higher-order LLVM flows so monomorphic

--- a/src/MLF/Backend/IR.hs
+++ b/src/MLF/Backend/IR.hs
@@ -812,8 +812,12 @@ validateBackendClosureFunctionType entryName resultTy params bodyTy =
         Left (BackendClosureTypeMismatch entryName resultTy expected)
 
 backendAppClosureHead :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
-backendAppClosureHead =
-  backendClosureValueName
+backendAppClosureHead mbContext fun
+  | backendExprMayDispatchByValueKind fun,
+    backendTypeIsFirstOrderFunctionPointer (backendExprType fun) =
+      Nothing
+  | otherwise =
+      backendClosureValueName mbContext fun
 
 backendClosureValueName :: Maybe BackendValidationContext -> BackendExpr -> Maybe String
 backendClosureValueName mbContext =
@@ -1433,6 +1437,44 @@ backendTypeIsClosureValue =
   \case
     BTArrow {} -> True
     _ -> False
+
+backendExprMayDispatchByValueKind :: BackendExpr -> Bool
+backendExprMayDispatchByValueKind =
+  \case
+    BackendVar {} -> True
+    BackendTyApp {} -> True
+    BackendLet {} -> True
+    BackendCase {} -> True
+    _ -> False
+
+backendTypeIsFirstOrderFunctionPointer :: BackendType -> Bool
+backendTypeIsFirstOrderFunctionPointer ty =
+  case ty of
+    BTArrow {} ->
+      let (params, returnTy) = collectArrows ty
+       in all backendTypeIsFirstOrderPointerValue (returnTy : params)
+    _ ->
+      False
+  where
+    collectArrows =
+      \case
+        BTArrow param result ->
+          let (params, returnTy) = collectArrows result
+           in (param : params, returnTy)
+        other ->
+          ([], other)
+
+backendTypeIsFirstOrderPointerValue :: BackendType -> Bool
+backendTypeIsFirstOrderPointerValue =
+  \case
+    BTVar {} -> False
+    BTArrow {} -> False
+    BTBase {} -> True
+    BTCon _ args -> all backendTypeIsFirstOrderPointerValue args
+    BTVarApp {} -> False
+    BTForall {} -> False
+    BTMu {} -> True
+    BTBottom -> False
 
 dropTermLocalsMaybe :: Maybe BackendValidationContext -> Maybe BackendValidationContext
 dropTermLocalsMaybe =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2243,6 +2243,18 @@ qualifyInstantiatedClosureEntries ownerName resolvedTypeArgs form
   | null resolvedTypeArgs = form
   | otherwise = qualifyClosureEntriesInForm (closureEntryOwnerName ownerName resolvedTypeArgs) form
 
+qualifyInstantiatedClosureEntriesWithParamKinds :: String -> [BackendType] -> Map String LowerValueKind -> FunctionForm -> FunctionForm
+qualifyInstantiatedClosureEntriesWithParamKinds ownerName resolvedTypeArgs suppliedParamKinds form
+  | null resolvedTypeArgs && null firstOrderParamKinds = form
+  | otherwise = qualifyClosureEntriesInForm (closureEntryOwnerNameWithParamKinds ownerName resolvedTypeArgs firstOrderParamKinds) form
+  where
+    firstOrderParamKinds =
+      [ suppliedKind
+      | (paramName, paramTy) <- ffParams form,
+        isFirstOrderFunctionPointerType paramTy,
+        Just suppliedKind <- [Map.lookup paramName suppliedParamKinds]
+      ]
+
 qualifyClosureEntriesInExpr :: String -> BackendExpr -> BackendExpr
 qualifyClosureEntriesInExpr ownerName =
   go
@@ -2290,6 +2302,13 @@ qualifyClosureEntriesInExpr ownerName =
 qualifiedClosureEntryName :: String -> String -> String
 qualifiedClosureEntryName ownerName entryName =
   ownerName ++ "$" ++ entryName
+
+closureEntryOwnerNameWithParamKinds :: String -> [BackendType] -> [LowerValueKind] -> String
+closureEntryOwnerNameWithParamKinds name typeArgs firstOrderParamKinds =
+  closureEntryOwnerName name typeArgs
+    ++ if null firstOrderParamKinds
+      then ""
+      else "$vk$" ++ intercalate "_" (map lowerValueKindKey firstOrderParamKinds)
 
 collectClosureEntriesInForm :: ProgramBase -> FunctionForm -> [ClosureEntry]
 collectClosureEntriesInForm base =
@@ -2526,8 +2545,10 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
           collectClosureEntriesInFormWithParamKinds
             base
             localForms
-            (suppliedArgumentValueKinds instantiated args)
-            (qualifyInstantiatedClosureEntries ownerName resolvedTypeArgs instantiated)
+            suppliedParamKinds
+            (qualifyInstantiatedClosureEntriesWithParamKinds ownerName resolvedTypeArgs suppliedParamKinds instantiated)
+          where
+            suppliedParamKinds = suppliedArgumentValueKinds instantiated args
         Left _ ->
           []
 
@@ -4021,20 +4042,33 @@ lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> Stri
 lowerLocalFunctionCall env callEnv context resultTy name localFunction typeArgs args = do
   let allowNestedEvidence = isEvidenceName name
   (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (lfForm localFunction) typeArgs args
-  let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
-      arity = length (ffParams form)
+  let arity = length (ffParams form0)
   case compare (length args) arity of
     GT -> do
-      unless (isFunctionLikeBackendType (ffReturnType form)) $
+      unless (isFunctionLikeBackendType (ffReturnType form0)) $
         liftEither (BackendLLVMArityMismatch name arity (length args))
       let (directArgs, closureArgs) = splitAt arity args
-      callee <- lowerLocalFunctionCall env callEnv context (ffReturnType form) name localFunction typeArgs directArgs
+      callee <- lowerLocalFunctionCall env callEnv context (ffReturnType form0) name localFunction typeArgs directArgs
       lowerReturnedFunctionValueCall env callEnv context name resultTy callee closureArgs
     LT ->
       liftEither (BackendLLVMArityMismatch name arity (length args))
     EQ -> do
-      bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form args
+      bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form0 args
+      let form = qualifyInstantiatedClosureEntriesWithParamKinds name resolvedTypeArgs (boundParamValueKinds form0 bodyEnv) form0
       lowerExpr env bodyEnv context (ffBody form)
+  where
+    boundParamValueKinds form bodyEnv =
+      Map.fromList
+        [ (paramName, paramValueKind bodyEnv paramName paramTy)
+        | (paramName, paramTy) <- ffParams form
+        ]
+
+    paramValueKind bodyEnv paramName paramTy =
+      case Map.lookup paramName (eeValues bodyEnv) of
+        Just value -> lvValueKind value
+        Nothing
+          | Map.member paramName (eeLocalFunctions bodyEnv) -> LowerFunctionPointer
+          | otherwise -> parameterValueKind paramName paramTy
 
 lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerDirectFunctionCall env exprEnv context resultTy form0 typeArgs args = do

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3027,7 +3027,7 @@ lowerGlobalValue env context resultTy name binding typeArgs =
       resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
       functionName <- globalFunctionName env context binding0 resolvedTypeArgs
       result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
-      pure (lowerValueForType expectedTy resultLLVMType result)
+      pure (LowerValue expectedTy resultLLVMType result (functionFormReturnValueKind env instantiated))
 
 lowerLit :: ProgramEnv -> String -> BackendType -> Lit -> LowerM LowerValue
 lowerLit env context ty lit = do
@@ -3163,6 +3163,16 @@ lowerClosureValueCall env exprEnv context resultTy callee typeArgs args = do
       then pure (lvBackendType callee)
       else instantiateCallableTypeM context (lvBackendType callee) typeArgs []
   lowerClosurePointerValueCall env exprEnv context resultTy callee {lvBackendType = calleeTy} args
+
+lowerReturnedFunctionValueCall :: ProgramEnv -> ExprEnv -> String -> String -> BackendType -> LowerValue -> [BackendExpr] -> LowerM LowerValue
+lowerReturnedFunctionValueCall env exprEnv context name resultTy callee args =
+  case lvValueKind callee of
+    LowerClosureRecord ->
+      lowerClosurePointerValueCall env exprEnv context resultTy callee args
+    LowerFunctionPointer ->
+      lowerIndirectValueCall env exprEnv context name callee [] args
+    LowerRuntimeValue ->
+      liftEither (BackendLLVMUnsupportedExpression context ("returned value is not callable: " ++ show (lvBackendType callee)))
 
 lowerClosureCallee :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
 lowerClosureCallee env exprEnv context =
@@ -3566,11 +3576,11 @@ lowerLocalFunctionCall env callEnv context resultTy name localFunction typeArgs 
       arity = length (ffParams form)
   case compare (length args) arity of
     GT -> do
-      unless (isClosureRuntimeValueType (ffReturnType form)) $
+      unless (isFunctionLikeBackendType (ffReturnType form)) $
         liftEither (BackendLLVMArityMismatch name arity (length args))
       let (directArgs, closureArgs) = splitAt arity args
       callee <- lowerLocalFunctionCall env callEnv context (ffReturnType form) name localFunction typeArgs directArgs
-      lowerClosurePointerValueCall env callEnv context resultTy callee closureArgs
+      lowerReturnedFunctionValueCall env callEnv context name resultTy callee closureArgs
     LT ->
       liftEither (BackendLLVMArityMismatch name arity (length args))
     EQ -> do
@@ -3584,11 +3594,11 @@ lowerDirectFunctionCall env exprEnv context resultTy form0 typeArgs args = do
       arity = length (ffParams form)
   case compare (length args) arity of
     GT -> do
-      unless (isClosureRuntimeValueType (ffReturnType form)) $
+      unless (isFunctionLikeBackendType (ffReturnType form)) $
         liftEither (BackendLLVMArityMismatch "lambda" arity (length args))
       let (directArgs, closureArgs) = splitAt arity args
       callee <- lowerSaturatedDirectFunctionCall form directArgs
-      lowerClosurePointerValueCall env exprEnv context resultTy callee closureArgs
+      lowerReturnedFunctionValueCall env exprEnv context "lambda" resultTy callee closureArgs
     LT ->
       liftEither (BackendLLVMArityMismatch "lambda" arity (length args))
     EQ ->
@@ -3607,11 +3617,11 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           arity = length (ffParams form)
       case compare (length args) arity of
         GT -> do
-          unless (isClosureRuntimeValueType (ffReturnType form)) $
+          unless (isFunctionLikeBackendType (ffReturnType form)) $
             liftEither (BackendLLVMArityMismatch name arity (length args))
           let (directArgs, closureArgs) = splitAt arity args
           callee <- lowerGlobalCall env exprEnv context (ffReturnType form) name typeArgs directArgs
-          lowerClosurePointerValueCall env exprEnv context resultTy callee closureArgs
+          lowerReturnedFunctionValueCall env exprEnv context name resultTy callee closureArgs
         LT ->
           liftEither (BackendLLVMArityMismatch name arity (length args))
         EQ ->
@@ -3647,7 +3657,7 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           llvmResultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
           functionName <- globalFunctionName env context binding resolvedTypeArgs
           result <- emitAssign "call" llvmResultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-          pure (lowerValueForType (ffReturnType form) llvmResultTy result)
+          pure (LowerValue (ffReturnType form) llvmResultTy result (functionFormReturnValueKind env form))
 
 shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
 shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =
@@ -4325,6 +4335,56 @@ valueKindForType :: BackendType -> LowerValueKind
 valueKindForType ty
   | isClosureRuntimeValueType ty = LowerClosureRecord
   | otherwise = LowerRuntimeValue
+
+functionFormReturnValueKind :: ProgramEnv -> FunctionForm -> LowerValueKind
+functionFormReturnValueKind env form =
+  backendExprValueKind env paramKinds (ffBody form)
+  where
+    paramKinds = Map.fromList [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- ffParams form]
+
+backendExprValueKind :: ProgramEnv -> Map String LowerValueKind -> BackendExpr -> LowerValueKind
+backendExprValueKind env valueKinds expr
+  | not (isFunctionLikeBackendType (backendExprType expr)) = LowerRuntimeValue
+  | otherwise =
+      case expr of
+        BackendVar ty name ->
+          variableValueKind ty name []
+        BackendTyApp _ fun _ ->
+          case collectTyApps expr of
+            (BackendVar ty name, typeArgs) ->
+              variableValueKind ty name typeArgs
+            _ ->
+              backendExprValueKind env valueKinds fun
+        BackendLet _ name bindingTy rhs body ->
+          backendExprValueKind env valueKindsForBody body
+          where
+            valueKindsForBody =
+              case functionFormFromExpected bindingTy rhs of
+                form
+                  | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                      Map.delete name valueKinds
+                _ ->
+                  Map.insert name (backendExprValueKind env valueKinds rhs) valueKinds
+        BackendClosure {} ->
+          LowerClosureRecord
+        _ ->
+          valueKindForType (backendExprType expr)
+  where
+    variableValueKind ty name typeArgs =
+      case Map.lookup name valueKinds of
+        Just kind ->
+          kind
+        Nothing ->
+          case Map.lookup name (pbBindings (peBase env)) of
+            Just binding ->
+              case instantiateFunctionFormWithTypeArgs "value-kind classification" (biForm binding) typeArgs [] of
+                Right (_, form)
+                  | null (ffParams form) ->
+                      functionFormReturnValueKind env form
+                _ ->
+                  LowerFunctionPointer
+            Nothing ->
+              valueKindForType ty
 
 parameterValueKind :: String -> BackendType -> LowerValueKind
 parameterValueKind name ty

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -222,9 +222,16 @@ mergeConstructedValues values =
 
 combineValueKinds :: BackendType -> [LowerValueKind] -> LowerValueKind
 combineValueKinds resultTy kinds =
-  case nub kinds of
+  case uniqueKinds of
     [kind] -> kind
+    _
+      | isFirstOrderFunctionPointerType resultTy,
+        LowerClosureRecord `elem` uniqueKinds,
+        LowerFunctionPointer `elem` uniqueKinds ->
+          LowerClosureRecord
     _ -> valueKindForType resultTy
+  where
+    uniqueKinds = nub kinds
 
 data LocalFunction = LocalFunction
   { lfForm :: FunctionForm,
@@ -239,6 +246,10 @@ data ExprEnv = ExprEnv
     eeActiveGlobalInlines :: Set String
   }
   deriving (Eq, Show)
+
+exprEnvValueKinds :: ExprEnv -> Map String LowerValueKind
+exprEnvValueKinds =
+  Map.map lvValueKind . eeValues
 
 data FunctionState = FunctionState
   { fsNextLocal :: Int,
@@ -2342,8 +2353,10 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
         Just entries -> entries
         Nothing -> collectTypeAppliedClosureEntries
     BackendConstruct _ _ args -> concatMap (collectClosureEntriesInExpr base localForms valueKinds) args
-    BackendCase _ scrutinee alternatives ->
-      collectClosureEntriesInExpr base localForms valueKinds scrutinee ++ concatMap collectAlternativeEntries (NE.toList alternatives)
+    BackendCase resultTy scrutinee alternatives ->
+      collectClosureEntriesInExpr base localForms valueKinds scrutinee
+        ++ concatMap collectAlternativeEntries (NE.toList alternatives)
+        ++ collectCaseResultAdapterEntries resultTy (NE.toList alternatives)
     BackendRoll _ payload -> collectClosureEntriesInExpr base localForms valueKinds payload
     BackendUnroll _ payload -> collectClosureEntriesInExpr base localForms valueKinds payload
     BackendClosure resultTy entryName captures params body ->
@@ -2661,6 +2674,21 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
             (Map.withoutKeys valueKinds binders)
             (backendAltBody alternative)
 
+    collectCaseResultAdapterEntries resultTy alternatives0 =
+      [ returnedPartialEntry LowerFunctionPointer resultTy [] paramTys returnTy [] resultTy
+      | isFirstOrderFunctionPointerType resultTy,
+        not (null paramTys),
+        resultKind == LowerClosureRecord,
+        LowerClosureRecord `elem` branchKinds
+      ]
+      where
+        branchKinds =
+          [ expressionValueKind localForms valueKinds (backendAltBody alternative)
+          | alternative <- alternatives0
+          ]
+        resultKind = combineValueKinds resultTy branchKinds
+        (paramTys, returnTy) = collectArrowsType resultTy
+
     patternBinders =
       \case
         BackendDefaultPattern -> Set.empty
@@ -2721,7 +2749,11 @@ backendExprIsExplicitClosure :: BackendExpr -> Bool
 backendExprIsExplicitClosure =
   \case
     BackendClosure {} -> True
+    BackendTyAbs _ _ _ body -> backendExprIsExplicitClosure body
+    BackendTyApp _ fun _ -> backendExprIsExplicitClosure fun
     BackendLet _ _ _ _ body -> backendExprIsExplicitClosure body
+    BackendCase _ _ alternatives ->
+      all (backendExprIsExplicitClosure . backendAltBody) (NE.toList alternatives)
     _ -> False
 
 lowerFunction :: ProgramEnv -> String -> Bool -> FunctionForm -> Either BackendLLVMError LLVMFunction
@@ -3143,11 +3175,26 @@ pushCallIntoExpression context resultTy fun typeArgs args =
 applyCallToExpr :: String -> BackendType -> BackendExpr -> [BackendType] -> [BackendExpr] -> Either BackendLLVMError BackendExpr
 applyCallToExpr context expectedTy expr typeArgs args = do
   (typedExpr, typedExprTy) <- applyTypeApplicationsToExprWithType context expr typeArgs
-  (applied, actualTy) <- foldM applyOne (typedExpr, typedExprTy) args
-  unless (alphaEqBackendType expectedTy actualTy) $
-    Left (BackendLLVMInternalError ("call result mismatch at " ++ context))
-  pure applied
+  case explicitClosureCall typedExpr typedExprTy of
+    Just applied ->
+      pure applied
+    Nothing -> do
+      (applied, actualTy) <- foldM applyOne (typedExpr, typedExprTy) args
+      unless (alphaEqBackendType expectedTy actualTy) $
+        Left (BackendLLVMInternalError ("call result mismatch at " ++ context))
+      pure applied
   where
+    explicitClosureCall typedExpr typedExprTy
+      | backendExprIsExplicitClosure typedExpr,
+        length args == length paramTys,
+        and (zipWith alphaEqBackendType paramTys (map backendExprType args)),
+        alphaEqBackendType expectedTy returnTy =
+          Just (BackendClosureCall expectedTy typedExpr args)
+      | otherwise =
+          Nothing
+      where
+        (paramTys, returnTy) = collectArrowsType typedExprTy
+
     applyOne (current, currentTy) arg =
       case currentTy of
         BTArrow expectedArgTy resultTy
@@ -4560,9 +4607,10 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
   joinLabel <- freshBlock "case.join"
   let constructorTargets = mapMaybe constructorSwitchTarget (zip (NE.toList alternatives) altLabels)
       switchTargets = [(tag, label) | (tag, label, _) <- constructorTargets]
+      resultValueKind = combineValueKinds resultTy (map (alternativeBodyValueKind scrutineeValue) alternativesList)
   rejectDuplicateSwitchTargets constructorTargets
   finishCurrentBlock (LLVMSwitch (LLVMInt 64) tagValue defaultLabel switchTargets)
-  incoming <- concat <$> zipWithM (lowerAlternative resultLLVMType joinLabel scrutineeValue) (NE.toList alternatives) altLabels
+  incoming <- concat <$> zipWithM (lowerAlternative resultValueKind resultLLVMType joinLabel scrutineeValue) (NE.toList alternatives) altLabels
   when (lookupDefaultLabel altLabels == Nothing) $ do
     startBlock defaultLabel
     finishCurrentBlock LLVMUnreachable
@@ -4573,7 +4621,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
         resultTy
         resultLLVMType
         result
-        (combineValueKinds resultTy [kind | (_, _, kind, _) <- incoming])
+        resultValueKind
         (mergeConstructedValues [constructed | (_, _, _, constructed) <- incoming])
     )
   where
@@ -4611,15 +4659,49 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
         Nothing ->
           pure ()
 
-    lowerAlternative resultLLVMType joinLabel scrutineeValue alternative label = do
+    lowerAlternative resultValueKind resultLLVMType joinLabel scrutineeValue alternative label = do
       startBlock label
       exprEnv' <- bindAlternativePattern scrutineeValue alternative
-      bodyValue <- lowerExpr env exprEnv' context (backendAltBody alternative)
+      rawBodyValue <- lowerExpr env exprEnv' context (backendAltBody alternative)
+      bodyValue <- normalizeCaseResultValue resultValueKind rawBodyValue
       unless (lvLLVMType bodyValue == resultLLVMType) $
         liftEither (BackendLLVMInternalError ("case alternative type mismatch at " ++ context))
       sourceLabel <- gets fsCurrentLabel
       finishCurrentBlock (LLVMBr joinLabel)
       pure [(lvOperand bodyValue, sourceLabel, lvValueKind bodyValue, lvConstructedValue bodyValue)]
+
+    normalizeCaseResultValue targetKind value
+      | targetKind == LowerClosureRecord,
+        lvValueKind value == LowerFunctionPointer,
+        isFirstOrderFunctionPointerType (lvBackendType value) =
+          let (paramTys, returnTy) = collectArrowsType (lvBackendType value)
+           in lowerReturnedPartialClosureValue env exprEnv (context ++ " case result") resultTy value paramTys returnTy []
+      | otherwise =
+          pure value
+
+    alternativeBodyValueKind scrutineeValue alternative =
+      backendExprValueKindWith env Set.empty (alternativeValueKinds scrutineeValue alternative) (backendAltBody alternative)
+
+    alternativeValueKinds scrutineeValue (BackendAlternative pattern0 _) =
+      case pattern0 of
+        BackendDefaultPattern ->
+          exprEnvValueKinds exprEnv
+        BackendConstructorPattern constructorName binders ->
+          patternBinderValueKinds scrutineeValue constructorName binders `Map.union` exprEnvValueKinds exprEnv
+
+    patternBinderValueKinds scrutineeValue constructorName binders =
+      Map.fromList
+        [ (binder, binderFieldValueKind index0 fieldTy)
+        | (index0, (binder, fieldTy)) <- zip [0 :: Int ..] (zip binders fieldTys)
+        ]
+      where
+        fieldTys =
+          fromMaybe [] $
+            Map.lookup constructorName (pbConstructors (peBase env)) >>= \constructorRuntime ->
+              constructorRuntimeFieldTypes constructorRuntime (lvBackendType scrutineeValue)
+        binderFieldValueKind index0 fieldTy =
+          fromMaybe (valueKindForType fieldTy) $
+            lvConstructedValue scrutineeValue >>= constructedFieldValueKind constructorName index0
 
     bindAlternativePattern scrutineeValue (BackendAlternative pattern0 body) =
       case pattern0 of

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -4352,12 +4352,16 @@ valueKindForType ty
 
 functionFormReturnValueKind :: ProgramEnv -> FunctionForm -> LowerValueKind
 functionFormReturnValueKind env form =
-  backendExprValueKind env paramKinds (ffBody form)
+  functionFormReturnValueKindWith env Set.empty form
+
+functionFormReturnValueKindWith :: ProgramEnv -> Set String -> FunctionForm -> LowerValueKind
+functionFormReturnValueKindWith env visitedGlobals form =
+  backendExprValueKindWith env visitedGlobals paramKinds (ffBody form)
   where
     paramKinds = Map.fromList [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- ffParams form]
 
-backendExprValueKind :: ProgramEnv -> Map String LowerValueKind -> BackendExpr -> LowerValueKind
-backendExprValueKind env valueKinds expr
+backendExprValueKindWith :: ProgramEnv -> Set String -> Map String LowerValueKind -> BackendExpr -> LowerValueKind
+backendExprValueKindWith env visitedGlobals valueKinds expr
   | not (isFunctionLikeBackendType (backendExprType expr)) = LowerRuntimeValue
   | otherwise =
       case expr of
@@ -4368,9 +4372,9 @@ backendExprValueKind env valueKinds expr
             (BackendVar ty name, typeArgs) ->
               variableValueKind ty name typeArgs
             _ ->
-              backendExprValueKind env valueKinds fun
+              backendExprValueKindWith env visitedGlobals valueKinds fun
         BackendLet _ name bindingTy rhs body ->
-          backendExprValueKind env valueKindsForBody body
+          backendExprValueKindWith env visitedGlobals valueKindsForBody body
           where
             valueKindsForBody =
               case functionLikeAliasValueKind valueKinds rhs of
@@ -4382,7 +4386,7 @@ backendExprValueKind env valueKinds expr
                       | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
                           Map.delete name valueKinds
                     _ ->
-                      Map.insert name (backendExprValueKind env valueKinds rhs) valueKinds
+                      Map.insert name (backendExprValueKindWith env visitedGlobals valueKinds rhs) valueKinds
         BackendClosure {} ->
           LowerClosureRecord
         _ ->
@@ -4415,7 +4419,7 @@ backendExprValueKind env valueKinds expr
                             | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
                                 Map.delete name kinds
                           _ ->
-                            Map.insert name (backendExprValueKind env kinds rhs) kinds
+                            Map.insert name (backendExprValueKindWith env visitedGlobals kinds rhs) kinds
                in functionLikeAliasValueKind kindsForBody body
         _ ->
           Nothing
@@ -4429,8 +4433,12 @@ backendExprValueKind env valueKinds expr
             Just binding ->
               case instantiateFunctionFormWithTypeArgs "value-kind classification" (biForm binding) typeArgs [] of
                 Right (_, form)
-                  | null (ffParams form) ->
-                      functionFormReturnValueKind env form
+                  | not (null (ffParams form)) ->
+                      LowerFunctionPointer
+                  | Set.member name visitedGlobals ->
+                      valueKindForType ty
+                  | otherwise ->
+                      functionFormReturnValueKindWith env (Set.insert name visitedGlobals) form
                 _ ->
                   LowerFunctionPointer
             Nothing ->

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3332,22 +3332,31 @@ lowerGlobalValue env context resultTy name binding typeArgs =
   where
     form = biForm binding
 
-    lowerInstantiatedGlobalValue expectedTy functionContext binding0 resolvedTypeArgs instantiated = do
-      unless (null (ffParams instantiated)) $
+    lowerInstantiatedGlobalValue expectedTy functionContext binding0 resolvedTypeArgs instantiated
+      | not (null (ffParams instantiated)) =
+          lowerInstantiatedGlobalFunctionValue expectedTy functionContext binding0 resolvedTypeArgs instantiated
+      | otherwise = do
+          unless (alphaEqBackendType expectedTy (ffReturnType instantiated)) $
+            liftEither (BackendLLVMInternalError ("global value type mismatch for " ++ functionContext ++ " at " ++ context))
+          resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
+          functionName <- globalFunctionName env context binding0 resolvedTypeArgs
+          result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
+          pure
+            ( LowerValue
+                expectedTy
+                resultLLVMType
+                result
+                (functionFormReturnValueKind env instantiated)
+                (functionFormReturnConstructedValue env instantiated)
+            )
+
+    lowerInstantiatedGlobalFunctionValue expectedTy functionContext binding0 resolvedTypeArgs instantiated = do
+      unless (isFirstOrderFunctionPointerType expectedTy) $
         liftEither (BackendLLVMUnsupportedExpression context ("escaping function " ++ show functionContext))
-      unless (alphaEqBackendType expectedTy (ffReturnType instantiated)) $
-        liftEither (BackendLLVMInternalError ("global value type mismatch for " ++ functionContext ++ " at " ++ context))
-      resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
+      let actualTy = functionTypeFromForm instantiated
+      requireEvidenceFunctionType context functionContext expectedTy actualTy
       functionName <- globalFunctionName env context binding0 resolvedTypeArgs
-      result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
-      pure
-        ( LowerValue
-            expectedTy
-            resultLLVMType
-            result
-            (functionFormReturnValueKind env instantiated)
-            (functionFormReturnConstructedValue env instantiated)
-        )
+      pure (functionPointerValue expectedTy (LLVMGlobalRef LLVMPtr functionName))
 
 lowerLit :: ProgramEnv -> String -> BackendType -> Lit -> LowerM LowerValue
 lowerLit env context ty lit = do

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3029,6 +3029,14 @@ lowerClosurePointerValueCall env exprEnv context resultTy callee args = do
     lowerClosureArg (index0, paramTy) arg =
       lowerExprForIndirectArgument env exprEnv context ("__mlfp_closure_arg" ++ show index0, paramTy) arg
 
+lowerClosureValueCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> LowerValue -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
+lowerClosureValueCall env exprEnv context resultTy callee typeArgs args = do
+  calleeTy <-
+    if null typeArgs
+      then pure (lvBackendType callee)
+      else instantiateCallableTypeM context (lvBackendType callee) typeArgs []
+  lowerClosurePointerValueCall env exprEnv context resultTy callee {lvBackendType = calleeTy} args
+
 lowerClosureCallee :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
 lowerClosureCallee env exprEnv context =
   \case
@@ -3051,6 +3059,10 @@ lowerCall env exprEnv context expr =
               lowerLocalFunctionCall env exprEnv context (backendExprType expr) name localFunction typeArgs args
             Nothing ->
               case Map.lookup name (eeValues exprEnv) of
+                Just value
+                  | isFunctionLikeBackendType (lvBackendType value),
+                    not (isEvidenceCallableName name) ->
+                      lowerClosureValueCall env exprEnv context (backendExprType expr) value typeArgs args
                 Just value
                   | isFunctionLikeBackendType (lvBackendType value) ->
                       lowerIndirectValueCall env exprEnv context name value typeArgs args

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2990,7 +2990,7 @@ lowerClosureCall env exprEnv context resultTy fun args = do
   case collectTyApps fun of
     (BackendVar _ name, typeArgs)
       | Just localFunction <- Map.lookup name (eeLocalFunctions exprEnv) ->
-          lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
+          lowerLocalFunctionCall env exprEnv context resultTy name localFunction typeArgs args
     _ ->
       lowerClosurePointerCall
   where
@@ -3048,7 +3048,7 @@ lowerCall env exprEnv context expr =
         BackendVar _ name ->
           case Map.lookup name (eeLocalFunctions exprEnv) of
             Just localFunction ->
-              lowerLocalFunctionCall env exprEnv context name localFunction typeArgs args
+              lowerLocalFunctionCall env exprEnv context (backendExprType expr) name localFunction typeArgs args
             Nothing ->
               case Map.lookup name (eeValues exprEnv) of
                 Just value
@@ -3419,13 +3419,24 @@ backendTypeVariableNames =
     BTBottom ->
       Set.empty
 
-lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
-lowerLocalFunctionCall env callEnv context name localFunction typeArgs args = do
+lowerLocalFunctionCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> LocalFunction -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
+lowerLocalFunctionCall env callEnv context resultTy name localFunction typeArgs args = do
   let allowNestedEvidence = isEvidenceName name
   (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (lfForm localFunction) typeArgs args
   let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
-  bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form args
-  lowerExpr env bodyEnv context (ffBody form)
+      arity = length (ffParams form)
+  case compare (length args) arity of
+    GT -> do
+      unless (isClosureRuntimeValueType (ffReturnType form)) $
+        liftEither (BackendLLVMArityMismatch name arity (length args))
+      let (directArgs, closureArgs) = splitAt arity args
+      callee <- lowerLocalFunctionCall env callEnv context (ffReturnType form) name localFunction typeArgs directArgs
+      lowerClosurePointerValueCall env callEnv context resultTy callee closureArgs
+    LT ->
+      liftEither (BackendLLVMArityMismatch name arity (length args))
+    EQ -> do
+      bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form args
+      lowerExpr env bodyEnv context (ffBody form)
 
 lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2996,32 +2996,36 @@ lowerClosureCall env exprEnv context resultTy fun args = do
   where
     lowerClosurePointerCall = do
       callee <- lowerClosureCallee env exprEnv context fun
-      unless (lvLLVMType callee == LLVMPtr) $
-        liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a pointer: " ++ show (lvBackendType callee)))
-      let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
-      when (null paramTys) $
-        liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
-      unless (length paramTys == length args) $
-        liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
-      resultLLVMType <- lowerBackendTypeM env context resultTy
-      returnLLVMType <- lowerBackendTypeM env context returnTy
-      unless (resultLLVMType == returnLLVMType) $
-        liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
-      callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
-      codePtrField <- emitGep "closure.code.ptr" (lvOperand callee) 0
-      codePtr <- emitAssign "closure.code" LLVMPtr (LLVMLoad LLVMPtr codePtrField)
-      envPtrField <- emitGep "closure.env.ptr" (lvOperand callee) 8
-      closureEnv <- emitAssign "closure.env" LLVMPtr (LLVMLoad LLVMPtr envPtrField)
-      result <-
-        emitAssign
-          "closure.call"
-          resultLLVMType
-          ( LLVMCallOperand
-              codePtr
-              ((LLVMPtr, closureEnv) : [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-          )
-      pure (LowerValue resultTy resultLLVMType result)
+      lowerClosurePointerValueCall env exprEnv context resultTy callee args
 
+lowerClosurePointerValueCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> LowerValue -> [BackendExpr] -> LowerM LowerValue
+lowerClosurePointerValueCall env exprEnv context resultTy callee args = do
+  unless (lvLLVMType callee == LLVMPtr) $
+    liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a pointer: " ++ show (lvBackendType callee)))
+  let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
+  when (null paramTys) $
+    liftEither (BackendLLVMUnsupportedExpression context ("closure callee is not a function: " ++ show (lvBackendType callee)))
+  unless (length paramTys == length args) $
+    liftEither (BackendLLVMArityMismatch "closure" (length paramTys) (length args))
+  resultLLVMType <- lowerBackendTypeM env context resultTy
+  returnLLVMType <- lowerBackendTypeM env context returnTy
+  unless (resultLLVMType == returnLLVMType) $
+    liftEither (BackendLLVMInternalError ("closure call result mismatch at " ++ context))
+  callArgs <- zipWithM lowerClosureArg (zip [0 :: Int ..] paramTys) args
+  codePtrField <- emitGep "closure.code.ptr" (lvOperand callee) 0
+  codePtr <- emitAssign "closure.code" LLVMPtr (LLVMLoad LLVMPtr codePtrField)
+  envPtrField <- emitGep "closure.env.ptr" (lvOperand callee) 8
+  closureEnv <- emitAssign "closure.env" LLVMPtr (LLVMLoad LLVMPtr envPtrField)
+  result <-
+    emitAssign
+      "closure.call"
+      resultLLVMType
+      ( LLVMCallOperand
+          codePtr
+          ((LLVMPtr, closureEnv) : [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+      )
+  pure (LowerValue resultTy resultLLVMType result)
+  where
     lowerClosureArg (index0, paramTy) arg =
       lowerExprForIndirectArgument env exprEnv context ("__mlfp_closure_arg" ++ show index0, paramTy) arg
 
@@ -3051,7 +3055,7 @@ lowerCall env exprEnv context expr =
                   | isFunctionLikeBackendType (lvBackendType value) ->
                       lowerIndirectValueCall env exprEnv context name value typeArgs args
                 _ ->
-                  lowerGlobalCall env exprEnv context name typeArgs args
+                  lowerGlobalCall env exprEnv context (backendExprType expr) name typeArgs args
         BackendLam {} ->
           lowerDirectFunctionCall env exprEnv context (functionFormFromExpr headExpr) typeArgs args
         BackendTyAbs {} ->
@@ -3430,14 +3434,37 @@ lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do
   bodyEnv <- bindCallArguments env exprEnv exprEnv context False "lambda" form args
   lowerExpr env bodyEnv context (ffBody form)
 
-lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> String -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
-lowerGlobalCall env exprEnv context name typeArgs args =
+lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
+lowerGlobalCall env exprEnv context resultTy name typeArgs args =
   case Map.lookup name (pbBindings (peBase env)) of
     Just binding -> do
       (resolvedTypeArgs, form0) <- instantiateFunctionFormWithTypeArgsM context (biForm binding) typeArgs args
       let form = qualifyInstantiatedClosureEntries name resolvedTypeArgs form0
-      unless (length args == length (ffParams form)) $
-        liftEither (BackendLLVMArityMismatch name (length (ffParams form)) (length args))
+          arity = length (ffParams form)
+      case compare (length args) arity of
+        GT -> do
+          unless (isClosureRuntimeValueType (ffReturnType form)) $
+            liftEither (BackendLLVMArityMismatch name arity (length args))
+          let (directArgs, closureArgs) = splitAt arity args
+          callee <- lowerGlobalCall env exprEnv context (ffReturnType form) name typeArgs directArgs
+          lowerClosurePointerValueCall env exprEnv context resultTy callee closureArgs
+        LT ->
+          liftEither (BackendLLVMArityMismatch name arity (length args))
+        EQ ->
+          lowerSaturatedGlobalCall binding resolvedTypeArgs form
+    Nothing
+      | name == runtimeAndName -> do
+          unless (length args == 2) $
+            liftEither (BackendLLVMArityMismatch name 2 (length args))
+          callArgs <- traverse (lowerExpr env exprEnv context) args
+          let expectedTypes = [LLVMInt 1, LLVMInt 1]
+          zipWithM_ (requireLLVMType context name) expectedTypes callArgs
+          result <- emitAssign "call" (LLVMInt 1) (LLVMCall runtimeAndName [(LLVMInt 1, lvOperand arg) | arg <- callArgs])
+          pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result)
+    Nothing ->
+      liftEither (BackendLLVMUnknownFunction name)
+  where
+    lowerSaturatedGlobalCall binding resolvedTypeArgs form =
       if requiresInlineCall form
         && Set.member (biName binding) (eeActiveGlobalInlines exprEnv)
         && not (canEmitFunctionForm form)
@@ -3453,21 +3480,10 @@ lowerGlobalCall env exprEnv context name typeArgs args =
         else do
           callArgs <- zipWithM (lowerExprForArgument env exprEnv context False) (ffParams form) args
           bindFunctionArguments env context False name form callArgs
-          resultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
+          llvmResultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
           functionName <- globalFunctionName env context binding resolvedTypeArgs
-          result <- emitAssign "call" resultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (ffReturnType form) resultTy result)
-    Nothing
-      | name == runtimeAndName -> do
-          unless (length args == 2) $
-            liftEither (BackendLLVMArityMismatch name 2 (length args))
-          callArgs <- traverse (lowerExpr env exprEnv context) args
-          let expectedTypes = [LLVMInt 1, LLVMInt 1]
-          zipWithM_ (requireLLVMType context name) expectedTypes callArgs
-          result <- emitAssign "call" (LLVMInt 1) (LLVMCall runtimeAndName [(LLVMInt 1, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result)
-    Nothing ->
-      liftEither (BackendLLVMUnknownFunction name)
+          result <- emitAssign "call" llvmResultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
+          pure (LowerValue (ffReturnType form) llvmResultTy result)
 
 shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
 shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -153,6 +153,12 @@ data ClosureCaptureSlot = ClosureCaptureSlot
   }
   deriving (Eq, Show)
 
+data ConstructedValue = ConstructedValue
+  { cvConstructorName :: String,
+    cvFieldValueKinds :: [LowerValueKind]
+  }
+  deriving (Eq, Show)
+
 data LoweredProgram = LoweredProgram
   { lpBase :: ProgramBase,
     lpEnv :: ProgramEnv,
@@ -170,7 +176,8 @@ data LowerValue = LowerValue
   { lvBackendType :: BackendType,
     lvLLVMType :: LLVMType,
     lvOperand :: LLVMOperand,
-    lvValueKind :: LowerValueKind
+    lvValueKind :: LowerValueKind,
+    lvConstructedValue :: Maybe ConstructedValue
   }
   deriving (Eq, Show)
 
@@ -2723,6 +2730,7 @@ lowerClosureEntry env entry = do
                       (llvmParameterType param)
                       (LLVMLocal (llvmParameterType param) paramName)
                       (parameterValueKind paramName paramTy)
+                      Nothing
                   )
                 | ((paramName, paramTy), param) <- zip (ceParams entry) params
                 ],
@@ -2771,7 +2779,7 @@ lowerClosureEntry env entry = do
           { eeValues =
               Map.insert
                 captureName
-                (LowerValue captureTy llvmTy loaded (ccsValueKind capture))
+                (LowerValue captureTy llvmTy loaded (ccsValueKind capture) Nothing)
                 (eeValues exprEnv0)
           }
 
@@ -2973,6 +2981,7 @@ initialFunctionEnv name form params =
                 (llvmParameterType param)
                 (LLVMLocal (llvmParameterType param) paramName)
                 (parameterValueKind paramName paramTy)
+                Nothing
             )
           | ((paramName, paramTy), param) <- zip (ffParams form) params
           ],
@@ -3245,21 +3254,21 @@ lowerGlobalValue env context resultTy name binding typeArgs =
       resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
       functionName <- globalFunctionName env context binding0 resolvedTypeArgs
       result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
-      pure (LowerValue expectedTy resultLLVMType result (functionFormReturnValueKind env instantiated))
+      pure (LowerValue expectedTy resultLLVMType result (functionFormReturnValueKind env instantiated) Nothing)
 
 lowerLit :: ProgramEnv -> String -> BackendType -> Lit -> LowerM LowerValue
 lowerLit env context ty lit = do
   llvmTy <- lowerBackendTypeM env context ty
   case lit of
     LInt value ->
-      pure (LowerValue ty llvmTy (LLVMIntLiteral 64 value) LowerRuntimeValue)
+      pure (LowerValue ty llvmTy (LLVMIntLiteral 64 value) LowerRuntimeValue Nothing)
     LBool value ->
-      pure (LowerValue ty llvmTy (LLVMIntLiteral 1 (if value then 1 else 0)) LowerRuntimeValue)
+      pure (LowerValue ty llvmTy (LLVMIntLiteral 1 (if value then 1 else 0)) LowerRuntimeValue Nothing)
     LString value ->
       case Map.lookup value (peStringGlobals env) of
         Just globalName
           | asciiString value ->
-              pure (LowerValue ty llvmTy (LLVMGlobalRef LLVMPtr globalName) LowerRuntimeValue)
+              pure (LowerValue ty llvmTy (LLVMGlobalRef LLVMPtr globalName) LowerRuntimeValue Nothing)
         Just _ ->
           liftEither (BackendLLVMUnsupportedString value)
         Nothing ->
@@ -3274,7 +3283,7 @@ lowerClosureValue env exprEnv context resultTy entryName captures = do
   emitStore LLVMPtr (LLVMGlobalRef LLVMPtr entryName) codePtrField
   envPtrField <- emitGep "closure.env.ptr" closurePointer 8
   emitStore LLVMPtr envPointer envPtrField
-  pure (LowerValue resultTy LLVMPtr closurePointer LowerClosureRecord)
+  pure (LowerValue resultTy LLVMPtr closurePointer LowerClosureRecord Nothing)
   where
     lowerCapture capture = do
       value <-
@@ -3438,7 +3447,7 @@ lowerReturnedPartialClosureValue env exprEnv context resultTy callee paramTys re
   emitStore LLVMPtr (LLVMGlobalRef LLVMPtr entryName) codePtrField
   envPtrField <- emitGep "closure.env.ptr" closurePointer 8
   emitStore LLVMPtr envPointer envPtrField
-  pure (LowerValue resultTy LLVMPtr closurePointer LowerClosureRecord)
+  pure (LowerValue resultTy LLVMPtr closurePointer LowerClosureRecord Nothing)
   where
     lowerPartialArg (index0, paramTy) arg =
       lowerExprForIndirectArgument env exprEnv context (returnedPartialSuppliedArgName index0, paramTy) arg
@@ -3915,7 +3924,7 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           let expectedTypes = [LLVMInt 1, LLVMInt 1]
           zipWithM_ (requireLLVMType context name) expectedTypes callArgs
           result <- emitAssign "call" (LLVMInt 1) (LLVMCall runtimeAndName [(LLVMInt 1, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result LowerRuntimeValue)
+          pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result LowerRuntimeValue Nothing)
     Nothing ->
       liftEither (BackendLLVMUnknownFunction name)
   where
@@ -3938,7 +3947,7 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           llvmResultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
           functionName <- globalFunctionName env context binding resolvedTypeArgs
           result <- emitAssign "call" llvmResultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (ffReturnType form) llvmResultTy result (functionFormReturnValueKind env form))
+          pure (LowerValue (ffReturnType form) llvmResultTy result (functionFormReturnValueKind env form) Nothing)
 
 shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
 shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =
@@ -4437,7 +4446,14 @@ lowerConstruct env exprEnv context resultTy name args =
       resultLLVMType <- lowerBackendTypeM env context resultTy
       unless (resultLLVMType == LLVMPtr) $
         liftEither (BackendLLVMUnsupportedType context resultTy)
-      pure (LowerValue resultTy LLVMPtr object LowerRuntimeValue)
+      pure
+        ( LowerValue
+            resultTy
+            LLVMPtr
+            object
+            LowerRuntimeValue
+            (Just (ConstructedValue name (map lvValueKind argValues)))
+        )
   where
     storeField object index0 value = do
       fieldPtr <- emitGep "field.ptr" object (8 * (index0 + 1))
@@ -4563,7 +4579,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
                     [ Map.findWithDefault fieldTy binder bodyBinderTypes
                       | (binder, fieldTy) <- zip binders fieldTys
                     ]
-              loadedFields <- mapMaybe id <$> traverse (loadUsedField usedBinders scrutineeValue) (zip3 [0 :: Int ..] binders effectiveFieldTys)
+              loadedFields <- mapMaybe id <$> traverse (loadUsedField name usedBinders scrutineeValue) (zip3 [0 :: Int ..] binders effectiveFieldTys)
               pure
                 exprEnv
                   { eeValues =
@@ -4572,18 +4588,27 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
                         (eeValues exprEnv)
                   }
 
-    loadUsedField usedBinders scrutineeValue (index0, binder, fieldTy)
+    loadUsedField constructorName usedBinders scrutineeValue (index0, binder, fieldTy)
       | Set.member binder usedBinders = do
-          loaded <- loadField scrutineeValue index0 fieldTy
+          loaded <- loadField constructorName scrutineeValue index0 fieldTy
           pure (Just (binder, loaded))
       | otherwise =
           pure Nothing
 
-    loadField scrutineeValue index0 fieldTy = do
+    loadField constructorName scrutineeValue index0 fieldTy = do
       llvmTy <- lowerStoredFieldTypeM env context fieldTy
       fieldPtr <- emitGep "case.field.ptr" (lvOperand scrutineeValue) (8 * (index0 + 1))
       loaded <- emitAssign "case.field" llvmTy (LLVMLoad llvmTy fieldPtr)
-      pure (LowerValue fieldTy llvmTy loaded (valueKindForType fieldTy))
+      pure (LowerValue fieldTy llvmTy loaded (fieldValueKind constructorName scrutineeValue index0 fieldTy) Nothing)
+
+    fieldValueKind constructorName scrutineeValue index0 fieldTy =
+      case lvConstructedValue scrutineeValue of
+        Just constructed
+          | cvConstructorName constructed == constructorName,
+            Just kind <- atMay (cvFieldValueKinds constructed) index0 ->
+              kind
+        _ ->
+          valueKindForType fieldTy
 
 lowerStoredFieldTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
 lowerStoredFieldTypeM env context fieldTy
@@ -4735,11 +4760,11 @@ localFunctionParameterValueKind name ty
 
 lowerValueForType :: BackendType -> LLVMType -> LLVMOperand -> LowerValue
 lowerValueForType ty llvmTy operand =
-  LowerValue ty llvmTy operand (valueKindForType ty)
+  LowerValue ty llvmTy operand (valueKindForType ty) Nothing
 
 functionPointerValue :: BackendType -> LLVMOperand -> LowerValue
 functionPointerValue ty operand =
-  LowerValue ty LLVMPtr operand LowerFunctionPointer
+  LowerValue ty LLVMPtr operand LowerFunctionPointer Nothing
 
 lowerImmediateConstructCase ::
   ProgramEnv ->
@@ -4803,7 +4828,7 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
       continuationLabel <- freshBlock "case.unreachable.cont"
       startBlock continuationLabel
       operand <- dummyOperandAfterUnreachable context expectedTy
-      pure (LowerValue resultTy expectedTy operand (valueKindForType resultTy))
+      pure (LowerValue resultTy expectedTy operand (valueKindForType resultTy) Nothing)
 
     bindImmediateAlternativePattern (BackendAlternative pattern0 body) =
       case pattern0 of

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -3069,9 +3069,9 @@ lowerCall env exprEnv context expr =
                 _ ->
                   lowerGlobalCall env exprEnv context (backendExprType expr) name typeArgs args
         BackendLam {} ->
-          lowerDirectFunctionCall env exprEnv context (functionFormFromExpr headExpr) typeArgs args
+          lowerDirectFunctionCall env exprEnv context (backendExprType expr) (functionFormFromExpr headExpr) typeArgs args
         BackendTyAbs {} ->
-          lowerDirectFunctionCall env exprEnv context (functionFormFromExpr headExpr) typeArgs args
+          lowerDirectFunctionCall env exprEnv context (backendExprType expr) (functionFormFromExpr headExpr) typeArgs args
         _ ->
           case pushCallIntoExpression context (backendExprType expr) headExpr typeArgs args of
             Right (Just applied) ->
@@ -3450,12 +3450,26 @@ lowerLocalFunctionCall env callEnv context resultTy name localFunction typeArgs 
       bodyEnv <- bindCallArguments env callEnv (lfCapturedEnv localFunction) context allowNestedEvidence name form args
       lowerExpr env bodyEnv context (ffBody form)
 
-lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
-lowerDirectFunctionCall env exprEnv context form0 typeArgs args = do
+lowerDirectFunctionCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> FunctionForm -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
+lowerDirectFunctionCall env exprEnv context resultTy form0 typeArgs args = do
   (resolvedTypeArgs, form1) <- instantiateFunctionFormWithTypeArgsM context form0 typeArgs args
   let form = qualifyInstantiatedClosureEntries "__mlfp_direct_typeapp" resolvedTypeArgs form1
-  bodyEnv <- bindCallArguments env exprEnv exprEnv context False "lambda" form args
-  lowerExpr env bodyEnv context (ffBody form)
+      arity = length (ffParams form)
+  case compare (length args) arity of
+    GT -> do
+      unless (isClosureRuntimeValueType (ffReturnType form)) $
+        liftEither (BackendLLVMArityMismatch "lambda" arity (length args))
+      let (directArgs, closureArgs) = splitAt arity args
+      callee <- lowerSaturatedDirectFunctionCall form directArgs
+      lowerClosurePointerValueCall env exprEnv context resultTy callee closureArgs
+    LT ->
+      liftEither (BackendLLVMArityMismatch "lambda" arity (length args))
+    EQ ->
+      lowerSaturatedDirectFunctionCall form args
+  where
+    lowerSaturatedDirectFunctionCall form2 args0 = do
+      bodyEnv <- bindCallArguments env exprEnv exprEnv context False "lambda" form2 args0
+      lowerExpr env bodyEnv context (ffBody form2)
 
 lowerGlobalCall :: ProgramEnv -> ExprEnv -> String -> BackendType -> String -> [BackendType] -> [BackendExpr] -> LowerM LowerValue
 lowerGlobalCall env exprEnv context resultTy name typeArgs args =

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -154,8 +154,7 @@ data ClosureCaptureSlot = ClosureCaptureSlot
   deriving (Eq, Show)
 
 data ConstructedValue = ConstructedValue
-  { cvConstructorName :: String,
-    cvFieldValueKinds :: [LowerValueKind]
+  { cvFieldValueKindsByConstructor :: Map String [LowerValueKind]
   }
   deriving (Eq, Show)
 
@@ -186,6 +185,46 @@ data LowerValueKind
   | LowerClosureRecord
   | LowerFunctionPointer
   deriving (Eq, Show)
+
+constructedValueForConstructor :: String -> [LowerValueKind] -> ConstructedValue
+constructedValueForConstructor name fieldKinds =
+  ConstructedValue (Map.singleton name fieldKinds)
+
+constructedFieldValueKind :: String -> Int -> ConstructedValue -> Maybe LowerValueKind
+constructedFieldValueKind constructorName index0 constructed =
+  Map.lookup constructorName (cvFieldValueKindsByConstructor constructed) >>= flip atMay index0
+
+mergeConstructedValues :: [Maybe ConstructedValue] -> Maybe ConstructedValue
+mergeConstructedValues values =
+  case foldM mergeValue Map.empty constructedFields of
+    Just fieldsByConstructor
+      | length constructedFields == length values,
+        not (Map.null fieldsByConstructor) ->
+          Just (ConstructedValue fieldsByConstructor)
+    _ ->
+      Nothing
+  where
+    constructedFields =
+      [fieldsByConstructor | Just (ConstructedValue fieldsByConstructor) <- values]
+
+    mergeValue acc fieldsByConstructor =
+      foldM mergeConstructor acc (Map.toList fieldsByConstructor)
+
+    mergeConstructor acc (constructorName, fieldKinds) =
+      case Map.lookup constructorName acc of
+        Nothing ->
+          Just (Map.insert constructorName fieldKinds acc)
+        Just existingKinds
+          | existingKinds == fieldKinds ->
+              Just acc
+        Just _ ->
+          Nothing
+
+combineValueKinds :: BackendType -> [LowerValueKind] -> LowerValueKind
+combineValueKinds resultTy kinds =
+  case nub kinds of
+    [kind] -> kind
+    _ -> valueKindForType resultTy
 
 data LocalFunction = LocalFunction
   { lfForm :: FunctionForm,
@@ -3254,7 +3293,14 @@ lowerGlobalValue env context resultTy name binding typeArgs =
       resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
       functionName <- globalFunctionName env context binding0 resolvedTypeArgs
       result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
-      pure (LowerValue expectedTy resultLLVMType result (functionFormReturnValueKind env instantiated) Nothing)
+      pure
+        ( LowerValue
+            expectedTy
+            resultLLVMType
+            result
+            (functionFormReturnValueKind env instantiated)
+            (functionFormReturnConstructedValue env instantiated)
+        )
 
 lowerLit :: ProgramEnv -> String -> BackendType -> Lit -> LowerM LowerValue
 lowerLit env context ty lit = do
@@ -3947,7 +3993,14 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           llvmResultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
           functionName <- globalFunctionName env context binding resolvedTypeArgs
           result <- emitAssign "call" llvmResultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (ffReturnType form) llvmResultTy result (functionFormReturnValueKind env form) Nothing)
+          pure
+            ( LowerValue
+                (ffReturnType form)
+                llvmResultTy
+                result
+                (functionFormReturnValueKind env form)
+                (functionFormReturnConstructedValue env form)
+            )
 
 shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
 shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =
@@ -4452,7 +4505,7 @@ lowerConstruct env exprEnv context resultTy name args =
             LLVMPtr
             object
             LowerRuntimeValue
-            (Just (ConstructedValue name (map lvValueKind argValues)))
+            (Just (constructedValueForConstructor name (map lvValueKind argValues)))
         )
   where
     storeField object index0 value = do
@@ -4514,8 +4567,15 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
     startBlock defaultLabel
     finishCurrentBlock LLVMUnreachable
   startBlock joinLabel
-  result <- emitAssign "case.result" resultLLVMType (LLVMPhi resultLLVMType incoming)
-  pure (lowerValueForType resultTy resultLLVMType result)
+  result <- emitAssign "case.result" resultLLVMType (LLVMPhi resultLLVMType [(operand, label) | (operand, label, _, _) <- incoming])
+  pure
+    ( LowerValue
+        resultTy
+        resultLLVMType
+        result
+        (combineValueKinds resultTy [kind | (_, _, kind, _) <- incoming])
+        (mergeConstructedValues [constructed | (_, _, _, constructed) <- incoming])
+    )
   where
     alternativesList = NE.toList alternatives
 
@@ -4559,7 +4619,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
         liftEither (BackendLLVMInternalError ("case alternative type mismatch at " ++ context))
       sourceLabel <- gets fsCurrentLabel
       finishCurrentBlock (LLVMBr joinLabel)
-      pure [(lvOperand bodyValue, sourceLabel)]
+      pure [(lvOperand bodyValue, sourceLabel, lvValueKind bodyValue, lvConstructedValue bodyValue)]
 
     bindAlternativePattern scrutineeValue (BackendAlternative pattern0 body) =
       case pattern0 of
@@ -4604,8 +4664,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
     fieldValueKind constructorName scrutineeValue index0 fieldTy =
       case lvConstructedValue scrutineeValue of
         Just constructed
-          | cvConstructorName constructed == constructorName,
-            Just kind <- atMay (cvFieldValueKinds constructed) index0 ->
+          | Just kind <- constructedFieldValueKind constructorName index0 constructed ->
               kind
         _ ->
           valueKindForType fieldTy
@@ -4660,6 +4719,12 @@ functionFormReturnValueKindWith env visitedGlobals form =
   where
     paramKinds = Map.fromList [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- ffParams form]
 
+functionFormReturnConstructedValue :: ProgramEnv -> FunctionForm -> Maybe ConstructedValue
+functionFormReturnConstructedValue env form =
+  backendExprConstructedValueWith env Set.empty paramKinds Map.empty (ffBody form)
+  where
+    paramKinds = Map.fromList [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- ffParams form]
+
 backendExprValueKindWith :: ProgramEnv -> Set String -> Map String LowerValueKind -> BackendExpr -> LowerValueKind
 backendExprValueKindWith env visitedGlobals valueKinds expr
   | not (isFunctionLikeBackendType (backendExprType expr)) = LowerRuntimeValue
@@ -4687,6 +4752,12 @@ backendExprValueKindWith env visitedGlobals valueKinds expr
                           Map.delete name valueKinds
                     _ ->
                       Map.insert name (backendExprValueKindWith env visitedGlobals valueKinds rhs) valueKinds
+        BackendCase {} ->
+          combineValueKinds
+            (backendExprType expr)
+            [ backendExprValueKindWith env visitedGlobals valueKinds (backendAltBody alternative)
+            | alternative <- NE.toList (backendAlternatives expr)
+            ]
         BackendClosure {} ->
           LowerClosureRecord
         _ ->
@@ -4743,6 +4814,135 @@ backendExprValueKindWith env visitedGlobals valueKinds expr
                   LowerFunctionPointer
             Nothing ->
               valueKindForType ty
+
+backendExprConstructedValueWith ::
+  ProgramEnv ->
+  Set String ->
+  Map String LowerValueKind ->
+  Map String ConstructedValue ->
+  BackendExpr ->
+  Maybe ConstructedValue
+backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues =
+  \case
+    BackendVar _ name ->
+      variableConstructedValue name []
+    expr@(BackendTyApp _ fun _) ->
+      case collectTyApps expr of
+        (BackendVar _ name, typeArgs) ->
+          variableConstructedValue name typeArgs
+        _ ->
+          backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues fun
+    BackendLet _ name bindingTy rhs body ->
+      backendExprConstructedValueWith env visitedGlobals valueKindsForBody constructedValuesForBody body
+      where
+        valueKindsForBody =
+          case functionLikeAliasValueKind valueKinds rhs of
+            Just kind ->
+              Map.insert name kind valueKinds
+            Nothing ->
+              case functionFormFromExpected bindingTy rhs of
+                form
+                  | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                      Map.delete name valueKinds
+                _ ->
+                  Map.insert name (backendExprValueKindWith env visitedGlobals valueKinds rhs) valueKinds
+        constructedValuesForBody =
+          case backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues rhs of
+            Just constructed ->
+              Map.insert name constructed constructedValues
+            Nothing ->
+              Map.delete name constructedValues
+    BackendConstruct resultTy name args ->
+      Just (constructedValueForConstructor name fieldKinds)
+      where
+        fieldTys =
+          fromMaybe (map backendExprType args) $
+            Map.lookup name (pbConstructors (peBase env)) >>= \constructorRuntime ->
+              constructorRuntimeFieldTypes constructorRuntime resultTy
+        fieldKinds =
+          zipWith constructFieldValueKind fieldTys args
+        constructFieldValueKind fieldTy arg
+          | isFunctionLikeBackendType fieldTy =
+              backendExprValueKindWith env visitedGlobals valueKinds arg
+          | otherwise =
+              LowerRuntimeValue
+    BackendCase _ _ alternatives ->
+      mergeConstructedValues
+        [ backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues (backendAltBody alternative)
+        | alternative <- NE.toList alternatives
+        ]
+    BackendRoll _ payload ->
+      backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues payload
+    BackendUnroll _ payload ->
+      backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues payload
+    _ ->
+      Nothing
+  where
+    functionLikeAliasValueKind kinds =
+      \case
+        BackendVar ty name
+          | isFunctionLikeBackendType ty ->
+              Just (variableValueKindWith kinds ty name [])
+        expr@(BackendTyApp ty fun _)
+          | isFunctionLikeBackendType ty ->
+              case collectTyApps expr of
+                (BackendVar varTy name, typeArgs) ->
+                  Just (variableValueKindWith kinds varTy name typeArgs)
+                _ ->
+                  functionLikeAliasValueKind kinds fun
+        BackendLet ty name bindingTy rhs body
+          | isFunctionLikeBackendType ty ->
+              let kindsForBody =
+                    case functionLikeAliasValueKind kinds rhs of
+                      Just kind ->
+                        Map.insert name kind kinds
+                      Nothing ->
+                        case functionFormFromExpected bindingTy rhs of
+                          form
+                            | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                                Map.delete name kinds
+                          _ ->
+                            Map.insert name (backendExprValueKindWith env visitedGlobals kinds rhs) kinds
+               in functionLikeAliasValueKind kindsForBody body
+        _ ->
+          Nothing
+
+    variableValueKindWith kinds ty name typeArgs =
+      case Map.lookup name kinds of
+        Just kind ->
+          kind
+        Nothing ->
+          case Map.lookup name (pbBindings (peBase env)) of
+            Just binding ->
+              case instantiateFunctionFormWithTypeArgs "value-kind classification" (biForm binding) typeArgs [] of
+                Right (_, form)
+                  | not (null (ffParams form)) ->
+                      LowerFunctionPointer
+                  | Set.member name visitedGlobals ->
+                      valueKindForType ty
+                  | otherwise ->
+                      functionFormReturnValueKindWith env (Set.insert name visitedGlobals) form
+                _ ->
+                  LowerFunctionPointer
+            Nothing ->
+              valueKindForType ty
+
+    variableConstructedValue name typeArgs =
+      case Map.lookup name constructedValues of
+        Just constructed ->
+          Just constructed
+        Nothing ->
+          case Map.lookup name (pbBindings (peBase env)) of
+            Just binding ->
+              case instantiateFunctionFormWithTypeArgs "constructed-value classification" (biForm binding) typeArgs [] of
+                Right (_, form)
+                  | null (ffParams form),
+                    Set.notMember name visitedGlobals ->
+                      backendExprConstructedValueWith env (Set.insert name visitedGlobals) valueKinds constructedValues (ffBody form)
+                _ ->
+                  Nothing
+            Nothing ->
+              Nothing
 
 parameterValueKind :: String -> BackendType -> LowerValueKind
 parameterValueKind name ty

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -140,9 +140,16 @@ data FunctionWrapper = FunctionWrapper
 data ClosureEntry = ClosureEntry
   { ceFunctionType :: BackendType,
     ceEntryName :: String,
-    ceCaptures :: [(String, BackendType)],
+    ceCaptures :: [ClosureCaptureSlot],
     ceParams :: [(String, BackendType)],
     ceBody :: BackendExpr
+  }
+  deriving (Eq, Show)
+
+data ClosureCaptureSlot = ClosureCaptureSlot
+  { ccsName :: String,
+    ccsType :: BackendType,
+    ccsValueKind :: LowerValueKind
   }
   deriving (Eq, Show)
 
@@ -162,8 +169,15 @@ data NativeRenderSpec = NativeRenderSpec
 data LowerValue = LowerValue
   { lvBackendType :: BackendType,
     lvLLVMType :: LLVMType,
-    lvOperand :: LLVMOperand
+    lvOperand :: LLVMOperand,
+    lvValueKind :: LowerValueKind
   }
+  deriving (Eq, Show)
+
+data LowerValueKind
+  = LowerRuntimeValue
+  | LowerClosureRecord
+  | LowerFunctionPointer
   deriving (Eq, Show)
 
 data LocalFunction = LocalFunction
@@ -214,7 +228,7 @@ lowerBackendProgramCore program = do
   specializations <- collectRequiredSpecializations base reachable
   let evidenceWrappers = collectEvidenceWrappers base reachable specializations
       functionWrappers = collectFunctionWrappers base reachable specializations
-      closureEntries0 = collectClosureEntries reachable specializations evidenceWrappers functionWrappers
+      closureEntries0 = collectClosureEntries base reachable specializations evidenceWrappers functionWrappers
       referencedFunctionNames = collectReferencedFunctionNames base reachable specializations evidenceWrappers functionWrappers
       stringGlobals = assignStringGlobals (collectProgramStrings reachable specializations evidenceWrappers functionWrappers)
       env =
@@ -2095,12 +2109,12 @@ lowerFunctionWrapper :: ProgramEnv -> FunctionWrapper -> Either BackendLLVMError
 lowerFunctionWrapper env wrapper =
   lowerFunction env (fwFunctionName wrapper) True (qualifiedFunctionWrapperForm wrapper)
 
-collectClosureEntries :: [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> [ClosureEntry]
-collectClosureEntries reachable specializations evidenceWrappers functionWrappers =
-  concatMap (collectClosureEntriesInForm . biForm) (filter (null . ffTypeBinders . biForm) reachable)
-    ++ concatMap (collectClosureEntriesInForm . qualifiedSpecializationForm) specializations
-    ++ concatMap (collectClosureEntriesInForm . qualifiedEvidenceWrapperForm) evidenceWrappers
-    ++ concatMap (collectClosureEntriesInForm . qualifiedFunctionWrapperForm) functionWrappers
+collectClosureEntries :: ProgramBase -> [BindingInfo] -> [Specialization] -> [EvidenceWrapper] -> [FunctionWrapper] -> [ClosureEntry]
+collectClosureEntries base reachable specializations evidenceWrappers functionWrappers =
+  concatMap (collectClosureEntriesInForm base . biForm) (filter (null . ffTypeBinders . biForm) reachable)
+    ++ concatMap (collectClosureEntriesInForm base . qualifiedSpecializationForm) specializations
+    ++ concatMap (collectClosureEntriesInForm base . qualifiedEvidenceWrapperForm) evidenceWrappers
+    ++ concatMap (collectClosureEntriesInForm base . qualifiedFunctionWrapperForm) functionWrappers
 
 requireUniqueClosureEntries :: [ClosureEntry] -> Either BackendLLVMError [ClosureEntry]
 requireUniqueClosureEntries entries =
@@ -2185,57 +2199,71 @@ qualifiedClosureEntryName :: String -> String -> String
 qualifiedClosureEntryName ownerName entryName =
   ownerName ++ "$" ++ entryName
 
-collectClosureEntriesInForm :: FunctionForm -> [ClosureEntry]
-collectClosureEntriesInForm =
-  collectClosureEntriesInFormWithLocals Map.empty
+collectClosureEntriesInForm :: ProgramBase -> FunctionForm -> [ClosureEntry]
+collectClosureEntriesInForm base =
+  collectClosureEntriesInFormWithLocals base Map.empty
 
-collectClosureEntriesInFormWithLocals :: LocalFunctionForms -> FunctionForm -> [ClosureEntry]
-collectClosureEntriesInFormWithLocals localForms form =
-  collectClosureEntriesInExpr (shadowLocalFunctionForms paramNames localForms) (ffBody form)
+collectClosureEntriesInFormWithLocals :: ProgramBase -> LocalFunctionForms -> FunctionForm -> [ClosureEntry]
+collectClosureEntriesInFormWithLocals base localForms form =
+  collectClosureEntriesInExpr base (shadowLocalFunctionForms paramNames localForms) paramValueKinds (ffBody form)
   where
     paramNames = Set.fromList (map fst (ffParams form))
+    paramValueKinds = Map.fromList [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- ffParams form]
 
-collectClosureEntriesInExpr :: LocalFunctionForms -> BackendExpr -> [ClosureEntry]
-collectClosureEntriesInExpr localForms expr =
+collectClosureEntriesInExpr :: ProgramBase -> LocalFunctionForms -> Map String LowerValueKind -> BackendExpr -> [ClosureEntry]
+collectClosureEntriesInExpr base localForms valueKinds expr =
   case expr of
     BackendVar {} -> []
     BackendLit {} -> []
-    BackendLam _ name _ body ->
-      collectClosureEntriesInExpr (Map.delete name localForms) body
+    BackendLam _ name paramTy body ->
+      collectClosureEntriesInExpr base (Map.delete name localForms) (Map.insert name (parameterValueKind name paramTy) valueKinds) body
     BackendApp _ fun arg ->
       case collectAdministrativeCallEntries of
         Just entries -> entries
         Nothing ->
           collectAppliedLocalClosureEntries
-            ++ collectClosureEntriesInExpr localForms fun
-            ++ collectClosureEntriesInExpr localForms arg
+            ++ collectClosureEntriesInExpr base localForms valueKinds fun
+            ++ collectClosureEntriesInExpr base localForms valueKinds arg
     BackendLet _ name bindingTy rhs body ->
-      collectClosureEntriesInExpr localForms rhs
-        ++ collectClosureEntriesInExpr (collectLetLocalForm name bindingTy rhs) body
+      collectClosureEntriesInExpr base localForms valueKinds rhs
+        ++ collectClosureEntriesInExpr base bodyLocalForms bodyValueKinds body
+      where
+        bodyLocalForms = collectLetLocalForm localForms name bindingTy rhs
+        bodyValueKinds =
+          case letBoundValueKind localForms valueKinds bindingTy rhs of
+            Just kind -> Map.insert name kind valueKinds
+            Nothing -> Map.delete name valueKinds
     BackendTyAbs {} -> []
     BackendTyApp {} ->
       case collectAdministrativeTypeAppEntries of
         Just entries -> entries
         Nothing -> collectTypeAppliedClosureEntries
-    BackendConstruct _ _ args -> concatMap (collectClosureEntriesInExpr localForms) args
+    BackendConstruct _ _ args -> concatMap (collectClosureEntriesInExpr base localForms valueKinds) args
     BackendCase _ scrutinee alternatives ->
-      collectClosureEntriesInExpr localForms scrutinee ++ concatMap collectAlternativeEntries (NE.toList alternatives)
-    BackendRoll _ payload -> collectClosureEntriesInExpr localForms payload
-    BackendUnroll _ payload -> collectClosureEntriesInExpr localForms payload
+      collectClosureEntriesInExpr base localForms valueKinds scrutinee ++ concatMap collectAlternativeEntries (NE.toList alternatives)
+    BackendRoll _ payload -> collectClosureEntriesInExpr base localForms valueKinds payload
+    BackendUnroll _ payload -> collectClosureEntriesInExpr base localForms valueKinds payload
     BackendClosure resultTy entryName captures params body ->
       ClosureEntry
         { ceFunctionType = resultTy,
           ceEntryName = entryName,
-          ceCaptures = [(backendClosureCaptureName capture, backendClosureCaptureType capture) | capture <- captures],
+          ceCaptures = captureSlots,
           ceParams = params,
           ceBody = body
         }
-        : concatMap (collectClosureEntriesInExpr localForms . backendClosureCaptureExpr) captures
-          ++ collectClosureEntriesInExpr (shadowLocalFunctionForms closureBound localForms) body
+        : concatMap (collectClosureEntriesInExpr base localForms valueKinds . backendClosureCaptureExpr) captures
+          ++ collectClosureEntriesInExpr base (shadowLocalFunctionForms closureBound localForms) closureBodyValueKinds body
       where
+        captureSlots = map (closureCaptureSlot localForms valueKinds) captures
         closureBound = Set.fromList (map backendClosureCaptureName captures ++ map fst params)
+        closureBodyValueKinds =
+          Map.fromList
+            ( [(ccsName capture, ccsValueKind capture) | capture <- captureSlots]
+                ++ [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- params]
+            )
+            `Map.union` Map.withoutKeys valueKinds closureBound
     BackendClosureCall _ fun args ->
-      collectClosureEntriesInExpr localForms fun ++ concatMap (collectClosureEntriesInExpr localForms) args
+      collectClosureEntriesInExpr base localForms valueKinds fun ++ concatMap (collectClosureEntriesInExpr base localForms valueKinds) args
   where
     collectAppliedLocalClosureEntries =
       case collectCall expr of
@@ -2248,7 +2276,7 @@ collectClosureEntriesInExpr localForms expr =
       case collectCall expr of
         Just (headExpr, typeArgs, args) ->
           case pushCallIntoExpression "closure entry collection" (backendExprType expr) headExpr typeArgs args of
-            Right (Just applied) -> Just (collectClosureEntriesInExpr localForms applied)
+            Right (Just applied) -> Just (collectClosureEntriesInExpr base localForms valueKinds applied)
             _ -> Nothing
         Nothing -> Nothing
 
@@ -2264,13 +2292,13 @@ collectClosureEntriesInExpr localForms expr =
             typeArgs
             []
         (fun, _) ->
-          collectClosureEntriesInExpr localForms fun
+          collectClosureEntriesInExpr base localForms valueKinds fun
 
     collectAdministrativeTypeAppEntries =
       case collectTyApps expr of
         (headExpr, typeArgs) ->
           case pushTypeApplicationsIntoExpression "closure entry collection" (backendExprType expr) headExpr typeArgs of
-            Right (Just applied) -> Just (collectClosureEntriesInExpr localForms applied)
+            Right (Just applied) -> Just (collectClosureEntriesInExpr base localForms valueKinds applied)
             _ -> Nothing
 
     collectInstantiatedLocalClosureEntries name form typeArgs args =
@@ -2280,23 +2308,107 @@ collectClosureEntriesInExpr localForms expr =
       case instantiateFunctionFormWithTypeArgs ("closure entry collection " ++ ownerName) form typeArgs args of
         Right (resolvedTypeArgs, instantiated) ->
           collectClosureEntriesInFormWithLocals
+            base
             localForms
             (qualifyInstantiatedClosureEntries ownerName resolvedTypeArgs instantiated)
         Left _ ->
           []
 
-    collectLetLocalForm name bindingTy rhs =
+    collectLetLocalForm localForms0 name bindingTy rhs =
       case functionFormFromExpected bindingTy rhs of
         form
           | not (null (ffTypeBinders form)) ->
-              Map.insert name form localForms
+              Map.insert name form localForms0
         _ ->
-          Map.delete name localForms
+          Map.delete name localForms0
+
+    letBoundValueKind localForms0 valueKinds0 bindingTy rhs =
+      case aliasValueKind localForms0 valueKinds0 rhs of
+        Just kind ->
+          Just kind
+        Nothing ->
+          case functionFormFromExpected bindingTy rhs of
+            form
+              | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                  Nothing
+            _ ->
+              Just (valueKindForType bindingTy)
+
+    closureCaptureSlot localForms0 valueKinds0 capture =
+      ClosureCaptureSlot
+        { ccsName = backendClosureCaptureName capture,
+          ccsType = captureTy,
+          ccsValueKind = captureValueKind
+        }
+      where
+        captureTy = backendClosureCaptureType capture
+        captureValueKind
+          | isEvidenceArgument True (backendClosureCaptureName capture) captureTy =
+              LowerFunctionPointer
+          | not (isClosureRuntimeValueType captureTy) =
+              LowerRuntimeValue
+          | shouldStoreFunctionPointerCapture localForms0 valueKinds0 capture =
+              LowerFunctionPointer
+          | otherwise =
+              LowerClosureRecord
+
+    shouldStoreFunctionPointerCapture localForms0 valueKinds0 capture =
+      isFirstOrderFunctionPointerType (backendClosureCaptureType capture)
+        && not (isEvidenceArgument True (backendClosureCaptureName capture) (backendClosureCaptureType capture))
+        && aliasValueKind localForms0 valueKinds0 (backendClosureCaptureExpr capture) /= Just LowerClosureRecord
+        && case collectTyApps (backendClosureCaptureExpr capture) of
+          (BackendVar {}, _) -> True
+          _ -> False
+
+    aliasValueKind localForms0 valueKinds0 expr0 =
+      case expr0 of
+        BackendVar ty name
+          | isFunctionLikeBackendType ty ->
+              variableValueKind localForms0 valueKinds0 name []
+        BackendTyApp ty fun _
+          | isFunctionLikeBackendType ty ->
+              case collectTyApps expr0 of
+                (BackendVar _ name, typeArgs) ->
+                  variableValueKind localForms0 valueKinds0 name typeArgs
+                _ ->
+                  aliasValueKind localForms0 valueKinds0 fun
+        BackendLet ty name bindingTy rhs body
+          | isFunctionLikeBackendType ty ->
+              let localForms' = collectLetLocalForm localForms0 name bindingTy rhs
+                  valueKinds' =
+                    case letBoundValueKind localForms0 valueKinds0 bindingTy rhs of
+                      Just kind -> Map.insert name kind valueKinds0
+                      Nothing -> Map.delete name valueKinds0
+               in aliasValueKind localForms' valueKinds' body
+        _ ->
+          Nothing
+
+    variableValueKind localForms0 valueKinds0 name typeArgs =
+      case Map.lookup name valueKinds0 of
+        Just kind ->
+          Just kind
+        Nothing
+          | Map.member name localForms0 ->
+              Just LowerFunctionPointer
+          | otherwise ->
+              case Map.lookup name (pbBindings base) of
+                Just binding ->
+                  case instantiateFunctionFormWithTypeArgs "closure capture classification" (biForm binding) typeArgs [] of
+                    Right (_, form)
+                      | null (ffParams form),
+                        isClosureRuntimeValueType (ffReturnType form) ->
+                          Just LowerClosureRecord
+                    _ ->
+                      Just LowerFunctionPointer
+                Nothing ->
+                  Just LowerClosureRecord
 
     collectAlternativeEntries alternative =
       let binders = patternBinders (backendAltPattern alternative)
        in collectClosureEntriesInExpr
+            base
             (shadowLocalFunctionForms binders localForms)
+            (Map.withoutKeys valueKinds binders)
             (backendAltBody alternative)
 
     patternBinders =
@@ -2401,7 +2513,13 @@ lowerClosureEntry env entry = do
         ExprEnv
           { eeValues =
               Map.fromList
-                [ (paramName, LowerValue paramTy (llvmParameterType param) (LLVMLocal (llvmParameterType param) paramName))
+                [ ( paramName,
+                    LowerValue
+                      paramTy
+                      (llvmParameterType param)
+                      (LLVMLocal (llvmParameterType param) paramName)
+                      (parameterValueKind paramName paramTy)
+                  )
                 | ((paramName, paramTy), param) <- zip (ceParams entry) params
                 ],
             eeLocalFunctions = Map.empty,
@@ -2438,7 +2556,9 @@ lowerClosureEntry env entry = do
     loadClosureCaptures exprEnv0 =
       foldM loadOne exprEnv0 (zip [0 :: Int ..] (ceCaptures entry))
 
-    loadOne exprEnv0 (index0, (captureName, captureTy)) = do
+    loadOne exprEnv0 (index0, capture) = do
+      let captureName = ccsName capture
+          captureTy = ccsType capture
       llvmTy <- lowerClosureStoredTypeM env ("closure capture " ++ show captureName ++ " of " ++ ceEntryName entry) captureTy
       fieldPtr <- emitGep "closure.env.field.ptr" (LLVMLocal LLVMPtr "__mlfp_env") (8 * index0)
       loaded <- emitAssign "closure.env.field" llvmTy (LLVMLoad llvmTy fieldPtr)
@@ -2447,7 +2567,7 @@ lowerClosureEntry env entry = do
           { eeValues =
               Map.insert
                 captureName
-                (LowerValue captureTy llvmTy loaded)
+                (LowerValue captureTy llvmTy loaded (ccsValueKind capture))
                 (eeValues exprEnv0)
           }
 
@@ -2643,7 +2763,13 @@ initialFunctionEnv name form params =
   ExprEnv
     { eeValues =
         Map.fromList
-          [ (paramName, LowerValue paramTy (llvmParameterType param) (LLVMLocal (llvmParameterType param) paramName))
+          [ ( paramName,
+              LowerValue
+                paramTy
+                (llvmParameterType param)
+                (LLVMLocal (llvmParameterType param) paramName)
+                (parameterValueKind paramName paramTy)
+            )
           | ((paramName, paramTy), param) <- zip (ffParams form) params
           ],
       eeLocalFunctions = Map.empty,
@@ -2838,7 +2964,8 @@ closurePointerAliasValue exprEnv =
     BackendVar ty name
       | isFunctionLikeBackendType ty,
         Just value <- Map.lookup name (eeValues exprEnv),
-        lvLLVMType value == LLVMPtr ->
+        lvLLVMType value == LLVMPtr,
+        lvValueKind value == LowerClosureRecord ->
           Just value {lvBackendType = ty}
     BackendTyApp ty fun _
       | isFunctionLikeBackendType ty,
@@ -2900,21 +3027,21 @@ lowerGlobalValue env context resultTy name binding typeArgs =
       resultLLVMType <- lowerRuntimeValueTypeM env context expectedTy
       functionName <- globalFunctionName env context binding0 resolvedTypeArgs
       result <- emitAssign "call" resultLLVMType (LLVMCall functionName [])
-      pure (LowerValue expectedTy resultLLVMType result)
+      pure (lowerValueForType expectedTy resultLLVMType result)
 
 lowerLit :: ProgramEnv -> String -> BackendType -> Lit -> LowerM LowerValue
 lowerLit env context ty lit = do
   llvmTy <- lowerBackendTypeM env context ty
   case lit of
     LInt value ->
-      pure (LowerValue ty llvmTy (LLVMIntLiteral 64 value))
+      pure (LowerValue ty llvmTy (LLVMIntLiteral 64 value) LowerRuntimeValue)
     LBool value ->
-      pure (LowerValue ty llvmTy (LLVMIntLiteral 1 (if value then 1 else 0)))
+      pure (LowerValue ty llvmTy (LLVMIntLiteral 1 (if value then 1 else 0)) LowerRuntimeValue)
     LString value ->
       case Map.lookup value (peStringGlobals env) of
         Just globalName
           | asciiString value ->
-              pure (LowerValue ty llvmTy (LLVMGlobalRef LLVMPtr globalName))
+              pure (LowerValue ty llvmTy (LLVMGlobalRef LLVMPtr globalName) LowerRuntimeValue)
         Just _ ->
           liftEither (BackendLLVMUnsupportedString value)
         Nothing ->
@@ -2929,7 +3056,7 @@ lowerClosureValue env exprEnv context resultTy entryName captures = do
   emitStore LLVMPtr (LLVMGlobalRef LLVMPtr entryName) codePtrField
   envPtrField <- emitGep "closure.env.ptr" closurePointer 8
   emitStore LLVMPtr envPointer envPtrField
-  pure (LowerValue resultTy LLVMPtr closurePointer)
+  pure (LowerValue resultTy LLVMPtr closurePointer LowerClosureRecord)
   where
     lowerCapture capture = do
       value <-
@@ -3024,7 +3151,7 @@ lowerClosurePointerValueCall env exprEnv context resultTy callee args = do
           codePtr
           ((LLVMPtr, closureEnv) : [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
       )
-  pure (LowerValue resultTy resultLLVMType result)
+  pure (lowerValueForType resultTy resultLLVMType result)
   where
     lowerClosureArg (index0, paramTy) arg =
       lowerExprForIndirectArgument env exprEnv context ("__mlfp_closure_arg" ++ show index0, paramTy) arg
@@ -3061,7 +3188,7 @@ lowerCall env exprEnv context expr =
               case Map.lookup name (eeValues exprEnv) of
                 Just value
                   | isFunctionLikeBackendType (lvBackendType value),
-                    not (isEvidenceCallableName name) ->
+                    lvValueKind value == LowerClosureRecord ->
                       lowerClosureValueCall env exprEnv context (backendExprType expr) value typeArgs args
                 Just value
                   | isFunctionLikeBackendType (lvBackendType value) ->
@@ -3104,7 +3231,7 @@ lowerIndirectValueCall env exprEnv context name callee typeArgs args = do
       bindIndirectFunctionArguments env context name form callArgs
       resultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
       result <- emitAssign "call" resultTy (LLVMCallOperand (lvOperand callee) [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-      pure (LowerValue (ffReturnType form) resultTy result)
+      pure (lowerValueForType (ffReturnType form) resultTy result)
 
 indirectCalleeFunctionForm :: ProgramEnv -> LowerValue -> Maybe FunctionForm
 indirectCalleeFunctionForm env callee =
@@ -3158,7 +3285,7 @@ lowerExprForIndirectArgument env exprEnv context (paramName, paramTy) arg
   | isFunctionLikeBackendType paramTy =
       case Map.lookup (evidenceWrapperKey paramTy arg) (peEvidenceWrappers env) of
         Just wrapper ->
-          pure (LowerValue paramTy LLVMPtr (LLVMGlobalRef LLVMPtr (ewFunctionName wrapper)))
+          pure (functionPointerValue paramTy (LLVMGlobalRef LLVMPtr (ewFunctionName wrapper)))
         Nothing ->
           lowerFunctionArgument env exprEnv context paramTy arg
   | otherwise =
@@ -3180,7 +3307,7 @@ lowerStoredFunctionArgument env exprEnv context expectedTy arg =
     _ ->
       case Map.lookup (functionWrapperKey expectedTy arg) (peFunctionWrappers env) of
         Just wrapper ->
-          pure (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper)))
+          pure (functionPointerValue expectedTy (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper)))
         Nothing ->
           liftEither (BackendLLVMUnsupportedExpression context "unsupported function argument")
 
@@ -3192,7 +3319,7 @@ lowerEvidenceArgument env exprEnv context expectedTy arg =
     _ ->
       case Map.lookup (evidenceWrapperKey expectedTy arg) (peEvidenceWrappers env) of
         Just wrapper ->
-          pure (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (ewFunctionName wrapper)))
+          pure (functionPointerValue expectedTy (LLVMGlobalRef LLVMPtr (ewFunctionName wrapper)))
         Nothing ->
           liftEither (BackendLLVMUnsupportedExpression context "unsupported evidence function argument")
 
@@ -3249,7 +3376,7 @@ lowerLocalFunctionStoredReference env context expectedTy localFunction typeArgs 
       sourceExpr <- storedReferenceSourceExpr context sourceExpr0 typeArgs
       case Map.lookup (functionWrapperKey expectedTy sourceExpr) (peFunctionWrappers env) of
         Just wrapper ->
-          pure (Just (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper))))
+          pure (Just (functionPointerValue expectedTy (LLVMGlobalRef LLVMPtr (fwFunctionName wrapper))))
         Nothing ->
           pure Nothing
     Nothing ->
@@ -3311,7 +3438,7 @@ lowerNonLocalFunctionReference env exprEnv context expectedTy name typeArgs =
           let actualTy = functionTypeFromForm form
           requireEvidenceFunctionType context name expectedTy actualTy
           functionName <- globalFunctionName env context binding resolvedTypeArgs
-          pure (LowerValue expectedTy LLVMPtr (LLVMGlobalRef LLVMPtr functionName))
+          pure (functionPointerValue expectedTy (LLVMGlobalRef LLVMPtr functionName))
         Nothing ->
           liftEither (BackendLLVMUnknownFunction name)
 
@@ -3322,7 +3449,7 @@ lowerValueFunctionReference context expectedTy name value typeArgs = do
       then pure (lvBackendType value)
       else instantiateCallableTypeM context (lvBackendType value) typeArgs []
   requireEvidenceFunctionType context name expectedTy actualTy
-  pure (LowerValue expectedTy LLVMPtr (lvOperand value))
+  pure value {lvBackendType = expectedTy}
 
 instantiateCallableTypeM :: String -> BackendType -> [BackendType] -> [BackendExpr] -> LowerM BackendType
 instantiateCallableTypeM context ty typeArgs args = do
@@ -3497,7 +3624,7 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           let expectedTypes = [LLVMInt 1, LLVMInt 1]
           zipWithM_ (requireLLVMType context name) expectedTypes callArgs
           result <- emitAssign "call" (LLVMInt 1) (LLVMCall runtimeAndName [(LLVMInt 1, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result)
+          pure (LowerValue (BTBase (BaseTy "Bool")) (LLVMInt 1) result LowerRuntimeValue)
     Nothing ->
       liftEither (BackendLLVMUnknownFunction name)
   where
@@ -3520,7 +3647,7 @@ lowerGlobalCall env exprEnv context resultTy name typeArgs args =
           llvmResultTy <- lowerRuntimeValueTypeM env context (ffReturnType form)
           functionName <- globalFunctionName env context binding resolvedTypeArgs
           result <- emitAssign "call" llvmResultTy (LLVMCall functionName [(lvLLVMType arg, lvOperand arg) | arg <- callArgs])
-          pure (LowerValue (ffReturnType form) llvmResultTy result)
+          pure (lowerValueForType (ffReturnType form) llvmResultTy result)
 
 shouldInlineGlobalCall :: ProgramEnv -> ExprEnv -> BindingInfo -> [BackendType] -> FunctionForm -> [BackendExpr] -> Bool
 shouldInlineGlobalCall env exprEnv binding resolvedTypeArgs form args =
@@ -4019,7 +4146,7 @@ lowerConstruct env exprEnv context resultTy name args =
       resultLLVMType <- lowerBackendTypeM env context resultTy
       unless (resultLLVMType == LLVMPtr) $
         liftEither (BackendLLVMUnsupportedType context resultTy)
-      pure (LowerValue resultTy LLVMPtr object)
+      pure (LowerValue resultTy LLVMPtr object LowerRuntimeValue)
   where
     storeField object index0 value = do
       fieldPtr <- emitGep "field.ptr" object (8 * (index0 + 1))
@@ -4074,7 +4201,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
     finishCurrentBlock LLVMUnreachable
   startBlock joinLabel
   result <- emitAssign "case.result" resultLLVMType (LLVMPhi resultLLVMType incoming)
-  pure (LowerValue resultTy resultLLVMType result)
+  pure (lowerValueForType resultTy resultLLVMType result)
   where
     alternativesList = NE.toList alternatives
 
@@ -4158,7 +4285,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
       llvmTy <- lowerStoredFieldTypeM env context fieldTy
       fieldPtr <- emitGep "case.field.ptr" (lvOperand scrutineeValue) (8 * (index0 + 1))
       loaded <- emitAssign "case.field" llvmTy (LLVMLoad llvmTy fieldPtr)
-      pure (LowerValue fieldTy llvmTy loaded)
+      pure (LowerValue fieldTy llvmTy loaded (valueKindForType fieldTy))
 
 lowerStoredFieldTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
 lowerStoredFieldTypeM env context fieldTy
@@ -4193,6 +4320,25 @@ isClosureRuntimeValueType =
   \case
     BTArrow {} -> True
     _ -> False
+
+valueKindForType :: BackendType -> LowerValueKind
+valueKindForType ty
+  | isClosureRuntimeValueType ty = LowerClosureRecord
+  | otherwise = LowerRuntimeValue
+
+parameterValueKind :: String -> BackendType -> LowerValueKind
+parameterValueKind name ty
+  | isEvidenceParameter name ty = LowerFunctionPointer
+  | isClosureRuntimeValueType ty = LowerClosureRecord
+  | otherwise = LowerRuntimeValue
+
+lowerValueForType :: BackendType -> LLVMType -> LLVMOperand -> LowerValue
+lowerValueForType ty llvmTy operand =
+  LowerValue ty llvmTy operand (valueKindForType ty)
+
+functionPointerValue :: BackendType -> LLVMOperand -> LowerValue
+functionPointerValue ty operand =
+  LowerValue ty LLVMPtr operand LowerFunctionPointer
 
 lowerImmediateConstructCase ::
   ProgramEnv ->
@@ -4256,7 +4402,7 @@ lowerImmediateConstructCase env exprEnv context resultTy constructorName args fi
       continuationLabel <- freshBlock "case.unreachable.cont"
       startBlock continuationLabel
       operand <- dummyOperandAfterUnreachable context expectedTy
-      pure (LowerValue resultTy expectedTy operand)
+      pure (LowerValue resultTy expectedTy operand (valueKindForType resultTy))
 
     bindImmediateAlternativePattern (BackendAlternative pattern0 body) =
       case pattern0 of
@@ -4556,7 +4702,7 @@ lowerRollLike env exprEnv context resultTy payload nodeName = do
   payloadValue <- lowerExpr env exprEnv context payload
   resultLLVMType <- lowerBackendTypeM env context resultTy
   if resultLLVMType == lvLLVMType payloadValue
-    then pure (LowerValue resultTy resultLLVMType (lvOperand payloadValue))
+    then pure payloadValue {lvBackendType = resultTy, lvLLVMType = resultLLVMType}
     else liftEither (BackendLLVMUnsupportedExpression context ("representation-changing " ++ nodeName))
 
 lowerBackendTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2646,6 +2646,16 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
                   case letBoundValueKind visitedGlobals localForms0 valueKinds0 bindingTy rhs of
                     Just kind -> Map.insert name kind valueKinds0
                     Nothing -> Map.delete name valueKinds0
+            BackendCase _ scrutinee alternatives ->
+              combineValueKinds
+                (backendExprType expr0)
+                [ expressionValueKindWith
+                    visitedGlobals
+                    localForms0
+                    (alternativeValueKinds valueKinds0 scrutinee alternative)
+                    (backendAltBody alternative)
+                | alternative <- NE.toList alternatives
+                ]
             BackendClosure {} ->
               LowerClosureRecord
             _ ->
@@ -2684,6 +2694,24 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
             (shadowLocalFunctionForms binders localForms)
             (Map.withoutKeys valueKinds binders)
             (backendAltBody alternative)
+
+    alternativeValueKinds valueKinds0 scrutinee alternative =
+      patternValueKinds (backendExprType scrutinee) (backendAltPattern alternative) `Map.union` valueKinds0
+
+    patternValueKinds scrutineeTy =
+      \case
+        BackendDefaultPattern ->
+          Map.empty
+        BackendConstructorPattern constructorName binders ->
+          Map.fromList
+            [ (binder, constructorFieldStoredValueKind fieldTy)
+            | (binder, fieldTy) <- zip binders fieldTys
+            ]
+          where
+            fieldTys =
+              fromMaybe [] $
+                Map.lookup constructorName (pbConstructors base) >>= \constructorRuntime ->
+                  constructorRuntimeFieldTypes constructorRuntime scrutineeTy
 
     collectCaseResultAdapterEntries resultTy alternatives0 =
       [ returnedPartialEntry LowerFunctionPointer resultTy [] paramTys returnTy [] resultTy

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2344,7 +2344,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
               collectClosureEntriesInExpr base localForms valueKinds rhs
         bodyLocalForms = collectLetLocalForm localForms name bindingTy rhs
         bodyValueKinds =
-          case letBoundValueKind localForms valueKinds bindingTy rhs of
+          case letBoundValueKind Set.empty localForms valueKinds bindingTy rhs of
             Just kind -> Map.insert name kind valueKinds
             Nothing -> Map.delete name valueKinds
     BackendTyAbs {} -> []
@@ -2539,8 +2539,8 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
         _ ->
           Map.delete name localForms0
 
-    letBoundValueKind localForms0 valueKinds0 bindingTy rhs =
-      case aliasValueKind localForms0 valueKinds0 rhs of
+    letBoundValueKind visitedGlobals localForms0 valueKinds0 bindingTy rhs =
+      case aliasValueKind visitedGlobals localForms0 valueKinds0 rhs of
         Just kind ->
           Just kind
         Nothing ->
@@ -2549,7 +2549,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
               | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
                   Nothing
             _ ->
-              Just (expressionValueKind localForms0 valueKinds0 rhs)
+              Just (expressionValueKindWith visitedGlobals localForms0 valueKinds0 rhs)
 
     closureCaptureSlot localForms0 valueKinds0 capture =
       ClosureCaptureSlot
@@ -2572,7 +2572,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
     shouldStoreFunctionPointerCapture localForms0 valueKinds0 capture =
       isFirstOrderFunctionPointerType (backendClosureCaptureType capture)
         && not (isEvidenceArgument True (backendClosureCaptureName capture) (backendClosureCaptureType capture))
-        && aliasValueKind localForms0 valueKinds0 (backendClosureCaptureExpr capture) /= Just LowerClosureRecord
+        && aliasValueKind Set.empty localForms0 valueKinds0 (backendClosureCaptureExpr capture) /= Just LowerClosureRecord
         && case collectTyApps (backendClosureCaptureExpr capture) of
           (BackendVar {}, _) -> True
           _ -> False
@@ -2590,7 +2590,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
           case arg of
             BackendClosure {} -> LowerClosureRecord
             _ ->
-              case aliasValueKind localForms0 valueKinds0 arg of
+              case aliasValueKind Set.empty localForms0 valueKinds0 arg of
                 Just kind -> kind
                 Nothing ->
                   case collectTyApps arg of
@@ -2599,48 +2599,51 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
       | otherwise =
           LowerRuntimeValue
 
-    aliasValueKind localForms0 valueKinds0 expr0 =
+    aliasValueKind visitedGlobals localForms0 valueKinds0 expr0 =
       case expr0 of
         BackendVar ty name
           | isFunctionLikeBackendType ty ->
-              variableValueKind localForms0 valueKinds0 name []
+              variableValueKind visitedGlobals localForms0 valueKinds0 name []
         BackendTyApp ty fun _
           | isFunctionLikeBackendType ty ->
               case collectTyApps expr0 of
                 (BackendVar _ name, typeArgs) ->
-                  variableValueKind localForms0 valueKinds0 name typeArgs
+                  variableValueKind visitedGlobals localForms0 valueKinds0 name typeArgs
                 _ ->
-                  aliasValueKind localForms0 valueKinds0 fun
+                  aliasValueKind visitedGlobals localForms0 valueKinds0 fun
         BackendLet ty name bindingTy rhs body
           | isFunctionLikeBackendType ty ->
               let localForms' = collectLetLocalForm localForms0 name bindingTy rhs
                   valueKinds' =
-                    case letBoundValueKind localForms0 valueKinds0 bindingTy rhs of
+                    case letBoundValueKind visitedGlobals localForms0 valueKinds0 bindingTy rhs of
                       Just kind -> Map.insert name kind valueKinds0
                       Nothing -> Map.delete name valueKinds0
-               in aliasValueKind localForms' valueKinds' body
+               in aliasValueKind visitedGlobals localForms' valueKinds' body
         _ ->
           Nothing
 
-    expressionValueKind localForms0 valueKinds0 expr0
+    expressionValueKind =
+      expressionValueKindWith Set.empty
+
+    expressionValueKindWith visitedGlobals localForms0 valueKinds0 expr0
       | not (isFunctionLikeBackendType (backendExprType expr0)) =
           LowerRuntimeValue
       | otherwise =
           case expr0 of
             BackendVar ty name ->
-              fromMaybe (valueKindForType ty) (variableValueKind localForms0 valueKinds0 name [])
+              fromMaybe (valueKindForType ty) (variableValueKind visitedGlobals localForms0 valueKinds0 name [])
             BackendTyApp ty fun _ ->
               case collectTyApps expr0 of
                 (BackendVar _ name, typeArgs) ->
-                  fromMaybe (valueKindForType ty) (variableValueKind localForms0 valueKinds0 name typeArgs)
+                  fromMaybe (valueKindForType ty) (variableValueKind visitedGlobals localForms0 valueKinds0 name typeArgs)
                 _ ->
-                  expressionValueKind localForms0 valueKinds0 fun
+                  expressionValueKindWith visitedGlobals localForms0 valueKinds0 fun
             BackendLet _ name bindingTy rhs body ->
-              expressionValueKind localForms' valueKinds' body
+              expressionValueKindWith visitedGlobals localForms' valueKinds' body
               where
                 localForms' = collectLetLocalForm localForms0 name bindingTy rhs
                 valueKinds' =
-                  case letBoundValueKind localForms0 valueKinds0 bindingTy rhs of
+                  case letBoundValueKind visitedGlobals localForms0 valueKinds0 bindingTy rhs of
                     Just kind -> Map.insert name kind valueKinds0
                     Nothing -> Map.delete name valueKinds0
             BackendClosure {} ->
@@ -2648,7 +2651,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
             _ ->
               valueKindForType (backendExprType expr0)
 
-    variableValueKind localForms0 valueKinds0 name typeArgs =
+    variableValueKind visitedGlobals localForms0 valueKinds0 name typeArgs =
       case Map.lookup name valueKinds0 of
         Just kind ->
           Just kind
@@ -2661,12 +2664,18 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
                   case instantiateFunctionFormWithTypeArgs "closure capture classification" (biForm binding) typeArgs [] of
                     Right (_, form)
                       | null (ffParams form),
-                        isClosureRuntimeValueType (ffReturnType form) ->
-                          Just LowerClosureRecord
+                        isFunctionLikeBackendType (ffReturnType form) ->
+                          Just (nullaryGlobalReturnValueKind visitedGlobals name (ffReturnType form) form)
                     _ ->
                       Just LowerFunctionPointer
                 Nothing ->
                   Just LowerClosureRecord
+
+    nullaryGlobalReturnValueKind visitedGlobals name returnTy form
+      | Set.member name visitedGlobals =
+          valueKindForType returnTy
+      | otherwise =
+          expressionValueKindWith (Set.insert name visitedGlobals) Map.empty Map.empty (ffBody form)
 
     collectAlternativeEntries alternative =
       let binders = patternBinders (backendAltPattern alternative)

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2352,7 +2352,9 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
       case collectAdministrativeTypeAppEntries of
         Just entries -> entries
         Nothing -> collectTypeAppliedClosureEntries
-    BackendConstruct _ _ args -> concatMap (collectClosureEntriesInExpr base localForms valueKinds) args
+    BackendConstruct resultTy name args ->
+      concatMap (collectClosureEntriesInExpr base localForms valueKinds) args
+        ++ collectConstructorFieldAdapterEntries resultTy name args
     BackendCase resultTy scrutinee alternatives ->
       collectClosureEntriesInExpr base localForms valueKinds scrutinee
         ++ concatMap collectAlternativeEntries (NE.toList alternatives)
@@ -2688,6 +2690,15 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
           ]
         resultKind = combineValueKinds resultTy branchKinds
         (paramTys, returnTy) = collectArrowsType resultTy
+
+    collectConstructorFieldAdapterEntries resultTy name args =
+      [ returnedPartialEntry LowerFunctionPointer fieldTy [] paramTys returnTy [] fieldTy
+      | Just fieldTys <- [Map.lookup name (pbConstructors base) >>= \constructorRuntime -> constructorRuntimeFieldTypes constructorRuntime resultTy],
+        fieldTy <- take (length args) fieldTys,
+        isFirstOrderFunctionPointerType fieldTy,
+        let (paramTys, returnTy) = collectArrowsType fieldTy,
+        not (null paramTys)
+      ]
 
     patternBinders =
       \case
@@ -4577,8 +4588,10 @@ lowerConstructField env exprEnv context fieldTy arg
           expectedTy <- lowerRuntimeValueTypeM env context fieldTy
           requireLLVMType context "constructor field" expectedTy value
           pure value {lvBackendType = fieldTy}
-        Nothing ->
-          lowerStoredFunctionArgument env exprEnv context fieldTy arg
+        Nothing -> do
+          value <- lowerStoredFunctionArgument env exprEnv context fieldTy arg
+          let (paramTys, returnTy) = collectArrowsType fieldTy
+          lowerReturnedPartialClosureValue env exprEnv context fieldTy value paramTys returnTy []
   | isClosureRuntimeValueType fieldTy = do
       value <- lowerExpr env exprEnv context arg
       expectedTy <- lowerRuntimeValueTypeM env context fieldTy
@@ -4709,7 +4722,7 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
             Map.lookup constructorName (pbConstructors (peBase env)) >>= \constructorRuntime ->
               constructorRuntimeFieldTypes constructorRuntime (lvBackendType scrutineeValue)
         binderFieldValueKind index0 fieldTy =
-          fromMaybe (valueKindForType fieldTy) $
+          fromMaybe (constructorFieldStoredValueKind fieldTy) $
             lvConstructedValue scrutineeValue >>= constructedFieldValueKind constructorName index0
 
     bindAlternativePattern scrutineeValue (BackendAlternative pattern0 body) =
@@ -4758,7 +4771,12 @@ lowerHeapCase env exprEnv context resultTy scrutinee alternatives = do
           | Just kind <- constructedFieldValueKind constructorName index0 constructed ->
               kind
         _ ->
-          valueKindForType fieldTy
+          constructorFieldStoredValueKind fieldTy
+
+constructorFieldStoredValueKind :: BackendType -> LowerValueKind
+constructorFieldStoredValueKind fieldTy
+  | isFunctionLikeBackendType fieldTy = LowerClosureRecord
+  | otherwise = LowerRuntimeValue
 
 lowerStoredFieldTypeM :: ProgramEnv -> String -> BackendType -> LowerM LLVMType
 lowerStoredFieldTypeM env context fieldTy
@@ -4843,11 +4861,11 @@ backendExprValueKindWith env visitedGlobals valueKinds expr
                           Map.delete name valueKinds
                     _ ->
                       Map.insert name (backendExprValueKindWith env visitedGlobals valueKinds rhs) valueKinds
-        BackendCase {} ->
+        BackendCase _ scrutinee alternatives ->
           combineValueKinds
             (backendExprType expr)
-            [ backendExprValueKindWith env visitedGlobals valueKinds (backendAltBody alternative)
-            | alternative <- NE.toList (backendAlternatives expr)
+            [ backendExprValueKindWith env visitedGlobals (alternativeValueKinds scrutinee alternative) (backendAltBody alternative)
+            | alternative <- NE.toList alternatives
             ]
         BackendClosure {} ->
           LowerClosureRecord
@@ -4856,6 +4874,24 @@ backendExprValueKindWith env visitedGlobals valueKinds expr
   where
     variableValueKind ty name typeArgs =
       variableValueKindWith valueKinds ty name typeArgs
+
+    alternativeValueKinds scrutinee alternative =
+      patternValueKinds (backendExprType scrutinee) (backendAltPattern alternative) `Map.union` valueKinds
+
+    patternValueKinds scrutineeTy =
+      \case
+        BackendDefaultPattern ->
+          Map.empty
+        BackendConstructorPattern constructorName binders ->
+          Map.fromList
+            [ (binder, constructorFieldStoredValueKind fieldTy)
+            | (binder, fieldTy) <- zip binders fieldTys
+            ]
+          where
+            fieldTys =
+              fromMaybe [] $
+                Map.lookup constructorName (pbConstructors (peBase env)) >>= \constructorRuntime ->
+                  constructorRuntimeFieldTypes constructorRuntime scrutineeTy
 
     functionLikeAliasValueKind kinds =
       \case
@@ -4952,14 +4988,11 @@ backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues 
               constructorRuntimeFieldTypes constructorRuntime resultTy
         fieldKinds =
           zipWith constructFieldValueKind fieldTys args
-        constructFieldValueKind fieldTy arg
-          | isFunctionLikeBackendType fieldTy =
-              backendExprValueKindWith env visitedGlobals valueKinds arg
-          | otherwise =
-              LowerRuntimeValue
-    BackendCase _ _ alternatives ->
+        constructFieldValueKind fieldTy _ =
+          constructorFieldStoredValueKind fieldTy
+    BackendCase _ scrutinee alternatives ->
       mergeConstructedValues
-        [ backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues (backendAltBody alternative)
+        [ backendExprConstructedValueWith env visitedGlobals (alternativeValueKinds scrutinee alternative) constructedValues (backendAltBody alternative)
         | alternative <- NE.toList alternatives
         ]
     BackendRoll _ payload ->
@@ -4997,6 +5030,24 @@ backendExprConstructedValueWith env visitedGlobals valueKinds constructedValues 
                in functionLikeAliasValueKind kindsForBody body
         _ ->
           Nothing
+
+    alternativeValueKinds scrutinee alternative =
+      patternValueKinds (backendExprType scrutinee) (backendAltPattern alternative) `Map.union` valueKinds
+
+    patternValueKinds scrutineeTy =
+      \case
+        BackendDefaultPattern ->
+          Map.empty
+        BackendConstructorPattern constructorName binders ->
+          Map.fromList
+            [ (binder, constructorFieldStoredValueKind fieldTy)
+            | (binder, fieldTy) <- zip binders fieldTys
+            ]
+          where
+            fieldTys =
+              fromMaybe [] $
+                Map.lookup constructorName (pbConstructors (peBase env)) >>= \constructorRuntime ->
+                  constructorRuntimeFieldTypes constructorRuntime scrutineeTy
 
     variableValueKindWith kinds ty name typeArgs =
       case Map.lookup name kinds of

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2681,11 +2681,20 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
                 Nothing ->
                   Just LowerClosureRecord
 
+    valueKindEnv =
+      ProgramEnv
+        { peBase = base,
+          peSpecializations = Map.empty,
+          peEvidenceWrappers = Map.empty,
+          peFunctionWrappers = Map.empty,
+          peStringGlobals = Map.empty
+        }
+
     nullaryGlobalReturnValueKind visitedGlobals name returnTy form
       | Set.member name visitedGlobals =
           valueKindForType returnTy
       | otherwise =
-          expressionValueKindWith (Set.insert name visitedGlobals) Map.empty Map.empty (ffBody form)
+          backendExprValueKindWith valueKindEnv (Set.insert name visitedGlobals) Map.empty (ffBody form)
 
     collectAlternativeEntries alternative =
       let binders = patternBinders (backendAltPattern alternative)

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2205,10 +2205,22 @@ collectClosureEntriesInForm base =
 
 collectClosureEntriesInFormWithLocals :: ProgramBase -> LocalFunctionForms -> FunctionForm -> [ClosureEntry]
 collectClosureEntriesInFormWithLocals base localForms form =
+  collectClosureEntriesInFormWithParamKinds base localForms Map.empty form
+
+collectClosureEntriesInFormWithParamKinds :: ProgramBase -> LocalFunctionForms -> Map String LowerValueKind -> FunctionForm -> [ClosureEntry]
+collectClosureEntriesInFormWithParamKinds base localForms suppliedParamKinds form =
   collectClosureEntriesInExpr base (shadowLocalFunctionForms paramNames localForms) paramValueKinds (ffBody form)
   where
     paramNames = Set.fromList (map fst (ffParams form))
-    paramValueKinds = Map.fromList [(paramName, parameterValueKind paramName paramTy) | (paramName, paramTy) <- ffParams form]
+    paramValueKinds =
+      Map.fromList
+        [ ( paramName,
+            case Map.lookup paramName suppliedParamKinds of
+              Just kind -> kind
+              Nothing -> parameterValueKind paramName paramTy
+          )
+        | (paramName, paramTy) <- ffParams form
+        ]
 
 collectClosureEntriesInExpr :: ProgramBase -> LocalFunctionForms -> Map String LowerValueKind -> BackendExpr -> [ClosureEntry]
 collectClosureEntriesInExpr base localForms valueKinds expr =
@@ -2216,7 +2228,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
     BackendVar {} -> []
     BackendLit {} -> []
     BackendLam _ name paramTy body ->
-      collectClosureEntriesInExpr base (Map.delete name localForms) (Map.insert name (parameterValueKind name paramTy) valueKinds) body
+      collectClosureEntriesInExpr base (Map.delete name localForms) (Map.insert name (localFunctionParameterValueKind name paramTy) valueKinds) body
     BackendApp _ fun arg ->
       case collectAdministrativeCallEntries of
         Just entries -> entries
@@ -2307,9 +2319,10 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
     collectInstantiatedClosureEntries ownerName form typeArgs args =
       case instantiateFunctionFormWithTypeArgs ("closure entry collection " ++ ownerName) form typeArgs args of
         Right (resolvedTypeArgs, instantiated) ->
-          collectClosureEntriesInFormWithLocals
+          collectClosureEntriesInFormWithParamKinds
             base
             localForms
+            (suppliedArgumentValueKinds instantiated args)
             (qualifyInstantiatedClosureEntries ownerName resolvedTypeArgs instantiated)
         Left _ ->
           []
@@ -2359,6 +2372,25 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
         && case collectTyApps (backendClosureCaptureExpr capture) of
           (BackendVar {}, _) -> True
           _ -> False
+
+    suppliedArgumentValueKinds instantiated args =
+      Map.fromList
+        [ (paramName, argumentValueKind localForms valueKinds paramName paramTy arg)
+        | ((paramName, paramTy), arg) <- zip (ffParams instantiated) args
+        ]
+
+    argumentValueKind localForms0 valueKinds0 paramName paramTy arg
+      | isEvidenceArgument True paramName paramTy =
+          LowerFunctionPointer
+      | isFunctionLikeBackendType paramTy =
+          case arg of
+            BackendClosure {} -> LowerClosureRecord
+            _ ->
+              case aliasValueKind localForms0 valueKinds0 arg of
+                Just kind -> kind
+                Nothing -> valueKindForType paramTy
+      | otherwise =
+          LowerRuntimeValue
 
     aliasValueKind localForms0 valueKinds0 expr0 =
       case expr0 of
@@ -4446,6 +4478,13 @@ backendExprValueKindWith env visitedGlobals valueKinds expr
 
 parameterValueKind :: String -> BackendType -> LowerValueKind
 parameterValueKind name ty
+  | isEvidenceParameter name ty = LowerFunctionPointer
+  | isFirstOrderFunctionPointerType ty = LowerFunctionPointer
+  | isClosureRuntimeValueType ty = LowerClosureRecord
+  | otherwise = LowerRuntimeValue
+
+localFunctionParameterValueKind :: String -> BackendType -> LowerValueKind
+localFunctionParameterValueKind name ty
   | isEvidenceParameter name ty = LowerFunctionPointer
   | isClosureRuntimeValueType ty = LowerClosureRecord
   | otherwise = LowerRuntimeValue

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -40,7 +40,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Numeric (showHex)
@@ -2237,9 +2237,24 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
             ++ collectClosureEntriesInExpr base localForms valueKinds fun
             ++ collectClosureEntriesInExpr base localForms valueKinds arg
     BackendLet _ name bindingTy rhs body ->
-      collectClosureEntriesInExpr base localForms valueKinds rhs
-        ++ collectClosureEntriesInExpr base bodyLocalForms bodyValueKinds body
+      rhsEntries ++ collectClosureEntriesInExpr base bodyLocalForms bodyValueKinds body
       where
+        rhsEntries =
+          case functionFormFromExpected bindingTy rhs of
+            form
+              | null (ffTypeBinders form),
+                not (null (ffParams form)) ->
+                  collectClosureEntriesInFormWithParamKinds
+                    base
+                    localForms
+                    ( Map.fromList
+                        [ (paramName, localFunctionBodyFallbackParameterValueKind paramName paramTy)
+                        | (paramName, paramTy) <- ffParams form
+                        ]
+                    )
+                    form
+            _ ->
+              collectClosureEntriesInExpr base localForms valueKinds rhs
         bodyLocalForms = collectLetLocalForm localForms name bindingTy rhs
         bodyValueKinds =
           case letBoundValueKind localForms valueKinds bindingTy rhs of
@@ -2345,7 +2360,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
               | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
                   Nothing
             _ ->
-              Just (valueKindForType bindingTy)
+              Just (expressionValueKind localForms0 valueKinds0 rhs)
 
     closureCaptureSlot localForms0 valueKinds0 capture =
       ClosureCaptureSlot
@@ -2388,7 +2403,10 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
             _ ->
               case aliasValueKind localForms0 valueKinds0 arg of
                 Just kind -> kind
-                Nothing -> valueKindForType paramTy
+                Nothing ->
+                  case collectTyApps arg of
+                    (BackendVar {}, _) -> valueKindForType paramTy
+                    _ -> LowerClosureRecord
       | otherwise =
           LowerRuntimeValue
 
@@ -2414,6 +2432,32 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
                in aliasValueKind localForms' valueKinds' body
         _ ->
           Nothing
+
+    expressionValueKind localForms0 valueKinds0 expr0
+      | not (isFunctionLikeBackendType (backendExprType expr0)) =
+          LowerRuntimeValue
+      | otherwise =
+          case expr0 of
+            BackendVar ty name ->
+              fromMaybe (valueKindForType ty) (variableValueKind localForms0 valueKinds0 name [])
+            BackendTyApp ty fun _ ->
+              case collectTyApps expr0 of
+                (BackendVar _ name, typeArgs) ->
+                  fromMaybe (valueKindForType ty) (variableValueKind localForms0 valueKinds0 name typeArgs)
+                _ ->
+                  expressionValueKind localForms0 valueKinds0 fun
+            BackendLet _ name bindingTy rhs body ->
+              expressionValueKind localForms' valueKinds' body
+              where
+                localForms' = collectLetLocalForm localForms0 name bindingTy rhs
+                valueKinds' =
+                  case letBoundValueKind localForms0 valueKinds0 bindingTy rhs of
+                    Just kind -> Map.insert name kind valueKinds0
+                    Nothing -> Map.delete name valueKinds0
+            BackendClosure {} ->
+              LowerClosureRecord
+            _ ->
+              valueKindForType (backendExprType expr0)
 
     variableValueKind localForms0 valueKinds0 name typeArgs =
       case Map.lookup name valueKinds0 of
@@ -4210,13 +4254,20 @@ lowerConstruct env exprEnv context resultTy name args =
 
 lowerConstructField :: ProgramEnv -> ExprEnv -> String -> BackendType -> BackendExpr -> LowerM LowerValue
 lowerConstructField env exprEnv context fieldTy arg
+  | isFirstOrderFunctionPointerType fieldTy = do
+      mbClosureValue <- lowerClosureRuntimeArgumentMaybe env exprEnv context fieldTy arg
+      case mbClosureValue of
+        Just value -> do
+          expectedTy <- lowerRuntimeValueTypeM env context fieldTy
+          requireLLVMType context "constructor field" expectedTy value
+          pure value {lvBackendType = fieldTy}
+        Nothing ->
+          lowerStoredFunctionArgument env exprEnv context fieldTy arg
   | isClosureRuntimeValueType fieldTy = do
       value <- lowerExpr env exprEnv context arg
       expectedTy <- lowerRuntimeValueTypeM env context fieldTy
       requireLLVMType context "constructor field" expectedTy value
       pure value {lvBackendType = fieldTy}
-  | isFirstOrderFunctionPointerType fieldTy =
-      lowerStoredFunctionArgument env exprEnv context fieldTy arg
   | otherwise =
       lowerExpr env exprEnv context arg
 
@@ -4379,6 +4430,7 @@ isClosureRuntimeValueType =
 
 valueKindForType :: BackendType -> LowerValueKind
 valueKindForType ty
+  | isFirstOrderFunctionPointerType ty = LowerFunctionPointer
   | isClosureRuntimeValueType ty = LowerClosureRecord
   | otherwise = LowerRuntimeValue
 
@@ -4485,6 +4537,13 @@ parameterValueKind name ty
 
 localFunctionParameterValueKind :: String -> BackendType -> LowerValueKind
 localFunctionParameterValueKind name ty
+  | isEvidenceParameter name ty = LowerFunctionPointer
+  | isFirstOrderFunctionPointerType ty = LowerFunctionPointer
+  | isClosureRuntimeValueType ty = LowerClosureRecord
+  | otherwise = LowerRuntimeValue
+
+localFunctionBodyFallbackParameterValueKind :: String -> BackendType -> LowerValueKind
+localFunctionBodyFallbackParameterValueKind name ty
   | isEvidenceParameter name ty = LowerFunctionPointer
   | isClosureRuntimeValueType ty = LowerClosureRecord
   | otherwise = LowerRuntimeValue

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2926,7 +2926,7 @@ lowerInstantiatedFunctionValue env exprEnv context name resultTy form = do
 
 bindLet :: ProgramEnv -> ExprEnv -> String -> String -> BackendExpr -> LowerM ExprEnv
 bindLet env exprEnv context name rhs =
-  case closurePointerAliasValue exprEnv rhs of
+  case callablePointerAliasValue exprEnv rhs of
     Just value ->
       pure
         exprEnv
@@ -2958,23 +2958,37 @@ bindLet env exprEnv context name rhs =
                 eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
               }
 
+callablePointerAliasValue :: ExprEnv -> BackendExpr -> Maybe LowerValue
+callablePointerAliasValue =
+  pointerAliasValue isCallablePointerAliasValue
+  where
+    isCallablePointerAliasValue value =
+      case lvValueKind value of
+        LowerClosureRecord -> True
+        LowerFunctionPointer -> True
+        LowerRuntimeValue -> False
+
 closurePointerAliasValue :: ExprEnv -> BackendExpr -> Maybe LowerValue
-closurePointerAliasValue exprEnv =
+closurePointerAliasValue =
+  pointerAliasValue ((== LowerClosureRecord) . lvValueKind)
+
+pointerAliasValue :: (LowerValue -> Bool) -> ExprEnv -> BackendExpr -> Maybe LowerValue
+pointerAliasValue matches exprEnv =
   \case
     BackendVar ty name
       | isFunctionLikeBackendType ty,
         Just value <- Map.lookup name (eeValues exprEnv),
         lvLLVMType value == LLVMPtr,
-        lvValueKind value == LowerClosureRecord ->
+        matches value ->
           Just value {lvBackendType = ty}
     BackendTyApp ty fun _
       | isFunctionLikeBackendType ty,
-        Just value <- closurePointerAliasValue exprEnv fun ->
+        Just value <- pointerAliasValue matches exprEnv fun ->
           Just value {lvBackendType = ty}
     BackendLet ty name bindingTy rhs body
       | isFunctionLikeBackendType ty ->
           let exprEnvForBody =
-                case closurePointerAliasValue exprEnv rhs of
+                case pointerAliasValue matches exprEnv rhs of
                   Just value ->
                     exprEnv
                       { eeValues = Map.insert name value {lvBackendType = bindingTy} (eeValues exprEnv),
@@ -2985,7 +2999,7 @@ closurePointerAliasValue exprEnv =
                       { eeValues = Map.delete name (eeValues exprEnv),
                         eeLocalFunctions = Map.delete name (eeLocalFunctions exprEnv)
                       }
-           in closurePointerAliasValue exprEnvForBody body
+           in pointerAliasValue matches exprEnvForBody body
     _ ->
       Nothing
 
@@ -4359,19 +4373,55 @@ backendExprValueKind env valueKinds expr
           backendExprValueKind env valueKindsForBody body
           where
             valueKindsForBody =
-              case functionFormFromExpected bindingTy rhs of
-                form
-                  | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
-                      Map.delete name valueKinds
-                _ ->
-                  Map.insert name (backendExprValueKind env valueKinds rhs) valueKinds
+              case functionLikeAliasValueKind valueKinds rhs of
+                Just kind ->
+                  Map.insert name kind valueKinds
+                Nothing ->
+                  case functionFormFromExpected bindingTy rhs of
+                    form
+                      | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                          Map.delete name valueKinds
+                    _ ->
+                      Map.insert name (backendExprValueKind env valueKinds rhs) valueKinds
         BackendClosure {} ->
           LowerClosureRecord
         _ ->
           valueKindForType (backendExprType expr)
   where
     variableValueKind ty name typeArgs =
-      case Map.lookup name valueKinds of
+      variableValueKindWith valueKinds ty name typeArgs
+
+    functionLikeAliasValueKind kinds =
+      \case
+        BackendVar ty name
+          | isFunctionLikeBackendType ty ->
+              Just (variableValueKindWith kinds ty name [])
+        expr0@(BackendTyApp ty fun _)
+          | isFunctionLikeBackendType ty ->
+              case collectTyApps expr0 of
+                (BackendVar varTy name, typeArgs) ->
+                  Just (variableValueKindWith kinds varTy name typeArgs)
+                _ ->
+                  functionLikeAliasValueKind kinds fun
+        BackendLet ty name bindingTy rhs body
+          | isFunctionLikeBackendType ty ->
+              let kindsForBody =
+                    case functionLikeAliasValueKind kinds rhs of
+                      Just kind ->
+                        Map.insert name kind kinds
+                      Nothing ->
+                        case functionFormFromExpected bindingTy rhs of
+                          form
+                            | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                                Map.delete name kinds
+                          _ ->
+                            Map.insert name (backendExprValueKind env kinds rhs) kinds
+               in functionLikeAliasValueKind kindsForBody body
+        _ ->
+          Nothing
+
+    variableValueKindWith kinds ty name typeArgs =
+      case Map.lookup name kinds of
         Just kind ->
           kind
         Nothing ->

--- a/src/MLF/Backend/LLVM/Lower.hs
+++ b/src/MLF/Backend/LLVM/Lower.hs
@@ -2093,6 +2093,41 @@ backendTypeKey :: BackendType -> String
 backendTypeKey =
   ("t" ++) . intercalate "_" . map (flip showHex "" . ord) . show
 
+lowerValueKindKey :: LowerValueKind -> String
+lowerValueKindKey =
+  \case
+    LowerRuntimeValue -> "runtime"
+    LowerClosureRecord -> "closure"
+    LowerFunctionPointer -> "function"
+
+returnedPartialClosureEntryName :: LowerValueKind -> BackendType -> Int -> [LowerValueKind] -> BackendType -> String
+returnedPartialClosureEntryName calleeKind calleeTy suppliedCount suppliedKinds resultTy =
+  intercalate
+    "$"
+    [ "__mlfp_returned_partial",
+      lowerValueKindKey calleeKind,
+      show suppliedCount,
+      intercalate "_" (map lowerValueKindKey suppliedKinds),
+      backendTypeKey calleeTy,
+      backendTypeKey resultTy
+    ]
+
+returnedPartialCalleeCaptureName :: String
+returnedPartialCalleeCaptureName =
+  "__mlfp_returned_partial_callee"
+
+returnedPartialSuppliedArgName :: Int -> String
+returnedPartialSuppliedArgName index0 =
+  "__mlfp_returned_partial_supplied" ++ show index0
+
+returnedPartialParamName :: Int -> String
+returnedPartialParamName index0 =
+  "__mlfp_returned_partial_param" ++ show index0
+
+functionTypeFromParts :: [BackendType] -> BackendType -> BackendType
+functionTypeFromParts params returnTy =
+  foldr BTArrow returnTy params
+
 lowerMonomorphicBinding :: ProgramEnv -> BindingInfo -> Either BackendLLVMError LLVMFunction
 lowerMonomorphicBinding env binding =
   lowerFunction env (biName binding) False (biForm binding)
@@ -2234,6 +2269,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
         Just entries -> entries
         Nothing ->
           collectAppliedLocalClosureEntries
+            ++ collectReturnedPartialClosureEntries
             ++ collectClosureEntriesInExpr base localForms valueKinds fun
             ++ collectClosureEntriesInExpr base localForms valueKinds arg
     BackendLet _ name bindingTy rhs body ->
@@ -2242,17 +2278,11 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
         rhsEntries =
           case functionFormFromExpected bindingTy rhs of
             form
-              | null (ffTypeBinders form),
-                not (null (ffParams form)) ->
-                  collectClosureEntriesInFormWithParamKinds
-                    base
-                    localForms
-                    ( Map.fromList
-                        [ (paramName, localFunctionBodyFallbackParameterValueKind paramName paramTy)
-                        | (paramName, paramTy) <- ffParams form
-                        ]
-                    )
-                    form
+              | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
+                  -- Function body entries can depend on whether arguments arrive
+                  -- as raw function pointers or closure records, so collect them
+                  -- from call sites where supplied argument kinds are known.
+                  []
             _ ->
               collectClosureEntriesInExpr base localForms valueKinds rhs
         bodyLocalForms = collectLetLocalForm localForms name bindingTy rhs
@@ -2298,6 +2328,104 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
           | Just form <- Map.lookup name localForms ->
               collectInstantiatedLocalClosureEntries name form typeArgs args
         _ -> []
+
+    collectReturnedPartialClosureEntries =
+      case collectCall expr of
+        Just (headExpr, typeArgs, args)
+          | Just form <- returnedPartialHeadForm headExpr ->
+              case instantiateFunctionFormWithTypeArgs "returned partial closure entry collection" form typeArgs args of
+                Right (_, instantiated) ->
+                  returnedPartialEntriesForExtraArgs (ffReturnType instantiated) (drop (length (ffParams instantiated)) args) (backendExprType expr)
+                Left _ -> []
+        _ -> []
+
+    returnedPartialHeadForm =
+      \case
+        BackendVar _ name
+          | Just form <- Map.lookup name localForms ->
+              Just form
+          | Just binding <- Map.lookup name (pbBindings base) ->
+              Just (biForm binding)
+        headExpr@BackendLam {} ->
+          Just (functionFormFromExpr headExpr)
+        headExpr@BackendTyAbs {} ->
+          Just (functionFormFromExpr headExpr)
+        _ ->
+          Nothing
+
+    returnedPartialEntriesForExtraArgs calleeTy args resultTy =
+      let (paramTys, returnTy) = collectArrowsType calleeTy
+       in case compare (length args) (length paramTys) of
+            LT
+              | not (null args),
+                not (null paramTys) ->
+                  returnedPartialEntries calleeTy args resultTy
+            GT
+              | isFunctionLikeBackendType returnTy ->
+                  returnedPartialEntriesForExtraArgs returnTy (drop (length paramTys) args) resultTy
+            _ ->
+              []
+
+    returnedPartialEntries calleeTy args resultTy =
+      [ returnedPartialEntry calleeKind calleeTy suppliedParamTys remainingParamTys finalReturnTy suppliedKinds resultTy
+      | not (null args),
+        length args < length paramTys,
+        alphaEqBackendType resultTy expectedResultTy,
+        calleeKind <- LowerClosureRecord : [LowerFunctionPointer | isFirstOrderFunctionPointerType calleeTy]
+      ]
+      where
+        (paramTys, finalReturnTy) = collectArrowsType calleeTy
+        suppliedCount = length args
+        suppliedParamTys = take suppliedCount paramTys
+        remainingParamTys = drop suppliedCount paramTys
+        expectedResultTy = functionTypeFromParts remainingParamTys finalReturnTy
+        suppliedKinds =
+          [ argumentValueKind localForms valueKinds (returnedPartialSuppliedArgName index0) paramTy arg
+          | (index0, (paramTy, arg)) <- zip [0 :: Int ..] (zip suppliedParamTys args)
+          ]
+
+    returnedPartialEntry calleeKind calleeTy suppliedParamTys remainingParamTys finalReturnTy suppliedKinds resultTy =
+      ClosureEntry
+        { ceFunctionType = resultTy,
+          ceEntryName = returnedPartialClosureEntryName calleeKind calleeTy (length suppliedParamTys) suppliedKinds resultTy,
+          ceCaptures =
+            ClosureCaptureSlot returnedPartialCalleeCaptureName calleeTy calleeKind
+              : [ ClosureCaptureSlot (returnedPartialSuppliedArgName index0) paramTy suppliedKind
+                  | (index0, (paramTy, suppliedKind)) <- zip [0 :: Int ..] (zip suppliedParamTys suppliedKinds)
+                ],
+          ceParams = remainingParams,
+          ceBody = returnedPartialBody calleeKind calleeTy suppliedParamTys remainingParams finalReturnTy
+        }
+      where
+        remainingParams =
+          [(returnedPartialParamName index0, paramTy) | (index0, paramTy) <- zip [0 :: Int ..] remainingParamTys]
+
+    returnedPartialBody calleeKind calleeTy suppliedParamTys remainingParams finalReturnTy =
+      case calleeKind of
+        LowerClosureRecord ->
+          BackendClosureCall finalReturnTy calleeExpr callArgs
+        LowerFunctionPointer ->
+          applyReturnedPartialArgs calleeExpr calleeTy callArgs
+        LowerRuntimeValue ->
+          BackendVar finalReturnTy "__mlfp_unreachable_returned_partial"
+      where
+        calleeExpr = BackendVar calleeTy returnedPartialCalleeCaptureName
+        suppliedArgs =
+          [ BackendVar paramTy (returnedPartialSuppliedArgName index0)
+          | (index0, paramTy) <- zip [0 :: Int ..] suppliedParamTys
+          ]
+        remainingArgs =
+          [BackendVar paramTy paramName | (paramName, paramTy) <- remainingParams]
+        callArgs = suppliedArgs ++ remainingArgs
+
+    applyReturnedPartialArgs fun _ [] =
+      fun
+    applyReturnedPartialArgs fun funTy (arg : rest) =
+      case funTy of
+        BTArrow _ resultTy ->
+          applyReturnedPartialArgs (BackendApp resultTy fun arg) resultTy rest
+        _ ->
+          fun
 
     collectAdministrativeCallEntries =
       case collectCall expr of
@@ -2345,7 +2473,7 @@ collectClosureEntriesInExpr base localForms valueKinds expr =
     collectLetLocalForm localForms0 name bindingTy rhs =
       case functionFormFromExpected bindingTy rhs of
         form
-          | not (null (ffTypeBinders form)) ->
+          | not (null (ffTypeBinders form)) || not (null (ffParams form)) ->
               Map.insert name form localForms0
         _ ->
           Map.delete name localForms0
@@ -3255,7 +3383,32 @@ lowerClosureValueCall env exprEnv context resultTy callee typeArgs args = do
   lowerClosurePointerValueCall env exprEnv context resultTy callee {lvBackendType = calleeTy} args
 
 lowerReturnedFunctionValueCall :: ProgramEnv -> ExprEnv -> String -> String -> BackendType -> LowerValue -> [BackendExpr] -> LowerM LowerValue
-lowerReturnedFunctionValueCall env exprEnv context name resultTy callee args =
+lowerReturnedFunctionValueCall env exprEnv context name resultTy callee args = do
+  when (lvValueKind callee == LowerRuntimeValue) $
+    liftEither (BackendLLVMUnsupportedExpression context ("returned value is not callable: " ++ show (lvBackendType callee)))
+  let (paramTys, returnTy) = collectArrowsType (lvBackendType callee)
+  when (null paramTys) $
+    liftEither (BackendLLVMUnsupportedExpression context ("returned value is not callable: " ++ show (lvBackendType callee)))
+  case compare (length args) (length paramTys) of
+    LT
+      | null args -> do
+          unless (alphaEqBackendType resultTy (lvBackendType callee)) $
+            liftEither (BackendLLVMInternalError ("returned function value type mismatch at " ++ context))
+          pure callee {lvBackendType = resultTy}
+      | otherwise ->
+          lowerReturnedPartialClosureValue env exprEnv context resultTy callee paramTys returnTy args
+    EQ ->
+      lowerSaturatedReturnedFunctionValueCall env exprEnv context name resultTy callee args
+    GT
+      | isFunctionLikeBackendType returnTy -> do
+          let (directArgs, remainingArgs) = splitAt (length paramTys) args
+          saturated <- lowerSaturatedReturnedFunctionValueCall env exprEnv context name returnTy callee directArgs
+          lowerReturnedFunctionValueCall env exprEnv context name resultTy saturated remainingArgs
+      | otherwise ->
+          liftEither (BackendLLVMArityMismatch name (length paramTys) (length args))
+
+lowerSaturatedReturnedFunctionValueCall :: ProgramEnv -> ExprEnv -> String -> String -> BackendType -> LowerValue -> [BackendExpr] -> LowerM LowerValue
+lowerSaturatedReturnedFunctionValueCall env exprEnv context name resultTy callee args =
   case lvValueKind callee of
     LowerClosureRecord ->
       lowerClosurePointerValueCall env exprEnv context resultTy callee args
@@ -3263,6 +3416,44 @@ lowerReturnedFunctionValueCall env exprEnv context name resultTy callee args =
       lowerIndirectValueCall env exprEnv context name callee [] args
     LowerRuntimeValue ->
       liftEither (BackendLLVMUnsupportedExpression context ("returned value is not callable: " ++ show (lvBackendType callee)))
+
+lowerReturnedPartialClosureValue :: ProgramEnv -> ExprEnv -> String -> BackendType -> LowerValue -> [BackendType] -> BackendType -> [BackendExpr] -> LowerM LowerValue
+lowerReturnedPartialClosureValue env exprEnv context resultTy callee paramTys returnTy args = do
+  unless (lvLLVMType callee == LLVMPtr) $
+    liftEither (BackendLLVMUnsupportedExpression context ("returned partial callee is not a pointer: " ++ show (lvBackendType callee)))
+  let suppliedCount = length args
+      suppliedParamTys = take suppliedCount paramTys
+      remainingParamTys = drop suppliedCount paramTys
+      expectedResultTy = functionTypeFromParts remainingParamTys returnTy
+  unless (suppliedCount < length paramTys) $
+    liftEither (BackendLLVMArityMismatch "returned partial" (length paramTys) suppliedCount)
+  unless (alphaEqBackendType resultTy expectedResultTy) $
+    liftEither (BackendLLVMInternalError ("returned partial result mismatch at " ++ context))
+  suppliedValues <- zipWithM lowerPartialArg (zip [0 :: Int ..] suppliedParamTys) args
+  let suppliedKinds = map lvValueKind suppliedValues
+      entryName = returnedPartialClosureEntryName (lvValueKind callee) (lvBackendType callee) suppliedCount suppliedKinds resultTy
+  envPointer <- lowerReturnedPartialEnvironment suppliedParamTys suppliedValues
+  closurePointer <- emitMalloc env context 16
+  codePtrField <- emitGep "closure.code.ptr" closurePointer 0
+  emitStore LLVMPtr (LLVMGlobalRef LLVMPtr entryName) codePtrField
+  envPtrField <- emitGep "closure.env.ptr" closurePointer 8
+  emitStore LLVMPtr envPointer envPtrField
+  pure (LowerValue resultTy LLVMPtr closurePointer LowerClosureRecord)
+  where
+    lowerPartialArg (index0, paramTy) arg =
+      lowerExprForIndirectArgument env exprEnv context (returnedPartialSuppliedArgName index0, paramTy) arg
+
+    lowerReturnedPartialEnvironment suppliedParamTys suppliedValues = do
+      envPointer <- emitMalloc env context (8 * (1 + length suppliedValues))
+      storeCapture envPointer 0 (lvBackendType callee, callee)
+      zipWithM_ (storeCapture envPointer) [1 :: Int ..] (zip suppliedParamTys suppliedValues)
+      pure envPointer
+
+    storeCapture envPointer index0 (captureTy, value) = do
+      expectedTy <- lowerClosureStoredTypeM env context captureTy
+      requireLLVMType context returnedPartialCalleeCaptureName expectedTy value
+      fieldPtr <- emitGep "closure.env.field.ptr" envPointer (8 * index0)
+      emitStore expectedTy (lvOperand value) fieldPtr
 
 lowerClosureCallee :: ProgramEnv -> ExprEnv -> String -> BackendExpr -> LowerM LowerValue
 lowerClosureCallee env exprEnv context =
@@ -4539,12 +4730,6 @@ localFunctionParameterValueKind :: String -> BackendType -> LowerValueKind
 localFunctionParameterValueKind name ty
   | isEvidenceParameter name ty = LowerFunctionPointer
   | isFirstOrderFunctionPointerType ty = LowerFunctionPointer
-  | isClosureRuntimeValueType ty = LowerClosureRecord
-  | otherwise = LowerRuntimeValue
-
-localFunctionBodyFallbackParameterValueKind :: String -> BackendType -> LowerValueKind
-localFunctionBodyFallbackParameterValueKind name ty
-  | isEvidenceParameter name ty = LowerFunctionPointer
   | isClosureRuntimeValueType ty = LowerClosureRecord
   | otherwise = LowerRuntimeValue
 

--- a/test/BackendIRSpec.hs
+++ b/test/BackendIRSpec.hs
@@ -294,6 +294,16 @@ spec = describe "MLF.Backend.IR" $ do
               backendClosureParams = [("x", intTy)],
               backendClosureBody = BackendVar intTy "x"
             }
+        higherOrderTy =
+          BTArrow idTy intTy
+        higherOrderClosure entryName =
+          BackendClosure
+            { backendExprType = higherOrderTy,
+              backendClosureEntryName = entryName,
+              backendClosureCaptures = [],
+              backendClosureParams = [("f", idTy)],
+              backendClosureBody = BackendApp intTy (BackendVar idTy "f") (intLit 1)
+            }
         captureMismatch =
           BackendClosure
             { backendExprType = idTy,
@@ -381,58 +391,59 @@ spec = describe "MLF.Backend.IR" $ do
           BackendLet
             intTy
             "f"
-            idTy
-            (goodClosure "__mlfp_closure$app")
-            (BackendApp intTy (BackendVar idTy "f") (intLit 1))
+            higherOrderTy
+            (higherOrderClosure "__mlfp_closure$app")
+            (BackendApp intTy (BackendVar higherOrderTy "f") intIdentityExpr)
         appCalledLetHeadClosure =
           BackendApp
             intTy
             ( BackendLet
-                idTy
+                higherOrderTy
                 "f"
-                idTy
-                (goodClosure "__mlfp_closure$app_let_head")
-                (BackendVar idTy "f")
+                higherOrderTy
+                (higherOrderClosure "__mlfp_closure$app_let_head")
+                (BackendVar higherOrderTy "f")
             )
-            (intLit 1)
+            intIdentityExpr
         appCalledClosureAlias =
           BackendLet
             intTy
             "g"
-            idTy
-            (goodClosure "__mlfp_closure$app_alias")
+            higherOrderTy
+            (higherOrderClosure "__mlfp_closure$app_alias")
             ( BackendLet
                 intTy
                 "f"
-                idTy
-                (BackendVar idTy "g")
-                (BackendApp intTy (BackendVar idTy "f") (intLit 1))
+                higherOrderTy
+                (BackendVar higherOrderTy "g")
+                (BackendApp intTy (BackendVar higherOrderTy "f") intIdentityExpr)
             )
         appCalledCaseHeadClosure =
           BackendApp
             intTy
             ( BackendCase
-                idTy
+                higherOrderTy
                 (BackendConstruct boxTy "Box" [intLit 0])
                 ( BackendAlternative
                     (BackendConstructorPattern "Box" ["n"])
-                    (goodClosure "__mlfp_closure$app_case")
+                    (higherOrderClosure "__mlfp_closure$app_case")
                     :| []
                 )
             )
-            (intLit 1)
+            intIdentityExpr
         appCalledCapturedClosure =
           BackendLet
             idTy
             "g"
-            idTy
-            (goodClosure "__mlfp_closure$app_captured_source")
+            higherOrderTy
+            (higherOrderClosure "__mlfp_closure$app_captured_source")
             ( BackendClosure
                 { backendExprType = idTy,
                   backendClosureEntryName = "__mlfp_closure$app_captured",
-                  backendClosureCaptures = [BackendClosureCapture "capturedClosure" idTy (BackendVar idTy "g")],
+                  backendClosureCaptures = [BackendClosureCapture "capturedClosure" higherOrderTy (BackendVar higherOrderTy "g")],
                   backendClosureParams = [("x", intTy)],
-                  backendClosureBody = BackendApp intTy (BackendVar idTy "capturedClosure") (intLit 1)
+                  backendClosureBody =
+                    BackendApp intTy (BackendVar higherOrderTy "capturedClosure") intIdentityExpr
                 }
             )
         closureCallMixedCaseHead =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1239,6 +1239,32 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "preserves let-bound first-order parameters captured by nested closures" $ do
+    output <- requireRight (renderBackendProgramLLVM letBoundFirstOrderParameterClosureProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$let_capture_first_order_param\""
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.env.field"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.closure.env.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "packages partial applications of returned closures" $ do
+    output <- requireRight (renderBackendProgramLLVM returnedClosurePartialApplicationProgram)
+
+    output `shouldSatisfy` isInfixOf "__mlfp_returned_partial$closure"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_returned_partial$closure"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "packages partial applications of returned raw function pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM rawReturnedFunctionPointerPartialApplicationProgram)
+
+    output `shouldSatisfy` isInfixOf "__mlfp_returned_partial$function"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.env.field"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.closure.env.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "guards nullary global value-kind cycles" $ do
     result <- timeout 1000000 (evaluate (renderBackendProgramLLVM nullaryGlobalValueKindCycleProgram))
     case result of
@@ -4755,6 +4781,131 @@ capturedFirstOrderParameterClosureProgram =
         ],
       backendProgramMain = "main"
     }
+
+letBoundFirstOrderParameterClosureProgram :: BackendProgram
+letBoundFirstOrderParameterClosureProgram =
+  programWithBindings
+    [ helperBinding,
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = intTy,
+          backendBindingExpr =
+            BackendApp
+              intTy
+              ( BackendApp
+                  unaryIntTy
+                  ( BackendLet
+                      (BTArrow unaryIntTy unaryIntTy)
+                      "makeCaller"
+                      (BTArrow unaryIntTy unaryIntTy)
+                      ( BackendLam
+                          { backendExprType = BTArrow unaryIntTy unaryIntTy,
+                            backendParamName = "f",
+                            backendParamType = unaryIntTy,
+                            backendBody =
+                              BackendClosure
+                                { backendExprType = unaryIntTy,
+                                  backendClosureEntryName = "__mlfp_closure$let_capture_first_order_param",
+                                  backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "f")],
+                                  backendClosureParams = [("x", intTy)],
+                                  backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                                }
+                          }
+                      )
+                      (BackendVar (BTArrow unaryIntTy unaryIntTy) "makeCaller")
+                  )
+                  (BackendVar unaryIntTy "helper")
+              )
+              (intLit 41),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+returnedClosurePartialApplicationProgram :: BackendProgram
+returnedClosurePartialApplicationProgram =
+  programWithBindings
+    [ BackendBinding
+        { backendBindingName = "makeBinary",
+          backendBindingType = BTArrow intTy binaryIntTy,
+          backendBindingExpr =
+            BackendLam
+              { backendExprType = BTArrow intTy binaryIntTy,
+                backendParamName = "base",
+                backendParamType = intTy,
+                backendBody =
+                  BackendClosure
+                    { backendExprType = binaryIntTy,
+                      backendClosureEntryName = "__mlfp_closure$returned_binary",
+                      backendClosureCaptures = [BackendClosureCapture "base" intTy (BackendVar intTy "base")],
+                      backendClosureParams = [("x", intTy), ("y", intTy)],
+                      backendClosureBody = BackendVar intTy "base"
+                    }
+              },
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr =
+            BackendApp
+              unaryIntTy
+              ( BackendApp
+                  binaryIntTy
+                  (BackendVar (BTArrow intTy binaryIntTy) "makeBinary")
+                  (intLit 41)
+              )
+              (intLit 0),
+          backendBindingExportedAsMain = True
+        }
+    ]
+
+rawReturnedFunctionPointerPartialApplicationProgram :: BackendProgram
+rawReturnedFunctionPointerPartialApplicationProgram =
+  programWithBindings
+    [ addBinding,
+      BackendBinding
+        { backendBindingName = "idRawBinary",
+          backendBindingType = BTArrow binaryIntTy (BTArrow intTy binaryIntTy),
+          backendBindingExpr =
+            BackendLam
+              { backendExprType = BTArrow binaryIntTy (BTArrow intTy binaryIntTy),
+                backendParamName = "$evidence_f",
+                backendParamType = binaryIntTy,
+                backendBody =
+                  BackendLam
+                    { backendExprType = BTArrow intTy binaryIntTy,
+                      backendParamName = "ignored",
+                      backendParamType = intTy,
+                      backendBody =
+                        BackendLet
+                          binaryIntTy
+                          "dummy"
+                          intTy
+                          (intLit 0)
+                          (BackendVar binaryIntTy "$evidence_f")
+                    }
+              },
+          backendBindingExportedAsMain = False
+        },
+      BackendBinding
+        { backendBindingName = "main",
+          backendBindingType = unaryIntTy,
+          backendBindingExpr =
+            BackendApp
+              unaryIntTy
+              ( BackendApp
+                  binaryIntTy
+                  ( BackendApp
+                      (BTArrow intTy binaryIntTy)
+                      (BackendVar (BTArrow binaryIntTy (BTArrow intTy binaryIntTy)) "idRawBinary")
+                      (BackendVar binaryIntTy "add")
+                  )
+                  (intLit 0)
+              )
+              (intLit 1),
+          backendBindingExportedAsMain = True
+        }
+    ]
 
 nullaryGlobalValueKindCycleProgram :: BackendProgram
 nullaryGlobalValueKindCycleProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1222,6 +1222,23 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "loads first-order function fields as raw function pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM rawFunctionPointerFieldCallProgram)
+
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.case.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "captures first-order lambda parameters as raw function pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM capturedFirstOrderParameterClosureProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$capture_first_order_param\""
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.env.field"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.closure.env.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "guards nullary global value-kind cycles" $ do
     result <- timeout 1000000 (evaluate (renderBackendProgramLLVM nullaryGlobalValueKindCycleProgram))
     case result of
@@ -4652,6 +4669,85 @@ closureFirstOrderFunctionParameterCallProgram =
                               }
                           )
                           [BackendVar unaryIntTy "helper", intLit 41],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+rawFunctionPointerFieldCallProgram :: BackendProgram
+rawFunctionPointerFieldCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ helperBinding,
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "box"
+                          fnBoxTy
+                          (BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "helper"])
+                          ( BackendCase
+                              intTy
+                              (BackendVar fnBoxTy "box")
+                              ( BackendAlternative
+                                  (BackendConstructorPattern "FnBox" ["f"])
+                                  (BackendApp intTy (BackendVar unaryIntTy "f") (intLit 41))
+                                  :| []
+                              )
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+capturedFirstOrderParameterClosureProgram :: BackendProgram
+capturedFirstOrderParameterClosureProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ helperBinding,
+                  BackendBinding
+                    { backendBindingName = "makeCaller",
+                      backendBindingType = BTArrow unaryIntTy unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = BTArrow unaryIntTy unaryIntTy,
+                            backendParamName = "f",
+                            backendParamType = unaryIntTy,
+                            backendBody =
+                              BackendClosure
+                                { backendExprType = unaryIntTy,
+                                  backendClosureEntryName = "__mlfp_closure$capture_first_order_param",
+                                  backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "f")],
+                                  backendClosureParams = [("x", intTy)],
+                                  backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                                }
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          (BackendApp unaryIntTy (BackendVar (BTArrow unaryIntTy unaryIntTy) "makeCaller") (BackendVar unaryIntTy "helper"))
+                          (intLit 41),
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1268,6 +1268,33 @@ spec = describe "MLF.Backend.LLVM" $ do
     runLLVMNativeExecutable nativeOutput
       `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
 
+  it "normalizes mixed callable case results to closure records" $ do
+    output <- requireRight (renderBackendProgramLLVM mixedCallableCaseResultProgram)
+
+    output `shouldSatisfy` isInfixOf "__mlfp_returned_partial$function$0"
+    output `shouldSatisfy` isInfixOf "store ptr @\"__mlfp_returned_partial$function$0"
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.call"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.call"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM mixedCallableCaseResultProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
+  it "lowers BackendApp case heads that select direct closures" $ do
+    output <- requireRight (renderBackendProgramLLVM caseHeadedDirectClosureBackendAppProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$backend_app_case_some\""
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM call"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM caseHeadedDirectClosureBackendAppProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
   it "captures first-order lambda parameters as raw function pointers" $ do
     output <- requireRight (renderBackendProgramLLVM capturedFirstOrderParameterClosureProgram)
 
@@ -4928,6 +4955,122 @@ caseReturnedClosureOverApplicationProgram =
                         BackendApp
                           intTy
                           (BackendApp unaryIntTy (BackendVar (BTArrow intTy unaryIntTy) "makeFromCase") (intLit 41))
+                          (intLit 0),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+mixedCallableCaseResultProgram :: BackendProgram
+mixedCallableCaseResultProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [optionData],
+              backendModuleBindings =
+                [ helperBinding,
+                  BackendBinding
+                    { backendBindingName = "makeMixed",
+                      backendBindingType = BTArrow unaryIntTy (BTArrow intTy unaryIntTy),
+                      backendBindingExpr =
+                        BackendLam
+                          (BTArrow unaryIntTy (BTArrow intTy unaryIntTy))
+                          "$evidence_f"
+                          unaryIntTy
+                          ( BackendLam
+                              (BTArrow intTy unaryIntTy)
+                              "base"
+                              intTy
+                              ( BackendCase
+                                  unaryIntTy
+                                  (BackendConstruct (optionTy intTy) "Some" [BackendVar intTy "base"])
+                                  ( BackendAlternative
+                                      (BackendConstructorPattern "Some" ["captured"])
+                                      ( BackendClosure
+                                          { backendExprType = unaryIntTy,
+                                            backendClosureEntryName = "__mlfp_closure$mixed_case_closure",
+                                            backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                            backendClosureParams = [("x", intTy)],
+                                            backendClosureBody = BackendVar intTy "captured"
+                                          }
+                                      )
+                                      :| [ BackendAlternative
+                                             (BackendConstructorPattern "None" [])
+                                             (BackendVar unaryIntTy "$evidence_f")
+                                         ]
+                                  )
+                              )
+                          ),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          ( BackendApp
+                              unaryIntTy
+                              ( BackendApp
+                                  (BTArrow intTy unaryIntTy)
+                                  (BackendVar (BTArrow unaryIntTy (BTArrow intTy unaryIntTy)) "makeMixed")
+                                  (BackendVar unaryIntTy "helper")
+                              )
+                              (intLit 41)
+                          )
+                          (intLit 0),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+caseHeadedDirectClosureBackendAppProgram :: BackendProgram
+caseHeadedDirectClosureBackendAppProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [optionData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          ( BackendCase
+                              unaryIntTy
+                              (BackendConstruct (optionTy intTy) "Some" [intLit 41])
+                              ( BackendAlternative
+                                  (BackendConstructorPattern "Some" ["captured"])
+                                  ( BackendClosure
+                                      { backendExprType = unaryIntTy,
+                                        backendClosureEntryName = "__mlfp_closure$backend_app_case_some",
+                                        backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                        backendClosureParams = [("x", intTy)],
+                                        backendClosureBody = BackendVar intTy "captured"
+                                      }
+                                  )
+                                  :| [ BackendAlternative
+                                         (BackendConstructorPattern "None" [])
+                                         ( BackendClosure
+                                             { backendExprType = unaryIntTy,
+                                               backendClosureEntryName = "__mlfp_closure$backend_app_case_none",
+                                               backendClosureCaptures = [],
+                                               backendClosureParams = [("x", intTy)],
+                                               backendClosureBody = intLit 0
+                                             }
+                                         )
+                                     ]
+                              )
+                          )
                           (intLit 0),
                       backendBindingExportedAsMain = True
                     }

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1378,11 +1378,24 @@ spec = describe "MLF.Backend.LLVM" $ do
   it "preserves let-bound first-order parameters captured by nested closures" $ do
     output <- requireRight (renderBackendProgramLLVM letBoundFirstOrderParameterClosureProgram)
 
-    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$let_capture_first_order_param\""
+    output `shouldSatisfy` isInfixOf "define private i64 @\"makeCaller$vk$function$__mlfp_closure$let_capture_first_order_param\""
     output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.env.field"
     output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.closure.env.field"
     validateLLVMAssembly output
     validateLLVMObjectCode output
+
+  it "specializes closure entries by callable capture representation" $ do
+    output <- requireRight (renderBackendProgramLLVM mixedCallableCaptureClosureEntryProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"makeCaller$vk$function$__mlfp_closure$mixed_callable_capture\""
+    output `shouldSatisfy` isInfixOf "define private i64 @\"makeCaller$vk$closure$__mlfp_closure$mixed_callable_capture\""
+    output `shouldNotSatisfy` isInfixOf "duplicate closure entry"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM mixedCallableCaptureClosureEntryProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "42\n" ""
 
   it "packages partial applications of returned closures" $ do
     output <- requireRight (renderBackendProgramLLVM returnedClosurePartialApplicationProgram)
@@ -5492,6 +5505,81 @@ letBoundFirstOrderParameterClosureProgram =
           backendBindingExportedAsMain = True
         }
     ]
+
+mixedCallableCaptureClosureEntryProgram :: BackendProgram
+mixedCallableCaptureClosureEntryProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ helperBinding,
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "makeCaller"
+                          (BTArrow unaryIntTy unaryIntTy)
+                          mixedCallableCaptureFunction
+                          ( BackendLet
+                              intTy
+                              "ignored"
+                              intTy
+                              ( BackendApp
+                                  intTy
+                                  ( BackendApp
+                                      unaryIntTy
+                                      (BackendVar (BTArrow unaryIntTy unaryIntTy) "makeCaller")
+                                      (BackendVar unaryIntTy "helper")
+                                  )
+                                  (intLit 7)
+                              )
+                              ( BackendApp
+                                  intTy
+                                  ( BackendApp
+                                      unaryIntTy
+                                      (BackendVar (BTArrow unaryIntTy unaryIntTy) "makeCaller")
+                                      mixedCallableCaptureClosureArgument
+                                  )
+                                  (intLit 0)
+                              )
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+mixedCallableCaptureFunction :: BackendExpr
+mixedCallableCaptureFunction =
+  BackendLam
+    { backendExprType = BTArrow unaryIntTy unaryIntTy,
+      backendParamName = "f",
+      backendParamType = unaryIntTy,
+      backendBody =
+        BackendClosure
+          { backendExprType = unaryIntTy,
+            backendClosureEntryName = "__mlfp_closure$mixed_callable_capture",
+            backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "f")],
+            backendClosureParams = [("x", intTy)],
+            backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+          }
+    }
+
+mixedCallableCaptureClosureArgument :: BackendExpr
+mixedCallableCaptureClosureArgument =
+  BackendClosure
+    { backendExprType = unaryIntTy,
+      backendClosureEntryName = "__mlfp_closure$mixed_callable_argument",
+      backendClosureCaptures = [],
+      backendClosureParams = [("x", intTy)],
+      backendClosureBody = intLit 42
+    }
 
 returnedClosurePartialApplicationProgram :: BackendProgram
 returnedClosurePartialApplicationProgram =

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1230,6 +1230,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "preserves closure-valued first-order function fields through case binders" $ do
+    output <- requireRight (renderBackendProgramLLVM closureFunctionFieldCallProgram)
+
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.case.field"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM closureFunctionFieldCallProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
   it "captures first-order lambda parameters as raw function pointers" $ do
     output <- requireRight (renderBackendProgramLLVM capturedFirstOrderParameterClosureProgram)
 
@@ -4736,6 +4748,57 @@ rawFunctionPointerFieldCallProgram =
             }
         ],
       backendProgramMain = "main"
+    }
+
+closureFunctionFieldCallProgram :: BackendProgram
+closureFunctionFieldCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "captured"
+                          intTy
+                          (intLit 41)
+                          ( BackendLet
+                              intTy
+                              "box"
+                              fnBoxTy
+                              ( BackendConstruct
+                                  fnBoxTy
+                                  "FnBox"
+                                  [ BackendClosure
+                                      { backendExprType = unaryIntTy,
+                                        backendClosureEntryName = "__mlfp_closure$field_case_closure",
+                                        backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                        backendClosureParams = [("x", intTy)],
+                                        backendClosureBody = BackendVar intTy "captured"
+                                      }
+                                  ]
+                              )
+                              ( BackendCase
+                                  intTy
+                                  (BackendVar fnBoxTy "box")
+                                  ( BackendAlternative
+                                      (BackendConstructorPattern "FnBox" ["f"])
+                                      (BackendApp intTy (BackendVar unaryIntTy "f") (intLit 0))
+                                      :| []
+                                  )
+                              )
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
     }
 
 capturedFirstOrderParameterClosureProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1177,6 +1177,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "unsupported function argument"
     validateLLVMAssembly output
 
+  it "preserves stored function-pointer captures on the indirect call path" $ do
+    output <- requireRight (renderBackendProgramLLVM capturedFunctionPointerCallProgram)
+
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.env.field"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.closure.env.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "rejects unknown base types" $ do
     renderBackendProgramLLVM unknownBaseProgram
       `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
@@ -4346,6 +4354,49 @@ capturedFunctionFieldProgram =
                                   }
                               ]
                           ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+capturedFunctionPointerCallProgram :: BackendProgram
+capturedFunctionPointerCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "inc",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = unaryIntTy,
+                            backendParamName = "x",
+                            backendParamType = intTy,
+                            backendBody = BackendVar intTy "x"
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendClosureCall
+                          intTy
+                          ( BackendClosure
+                              { backendExprType = unaryIntTy,
+                                backendClosureEntryName = "__mlfp_closure$call_captured_function",
+                                backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "inc")],
+                                backendClosureParams = [("x", intTy)],
+                                backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                              }
+                          )
+                          [intLit 41],
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -2,12 +2,14 @@
 
 module BackendLLVMSpec (spec) where
 
+import Control.Exception (evaluate)
 import Control.Monad (forM_, when)
 import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import System.Exit (ExitCode (..))
+import System.Timeout (timeout)
 import Test.Hspec
 
 import LLVMToolSupport
@@ -1201,6 +1203,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.call."
     validateLLVMAssembly output
     validateLLVMObjectCode output
+
+  it "guards nullary global value-kind cycles" $ do
+    result <- timeout 1000000 (evaluate (renderBackendProgramLLVM nullaryGlobalValueKindCycleProgram))
+    case result of
+      Nothing ->
+        expectationFailure "value-kind classification did not terminate"
+      Just llvmResult -> do
+        output <- requireRight llvmResult
+        output `shouldSatisfy` isInfixOf "define ptr @\"left\"()"
+        output `shouldSatisfy` isInfixOf "call ptr @\"right\"()"
+        output `shouldSatisfy` isInfixOf "call ptr @\"left\"()"
+        validateLLVMAssembly output
 
   it "rejects unknown base types" $ do
     renderBackendProgramLLVM unknownBaseProgram
@@ -4562,6 +4576,43 @@ rawFunctionPointerAliasReturnProgram =
             }
         ],
       backendProgramMain = "main"
+    }
+
+nullaryGlobalValueKindCycleProgram :: BackendProgram
+nullaryGlobalValueKindCycleProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ nullaryFunctionAliasBinding "left" "right",
+                  nullaryFunctionAliasBinding "right" "left",
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr = BackendApp intTy (BackendVar unaryIntTy "left") (intLit 41),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+nullaryFunctionAliasBinding :: String -> String -> BackendBinding
+nullaryFunctionAliasBinding name target =
+  BackendBinding
+    { backendBindingName = name,
+      backendBindingType = unaryIntTy,
+      backendBindingExpr =
+        BackendLet
+          unaryIntTy
+          "dummy"
+          intTy
+          (intLit 0)
+          (BackendVar unaryIntTy target),
+      backendBindingExportedAsMain = False
     }
 
 unknownBaseProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1200,6 +1200,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     runLLVMNativeExecutable nativeOutput
       `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
 
+  it "infers captured nullary global case closures from their bodies" $ do
+    output <- requireRight (renderBackendProgramLLVM capturedNullaryGlobalCaseClosureProgram)
+
+    output `shouldSatisfy` isInfixOf "call ptr @\"getCaseClosure\"()"
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.closure.env.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM capturedNullaryGlobalCaseClosureProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
   it "routes over-applied raw function-pointer results through indirect calls" $ do
     output <- requireRight (renderBackendProgramLLVM rawReturnedFunctionPointerCallProgram)
 
@@ -4700,6 +4712,58 @@ capturedNullaryGlobalFunctionAliasProgram =
                               { backendExprType = unaryIntTy,
                                 backendClosureEntryName = "__mlfp_closure$call_captured_nullary_global_alias",
                                 backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "get")],
+                                backendClosureParams = [("x", intTy)],
+                                backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                              }
+                          )
+                          [intLit 41],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+capturedNullaryGlobalCaseClosureProgram :: BackendProgram
+capturedNullaryGlobalCaseClosureProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [optionData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "getCaseClosure",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr =
+                        BackendCase
+                          unaryIntTy
+                          (BackendConstruct (optionTy intTy) "Some" [intLit 0])
+                          ( BackendAlternative
+                              (BackendConstructorPattern "Some" ["ignored"])
+                              ( BackendClosure
+                                  { backendExprType = unaryIntTy,
+                                    backendClosureEntryName = "__mlfp_closure$nullary_global_case_result",
+                                    backendClosureCaptures = [],
+                                    backendClosureParams = [("x", intTy)],
+                                    backendClosureBody = BackendVar intTy "x"
+                                  }
+                              )
+                              :| []
+                          ),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendClosureCall
+                          intTy
+                          ( BackendClosure
+                              { backendExprType = unaryIntTy,
+                                backendClosureEntryName = "__mlfp_closure$call_captured_nullary_global_case",
+                                backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "getCaseClosure")],
                                 backendClosureParams = [("x", intTy)],
                                 backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
                               }

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1187,6 +1187,19 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "infers captured nullary global callable aliases from their bodies" $ do
+    output <- requireRight (renderBackendProgramLLVM capturedNullaryGlobalFunctionAliasProgram)
+
+    output `shouldSatisfy` isInfixOf "call ptr @\"get\"()"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.env.field"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.closure.env.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM capturedNullaryGlobalFunctionAliasProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
   it "routes over-applied raw function-pointer results through indirect calls" $ do
     output <- requireRight (renderBackendProgramLLVM rawReturnedFunctionPointerCallProgram)
 
@@ -4643,6 +4656,61 @@ capturedFunctionPointerCallProgram =
             }
         ],
       backendProgramMain = "main"
+    }
+
+capturedNullaryGlobalFunctionAliasProgram :: BackendProgram
+capturedNullaryGlobalFunctionAliasProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "helper",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = unaryIntTy,
+                            backendParamName = "x",
+                            backendParamType = intTy,
+                            backendBody = BackendVar intTy "x"
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "get",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr =
+                        BackendLet
+                          unaryIntTy
+                          "ignored"
+                          intTy
+                          (intLit 0)
+                          (BackendVar unaryIntTy "helper"),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendClosureCall
+                          intTy
+                          ( BackendClosure
+                              { backendExprType = unaryIntTy,
+                                backendClosureEntryName = "__mlfp_closure$call_captured_nullary_global_alias",
+                                backendClosureCaptures = [BackendClosureCapture "f" unaryIntTy (BackendVar unaryIntTy "get")],
+                                backendClosureParams = [("x", intTy)],
+                                backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                              }
+                          )
+                          [intLit 41],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
     }
 
 rawReturnedFunctionPointerCallProgram :: BackendProgram

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -957,6 +957,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "lowers source-level local returned closure calls through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceLocalReturnedClosureCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "Backend LLVM arity mismatch"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceLocalReturnedClosureCallProgram "41"
+
   it "lowers type-abstracted top-level closure calls through the explicit closure ABI" $ do
     output <-
       withTempProgram sourcePolymorphicTopLevelClosureCallProgram $ \path ->
@@ -3492,6 +3504,17 @@ sourceTopLevelClosureCallProgram =
     [ "module Main export (main) {",
       "  def maker : Int -> Int = let captured : Int = 41 in \\(x : Int) captured;",
       "  def main : Int = maker 0;",
+      "}"
+    ]
+
+sourceLocalReturnedClosureCallProgram :: String
+sourceLocalReturnedClosureCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    let make : Int -> (Int -> Int) =",
+      "      \\(base : Int) let captured : Int = base in \\(x : Int) captured in",
+      "    (make 41) 0;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1185,6 +1185,14 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "routes over-applied raw function-pointer results through indirect calls" $ do
+    output <- requireRight (renderBackendProgramLLVM rawReturnedFunctionPointerCallProgram)
+
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.call."
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.call."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "rejects unknown base types" $ do
     renderBackendProgramLLVM unknownBaseProgram
       `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
@@ -4397,6 +4405,74 @@ capturedFunctionPointerCallProgram =
                               }
                           )
                           [intLit 41],
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+rawReturnedFunctionPointerCallProgram :: BackendProgram
+rawReturnedFunctionPointerCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "inc",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = unaryIntTy,
+                            backendParamName = "x",
+                            backendParamType = intTy,
+                            backendBody = BackendVar intTy "x"
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "idRaw",
+                      backendBindingType = BTArrow unaryIntTy (BTArrow intTy unaryIntTy),
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = BTArrow unaryIntTy (BTArrow intTy unaryIntTy),
+                            backendParamName = "$evidence_f",
+                            backendParamType = unaryIntTy,
+                            backendBody =
+                              BackendLam
+                                { backendExprType = BTArrow intTy unaryIntTy,
+                                  backendParamName = "ignored",
+                                  backendParamType = intTy,
+                                  backendBody =
+                                    BackendLet
+                                      unaryIntTy
+                                      "dummy"
+                                      intTy
+                                      (intLit 0)
+                                      (BackendVar unaryIntTy "$evidence_f")
+                                }
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          ( BackendApp
+                              unaryIntTy
+                              ( BackendApp
+                                  (BTArrow intTy unaryIntTy)
+                                  (BackendVar (BTArrow unaryIntTy (BTArrow intTy unaryIntTy)) "idRaw")
+                                  (BackendVar unaryIntTy "inc")
+                              )
+                              (intLit 0)
+                          )
+                          (intLit 41),
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1222,11 +1222,12 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
-  it "loads first-order function fields as raw function pointers" $ do
+  it "normalizes first-order function fields through closure records" $ do
     output <- requireRight (renderBackendProgramLLVM rawFunctionPointerFieldCallProgram)
 
-    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
-    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.case.field"
+    output `shouldSatisfy` isInfixOf "__mlfp_returned_partial$function$0"
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.case.field"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
@@ -1276,6 +1277,16 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
     assertNativeProgram sourceCaseReturnedGlobalFunctionProgram "41"
+
+  it "preserves closure-valued fields through function-parameter scrutinees" $ do
+    output <- requireRight =<< emitBackendSource sourceCaseParameterClosureFieldProgram
+
+    output `shouldSatisfy` isInfixOf "load ptr, ptr %\"__llvm.case.field.ptr"
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.call"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceCaseParameterClosureFieldProgram "41"
 
   it "normalizes mixed callable case results to closure records" $ do
     output <- requireRight (renderBackendProgramLLVM mixedCallableCaseResultProgram)
@@ -4065,6 +4076,26 @@ sourceCaseReturnedGlobalFunctionProgram =
       "    ChoiceNone -> helper",
       "  };",
       "  def main : Int = (pick ChoiceNone) 41;",
+      "}"
+    ]
+
+sourceCaseParameterClosureFieldProgram :: String
+sourceCaseParameterClosureFieldProgram =
+  unlines
+    [ "module Main export (Choice(..), main) {",
+      "  data Choice =",
+      "      ChoiceSome : (Int -> Int) -> Choice",
+      "    | ChoiceNone : Choice;",
+      "",
+      "  def helper : Int -> Int = \\(x : Int) x;",
+      "  def pick : Choice -> (Int -> Int) = \\(choice : Choice) case choice of {",
+      "    ChoiceSome f -> f;",
+      "    ChoiceNone -> helper",
+      "  };",
+      "  def main : Int =",
+      "    let captured : Int = 41 in",
+      "    let local : Int -> Int = \\(x : Int) captured in",
+      "    (pick (ChoiceSome local)) 0;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -969,6 +969,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourceLocalReturnedClosureCallProgram "41"
 
+  it "lowers let-bound returned closure records through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceLetBoundReturnedClosureRecordCallProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.malloc"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceLetBoundReturnedClosureRecordCallProgram "41"
+
   it "lowers type-abstracted top-level closure calls through the explicit closure ABI" $ do
     output <-
       withTempProgram sourcePolymorphicTopLevelClosureCallProgram $ \path ->
@@ -3515,6 +3527,17 @@ sourceLocalReturnedClosureCallProgram =
       "    let make : Int -> (Int -> Int) =",
       "      \\(base : Int) let captured : Int = base in \\(x : Int) captured in",
       "    (make 41) 0;",
+      "}"
+    ]
+
+sourceLetBoundReturnedClosureRecordCallProgram :: String
+sourceLetBoundReturnedClosureRecordCallProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    let f : Int -> Int =",
+      "      ((\\(base : Int) let captured : Int = base in \\(x : Int) captured) 41) in",
+      "    f 0;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -4595,6 +4595,10 @@ llvmObjectCodeParityCases =
       "boundary: runs aliased bulk-imported hidden-owner constructors in one case",
       "boundary: runs exposed constructor with qualified alias type identity",
       "unified fixture: test/programs/unified/first-class-polymorphism.mlfp",
+      "unified fixture: test/programs/unified/higher-order-function-field.mlfp",
+      "unified fixture: test/programs/unified/higher-order-local-function-flow.mlfp",
+      "unified fixture: test/programs/unified/higher-order-partial-application.mlfp",
+      "unified fixture: test/programs/unified/higher-order-returned-function.mlfp",
       "standalone: does not decode typed non-data constructor fields through fallback ADT decoding",
       "standalone: applies captured function-valued constructor fields"
     ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1193,6 +1193,15 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "preserves let-bound raw function-pointer aliases as values" $ do
+    output <- requireRight (renderBackendProgramLLVM rawFunctionPointerAliasReturnProgram)
+
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.call."
+    output `shouldNotSatisfy` isInfixOf "escaping function"
+    output `shouldNotSatisfy` isInfixOf "closure.code.ptr\" %\"__llvm.call."
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "rejects unknown base types" $ do
     renderBackendProgramLLVM unknownBaseProgram
       `shouldSatisfyLeft` isInfixOf "Unsupported backend LLVM type"
@@ -4468,6 +4477,80 @@ rawReturnedFunctionPointerCallProgram =
                               ( BackendApp
                                   (BTArrow intTy unaryIntTy)
                                   (BackendVar (BTArrow unaryIntTy (BTArrow intTy unaryIntTy)) "idRaw")
+                                  (BackendVar unaryIntTy "inc")
+                              )
+                              (intLit 0)
+                          )
+                          (intLit 41),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+rawFunctionPointerAliasReturnProgram :: BackendProgram
+rawFunctionPointerAliasReturnProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "inc",
+                      backendBindingType = unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = unaryIntTy,
+                            backendParamName = "x",
+                            backendParamType = intTy,
+                            backendBody = BackendVar intTy "x"
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "idAlias",
+                      backendBindingType = BTArrow unaryIntTy (BTArrow intTy unaryIntTy),
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = BTArrow unaryIntTy (BTArrow intTy unaryIntTy),
+                            backendParamName = "$evidence_f",
+                            backendParamType = unaryIntTy,
+                            backendBody =
+                              BackendLam
+                                { backendExprType = BTArrow intTy unaryIntTy,
+                                  backendParamName = "ignored",
+                                  backendParamType = intTy,
+                                  backendBody =
+                                    BackendLet
+                                      unaryIntTy
+                                      "dummy"
+                                      intTy
+                                      (intLit 0)
+                                      ( BackendLet
+                                          unaryIntTy
+                                          "g"
+                                          unaryIntTy
+                                          (BackendVar unaryIntTy "$evidence_f")
+                                          (BackendVar unaryIntTy "g")
+                                      )
+                                }
+                          },
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          ( BackendApp
+                              unaryIntTy
+                              ( BackendApp
+                                  (BTArrow intTy unaryIntTy)
+                                  (BackendVar (BTArrow unaryIntTy (BTArrow intTy unaryIntTy)) "idAlias")
                                   (BackendVar unaryIntTy "inc")
                               )
                               (intLit 0)

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1268,6 +1268,15 @@ spec = describe "MLF.Backend.LLVM" $ do
     runLLVMNativeExecutable nativeOutput
       `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
 
+  it "returns global functions from source-level case branches" $ do
+    output <- requireRight =<< emitBackendSource sourceCaseReturnedGlobalFunctionProgram
+
+    output `shouldSatisfy` isInfixOf "@\"Main__helper\""
+    output `shouldNotSatisfy` isInfixOf "escaping function \"Main__helper\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceCaseReturnedGlobalFunctionProgram "41"
+
   it "normalizes mixed callable case results to closure records" $ do
     output <- requireRight (renderBackendProgramLLVM mixedCallableCaseResultProgram)
 
@@ -4039,6 +4048,23 @@ sourceClosureValuedConstructorFieldProgram =
       "    let captured : Int = 41 in",
       "    let f : Int -> Int = \\(x : Int) captured in",
       "    case FnBox f of { FnBox g -> g 0 };",
+      "}"
+    ]
+
+sourceCaseReturnedGlobalFunctionProgram :: String
+sourceCaseReturnedGlobalFunctionProgram =
+  unlines
+    [ "module Main export (Choice(..), main) {",
+      "  data Choice =",
+      "      ChoiceSome : (Int -> Int) -> Choice",
+      "    | ChoiceNone : Choice;",
+      "",
+      "  def helper : Int -> Int = \\(x : Int) x;",
+      "  def pick : Choice -> (Int -> Int) = \\(choice : Choice) case choice of {",
+      "    ChoiceSome f -> f;",
+      "    ChoiceNone -> helper",
+      "  };",
+      "  def main : Int = (pick ChoiceNone) 41;",
       "}"
     ]
 

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1204,6 +1204,24 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMAssembly output
     validateLLVMObjectCode output
 
+  it "classifies first-order function parameters as raw function pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM firstOrderFunctionParameterCallProgram)
+
+    output `shouldSatisfy` isInfixOf "define i64 @\"applyFirst\"(ptr %\"f\", i64 %\"x\")"
+    output `shouldSatisfy` isInfixOf "call i64 %\"f\"(i64 %\"x\")"
+    output `shouldNotSatisfy` isInfixOf "getelementptr i8, ptr %\"f\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+  it "classifies first-order closure parameters as raw function pointers" $ do
+    output <- requireRight (renderBackendProgramLLVM closureFirstOrderFunctionParameterCallProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$call_first_order_param\""
+    output `shouldSatisfy` isInfixOf "call i64 %\"f\"(i64 %\"x\")"
+    output `shouldNotSatisfy` isInfixOf "getelementptr i8, ptr %\"f\""
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
   it "guards nullary global value-kind cycles" $ do
     result <- timeout 1000000 (evaluate (renderBackendProgramLLVM nullaryGlobalValueKindCycleProgram))
     case result of
@@ -4570,6 +4588,70 @@ rawFunctionPointerAliasReturnProgram =
                               (intLit 0)
                           )
                           (intLit 41),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "main"
+    }
+
+firstOrderFunctionParameterCallProgram :: BackendProgram
+firstOrderFunctionParameterCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "applyFirst",
+                      backendBindingType = BTArrow unaryIntTy unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          { backendExprType = BTArrow unaryIntTy unaryIntTy,
+                            backendParamName = "f",
+                            backendParamType = unaryIntTy,
+                            backendBody =
+                              BackendLam
+                                { backendExprType = unaryIntTy,
+                                  backendParamName = "x",
+                                  backendParamType = intTy,
+                                  backendBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                                }
+                          },
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "applyFirst"
+    }
+
+closureFirstOrderFunctionParameterCallProgram :: BackendProgram
+closureFirstOrderFunctionParameterCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ helperBinding,
+                  BackendBinding
+                    { backendBindingName = "main",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendClosureCall
+                          intTy
+                          ( BackendClosure
+                              { backendExprType = BTArrow unaryIntTy unaryIntTy,
+                                backendClosureEntryName = "__mlfp_closure$call_first_order_param",
+                                backendClosureCaptures = [],
+                                backendClosureParams = [("f", unaryIntTy), ("x", intTy)],
+                                backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
+                              }
+                          )
+                          [BackendVar unaryIntTy "helper", intLit 41],
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1256,6 +1256,19 @@ spec = describe "MLF.Backend.LLVM" $ do
     runLLVMNativeExecutable nativeOutput
       `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
 
+  it "preserves case-reboxed closure fields from returned constructors" $ do
+    output <- requireRight (renderBackendProgramLLVM returnedReboxedClosureFunctionFieldCallProgram)
+
+    output `shouldSatisfy` isInfixOf "call ptr @\"makeRestored\""
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.case.field"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM returnedReboxedClosureFunctionFieldCallProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
   it "classifies case-returned closures for over-applied global calls" $ do
     output <- requireRight (renderBackendProgramLLVM caseReturnedClosureOverApplicationProgram)
 
@@ -1312,6 +1325,19 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
 
     nativeOutput <- requireRight (renderBackendProgramNativeLLVM caseHeadedDirectClosureBackendAppProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
+  it "lowers BackendApp let heads that select direct closures" $ do
+    output <- requireRight (renderBackendProgramLLVM letHeadedDirectClosureBackendAppProgram)
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$backend_app_let\""
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "Unsupported backend LLVM call"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM letHeadedDirectClosureBackendAppProgram)
     runLLVMNativeExecutable nativeOutput
       `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
 
@@ -4961,6 +4987,74 @@ returnedClosureFunctionFieldCallProgram =
       backendProgramMain = "entry"
     }
 
+returnedReboxedClosureFunctionFieldCallProgram :: BackendProgram
+returnedReboxedClosureFunctionFieldCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "makeRestored",
+                      backendBindingType = BTArrow fnBoxTy fnBoxTy,
+                      backendBindingExpr =
+                        BackendLam
+                          (BTArrow fnBoxTy fnBoxTy)
+                          "box"
+                          fnBoxTy
+                          ( BackendCase
+                              fnBoxTy
+                              (BackendVar fnBoxTy "box")
+                              ( BackendAlternative
+                                  (BackendConstructorPattern "FnBox" ["f"])
+                                  (BackendConstruct fnBoxTy "FnBox" [BackendVar unaryIntTy "f"])
+                                  :| []
+                              )
+                          ),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendLet
+                          intTy
+                          "captured"
+                          intTy
+                          (intLit 41)
+                          ( BackendCase
+                              intTy
+                              ( BackendApp
+                                  fnBoxTy
+                                  (BackendVar (BTArrow fnBoxTy fnBoxTy) "makeRestored")
+                                  ( BackendConstruct
+                                      fnBoxTy
+                                      "FnBox"
+                                      [ BackendClosure
+                                          { backendExprType = unaryIntTy,
+                                            backendClosureEntryName = "__mlfp_closure$returned_reboxed_field_case_closure",
+                                            backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                            backendClosureParams = [("x", intTy)],
+                                            backendClosureBody = BackendVar intTy "captured"
+                                          }
+                                      ]
+                                  )
+                              )
+                              ( BackendAlternative
+                                  (BackendConstructorPattern "FnBox" ["f"])
+                                  (BackendApp intTy (BackendVar unaryIntTy "f") (intLit 0))
+                                  :| []
+                              )
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
 caseReturnedClosureOverApplicationProgram :: BackendProgram
 caseReturnedClosureOverApplicationProgram =
   BackendProgram
@@ -5126,6 +5220,43 @@ caseHeadedDirectClosureBackendAppProgram =
                                              }
                                          )
                                      ]
+                              )
+                          )
+                          (intLit 0),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+letHeadedDirectClosureBackendAppProgram :: BackendProgram
+letHeadedDirectClosureBackendAppProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          ( BackendLet
+                              unaryIntTy
+                              "captured"
+                              intTy
+                              (intLit 41)
+                              ( BackendClosure
+                                  { backendExprType = unaryIntTy,
+                                    backendClosureEntryName = "__mlfp_closure$backend_app_let",
+                                    backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                    backendClosureParams = [("x", intTy)],
+                                    backendClosureBody = BackendVar intTy "captured"
+                                  }
                               )
                           )
                           (intLit 0),

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -4739,18 +4739,28 @@ capturedNullaryGlobalCaseClosureProgram =
                       backendBindingExpr =
                         BackendCase
                           unaryIntTy
-                          (BackendConstruct (optionTy intTy) "Some" [intLit 0])
+                          (BackendConstruct (optionTy intTy) "Some" [intLit 41])
                           ( BackendAlternative
-                              (BackendConstructorPattern "Some" ["ignored"])
+                              (BackendConstructorPattern "Some" ["n"])
                               ( BackendClosure
                                   { backendExprType = unaryIntTy,
-                                    backendClosureEntryName = "__mlfp_closure$nullary_global_case_result",
-                                    backendClosureCaptures = [],
+                                    backendClosureEntryName = "__mlfp_closure$nullary_global_case_some",
+                                    backendClosureCaptures = [BackendClosureCapture "n" intTy (BackendVar intTy "n")],
                                     backendClosureParams = [("x", intTy)],
-                                    backendClosureBody = BackendVar intTy "x"
+                                    backendClosureBody = BackendVar intTy "n"
                                   }
                               )
-                              :| []
+                              :| [ BackendAlternative
+                                     (BackendConstructorPattern "None" [])
+                                     ( BackendClosure
+                                         { backendExprType = unaryIntTy,
+                                           backendClosureEntryName = "__mlfp_closure$nullary_global_case_none",
+                                           backendClosureCaptures = [],
+                                           backendClosureParams = [("x", intTy)],
+                                           backendClosureBody = intLit 0
+                                         }
+                                     )
+                                 ]
                           ),
                       backendBindingExportedAsMain = False
                     },
@@ -4768,7 +4778,7 @@ capturedNullaryGlobalCaseClosureProgram =
                                 backendClosureBody = BackendApp intTy (BackendVar unaryIntTy "f") (BackendVar intTy "x")
                               }
                           )
-                          [intLit 41],
+                          [intLit 999],
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -1242,6 +1242,32 @@ spec = describe "MLF.Backend.LLVM" $ do
     runLLVMNativeExecutable nativeOutput
       `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
 
+  it "preserves closure-valued fields from returned constructors through case binders" $ do
+    output <- requireRight (renderBackendProgramLLVM returnedClosureFunctionFieldCallProgram)
+
+    output `shouldSatisfy` isInfixOf "call ptr @\"makeBox\""
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.case.field"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.case.field"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM returnedClosureFunctionFieldCallProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
+  it "classifies case-returned closures for over-applied global calls" $ do
+    output <- requireRight (renderBackendProgramLLVM caseReturnedClosureOverApplicationProgram)
+
+    output `shouldSatisfy` isInfixOf "call ptr @\"makeFromCase\""
+    output `shouldSatisfy` isInfixOf "getelementptr i8, ptr %\"__llvm.call"
+    output `shouldNotSatisfy` isInfixOf "call i64 %\"__llvm.call"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+
+    nativeOutput <- requireRight (renderBackendProgramNativeLLVM caseReturnedClosureOverApplicationProgram)
+    runLLVMNativeExecutable nativeOutput
+      `shouldReturn` NativeRunResult ExitSuccess "41\n" ""
+
   it "captures first-order lambda parameters as raw function pointers" $ do
     output <- requireRight (renderBackendProgramLLVM capturedFirstOrderParameterClosureProgram)
 
@@ -4793,6 +4819,116 @@ closureFunctionFieldCallProgram =
                                   )
                               )
                           ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+returnedClosureFunctionFieldCallProgram :: BackendProgram
+returnedClosureFunctionFieldCallProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [fnBoxData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "makeBox",
+                      backendBindingType = BTArrow intTy fnBoxTy,
+                      backendBindingExpr =
+                        BackendLam
+                          (BTArrow intTy fnBoxTy)
+                          "base"
+                          intTy
+                          ( BackendConstruct
+                              fnBoxTy
+                              "FnBox"
+                              [ BackendClosure
+                                  { backendExprType = unaryIntTy,
+                                    backendClosureEntryName = "__mlfp_closure$returned_field_case_closure",
+                                    backendClosureCaptures = [BackendClosureCapture "base" intTy (BackendVar intTy "base")],
+                                    backendClosureParams = [("x", intTy)],
+                                    backendClosureBody = BackendVar intTy "base"
+                                  }
+                              ]
+                          ),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendCase
+                          intTy
+                          (BackendApp fnBoxTy (BackendVar (BTArrow intTy fnBoxTy) "makeBox") (intLit 41))
+                          ( BackendAlternative
+                              (BackendConstructorPattern "FnBox" ["f"])
+                              (BackendApp intTy (BackendVar unaryIntTy "f") (intLit 0))
+                              :| []
+                          ),
+                      backendBindingExportedAsMain = True
+                    }
+                ]
+            }
+        ],
+      backendProgramMain = "entry"
+    }
+
+caseReturnedClosureOverApplicationProgram :: BackendProgram
+caseReturnedClosureOverApplicationProgram =
+  BackendProgram
+    { backendProgramModules =
+        [ BackendModule
+            { backendModuleName = "Main",
+              backendModuleData = [optionData],
+              backendModuleBindings =
+                [ BackendBinding
+                    { backendBindingName = "makeFromCase",
+                      backendBindingType = BTArrow intTy unaryIntTy,
+                      backendBindingExpr =
+                        BackendLam
+                          (BTArrow intTy unaryIntTy)
+                          "base"
+                          intTy
+                          ( BackendCase
+                              unaryIntTy
+                              (BackendConstruct (optionTy intTy) "Some" [BackendVar intTy "base"])
+                              ( BackendAlternative
+                                  (BackendConstructorPattern "Some" ["captured"])
+                                  ( BackendClosure
+                                      { backendExprType = unaryIntTy,
+                                        backendClosureEntryName = "__mlfp_closure$case_returned_some",
+                                        backendClosureCaptures = [BackendClosureCapture "captured" intTy (BackendVar intTy "captured")],
+                                        backendClosureParams = [("x", intTy)],
+                                        backendClosureBody = BackendVar intTy "captured"
+                                      }
+                                  )
+                                  :| [ BackendAlternative
+                                         (BackendConstructorPattern "None" [])
+                                         ( BackendClosure
+                                             { backendExprType = unaryIntTy,
+                                               backendClosureEntryName = "__mlfp_closure$case_returned_none",
+                                               backendClosureCaptures = [],
+                                               backendClosureParams = [("x", intTy)],
+                                               backendClosureBody = intLit 0
+                                             }
+                                         )
+                                     ]
+                              )
+                          ),
+                      backendBindingExportedAsMain = False
+                    },
+                  BackendBinding
+                    { backendBindingName = "entry",
+                      backendBindingType = intTy,
+                      backendBindingExpr =
+                        BackendApp
+                          intTy
+                          (BackendApp unaryIntTy (BackendVar (BTArrow intTy unaryIntTy) "makeFromCase") (intLit 41))
+                          (intLit 0),
                       backendBindingExportedAsMain = True
                     }
                 ]

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -981,6 +981,18 @@ spec = describe "MLF.Backend.LLVM" $ do
     validateLLVMObjectCode output
     assertNativeProgram sourceLetBoundReturnedClosureRecordCallProgram "41"
 
+  it "lowers direct returned closure applications through the explicit closure ABI" $ do
+    output <-
+      withTempProgram sourceDirectReturnedClosureApplicationProgram $ \path ->
+        requireRight =<< emitBackendFile path
+
+    output `shouldSatisfy` isInfixOf "define private i64 @\"__mlfp_closure$Main__main$"
+    output `shouldSatisfy` isInfixOf "call i64 %\"__llvm.closure.code."
+    output `shouldNotSatisfy` isInfixOf "Backend LLVM arity mismatch"
+    validateLLVMAssembly output
+    validateLLVMObjectCode output
+    assertNativeProgram sourceDirectReturnedClosureApplicationProgram "41"
+
   it "lowers type-abstracted top-level closure calls through the explicit closure ABI" $ do
     output <-
       withTempProgram sourcePolymorphicTopLevelClosureCallProgram $ \path ->
@@ -3538,6 +3550,15 @@ sourceLetBoundReturnedClosureRecordCallProgram =
       "    let f : Int -> Int =",
       "      ((\\(base : Int) let captured : Int = base in \\(x : Int) captured) 41) in",
       "    f 0;",
+      "}"
+    ]
+
+sourceDirectReturnedClosureApplicationProgram :: String
+sourceDirectReturnedClosureApplicationProgram =
+  unlines
+    [ "module Main export (main) {",
+      "  def main : Int =",
+      "    (\\(base : Int) let captured : Int = base in \\(x : Int) captured) 41 0;",
       "}"
     ]
 

--- a/test/Parity/ProgramMatrix.hs
+++ b/test/Parity/ProgramMatrix.hs
@@ -37,6 +37,10 @@ unifiedFixtureExpectations =
     , ("test/programs/unified/authoritative-nullary-overloaded-method.mlfp", "Zero")
     , ("test/programs/unified/authoritative-recursive-let.mlfp", "true")
     , ("test/programs/unified/first-class-polymorphism.mlfp", "true")
+    , ("test/programs/unified/higher-order-function-field.mlfp", "41")
+    , ("test/programs/unified/higher-order-local-function-flow.mlfp", "41")
+    , ("test/programs/unified/higher-order-partial-application.mlfp", "1")
+    , ("test/programs/unified/higher-order-returned-function.mlfp", "41")
     ]
 
 data ProgramMatrixSource

--- a/test/programs/unified/higher-order-function-field.mlfp
+++ b/test/programs/unified/higher-order-function-field.mlfp
@@ -1,0 +1,9 @@
+module Main export (FnBox(..), main) {
+  data FnBox =
+      FnBox : (Int -> Int) -> FnBox;
+
+  def main : Int =
+    let captured : Int = 41 in
+    let f : Int -> Int = \(x : Int) captured in
+    case FnBox f of { FnBox g -> g 0 };
+}

--- a/test/programs/unified/higher-order-local-function-flow.mlfp
+++ b/test/programs/unified/higher-order-local-function-flow.mlfp
@@ -1,0 +1,8 @@
+module Main export (main) {
+  def use : (Int -> Int) -> Int = \(f : Int -> Int) f 1;
+
+  def main : Int =
+    let captured : Int = 41 in
+    let f : Int -> Int = \(x : Int) captured in
+    use f;
+}

--- a/test/programs/unified/higher-order-partial-application.mlfp
+++ b/test/programs/unified/higher-order-partial-application.mlfp
@@ -1,0 +1,6 @@
+module Main export (main) {
+  def keepLeft : Int -> Int -> Int = \x \y x;
+  def apply : (Int -> Int) -> Int = \f f 2;
+
+  def main : Int = apply (keepLeft 1);
+}

--- a/test/programs/unified/higher-order-returned-function.mlfp
+++ b/test/programs/unified/higher-order-returned-function.mlfp
@@ -1,7 +1,8 @@
 module Main export (main) {
-  def make : Int -> Int =
-    let captured : Int = 41 in
-    \(x : Int) captured;
+  def make : Int -> (Int -> Int) =
+    \(base : Int)
+      let captured : Int = base in
+      \(x : Int) captured;
 
-  def main : Int = make 0;
+  def main : Int = (make 41) 0;
 }

--- a/test/programs/unified/higher-order-returned-function.mlfp
+++ b/test/programs/unified/higher-order-returned-function.mlfp
@@ -1,0 +1,7 @@
+module Main export (main) {
+  def make : Int -> Int =
+    let captured : Int = 41 in
+    \(x : Int) captured;
+
+  def main : Int = make 0;
+}


### PR DESCRIPTION
Closes #88.

## Implementation Plan

---
issue_number: 88
pr_number: 121
branch: codex/issue-88
---

# Implementation Plan

1. Start implementation by reading the watcher-written `issue-plan.md`, confirming `git status --short --branch`, and verifying PR #121 still targets `master` from `codex/issue-88`. The current branch is clean and has no file diff against `origin/HEAD`, so avoid staging watcher/runtime files and do not create another PR.

2. Audit the current LLVM higher-order support against issue #88 before changing code. The relevant surfaces are `src/MLF/Backend/Convert.hs`, `src/MLF/Backend/IR.hs`, `src/MLF/Backend/LLVM/Lower.hs`, `test/BackendLLVMSpec.hs`, and `test/Parity/ProgramMatrix.hs`. Existing base code already has `BackendClosure` / `BackendClosureCall`, a documented closure ABI, inline backend tests for partial applications, returned closures, closure-valued parameters, and function-valued constructor fields, plus changelog notes.

3. Close the remaining acceptance-evidence gap by adding canonical `.mlfp` fixtures under `test/programs/unified/` for the issue-owned higher-order source shapes: a local higher-order function flow, a returned function that is applied by `main`, a function-valued ADT field projected and called, and a partial application. Keep fixtures small and expected native results simple, preferably `1` or `41`.

4. Wire the new fixtures into `test/Parity/ProgramMatrix.hs` via `unifiedFixtureExpectations` so they run through the existing `emit-backend`, object-code, and native parity paths where applicable. If any fixture has a non-native-renderable function result, prefer rewriting it so `main` applies the function and returns `Int`; do not add new unsupported classifications unless unavoidable.

5. If the new fixture tests expose an actual lowering/conversion failure, fix the root cause in the narrowest backend layer: closure construction and demand tracking in `Convert.hs`, IR validation/classification in `IR.hs`, or pointer/call lowering in `LLVM/Lower.hs`. Preserve the existing explicit closure ABI and keep polymorphic or higher-rank runtime escapes fail-closed unless the checked source can be statically specialized.

6. Run focused validation first: `cabal test mlf2-test --test-show-details=direct --test-options='--match MLF.Backend.LLVM'` or a narrower fixture/test-name match if available. Then run the required behavior-change gate: `cabal build all && cabal test`.

7. Before publishing, inspect `git status --short` and relevant diffs. Stage only issue-related fixture/test/source/doc changes, commit as `codex-watcher <codex-watcher@users.noreply.github.com>` with an imperative message such as `Add higher-order LLVM backend fixtures`, run `gh auth status` and `gh auth setup-git`, and push `codex/issue-88` to update PR #121. Do not resolve PR review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.