### PR TITLE
Implement #102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Added
+- Broadened native LLVM run-result coverage accounting so every shared
+  `ProgramSpec`-to-LLVM runtime-success row is explicitly classified as
+  native-run checked or native-unsupported with a diagnostic, with advanced
+  typeclass, first-class polymorphism, and higher-order rows required to stay on
+  the native-run path when renderable. Added backend native pipeline
+  documentation for tool discovery, generated artifacts, runtime support, and
+  result comparison.
 - Added LLVM backend support for checked-source partial applications by
   packaging supplied arguments into explicit closure values. Top-level and local
   function partials now participate in the shared ProgramSpec-to-LLVM parity

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ polymorphic, `String`, unknown, and IO-like results are rejected before native
 run assertions use them. Native mode declares libc `malloc` and vararg `printf`
 and defines the backend-owned `__mlfp_and` primitive when no program binding owns
 that runtime name; broader IO runtime linking remains outside this pure
-contract.
+contract. The full test pipeline is documented in
+`docs/backend-native-pipeline.md`.
 
 Backend LLVM validation tests use LLVM command-line tools with opaque pointer
 support when available. The test suite looks for `llvm-as` and `llc` on `PATH`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,9 @@ exit status `0`. Native emission declares libc `malloc`/`printf` and emits
 backend-owned runtime definitions such as `__mlfp_and` when those names are not
 program bindings. Unsupported result types fail before native-run assertions,
 so the native process boundary does not invent source or IO semantics.
+`docs/backend-native-pipeline.md` records the linked-executable test pipeline,
+toolchain discovery, generated artifacts, runtime support, and row coverage
+classification.
 
 The explicit closure ABI is private to the backend IR-to-LLVM path. A closure
 value is a heap pointer to a two-word record containing a code pointer and an

--- a/docs/backend-native-pipeline.md
+++ b/docs/backend-native-pipeline.md
@@ -1,0 +1,98 @@
+# Backend Native Pipeline
+
+This document describes the native executable path used by the LLVM backend
+tests. It is a test and inspection contract for checked pure `.mlfp` programs;
+it is not a separate source-language runtime or an IO implementation.
+
+## Emission Modes
+
+`emit-backend` prints the raw backend LLVM module. The checked `.mlfp` `main`
+binding remains a module-qualified LLVM function such as `Main__main`, and the
+output is used for backend inspection, `llvm-as` validation, and selected
+`llc -filetype=obj` smoke checks.
+
+`emit-native` starts from the same checked backend program, then adds a C ABI
+`i32 @main()` process entrypoint. The entrypoint calls the checked zero-argument
+`.mlfp` `main`, renders the pure result to stdout, prints exactly one trailing
+newline, writes no stderr on success, and returns exit status `0`.
+
+## Generated Artifacts
+
+The Hspec helper writes temporary files only under the system temporary
+directory:
+
+- `program.ll` is the emitted LLVM module.
+- `program.o` is produced by `llc -filetype=obj`.
+- `program` is the linked native executable.
+
+The temporary build directory is removed after the test action finishes.
+
+## Toolchain
+
+Assembly validation looks for `llvm-as`. Object-code and native execution look
+for `llc`. Tool discovery checks tool-specific environment variables first,
+then `PATH`, then standard local LLVM installation paths used by Homebrew LLVM.
+LLVM 14-era tools are retried with `-opaque-pointers`; LLVM 15 and newer accept
+the emitted opaque-pointer IR directly.
+
+Native linking looks for a C compiler/linker through `CC`, then `cc`, `clang`,
+or `gcc` on `PATH`. `CC` may include launcher arguments, for example
+`ccache clang` or `xcrun clang`.
+
+When a required LLVM or native linker tool is absent, the relevant Hspec
+assertion is marked pending. The row remains part of the mechanical coverage
+matrix; it is not silently removed from the native pipeline.
+
+## Runtime Support
+
+Native emission owns the small process/runtime surface it needs:
+
+- `main`: the C ABI wrapper added only by `emit-native`.
+- `printf`: declared for deterministic result printing.
+- `malloc`: declared when heap-allocated constructors or closure records need
+  allocation.
+- `__mlfp_and`: emitted as a backend-owned boolean primitive when no program
+  binding owns that name.
+- `__mlfp_native_render$...`: private renderer functions generated for each
+  native-renderable result type reachable from the program `main` result.
+- `__mlfp_native_*` string globals: format strings, booleans, punctuation, and
+  constructor names used by generated renderers.
+
+Source bindings that collide with native-owned runtime symbols are rejected
+before native LLVM is emitted.
+
+## Result Comparison
+
+Native run-result checks compare the executable process output with the same
+runtime expectations used by the shared `ProgramSpec` interpreter matrix.
+Supported result shapes are:
+
+- `Int`
+- `Bool`
+- first-order ADT values whose fields are recursively native-renderable
+
+The native renderer uses the same value text expected by `run-program`, adds one
+newline, and requires empty stderr plus `ExitSuccess`.
+
+Unsupported result shapes fail before native execution instead of becoming
+assembly-only rows. Current unsupported shapes include function-valued,
+polymorphic, variable-headed, `String`, IO-like, and structurally recursive main
+results that have no named data runtime. These rows stay named in
+`BackendLLVMSpec` with the expected diagnostic fragment.
+
+## Coverage Contract
+
+`BackendLLVMSpec` drives the shared `programSpecToLLVMParityCases` matrix
+through one explicit coverage classification per interpreter-success row. Each
+row is exactly one of:
+
+- native-run checked, with raw LLVM assembly validation and native
+  compile/link/run/result comparison;
+- native-unsupported, with raw LLVM assembly validation and a required
+  `emit-native` diagnostic; or
+- object-code smoke in addition to either native classification.
+
+Advanced rows added by the typeclass/evidence, first-class polymorphism, and
+higher-order backend slices are required native-run rows when their result is
+native-renderable. This prevents supported LLVM parity rows from silently
+remaining unlinked or unexecuted.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,18 @@
+## 2026-05-01 - Native LLVM parity coverage closeout
+
+- `BackendLLVMSpec` now classifies every shared `ProgramSpec`-to-LLVM
+  runtime-success row with one explicit coverage record: native-run checked or
+  native-unsupported with a required diagnostic, plus object-code smoke where
+  selected.
+- The coverage guard requires advanced renderable rows from the typeclass,
+  first-class polymorphism, and higher-order backend slices to remain on the
+  native-run path, preventing supported parity rows from quietly staying
+  assembly-only.
+- Added `docs/backend-native-pipeline.md` to document the raw/native emission
+  split, temporary `.ll`/object/executable artifacts, LLVM and linker discovery,
+  backend-owned runtime support, result comparison, unsupported result shapes,
+  and Hspec pending behavior when tools are absent.
+
 ## 2026-04-30 - Partial applications lower as closure values
 
 - Checked-program conversion now packages underapplied monomorphic function

--- a/test/BackendLLVMSpec.hs
+++ b/test/BackendLLVMSpec.hs
@@ -651,16 +651,19 @@ spec = describe "MLF.Backend.LLVM" $ do
     it "classifies every interpreter-success case exactly once" $ do
       let caseNames = map runtimeCaseName programSpecToLLVMParityCases
           uniqueCaseNames = Set.fromList caseNames
+          coverageCaseNames = Map.keysSet llvmParityCoverage
           objectCodeNames = Set.fromList llvmObjectCodeParityCases
-          nativeUnsupportedNames = Map.keysSet llvmNativeUnsupportedParityCases
-          nativeRepresentativeNames = Set.fromList llvmNativeRepresentativeParityCases
+          nativeRunNames = Map.keysSet (Map.filter isLLVMNativeRunCoverage llvmParityCoverage)
+          nativeUnsupportedNames = Map.keysSet (Map.filter isLLVMNativeUnsupportedCoverage llvmParityCoverage)
+          requiredNativeRunNames = Set.fromList llvmRequiredNativeRunParityCases
 
       length caseNames `shouldBe` Set.size uniqueCaseNames
+      coverageCaseNames `shouldBe` uniqueCaseNames
       objectCodeNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
-      nativeUnsupportedNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
-      nativeRepresentativeNames `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
-      nativeRepresentativeNames `Set.disjoint` nativeUnsupportedNames `shouldBe` True
-      Map.keysSet llvmParityExpectations `shouldBe` uniqueCaseNames
+      Map.keysSet llvmNativeUnsupportedParityCases `Set.isSubsetOf` uniqueCaseNames `shouldBe` True
+      nativeRunNames `Set.union` nativeUnsupportedNames `shouldBe` uniqueCaseNames
+      nativeRunNames `Set.disjoint` nativeUnsupportedNames `shouldBe` True
+      requiredNativeRunNames `Set.isSubsetOf` nativeRunNames `shouldBe` True
 
     mapM_ runLLVMParityCase programSpecToLLVMParityCases
 
@@ -5966,20 +5969,46 @@ recIntTy :: BackendType
 recIntTy =
   BTMu "self" intTy
 
-data LLVMParityExpectation
-  = ExpectLLVMNativeRun
-  | ExpectLLVMNativeUnsupported String
+data LLVMParityCoverage = LLVMParityCoverage
+  { llvmParityNativeCoverage :: LLVMNativeCoverage,
+    llvmParityObjectCodeSmoke :: Bool
+  }
+  deriving (Eq, Show)
 
-llvmParityExpectations :: Map.Map String LLVMParityExpectation
-llvmParityExpectations =
+data LLVMNativeCoverage
+  = LLVMNativeRun
+  | LLVMNativeUnsupported String
+  deriving (Eq, Show)
+
+llvmParityCoverage :: Map.Map String LLVMParityCoverage
+llvmParityCoverage =
   Map.fromList
     [ ( runtimeCaseName runtimeCase,
-        case Map.lookup (runtimeCaseName runtimeCase) llvmNativeUnsupportedParityCases of
-          Just reason -> ExpectLLVMNativeUnsupported reason
-          Nothing -> ExpectLLVMNativeRun
+        LLVMParityCoverage
+          { llvmParityNativeCoverage = classifyLLVMNativeCoverage (runtimeCaseName runtimeCase),
+            llvmParityObjectCodeSmoke = runtimeCaseName runtimeCase `Set.member` llvmObjectCodeParityCaseNames
+          }
       )
     | runtimeCase <- programSpecToLLVMParityCases
     ]
+
+classifyLLVMNativeCoverage :: String -> LLVMNativeCoverage
+classifyLLVMNativeCoverage caseName =
+  case Map.lookup caseName llvmNativeUnsupportedParityCases of
+    Just reason -> LLVMNativeUnsupported reason
+    Nothing -> LLVMNativeRun
+
+isLLVMNativeRunCoverage :: LLVMParityCoverage -> Bool
+isLLVMNativeRunCoverage coverage =
+  case llvmParityNativeCoverage coverage of
+    LLVMNativeRun -> True
+    LLVMNativeUnsupported _ -> False
+
+isLLVMNativeUnsupportedCoverage :: LLVMParityCoverage -> Bool
+isLLVMNativeUnsupportedCoverage coverage =
+  case llvmParityNativeCoverage coverage of
+    LLVMNativeRun -> False
+    LLVMNativeUnsupported _ -> True
 
 llvmNativeUnsupportedParityCases :: Map.Map String String
 llvmNativeUnsupportedParityCases =
@@ -5992,14 +6021,22 @@ llvmNativeUnsupportedParityCases =
       )
     ]
 
-llvmNativeRepresentativeParityCases :: [String]
-llvmNativeRepresentativeParityCases =
+llvmRequiredNativeRunParityCases :: [String]
+llvmRequiredNativeRunParityCases =
   [ "surface: runs lambda/application",
-    "surface: runs let polymorphism at Int and Bool",
-    "unified fixture: test/programs/unified/authoritative-case-analysis.mlfp",
-    "unified fixture: test/programs/unified/authoritative-recursive-let.mlfp",
+    "surface: runs top-level partial application",
+    "surface: runs local partial application",
+    "fixture: test/programs/recursive-adt/deriving-eq.mlfp",
+    "fixture: test/programs/recursive-adt/recursive-tree-deriving.mlfp",
+    "fixture: test/programs/recursive-adt/typeclass-integration.mlfp",
     "unified fixture: test/programs/unified/authoritative-overloaded-method.mlfp",
-    "unified fixture: test/programs/unified/first-class-polymorphism.mlfp"
+    "unified fixture: test/programs/unified/authoritative-nullary-overloaded-method.mlfp",
+    "unified fixture: test/programs/unified/first-class-polymorphism.mlfp",
+    "unified fixture: test/programs/unified/higher-order-function-field.mlfp",
+    "unified fixture: test/programs/unified/higher-order-local-function-flow.mlfp",
+    "unified fixture: test/programs/unified/higher-order-partial-application.mlfp",
+    "unified fixture: test/programs/unified/higher-order-returned-function.mlfp",
+    "standalone: applies captured function-valued constructor fields"
   ]
 
 llvmObjectCodeParityCases :: [String]
@@ -6028,36 +6065,34 @@ runLLVMParityCase :: ProgramRuntimeCase -> Spec
 runLLVMParityCase runtimeCase =
   it (runtimeCaseName runtimeCase) $ do
     result <- emitProgramRuntimeLLVM (runtimeCaseSource runtimeCase)
-    case Map.lookup (runtimeCaseName runtimeCase) llvmParityExpectations of
+    case Map.lookup (runtimeCaseName runtimeCase) llvmParityCoverage of
       Nothing ->
-        expectationFailure ("missing LLVM parity expectation for " ++ runtimeCaseName runtimeCase)
-      Just ExpectLLVMNativeRun -> do
+        expectationFailure ("missing LLVM parity coverage for " ++ runtimeCaseName runtimeCase)
+      Just coverage -> do
         output <- requireRight result
         validateLLVMAssembly output
-        when (runtimeCaseName runtimeCase `Set.member` llvmObjectCodeParityCaseNames) $
+        when (llvmParityObjectCodeSmoke coverage) $
           validateLLVMObjectCode output
-        nativeOutput <- requireRight =<< emitProgramRuntimeNativeLLVM (runtimeCaseSource runtimeCase)
-        validateLLVMAssembly nativeOutput
-        validateLLVMObjectCode nativeOutput
-        nativeResult <- runLLVMNativeExecutable nativeOutput
-        assertNativeRuntimeResult (runtimeCaseExpectation runtimeCase) nativeResult
-      Just (ExpectLLVMNativeUnsupported fragment) -> do
-        output <- requireRight result
-        validateLLVMAssembly output
-        when (runtimeCaseName runtimeCase `Set.member` llvmObjectCodeParityCaseNames) $
-          validateLLVMObjectCode output
-        nativeResult <- emitProgramRuntimeNativeLLVM (runtimeCaseSource runtimeCase)
-        case nativeResult of
-          Left err ->
-            err `shouldSatisfy` isInfixOf fragment
-          Right nativeOutput ->
-            expectationFailure $
-              "expected native LLVM emission to reject "
-                ++ runtimeCaseName runtimeCase
-                ++ " with "
-                ++ show fragment
-                ++ ", but it emitted:\n"
-                ++ nativeOutput
+        case llvmParityNativeCoverage coverage of
+          LLVMNativeRun -> do
+            nativeOutput <- requireRight =<< emitProgramRuntimeNativeLLVM (runtimeCaseSource runtimeCase)
+            validateLLVMAssembly nativeOutput
+            validateLLVMObjectCode nativeOutput
+            nativeResult <- runLLVMNativeExecutable nativeOutput
+            assertNativeRuntimeResult (runtimeCaseExpectation runtimeCase) nativeResult
+          LLVMNativeUnsupported fragment -> do
+            nativeResult <- emitProgramRuntimeNativeLLVM (runtimeCaseSource runtimeCase)
+            case nativeResult of
+              Left err ->
+                err `shouldSatisfy` isInfixOf fragment
+              Right nativeOutput ->
+                expectationFailure $
+                  "expected native LLVM emission to reject "
+                    ++ runtimeCaseName runtimeCase
+                    ++ " with "
+                    ++ show fragment
+                    ++ ", but it emitted:\n"
+                    ++ nativeOutput
 
 emitProgramRuntimeLLVM :: ProgramMatrixSource -> IO (Either String String)
 emitProgramRuntimeLLVM source =


### PR DESCRIPTION
Closes #102.

## Implementation Plan

---
issue_number: 102
pr_number: 122
branch: codex/issue-102
---

## Implementation Plan

1. Reconfirm the workspace before edits: stay on `codex/issue-102`, verify PR #122 still targets `master`, and check `git status --short` for unrelated dirt.

2. Tighten `test/BackendLLVMSpec.hs` coverage accounting around `programSpecToLLVMParityCases`:
   - Replace the loose native unsupported map/list split with an explicit per-row coverage classification, e.g. native-run, assembly-only/native-unsupported with diagnostic fragment, and object-code smoke where applicable.
   - Keep the classification mechanically derived from the shared runtime-success matrix, and assert exact partitioning: no duplicate rows, no missing rows, unsupported/assembly-only rows are named with reasons, and native-run rows include the advanced rows now supported by #67/#88: typeclass/evidence, first-class polymorphism, higher-order local/function-field/partial/returned-function fixtures.
   - Preserve the current fail-closed rule: do not mark a row assembly-only just to hide a backend failure. Only classify rows as native-unsupported when native result rendering genuinely cannot compare them, such as function-valued main results.

3. Update the parity runner logic in `BackendLLVMSpec` so every native-run row emits raw LLVM, validates assembly, performs selected object-code smoke, emits native LLVM, validates object code, links/runs through `LLVMToolSupport`, and compares stdout/stderr/exit status against `ProgramRuntimeExpectation`. Assembly-only rows should still validate raw LLVM and assert the expected `emit-native` diagnostic.

4. Document the native pipeline:
   - Add or update backend docs, preferably `docs/backend-native-pipeline.md`, covering `emit-backend` vs `emit-native`, generated `.ll`/object/executable artifacts, required tools (`llvm-as`, `llc`, `CC`/`cc`/`clang`/`gcc`), runtime support (`main`, `printf`, `malloc`, `__mlfp_and`, result renderers), supported result comparison (`Int`, `Bool`, first-order ADTs), unsupported shapes, and Hspec toolchain pending behavior.
   - Link the doc from `README.md` and, if useful, `docs/architecture.md` rather than duplicating all details.

5. Record meaningful project progress in `CHANGELOG.md` and `implementation_notes.md`. Do not update `Bugs.md` because this is coverage/documentation closeout, not a newly discovered implementation defect.

6. Validate in increasing scope:
   - First run the targeted slice: `cabal test mlf2-test --test-show-details=direct --test-options='--match "ProgramSpec-to-LLVM parity matrix|native process entrypoint|runs a linked native executable"'`.
   - Then run the required behavior-changing gate: `cabal build all && cabal test`.
   - If the local machine lacks LLVM/native linker tools, ensure the suite reports pending skips rather than silent passes and state that in the handoff.

7. Publish through the existing PR only: inspect `git status --short` and relevant diffs, stage only issue-related files, commit as `codex-watcher <codex-watcher@users.noreply.github.com>`, run `gh auth status` and `gh auth setup-git`, push `codex/issue-102`, and leave PR #122 ready for review without creating a duplicate PR or resolving review threads.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.