### PR TITLE
Implement #127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
   partial applications now run through shared backend parity.
 
 ### Changed
+- Classified core constraint graph helpers by phase requirement: normalization
+  internals now stay raw-phase owned, acyclicity dependency graph construction
+  consumes normalized constraints, and a repository guard keeps
+  `castConstraint` quarantined to its defining module.
 - Replaced several tautological or smoke-only tests with structural assertions
   for backend conversion, binding canonicalization, elaboration, pipeline
   normalization, presolution witness operation generation, reification, and type

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,6 +127,11 @@ runtime invariants as compile-time types:
   encode those boundaries; `castConstraint` remains only as a quarantined legacy
   escape hatch, and raw-view bridges are named where older elaboration/query code
   still expects the historical raw surface.
+  Phase-specific helpers should expose the narrowest phase they actually
+  require: normalization's mutable helper state is raw-phase owned, dependency
+  graph construction consumes normalized constraints, and acyclicity results are
+  assembled from the acyclic constraint. Structural readers such as node access
+  and binding-tree queries remain phase-polymorphic.
 
 - **`ForallSpec`** (`MLF.Constraint.Types.Witness`): `fsBinderCount` was removed;
   binder count is derived from `length fsBounds`. `mkForallSpec` validates

--- a/docs/thesis-claims.yaml
+++ b/docs/thesis-claims.yaml
@@ -22,7 +22,7 @@ claims:
       property_tests: []
       code_paths:
         - src/MLF/Frontend/ConstraintGen/Translate.hs#buildExprRaw
-        - src/MLF/Constraint/Types.hs#Constraint
+        - src/MLF/Constraint/Types/Graph.hs#data Constraint
     deviations:
       - DEV-CONSTRAINT-REPR-SIMPLIFIED
     status: defended

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,3 +1,16 @@
+## 2026-05-05 - Core constraint helpers classified by phase requirement
+
+- Normalization's internal mutable state is now raw-phase owned, matching the
+  Phase 2 boundary that advances generated constraints from `Raw` to
+  `Normalized`.
+- Acyclicity dependency graph construction now consumes normalized constraints,
+  while the successful result assembly is tied to the acyclic constraint
+  returned by Phase 3.
+- Structural graph and binding helpers remain phase-polymorphic where they only
+  read or rewrite the common graph representation. `castConstraint` stays
+  quarantined to its defining module, with a repository guard covering
+  production callers.
+
 ## 2026-05-03 - Backend IR executable-boundary family closed on the merged 710c92eb baseline
 
 - The backend IR executable-boundary family now has rows 1 through 7 closed on the merged `710c92eb` baseline.

--- a/src/MLF/Constraint/Acyclicity.hs
+++ b/src/MLF/Constraint/Acyclicity.hs
@@ -113,7 +113,9 @@ checkAcyclicity c =
                   "Cyclic instantiation dependency detected: "
                     ++ show (map getEdgeId cycleIds)
               }
-        Right sortedIds -> Right (toAcyclicConstraint c, mkAcyclicityResult c depGraph sortedIds)
+        Right sortedIds ->
+          let cAcyclic = toAcyclicConstraint c
+           in Right (cAcyclic, mkAcyclicityResult cAcyclic depGraph sortedIds)
 
 -- | Break dependency cycles one-by-one by introducing `TyMu` nodes until the
 -- instantiation graph becomes acyclic.
@@ -135,7 +137,7 @@ breakCyclesAndCheckAcyclicity = go
                   }
             else go c'
 
-mkAcyclicityResult :: Constraint p -> DepGraph EdgeId -> [EdgeId] -> AcyclicityResult
+mkAcyclicityResult :: Constraint 'Acyclic -> DepGraph EdgeId -> [EdgeId] -> AcyclicityResult
 mkAcyclicityResult c depGraph sortedIds =
   let edgeMap =
         IntMap.fromList
@@ -158,7 +160,7 @@ data CycleRewriteState = CycleRewriteState
 
 type CycleRewriteM a = State CycleRewriteState a
 
-breakSingleCycle :: Constraint p -> [EdgeId] -> Either CycleError (Constraint p)
+breakSingleCycle :: Constraint 'Normalized -> [EdgeId] -> Either CycleError (Constraint 'Normalized)
 breakSingleCycle _ [] = Left (invalidCycleError [] "empty cycle reported by dependency graph")
 breakSingleCycle c cycleIds = do
   pivotEdge <-
@@ -212,14 +214,14 @@ invalidCycleError cycleIds msg =
       ceMessage = msg
     }
 
-lookupInstEdge :: Constraint p -> EdgeId -> Maybe InstEdge
+lookupInstEdge :: Constraint 'Normalized -> EdgeId -> Maybe InstEdge
 lookupInstEdge c eid =
   case filter ((== eid) . instEdgeId) (cInstEdges c) of
     edge : _ -> Just edge
     [] -> Nothing
 
 runCycleRewrite ::
-  Constraint p ->
+  Constraint 'Normalized ->
   InstEdge ->
   IntSet ->
   CycleRewriteState ->
@@ -341,7 +343,7 @@ cloneWithSubstitution originalNodes recursiveNodes binderId nid
               pure cloneId
 
 attachClonedBindParentsWithMu ::
-  Constraint p ->
+  Constraint 'Normalized ->
   NodeId ->
   NodeId ->
   NodeId ->
@@ -368,7 +370,7 @@ attachClonedBindParentsWithMu c bodyId binderId muId rhsParent = do
                   setBindParentCR (typeRef cloneId) (translateParent clones parentRef, flag)
 
 attachClonedBindParentsNoMu ::
-  Constraint p ->
+  Constraint 'Normalized ->
   NodeId ->
   Maybe (NodeRef, BindFlag) ->
   CycleRewriteM ()
@@ -397,7 +399,7 @@ translateParent clones parentRef =
         Nothing -> parentRef
     GenRef _ -> parentRef
 
-lookupBindParentInfo :: Constraint p -> NodeRef -> Maybe (NodeRef, BindFlag)
+lookupBindParentInfo :: Constraint 'Normalized -> NodeRef -> Maybe (NodeRef, BindFlag)
 lookupBindParentInfo c ref = IntMap.lookup (nodeRefKey ref) (cBindParents c)
 
 freshNodeIdCR :: CycleRewriteM NodeId
@@ -453,7 +455,7 @@ This ensures topological order processes e₂ before e₁.
 -}
 
 -- | Build the dependency graph between instantiation edges.
-buildDependencyGraph :: Constraint p -> DepGraph EdgeId
+buildDependencyGraph :: Constraint 'Normalized -> DepGraph EdgeId
 buildDependencyGraph c =
   let edges = cInstEdges c
       nodes = cNodes c

--- a/src/MLF/Constraint/Normalize.hs
+++ b/src/MLF/Constraint/Normalize.hs
@@ -99,7 +99,7 @@ normalize c = toNormalizedConstraint (nsConstraint finalState)
     finalState = execState (normalizeLoop >> enforcePaperShapedInstEdges) initialState
 
 -- | Main normalization loop: apply transformations until fixed point.
-normalizeLoop :: NormalizeM p ()
+normalizeLoop :: NormalizeM ()
 normalizeLoop = do
     before <- gets nsConstraint
     modify' $ \s -> s { nsConstraint = dropReflexiveInstEdges (nsConstraint s) }

--- a/src/MLF/Constraint/Normalize/Graft.hs
+++ b/src/MLF/Constraint/Normalize/Graft.hs
@@ -97,7 +97,7 @@ See also:
 -}
 
 -- | Process instantiation edges by grafting structure onto variables.
-graftInstEdges :: NormalizeM p ()
+graftInstEdges :: NormalizeM ()
 graftInstEdges = do
   c <- gets nsConstraint
   let edges = cInstEdges c
@@ -131,7 +131,7 @@ graftInstEdges = do
 -- | Partition edges into (graftable, non-graftable).
 -- An edge is graftable if we can structurally transform it without needing
 -- presolution decisions. See Note [Grafting Cases].
-partitionGraftable :: [InstEdge] -> NodeMap TyNode -> NormalizeM p ([InstEdge], [InstEdge])
+partitionGraftable :: [InstEdge] -> NodeMap TyNode -> NormalizeM ([InstEdge], [InstEdge])
 partitionGraftable edges nodes = do
   polySyms <- gets (cPolySyms . nsConstraint)
   uf <- gets nsUnionFind
@@ -229,7 +229,7 @@ error reporting to a later phase with better diagnostics.
 
 -- | Graft a single edge, returning new unification edges.
 -- Returns Nothing if the edge represents a type error that should be kept.
-graftEdge :: InstEdge -> NormalizeM p (Maybe [UnifyEdge])
+graftEdge :: InstEdge -> NormalizeM (Maybe [UnifyEdge])
 graftEdge edge = do
   c <- gets nsConstraint
   uf <- gets nsUnionFind

--- a/src/MLF/Constraint/Normalize/Internal.hs
+++ b/src/MLF/Constraint/Normalize/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {- |
 Module      : MLF.Constraint.Normalize.Internal
 Description : Shared normalization state and helper operations
@@ -19,7 +20,7 @@ module MLF.Constraint.Normalize.Internal (
 
 {- Note [Normalization state and shared helpers]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This module provides the shared mutable state ('NormalizeState p', 'NormalizeM p')
+This module provides the shared mutable state ('NormalizeState', 'NormalizeM')
 and primitive operations used by both the grafting ('Normalize.Graft') and
 merging ('Normalize.Merge') normalization submodules.
 
@@ -50,6 +51,7 @@ import MLF.Constraint.Types.Graph
     , TyNode (..)
     , typeRef
     )
+import MLF.Constraint.Types.Phase (Phase(Raw))
 import MLF.Constraint.Types.SynthesizedExpVar
     ( SynthExpVarSupply
     , takeSynthExpVar
@@ -57,22 +59,22 @@ import MLF.Constraint.Types.SynthesizedExpVar
 import qualified MLF.Util.UnionFind as UnionFind
 
 -- | State maintained during normalization.
-data NormalizeState p = NormalizeState { nsNextNodeId :: !Int
+data NormalizeState = NormalizeState { nsNextNodeId :: !Int
       -- ^ Counter for allocating fresh nodes during grafting.
     , nsSynthExpVarSupply :: !SynthExpVarSupply
       -- ^ Opaque allocator for synthesized-wrapper expansion variables in
       -- a reserved negative-ID space.
     , nsUnionFind :: !(IntMap NodeId)
       -- ^ Union-find structure: maps node IDs to their canonical representative.
-    , nsConstraint :: !(Constraint p)
-      -- ^ The constraint being normalized.
+    , nsConstraint :: !(Constraint 'Raw)
+      -- ^ The raw constraint being normalized before Phase 2 advances it.
     }
     deriving (Eq, Show)
 
-type NormalizeM p a = State (NormalizeState p) a
+type NormalizeM a = State NormalizeState a
 
 -- | Allocate a fresh variable node.
-freshVar :: NormalizeM p NodeId
+freshVar :: NormalizeM NodeId
 freshVar = do
     nid <- freshNodeId
     let node = TyVar { tnId = nid, tnBound = Nothing }
@@ -81,7 +83,7 @@ freshVar = do
     pure nid
 
 -- | Set the binding parent for a node in the constraint.
-setBindParentNorm :: NodeId -> NodeId -> BindFlag -> NormalizeM p ()
+setBindParentNorm :: NodeId -> NodeId -> BindFlag -> NormalizeM ()
 setBindParentNorm child parent flag =
     when (child /= parent) $
         modify' $ \s ->
@@ -89,7 +91,7 @@ setBindParentNorm child parent flag =
                 c' = Binding.setBindParent (typeRef child) (typeRef parent, flag) c
             in s { nsConstraint = c' }
 
-setBindParentRefNorm :: NodeRef -> NodeRef -> BindFlag -> NormalizeM p ()
+setBindParentRefNorm :: NodeRef -> NodeRef -> BindFlag -> NormalizeM ()
 setBindParentRefNorm child parent flag =
     when (child /= parent) $
         modify' $ \s ->
@@ -98,14 +100,14 @@ setBindParentRefNorm child parent flag =
             in s { nsConstraint = c' }
 
 -- | Get a fresh NodeId.
-freshNodeId :: NormalizeM p NodeId
+freshNodeId :: NormalizeM NodeId
 freshNodeId = do
     n <- gets nsNextNodeId
     modify' $ \s -> s { nsNextNodeId = n + 1 }
     pure (NodeId n)
 
 -- | Insert a node into the constraint.
-insertNode :: TyNode -> NormalizeM p ()
+insertNode :: TyNode -> NormalizeM ()
 insertNode node = modify' $ \s ->
     let c = nsConstraint s
         nodes' = Graph.insertNode (tnId node) node (cNodes c)
@@ -113,7 +115,7 @@ insertNode node = modify' $ \s ->
 
 -- Union-find link; caller is responsible for any scope maintenance (e.g.
 -- binding-edge harmonization / paper Raise(n) for Var/Var unions).
-unionNodes :: NodeId -> NodeId -> NormalizeM p ()
+unionNodes :: NodeId -> NodeId -> NormalizeM ()
 unionNodes from to = modify' $ \s ->
     s { nsUnionFind = IntMap.insert (getNodeId from) to (nsUnionFind s) }
 
@@ -122,7 +124,7 @@ findRoot :: IntMap NodeId -> NodeId -> NodeId
 findRoot = UnionFind.frWith
 
 -- | Allocate a fresh expansion variable for synthesized wrappers.
-freshSynthExpVarNorm :: NormalizeM p ExpVarId
+freshSynthExpVarNorm :: NormalizeM ExpVarId
 freshSynthExpVarNorm = do
     supply <- gets nsSynthExpVarSupply
     let (expVar, supply') = takeSynthExpVar supply

--- a/src/MLF/Constraint/Normalize/Merge.hs
+++ b/src/MLF/Constraint/Normalize/Merge.hs
@@ -108,7 +108,7 @@ See also:
 -}
 
 -- | Process unification edges using union-find.
-mergeUnifyEdges :: NormalizeM p ()
+mergeUnifyEdges :: NormalizeM ()
 mergeUnifyEdges = do
     c <- gets nsConstraint
     let edges = cUnifyEdges c
@@ -118,7 +118,7 @@ mergeUnifyEdges = do
         in s { nsConstraint = c' { cUnifyEdges = remainingEdges } }
 
 -- | Process unification edges, returning any that couldn't be resolved.
-processUnifyEdges :: [UnifyEdge] -> NormalizeM p [UnifyEdge]
+processUnifyEdges :: [UnifyEdge] -> NormalizeM [UnifyEdge]
 processUnifyEdges edges =
     UnifyCore.processUnifyEdgesWith
         normalizeUnifyStrategy
@@ -127,17 +127,17 @@ processUnifyEdges edges =
         unionNodes
         edges
 
-normalizeFindRoot :: NodeId -> NormalizeM p NodeId
+normalizeFindRoot :: NodeId -> NormalizeM NodeId
 normalizeFindRoot nid = do
     uf <- gets nsUnionFind
     pure (findRoot uf nid)
 
-normalizeLookupNode :: NodeId -> NormalizeM p (Maybe TyNode)
+normalizeLookupNode :: NodeId -> NormalizeM (Maybe TyNode)
 normalizeLookupNode nid = do
     nodes <- gets (cNodes . nsConstraint)
     pure (lookupNodeIn nodes nid)
 
-normalizeUnifyStrategy :: UnifyCore.UnifyStrategy (State (NormalizeState p))
+normalizeUnifyStrategy :: UnifyCore.UnifyStrategy (State NormalizeState)
 normalizeUnifyStrategy = UnifyCore.UnifyStrategy
     { UnifyCore.usOccursCheck = UnifyCore.OccursCheckNone
     , UnifyCore.usTyExpPolicy = UnifyCore.TyExpAllow
@@ -146,7 +146,7 @@ normalizeUnifyStrategy = UnifyCore.UnifyStrategy
     , UnifyCore.usOnMismatch = \_ -> pure UnifyCore.KeepEdge
     }
 
-normalizeForallArity :: NodeId -> NormalizeM p (Maybe Int)
+normalizeForallArity :: NodeId -> NormalizeM (Maybe Int)
 normalizeForallArity nid = do
     c0 <- gets nsConstraint
     uf <- gets nsUnionFind
@@ -168,7 +168,7 @@ unifying Var ~ (s·Var) would create a self-loop if we made Var point to the
 point to the variable (this corresponds to forcing `s` to be the identity
 expansion).
 -}
-normalizeRepresentative :: NodeId -> TyNode -> NodeId -> TyNode -> NormalizeM p (NodeId, NodeId)
+normalizeRepresentative :: NodeId -> TyNode -> NodeId -> TyNode -> NormalizeM (NodeId, NodeId)
 normalizeRepresentative left leftNode right rightNode = case (leftNode, rightNode) of
     (TyVar {}, TyVar {}) -> do
         modify' $ \s ->
@@ -193,7 +193,7 @@ normalizeRepresentative left leftNode right rightNode = case (leftNode, rightNod
     _ -> pure (left, right)
 
 -- | Apply the union-find substitution to all node references in the constraint.
-applyUnionFindToConstraint :: NormalizeM p ()
+applyUnionFindToConstraint :: NormalizeM ()
 applyUnionFindToConstraint = do
     uf <- gets nsUnionFind
     when (not (IntMap.null uf)) $
@@ -282,14 +282,14 @@ applyToStructure uf node = case node of
 -- | Post-loop pass: force residual instantiation edges to paper-shaped form.
 -- Every residual edge becomes `TyExp(s, body) ≤ τ` by wrapping non-`TyExp`
 -- left nodes in a synthesized expansion node.
-enforcePaperShapedInstEdges :: NormalizeM p ()
+enforcePaperShapedInstEdges :: NormalizeM ()
 enforcePaperShapedInstEdges = do
     c <- gets nsConstraint
     wrappedEdges <- mapM wrapInstEdgeLeft (cInstEdges c)
     modify' $ \st -> st { nsConstraint = (nsConstraint st) { cInstEdges = wrappedEdges } }
 
 -- | Wrap a residual edge's left node with a fresh `TyExp` node when needed.
-wrapInstEdgeLeft :: InstEdge -> NormalizeM p InstEdge
+wrapInstEdgeLeft :: InstEdge -> NormalizeM InstEdge
 wrapInstEdgeLeft edge = do
     nodes <- gets (cNodes . nsConstraint)
     case lookupNodeIn nodes (instLeft edge) of
@@ -304,7 +304,7 @@ wrapInstEdgeLeft edge = do
             pure edge { instLeft = wrapperNid }
 
 -- | Keep synthesized wrappers on the same binding-parent chain as their body.
-inheritWrapperBindParent :: NodeId -> NodeId -> NormalizeM p ()
+inheritWrapperBindParent :: NodeId -> NodeId -> NormalizeM ()
 inheritWrapperBindParent bodyId wrapperId = do
     bindParents <- gets (cBindParents . nsConstraint)
     case IntMap.lookup (nodeRefKey (typeRef bodyId)) bindParents of

--- a/test/AcyclicitySpec.hs
+++ b/test/AcyclicitySpec.hs
@@ -22,6 +22,9 @@ breakCyclesAndCheckAcyclicity =
     . Acyclicity.breakCyclesAndCheckAcyclicity
     . toNormalizedConstraint
 
+normalizedDependencyGraph :: Constraint 'Raw -> DepGraph EdgeId
+normalizedDependencyGraph = buildDependencyGraph . toNormalizedConstraint
+
 spec :: Spec
 spec = do
   describe "Phase 3 — Acyclicity Check" $ do
@@ -495,7 +498,7 @@ spec = do
             constraint = emptyConstraint {cNodes = nodes, cInstEdges = [e1, e2]}
         checkAcyclicity constraint `shouldSatisfy` isRight
         -- No dependency between them (independent)
-        let g = buildDependencyGraph constraint
+        let g = normalizedDependencyGraph constraint
         -- e₁ should NOT depend on e₂ and vice versa
         case IntMap.lookup 0 (dgEdges g) of
           Just deps -> deps `shouldNotContain` [EdgeId 1]
@@ -621,7 +624,7 @@ spec = do
 
     describe "Dependency graph construction" $ do
       it "builds empty graph for empty constraint" $ do
-        let g = buildDependencyGraph emptyConstraint
+        let g = normalizedDependencyGraph emptyConstraint
         dgVertices g `shouldBe` []
 
       it "builds graph with correct vertices" $ do
@@ -632,7 +635,7 @@ spec = do
                 ]
             edges = [InstEdge (EdgeId 42) (NodeId 0) (NodeId 1)]
             constraint = emptyConstraint {cNodes = nodes, cInstEdges = edges}
-            g = buildDependencyGraph constraint
+            g = normalizedDependencyGraph constraint
         dgVertices g `shouldBe` [EdgeId 42]
 
       it "creates dependency edge when nodes overlap" $ do
@@ -647,7 +650,7 @@ spec = do
             e1 = InstEdge (EdgeId 0) (NodeId 0) (NodeId 1)
             e2 = InstEdge (EdgeId 1) (NodeId 1) (NodeId 2)
             constraint = emptyConstraint {cNodes = nodes, cInstEdges = [e1, e2]}
-            g = buildDependencyGraph constraint
+            g = normalizedDependencyGraph constraint
         -- e₁ should depend on e₂
         case IntMap.lookup 0 (dgEdges g) of
           Just deps -> deps `shouldContain` [EdgeId 1]

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -45,6 +45,8 @@ spec = describe "Repository guardrails" $ do
         guardedLines = lines (stripHaskellCommentsAndLiterals guardedSource)
     any containsCastConstraintCall guardedLines `shouldBe` False
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
+    any containsCastConstraintCall (lines (stripHaskellCommentsAndLiterals "x' = castConstraint c"))
+      `shouldBe` True
     containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
   it "MLF.API no longer exports pipeline/runtime helpers and MLF.Pipeline owns them" $ do
@@ -449,7 +451,6 @@ data SourceMode
   | SourceLineComment
   | SourceBlockComment Int
   | SourceString
-  | SourceChar
 
 stripHaskellCommentsAndLiterals :: String -> String
 stripHaskellCommentsAndLiterals = go SourceCode
@@ -458,7 +459,6 @@ stripHaskellCommentsAndLiterals = go SourceCode
     go SourceCode ('-' : '-' : rest) = ' ' : ' ' : go SourceLineComment rest
     go SourceCode ('{' : '-' : rest) = ' ' : ' ' : go (SourceBlockComment 1) rest
     go SourceCode ('"' : rest) = ' ' : go SourceString rest
-    go SourceCode ('\'' : rest) = ' ' : go SourceChar rest
     go SourceCode (ch : rest) = ch : go SourceCode rest
     go SourceLineComment ('\n' : rest) = '\n' : go SourceCode rest
     go SourceLineComment (_ : rest) = ' ' : go SourceLineComment rest
@@ -473,10 +473,6 @@ stripHaskellCommentsAndLiterals = go SourceCode
     go SourceString ('"' : rest) = ' ' : go SourceCode rest
     go SourceString ('\n' : rest) = '\n' : go SourceCode rest
     go SourceString (_ : rest) = ' ' : go SourceString rest
-    go SourceChar ('\\' : _ : rest) = ' ' : ' ' : go SourceChar rest
-    go SourceChar ('\'' : rest) = ' ' : go SourceCode rest
-    go SourceChar ('\n' : rest) = '\n' : go SourceCode rest
-    go SourceChar (_ : rest) = ' ' : go SourceChar rest
 
 containsCastConstraintCall :: String -> Bool
 containsCastConstraintCall line

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -60,10 +60,17 @@ spec = describe "Repository guardrails" $ do
               "    castConstraint",
               "  ) where"
             ]
+        classSignature =
+          unlines
+            [ "class Legacy c where",
+              "  castConstraint",
+              "    :: Constraint p -> Constraint q"
+            ]
     containsCastConstraintCall guardedSource `shouldBe` False
     containsCastConstraintCall multilineSignature `shouldBe` False
     containsCastConstraintCall multilineImport `shouldBe` False
     containsCastConstraintCall multilineExport `shouldBe` False
+    containsCastConstraintCall classSignature `shouldBe` False
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
     containsCastConstraintCall "x' = castConstraint c" `shouldBe` True
     containsCastConstraintCall (unlines ["legacy =", "  castConstraint", "    c"])
@@ -71,6 +78,8 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall (unlines ["legacy =", "  (castConstraint)", "    c"])
       `shouldBe` True
     containsCastConstraintCall (unlines ["legacy =", "  castConstraint", "  :: Constraint p -> Constraint q"])
+      `shouldBe` True
+    containsCastConstraintCall (unlines ["legacy =", "  id", "    castConstraint", "    :: Constraint p -> Constraint q"])
       `shouldBe` True
     containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
@@ -523,17 +532,18 @@ containsCastConstraintCall source =
        in isCastConstraintCallContext
             inImportExportList
             (nextLineStartsSignature lineIndex)
-            (previousLineContinuesExpression lineIndex)
+            (previousLinesContinueExpression lineIndex)
             prefix
             suffix
     nextLineStartsSignature lineIndex =
       case firstNonEmpty (drop (lineIndex + 1) sourceLines) of
         Just nextLine -> "::" `isPrefixOf` trim nextLine
         Nothing -> False
-    previousLineContinuesExpression lineIndex =
-      case lastNonEmpty (take lineIndex sourceLines) of
-        Just previousLine -> lineContinuesExpression previousLine
-        Nothing -> False
+    previousLinesContinueExpression lineIndex =
+      case drop lineIndex sourceLines of
+        currentLine : _ ->
+          priorLinesContinueExpression (lineIndent currentLine) (reverse (take lineIndex sourceLines))
+        [] -> False
 
 isImportLine :: String -> Bool
 isImportLine line = "import " `isPrefixOf` trim line
@@ -648,12 +658,32 @@ firstNonEmpty (line : rest)
   | null (trim line) = firstNonEmpty rest
   | otherwise = Just line
 
-lastNonEmpty :: [String] -> Maybe String
-lastNonEmpty = firstNonEmpty . reverse
-
 lineContinuesExpression :: String -> Bool
 lineContinuesExpression line =
   any (`isSuffixOf` trimmed) ["=", "(", "$", "\\", "->"]
+  where
+    trimmed = trim line
+
+priorLinesContinueExpression :: Int -> [String] -> Bool
+priorLinesContinueExpression currentIndent = go
+  where
+    go [] = False
+    go (line : rest)
+      | null (trim line) = go rest
+      | lineIndent line < currentIndent = lineContinuesExpression line
+          || (not (lineStartsDeclarationBoundary line) && go rest)
+      | currentIndent == 0 = lineContinuesExpression line
+      | otherwise = go rest
+
+lineIndent :: String -> Int
+lineIndent = length . takeWhile (== ' ')
+
+lineStartsDeclarationBoundary :: String -> Bool
+lineStartsDeclarationBoundary line =
+  any
+    (`isPrefixOf` trimmed)
+    ["class ", "data ", "instance ", "module ", "import "]
+    || " where" `isSuffixOf` trimmed
   where
     trimmed = trim line
 

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -53,6 +53,14 @@ spec = describe "Repository guardrails" $ do
               "    castConstraint",
               "  )"
             ]
+        multilineQualifiedImport =
+          unlines
+            [ "import qualified MLF.Constraint.Types.Graph",
+              "  as Graph",
+              "  (",
+              "    castConstraint",
+              "  )"
+            ]
         multilineExport =
           unlines
             [ "module MLF.Constraint.Types.Graph",
@@ -69,6 +77,7 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall guardedSource `shouldBe` False
     containsCastConstraintCall multilineSignature `shouldBe` False
     containsCastConstraintCall multilineImport `shouldBe` False
+    containsCastConstraintCall multilineQualifiedImport `shouldBe` False
     containsCastConstraintCall multilineExport `shouldBe` False
     containsCastConstraintCall classSignature `shouldBe` False
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
@@ -80,6 +89,8 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall (unlines ["legacy =", "  castConstraint", "  :: Constraint p -> Constraint q"])
       `shouldBe` True
     containsCastConstraintCall (unlines ["legacy =", "  id", "    castConstraint", "    :: Constraint p -> Constraint q"])
+      `shouldBe` True
+    containsCastConstraintCall (unlines ["legacy = id", "  castConstraint", "  :: Constraint p -> Constraint q"])
       `shouldBe` True
     containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
@@ -575,6 +586,7 @@ advanceSymbolListContext listContext line =
     PendingSymbolList
       | null (trim line) -> PendingSymbolList
       | "(" `isPrefixOf` trim line -> continueList (parenDelta line)
+      | isImportQualifierContinuation line -> PendingSymbolList
       | otherwise -> OutsideSymbolList
     OutsideSymbolList
       | startsSymbolListOwner line ->
@@ -669,11 +681,13 @@ priorLinesContinueExpression currentIndent = go
   where
     go [] = False
     go (line : rest)
-      | null (trim line) = go rest
-      | lineIndent line < currentIndent = lineContinuesExpression line
+      | null trimmed = go rest
+      | lineIndent line < currentIndent = lineContinuesExpression line || lineIntroducesExpression trimmed
           || (not (lineStartsDeclarationBoundary line) && go rest)
       | currentIndent == 0 = lineContinuesExpression line
       | otherwise = go rest
+      where
+        trimmed = trim line
 
 lineIndent :: String -> Int
 lineIndent = length . takeWhile (== ' ')
@@ -686,6 +700,17 @@ lineStartsDeclarationBoundary line =
     || " where" `isSuffixOf` trimmed
   where
     trimmed = trim line
+
+lineIntroducesExpression :: String -> Bool
+lineIntroducesExpression line =
+  "=" `isInfixOf` line
+    && not ("::" `isInfixOf` line)
+
+isImportQualifierContinuation :: String -> Bool
+isImportQualifierContinuation line =
+  case words line of
+    ["as", _alias] -> True
+    _ -> False
 
 collectHsFiles :: FilePath -> IO [FilePath]
 collectHsFiles root = do

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -27,6 +27,10 @@ spec = describe "Repository guardrails" $ do
     offenders <- findImportOffenders ["src", "src-public", "test", "app"]
     offenders `shouldBe` []
 
+  it "production code keeps castConstraint quarantined to the defining module" $ do
+    offenders <- findCastConstraintOffenders ["src", "src-public", "app"]
+    offenders `shouldBe` []
+
   it "MLF.API no longer exports pipeline/runtime helpers and MLF.Pipeline owns them" $ do
     apiSrc <- readFile "src-public/MLF/API.hs"
     pipelineSrc <- readFile "src-public/MLF/Pipeline.hs"
@@ -411,6 +415,18 @@ hasMyLibImport :: FilePath -> IO (FilePath, Bool)
 hasMyLibImport path = do
   src <- readFile path
   pure (path, any (== "import MyLib") (map trimImport (lines src)))
+
+findCastConstraintOffenders :: [FilePath] -> IO [FilePath]
+findCastConstraintOffenders roots = do
+  hsFiles <- concat <$> mapM collectHsFiles roots
+  offenders <- mapM hasCastConstraintUse hsFiles
+  pure [path | (path, True) <- offenders]
+
+hasCastConstraintUse :: FilePath -> IO (FilePath, Bool)
+hasCastConstraintUse path = do
+  src <- readFile path
+  let definingModule = path == "src/MLF/Constraint/Types/Graph.hs"
+  pure (path, not definingModule && "castConstraint" `isInfixOf` src)
 
 collectHsFiles :: FilePath -> IO [FilePath]
 collectHsFiles root = do

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -49,6 +49,8 @@ spec = describe "Repository guardrails" $ do
       `shouldBe` True
     any containsCastConstraintCall (lines (unlines ["legacy =", "  castConstraint", "    c"]))
       `shouldBe` True
+    any containsCastConstraintCall (lines (unlines ["legacy =", "  (castConstraint)", "    c"]))
+      `shouldBe` True
     containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
   it "MLF.API no longer exports pipeline/runtime helpers and MLF.Pipeline owns them" $ do
@@ -493,7 +495,7 @@ isCastConstraintCallContext prefix suffix =
   where
     prefixTrimmed = trim prefix
     suffixTrimmed = trim suffix
-    onlyExportPunctuation = all (`elem` "(),")
+    onlyExportPunctuation = all (== ',')
     onlySignaturePrefix = all (== ',')
     isSignatureEntry =
       "::" `isPrefixOf` suffixTrimmed

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -2,6 +2,7 @@
 module RepoGuardSpec (spec) where
 
 import Control.Monad (forM_)
+import Data.Char (isAlphaNum)
 import Data.List (intercalate, isInfixOf, isSuffixOf, sort)
 import System.Directory (doesFileExist, listDirectory)
 import System.FilePath (dropExtension, makeRelative, splitDirectories, takeExtension, (</>))
@@ -30,6 +31,21 @@ spec = describe "Repository guardrails" $ do
   it "production code keeps castConstraint quarantined to the defining module" $ do
     offenders <- findCastConstraintOffenders ["src", "src-public", "app"]
     offenders `shouldBe` []
+
+  it "castConstraint guard ignores non-call mentions" $ do
+    let guardedSource =
+          unlines
+            [ "-- castConstraint is mentioned in a comment",
+              "{- castConstraint is mentioned in a block comment -}",
+              "message = \"castConstraint is mentioned in a string\"",
+              "castConstraint :: Constraint p -> Constraint q",
+              "    castConstraint,",
+              "import MLF.Constraint.Types.Graph (castConstraint)"
+            ]
+        guardedLines = lines (stripHaskellCommentsAndLiterals guardedSource)
+    any containsCastConstraintCall guardedLines `shouldBe` False
+    containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
+    containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
   it "MLF.API no longer exports pipeline/runtime helpers and MLF.Pipeline owns them" $ do
     apiSrc <- readFile "src-public/MLF/API.hs"
@@ -424,9 +440,91 @@ findCastConstraintOffenders roots = do
 
 hasCastConstraintUse :: FilePath -> IO (FilePath, Bool)
 hasCastConstraintUse path = do
-  src <- readFile path
+  src <- stripHaskellCommentsAndLiterals <$> readFile path
   let definingModule = path == "src/MLF/Constraint/Types/Graph.hs"
-  pure (path, not definingModule && "castConstraint" `isInfixOf` src)
+  pure (path, not definingModule && any containsCastConstraintCall (lines src))
+
+data SourceMode
+  = SourceCode
+  | SourceLineComment
+  | SourceBlockComment Int
+  | SourceString
+  | SourceChar
+
+stripHaskellCommentsAndLiterals :: String -> String
+stripHaskellCommentsAndLiterals = go SourceCode
+  where
+    go _ [] = []
+    go SourceCode ('-' : '-' : rest) = ' ' : ' ' : go SourceLineComment rest
+    go SourceCode ('{' : '-' : rest) = ' ' : ' ' : go (SourceBlockComment 1) rest
+    go SourceCode ('"' : rest) = ' ' : go SourceString rest
+    go SourceCode ('\'' : rest) = ' ' : go SourceChar rest
+    go SourceCode (ch : rest) = ch : go SourceCode rest
+    go SourceLineComment ('\n' : rest) = '\n' : go SourceCode rest
+    go SourceLineComment (_ : rest) = ' ' : go SourceLineComment rest
+    go (SourceBlockComment depth) ('{' : '-' : rest) =
+      ' ' : ' ' : go (SourceBlockComment (depth + 1)) rest
+    go (SourceBlockComment 1) ('-' : '}' : rest) = ' ' : ' ' : go SourceCode rest
+    go (SourceBlockComment depth) ('-' : '}' : rest) =
+      ' ' : ' ' : go (SourceBlockComment (depth - 1)) rest
+    go mode@(SourceBlockComment _) ('\n' : rest) = '\n' : go mode rest
+    go mode@(SourceBlockComment _) (_ : rest) = ' ' : go mode rest
+    go SourceString ('\\' : _ : rest) = ' ' : ' ' : go SourceString rest
+    go SourceString ('"' : rest) = ' ' : go SourceCode rest
+    go SourceString ('\n' : rest) = '\n' : go SourceCode rest
+    go SourceString (_ : rest) = ' ' : go SourceString rest
+    go SourceChar ('\\' : _ : rest) = ' ' : ' ' : go SourceChar rest
+    go SourceChar ('\'' : rest) = ' ' : go SourceCode rest
+    go SourceChar ('\n' : rest) = '\n' : go SourceCode rest
+    go SourceChar (_ : rest) = ' ' : go SourceChar rest
+
+containsCastConstraintCall :: String -> Bool
+containsCastConstraintCall line
+  | Just _ <- stripPrefix "import " stripped = False
+  | otherwise = any isCallAt (identifierTokenOffsets "castConstraint" line)
+  where
+    stripped = trim line
+    isCallAt offset =
+      let (prefix, tokenAndSuffix) = splitAt offset line
+          suffix = drop (length "castConstraint") tokenAndSuffix
+       in isCastConstraintCallContext prefix suffix
+
+isCastConstraintCallContext :: String -> String -> Bool
+isCastConstraintCallContext prefix suffix =
+  not (isSignatureEntry || isExportListEntry)
+  where
+    prefixTrimmed = trim prefix
+    suffixTrimmed = trim suffix
+    onlyExportPunctuation = all (`elem` "(),")
+    onlySignaturePrefix = all (== ',')
+    isSignatureEntry =
+      "::" `isPrefixOf` suffixTrimmed
+        && onlySignaturePrefix prefixTrimmed
+    isExportListEntry =
+      onlyExportPunctuation prefixTrimmed
+        && onlyExportPunctuation suffixTrimmed
+
+identifierTokenOffsets :: String -> String -> [Int]
+identifierTokenOffsets needle haystack = go 0 haystack
+  where
+    go _ [] = []
+    go offset rest@(_ : tailRest)
+      | Just suffix <- stripPrefix needle rest,
+        hasIdentifierBoundary offset suffix =
+          offset : go (offset + 1) tailRest
+      | otherwise = go (offset + 1) tailRest
+    hasIdentifierBoundary offset suffix =
+      let beforeOk =
+            offset == 0
+              || not (isIdentifierChar (haystack !! (offset - 1)))
+          afterOk =
+            case suffix of
+              ch : _ -> not (isIdentifierChar ch)
+              [] -> True
+       in beforeOk && afterOk
+
+isIdentifierChar :: Char -> Bool
+isIdentifierChar ch = isAlphaNum ch || ch == '_' || ch == '\''
 
 collectHsFiles :: FilePath -> IO [FilePath]
 collectHsFiles root = do
@@ -448,13 +546,6 @@ dropFieldPrefix line =
   case break (== ':') line of
     (_field, ':' : rest) -> rest
     _ -> line
-
-parseImportModule :: String -> Maybe String
-parseImportModule line =
-  case words (trim line) of
-    ("import" : "qualified" : modName : _) -> Just modName
-    ("import" : modName : _) -> Just modName
-    _ -> Nothing
 
 trimImport :: String -> String
 trimImport = unwords . take 2 . words

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -39,17 +39,38 @@ spec = describe "Repository guardrails" $ do
               "{- castConstraint is mentioned in a block comment -}",
               "message = \"castConstraint is mentioned in a string\"",
               "castConstraint :: Constraint p -> Constraint q",
-              "    castConstraint,",
               "import MLF.Constraint.Types.Graph (castConstraint)"
             ]
-        guardedLines = lines (stripHaskellCommentsAndLiterals guardedSource)
-    any containsCastConstraintCall guardedLines `shouldBe` False
+        multilineSignature =
+          unlines
+            [ "castConstraint",
+              "  :: Constraint p -> Constraint q"
+            ]
+        multilineImport =
+          unlines
+            [ "import MLF.Constraint.Types.Graph",
+              "  (",
+              "    castConstraint",
+              "  )"
+            ]
+        multilineExport =
+          unlines
+            [ "module MLF.Constraint.Types.Graph",
+              "  (",
+              "    castConstraint",
+              "  ) where"
+            ]
+    containsCastConstraintCall guardedSource `shouldBe` False
+    containsCastConstraintCall multilineSignature `shouldBe` False
+    containsCastConstraintCall multilineImport `shouldBe` False
+    containsCastConstraintCall multilineExport `shouldBe` False
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
-    any containsCastConstraintCall (lines (stripHaskellCommentsAndLiterals "x' = castConstraint c"))
+    containsCastConstraintCall "x' = castConstraint c" `shouldBe` True
+    containsCastConstraintCall (unlines ["legacy =", "  castConstraint", "    c"])
       `shouldBe` True
-    any containsCastConstraintCall (lines (unlines ["legacy =", "  castConstraint", "    c"]))
+    containsCastConstraintCall (unlines ["legacy =", "  (castConstraint)", "    c"])
       `shouldBe` True
-    any containsCastConstraintCall (lines (unlines ["legacy =", "  (castConstraint)", "    c"]))
+    containsCastConstraintCall (unlines ["legacy =", "  castConstraint", "  :: Constraint p -> Constraint q"])
       `shouldBe` True
     containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
@@ -446,15 +467,20 @@ findCastConstraintOffenders roots = do
 
 hasCastConstraintUse :: FilePath -> IO (FilePath, Bool)
 hasCastConstraintUse path = do
-  src <- stripHaskellCommentsAndLiterals <$> readFile path
+  src <- readFile path
   let definingModule = path == "src/MLF/Constraint/Types/Graph.hs"
-  pure (path, not definingModule && any containsCastConstraintCall (lines src))
+  pure (path, not definingModule && containsCastConstraintCall src)
 
 data SourceMode
   = SourceCode
   | SourceLineComment
   | SourceBlockComment Int
   | SourceString
+
+data SymbolListContext
+  = OutsideSymbolList
+  | PendingSymbolList
+  | InsideSymbolList Int
 
 stripHaskellCommentsAndLiterals :: String -> String
 stripHaskellCommentsAndLiterals = go SourceCode
@@ -479,31 +505,120 @@ stripHaskellCommentsAndLiterals = go SourceCode
     go SourceString (_ : rest) = ' ' : go SourceString rest
 
 containsCastConstraintCall :: String -> Bool
-containsCastConstraintCall line
-  | Just _ <- stripPrefix "import " stripped = False
-  | otherwise = any isCallAt (identifierTokenOffsets "castConstraint" line)
+containsCastConstraintCall source =
+  any lineHasCastConstraintCall (zip3 [0 ..] symbolListLines sourceLines)
   where
-    stripped = trim line
-    isCallAt offset =
+    sourceLines = lines (stripHaskellCommentsAndLiterals source)
+    symbolListLines = importExportSymbolListLines sourceLines
+    lineHasCastConstraintCall (lineIndex, inImportExportList, line)
+      | isImportLine line = False
+      | isModuleHeaderLine line = False
+      | otherwise =
+          any
+            (isCallAt lineIndex inImportExportList line)
+            (identifierTokenOffsets "castConstraint" line)
+    isCallAt lineIndex inImportExportList line offset =
       let (prefix, tokenAndSuffix) = splitAt offset line
           suffix = drop (length "castConstraint") tokenAndSuffix
-       in isCastConstraintCallContext prefix suffix
+       in isCastConstraintCallContext
+            inImportExportList
+            (nextLineStartsSignature lineIndex)
+            (previousLineContinuesExpression lineIndex)
+            prefix
+            suffix
+    nextLineStartsSignature lineIndex =
+      case firstNonEmpty (drop (lineIndex + 1) sourceLines) of
+        Just nextLine -> "::" `isPrefixOf` trim nextLine
+        Nothing -> False
+    previousLineContinuesExpression lineIndex =
+      case lastNonEmpty (take lineIndex sourceLines) of
+        Just previousLine -> lineContinuesExpression previousLine
+        Nothing -> False
 
-isCastConstraintCallContext :: String -> String -> Bool
-isCastConstraintCallContext prefix suffix =
-  not (isSignatureEntry || isExportListEntry)
+isImportLine :: String -> Bool
+isImportLine line = "import " `isPrefixOf` trim line
+
+isModuleHeaderLine :: String -> Bool
+isModuleHeaderLine line = "module " `isPrefixOf` trim line
+
+importExportSymbolListLines :: [String] -> [Bool]
+importExportSymbolListLines = go OutsideSymbolList
+  where
+    go _ [] = []
+    go listContext (line : rest) =
+      let startsPendingList =
+            case listContext of
+              PendingSymbolList -> "(" `isPrefixOf` trim line
+              _ -> False
+          inSymbolList =
+            startsPendingList
+              || case listContext of
+                InsideSymbolList _ -> True
+                _ -> False
+          nextContext = advanceSymbolListContext listContext line
+       in inSymbolList : go nextContext rest
+
+advanceSymbolListContext :: SymbolListContext -> String -> SymbolListContext
+advanceSymbolListContext listContext line =
+  case listContext of
+    InsideSymbolList depth -> continueList (depth + parenDelta line)
+    PendingSymbolList
+      | null (trim line) -> PendingSymbolList
+      | "(" `isPrefixOf` trim line -> continueList (parenDelta line)
+      | otherwise -> OutsideSymbolList
+    OutsideSymbolList
+      | startsSymbolListOwner line ->
+          let depth = parenDelta line
+           in if depth > 0
+                then InsideSymbolList depth
+                else
+                  if hasOpeningParen line
+                    then OutsideSymbolList
+                    else PendingSymbolList
+      | otherwise -> OutsideSymbolList
+  where
+    continueList depth
+      | depth > 0 = InsideSymbolList depth
+      | otherwise = OutsideSymbolList
+
+startsSymbolListOwner :: String -> Bool
+startsSymbolListOwner line =
+  isImportLine line
+    || (isModuleHeaderLine line && not (" where" `isInfixOf` trim line))
+
+parenDelta :: String -> Int
+parenDelta = go 0
+  where
+    go depth [] = depth
+    go depth ('(' : rest) = go (depth + 1) rest
+    go depth (')' : rest) = go (depth - 1) rest
+    go depth (_ : rest) = go depth rest
+
+hasOpeningParen :: String -> Bool
+hasOpeningParen [] = False
+hasOpeningParen ('(' : _) = True
+hasOpeningParen (_ : rest) = hasOpeningParen rest
+
+isCastConstraintCallContext :: Bool -> Bool -> Bool -> String -> String -> Bool
+isCastConstraintCallContext inImportExportList nextLineStartsSignature previousLineContinuesExpression prefix suffix =
+  not (isSignatureEntry || isImportExportListEntry)
   where
     prefixTrimmed = trim prefix
     suffixTrimmed = trim suffix
-    onlyExportPunctuation = all (== ',')
-    onlySignaturePrefix = all (== ',')
+    onlyImportExportPunctuation = all (`elem` "(),")
+    onlySignaturePunctuation = all (== ',')
     isSignatureEntry =
-      "::" `isPrefixOf` suffixTrimmed
-        && onlySignaturePrefix prefixTrimmed
-    isExportListEntry =
-      not (null prefixTrimmed && null suffixTrimmed)
-        && onlyExportPunctuation prefixTrimmed
-        && onlyExportPunctuation suffixTrimmed
+      onlySignaturePunctuation prefixTrimmed
+        && ( "::" `isPrefixOf` suffixTrimmed
+              || ( nextLineStartsSignature
+                     && not previousLineContinuesExpression
+                     && onlySignaturePunctuation suffixTrimmed
+                 )
+           )
+    isImportExportListEntry =
+      inImportExportList
+        && onlyImportExportPunctuation prefixTrimmed
+        && onlyImportExportPunctuation suffixTrimmed
 
 identifierTokenOffsets :: String -> String -> [Int]
 identifierTokenOffsets needle haystack = go 0 haystack
@@ -526,6 +641,21 @@ identifierTokenOffsets needle haystack = go 0 haystack
 
 isIdentifierChar :: Char -> Bool
 isIdentifierChar ch = isAlphaNum ch || ch == '_' || ch == '\''
+
+firstNonEmpty :: [String] -> Maybe String
+firstNonEmpty [] = Nothing
+firstNonEmpty (line : rest)
+  | null (trim line) = firstNonEmpty rest
+  | otherwise = Just line
+
+lastNonEmpty :: [String] -> Maybe String
+lastNonEmpty = firstNonEmpty . reverse
+
+lineContinuesExpression :: String -> Bool
+lineContinuesExpression line =
+  any (`isSuffixOf` trimmed) ["=", "(", "$", "\\", "->"]
+  where
+    trimmed = trim line
 
 collectHsFiles :: FilePath -> IO [FilePath]
 collectHsFiles root = do

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -97,6 +97,10 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall classSignature `shouldBe` False
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
     containsCastConstraintCall "x' = castConstraint c" `shouldBe` True
+    containsCastConstraintCall "legacy = lhs --> castConstraint c" `shouldBe` True
+    containsCastConstraintCall "legacy = lhs |-- castConstraint c" `shouldBe` True
+    containsCastConstraintCall "legacy = lhs -- castConstraint c" `shouldBe` False
+    containsCastConstraintCall "legacy = lhs --castConstraint c" `shouldBe` False
     containsCastConstraintCall (unlines ["legacy =", "  castConstraint", "    c"])
       `shouldBe` True
     containsCastConstraintCall (unlines ["legacy =", "  (castConstraint)", "    c"])
@@ -518,26 +522,39 @@ data SymbolListContext
   | InsideSymbolList Int
 
 stripHaskellCommentsAndLiterals :: String -> String
-stripHaskellCommentsAndLiterals = go SourceCode
+stripHaskellCommentsAndLiterals = go Nothing SourceCode
   where
-    go _ [] = []
-    go SourceCode ('-' : '-' : rest) = ' ' : ' ' : go SourceLineComment rest
-    go SourceCode ('{' : '-' : rest) = ' ' : ' ' : go (SourceBlockComment 1) rest
-    go SourceCode ('"' : rest) = ' ' : go SourceString rest
-    go SourceCode (ch : rest) = ch : go SourceCode rest
-    go SourceLineComment ('\n' : rest) = '\n' : go SourceCode rest
-    go SourceLineComment (_ : rest) = ' ' : go SourceLineComment rest
-    go (SourceBlockComment depth) ('{' : '-' : rest) =
-      ' ' : ' ' : go (SourceBlockComment (depth + 1)) rest
-    go (SourceBlockComment 1) ('-' : '}' : rest) = ' ' : ' ' : go SourceCode rest
-    go (SourceBlockComment depth) ('-' : '}' : rest) =
-      ' ' : ' ' : go (SourceBlockComment (depth - 1)) rest
-    go mode@(SourceBlockComment _) ('\n' : rest) = '\n' : go mode rest
-    go mode@(SourceBlockComment _) (_ : rest) = ' ' : go mode rest
-    go SourceString ('\\' : _ : rest) = ' ' : ' ' : go SourceString rest
-    go SourceString ('"' : rest) = ' ' : go SourceCode rest
-    go SourceString ('\n' : rest) = '\n' : go SourceCode rest
-    go SourceString (_ : rest) = ' ' : go SourceString rest
+    go _ _ [] = []
+    go previous SourceCode input@('-' : '-' : _) =
+      let (dashes, rest) = span (== '-') input
+       in if dashRunIsOperator previous rest
+            then dashes ++ go (Just '-') SourceCode rest
+            else replicate (length dashes) ' ' ++ go Nothing SourceLineComment rest
+    go _ SourceCode ('{' : '-' : rest) = ' ' : ' ' : go Nothing (SourceBlockComment 1) rest
+    go _ SourceCode ('"' : rest) = ' ' : go Nothing SourceString rest
+    go _ SourceCode ('\n' : rest) = '\n' : go Nothing SourceCode rest
+    go _ SourceCode (ch : rest) = ch : go (Just ch) SourceCode rest
+    go _ SourceLineComment ('\n' : rest) = '\n' : go Nothing SourceCode rest
+    go _ SourceLineComment (_ : rest) = ' ' : go Nothing SourceLineComment rest
+    go _ (SourceBlockComment depth) ('{' : '-' : rest) =
+      ' ' : ' ' : go Nothing (SourceBlockComment (depth + 1)) rest
+    go _ (SourceBlockComment 1) ('-' : '}' : rest) = ' ' : ' ' : go Nothing SourceCode rest
+    go _ (SourceBlockComment depth) ('-' : '}' : rest) =
+      ' ' : ' ' : go Nothing (SourceBlockComment (depth - 1)) rest
+    go _ mode@(SourceBlockComment _) ('\n' : rest) = '\n' : go Nothing mode rest
+    go _ mode@(SourceBlockComment _) (_ : rest) = ' ' : go Nothing mode rest
+    go _ SourceString ('\\' : _ : rest) = ' ' : ' ' : go Nothing SourceString rest
+    go _ SourceString ('"' : rest) = ' ' : go Nothing SourceCode rest
+    go _ SourceString ('\n' : rest) = '\n' : go Nothing SourceCode rest
+    go _ SourceString (_ : rest) = ' ' : go Nothing SourceString rest
+    dashRunIsOperator previous rest =
+      maybe False isHaskellSymbolChar previous
+        || case rest of
+          ch : _ -> isHaskellSymbolChar ch
+          [] -> False
+
+isHaskellSymbolChar :: Char -> Bool
+isHaskellSymbolChar ch = ch `elem` "!#$%&*+./<=>?@\\^|-~:"
 
 containsCastConstraintCall :: String -> Bool
 containsCastConstraintCall source =

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -47,6 +47,8 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
     any containsCastConstraintCall (lines (stripHaskellCommentsAndLiterals "x' = castConstraint c"))
       `shouldBe` True
+    any containsCastConstraintCall (lines (unlines ["legacy =", "  castConstraint", "    c"]))
+      `shouldBe` True
     containsCastConstraintCall "legacy = Graph.castConstraint c" `shouldBe` True
 
   it "MLF.API no longer exports pipeline/runtime helpers and MLF.Pipeline owns them" $ do
@@ -497,7 +499,8 @@ isCastConstraintCallContext prefix suffix =
       "::" `isPrefixOf` suffixTrimmed
         && onlySignaturePrefix prefixTrimmed
     isExportListEntry =
-      onlyExportPunctuation prefixTrimmed
+      not (null prefixTrimmed && null suffixTrimmed)
+        && onlyExportPunctuation prefixTrimmed
         && onlyExportPunctuation suffixTrimmed
 
 identifierTokenOffsets :: String -> String -> [Int]

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -61,6 +61,22 @@ spec = describe "Repository guardrails" $ do
               "    castConstraint",
               "  )"
             ]
+        multilineQualifiedPostImport =
+          unlines
+            [ "import MLF.Constraint.Types.Graph",
+              "  qualified as Graph",
+              "  (",
+              "    castConstraint",
+              "  )"
+            ]
+        multilineBareQualifiedPostImport =
+          unlines
+            [ "import MLF.Constraint.Types.Graph",
+              "  qualified",
+              "  (",
+              "    castConstraint",
+              "  )"
+            ]
         multilineHidingImport =
           unlines
             [ "import MLF.Constraint.Types.Graph",
@@ -91,6 +107,8 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall multilineSignature `shouldBe` False
     containsCastConstraintCall multilineImport `shouldBe` False
     containsCastConstraintCall multilineQualifiedImport `shouldBe` False
+    containsCastConstraintCall multilineQualifiedPostImport `shouldBe` False
+    containsCastConstraintCall multilineBareQualifiedPostImport `shouldBe` False
     containsCastConstraintCall multilineHidingImport `shouldBe` False
     containsCastConstraintCall sameLineHidingImport `shouldBe` False
     containsCastConstraintCall multilineExport `shouldBe` False
@@ -755,6 +773,10 @@ pendingSymbolListLineOpens line =
 isImportSpecContinuation :: String -> Bool
 isImportSpecContinuation line =
   case words (takeWhile (/= '(') (trim line)) of
+    ["qualified"] -> True
+    ["qualified", "as", _alias] -> True
+    ["qualified", "hiding"] -> True
+    ["qualified", "as", _alias, "hiding"] -> True
     ["as", _alias] -> True
     ["as", _alias, "hiding"] -> True
     ["hiding"] -> True

--- a/test/RepoGuardSpec.hs
+++ b/test/RepoGuardSpec.hs
@@ -61,6 +61,19 @@ spec = describe "Repository guardrails" $ do
               "    castConstraint",
               "  )"
             ]
+        multilineHidingImport =
+          unlines
+            [ "import MLF.Constraint.Types.Graph",
+              "  hiding",
+              "  (",
+              "    castConstraint",
+              "  )"
+            ]
+        sameLineHidingImport =
+          unlines
+            [ "import MLF.Constraint.Types.Graph",
+              "  hiding (castConstraint)"
+            ]
         multilineExport =
           unlines
             [ "module MLF.Constraint.Types.Graph",
@@ -78,6 +91,8 @@ spec = describe "Repository guardrails" $ do
     containsCastConstraintCall multilineSignature `shouldBe` False
     containsCastConstraintCall multilineImport `shouldBe` False
     containsCastConstraintCall multilineQualifiedImport `shouldBe` False
+    containsCastConstraintCall multilineHidingImport `shouldBe` False
+    containsCastConstraintCall sameLineHidingImport `shouldBe` False
     containsCastConstraintCall multilineExport `shouldBe` False
     containsCastConstraintCall classSignature `shouldBe` False
     containsCastConstraintCall "legacy = castConstraint c" `shouldBe` True
@@ -569,7 +584,7 @@ importExportSymbolListLines = go OutsideSymbolList
     go listContext (line : rest) =
       let startsPendingList =
             case listContext of
-              PendingSymbolList -> "(" `isPrefixOf` trim line
+              PendingSymbolList -> pendingSymbolListLineOpens line
               _ -> False
           inSymbolList =
             startsPendingList
@@ -585,8 +600,8 @@ advanceSymbolListContext listContext line =
     InsideSymbolList depth -> continueList (depth + parenDelta line)
     PendingSymbolList
       | null (trim line) -> PendingSymbolList
-      | "(" `isPrefixOf` trim line -> continueList (parenDelta line)
-      | isImportQualifierContinuation line -> PendingSymbolList
+      | pendingSymbolListLineOpens line -> continueList (parenDelta line)
+      | isImportSpecContinuation line -> PendingSymbolList
       | otherwise -> OutsideSymbolList
     OutsideSymbolList
       | startsSymbolListOwner line ->
@@ -629,6 +644,13 @@ isCastConstraintCallContext inImportExportList nextLineStartsSignature previousL
     suffixTrimmed = trim suffix
     onlyImportExportPunctuation = all (`elem` "(),")
     onlySignaturePunctuation = all (== ',')
+    isImportExportPrefix =
+      onlyImportExportPunctuation prefixTrimmed
+        || case break (== '(') prefixTrimmed of
+          (beforeParen, '(' : afterParen) ->
+            isImportSpecContinuation beforeParen
+              && onlyImportExportPunctuation ('(' : afterParen)
+          _ -> False
     isSignatureEntry =
       onlySignaturePunctuation prefixTrimmed
         && ( "::" `isPrefixOf` suffixTrimmed
@@ -639,7 +661,7 @@ isCastConstraintCallContext inImportExportList nextLineStartsSignature previousL
            )
     isImportExportListEntry =
       inImportExportList
-        && onlyImportExportPunctuation prefixTrimmed
+        && isImportExportPrefix
         && onlyImportExportPunctuation suffixTrimmed
 
 identifierTokenOffsets :: String -> String -> [Int]
@@ -706,10 +728,19 @@ lineIntroducesExpression line =
   "=" `isInfixOf` line
     && not ("::" `isInfixOf` line)
 
-isImportQualifierContinuation :: String -> Bool
-isImportQualifierContinuation line =
-  case words line of
+pendingSymbolListLineOpens :: String -> Bool
+pendingSymbolListLineOpens line =
+  "(" `isPrefixOf` trimmed
+    || (hasOpeningParen trimmed && isImportSpecContinuation line)
+  where
+    trimmed = trim line
+
+isImportSpecContinuation :: String -> Bool
+isImportSpecContinuation line =
+  case words (takeWhile (/= '(') (trim line)) of
     ["as", _alias] -> True
+    ["as", _alias, "hiding"] -> True
+    ["hiding"] -> True
     _ -> False
 
 collectHsFiles :: FilePath -> IO [FilePath]


### PR DESCRIPTION
Closes #127.

## Implementation Plan

---
issue_number: 127
pr_number: 132
branch: codex/issue-127
---

## Implementation Plan

Context verified: issue #127 is open; PR #132 is open from `codex/issue-127` to `master`; the local branch is clean and has no implementation diff yet.

1. Re-check local state before editing: `git status --short --branch`, confirm `codex/issue-127`, and avoid touching watcher-owned files.

2. Tighten phase-specific APIs where the inspected code is genuinely phase-bound:
   - In `src/MLF/Constraint/Acyclicity.hs`, make `buildDependencyGraph` accept `Constraint 'Normalized` because dependency graph construction is Phase 3 input over normalized instantiation edges.
   - Make cycle-rewrite internals that are only used by `breakCyclesAndCheckAcyclicity` operate on `Constraint 'Normalized` and return `Constraint 'Normalized`.
   - After a successful sort, create the `Constraint 'Acyclic` once and pass that to `mkAcyclicityResult :: Constraint 'Acyclic -> ...`, keeping the sorted-edge result tied to the acyclic phase.
   - Keep `collectReachableNodes` phase-free because it only traverses a `NodeMap`.

3. Classify normalization internals without broad churn:
   - Specialize `NormalizeState` / `NormalizeM` in `src/MLF/Constraint/Normalize/Internal.hs`, `Graft.hs`, `Merge.hs`, and `Normalize.hs` to the raw normalization phase (`nsConstraint :: Constraint 'Raw`) because these are Phase 2 implementation helpers.
   - Keep `dropReflexiveInstEdges` and `dropReflexiveUnifyEdges` polymorphic if they remain simple edge-list filters; add a short comment only if needed to make that phase-insensitive choice explicit.

4. Leave genuinely phase-insensitive helper surfaces polymorphic:
   - Do not mechanically specialize `src/MLF/Constraint/NodeAccess.hs`, low-level `src/MLF/Binding/**` readers/updates, or `src/MLF/Constraint/Inert.hs` unless a compile error exposes a real phase requirement. The inspected uses are structural graph access, binding-tree queries, or omega-style binding transformations, and presolution still uses a named raw compatibility state internally.

5. Update tests for the new API boundaries:
   - Adjust direct `buildDependencyGraph` calls in `test/AcyclicitySpec.hs` to convert raw fixtures with `toNormalizedConstraint`.
   - Add or extend a repository guard in `test/RepoGuardSpec.hs` so production files under `src`, `src-public`, and `app` have no `castConstraint` callers outside `src/MLF/Constraint/Types/Graph.hs`.
   - Do not add a broad ban on `toRawConstraintForLegacy`; existing named compatibility bridges in solved/presolution/elaboration code are currently intentional.

6. Update durable guidance only where it reflects the new boundary:
   - Add a concise note to `docs/architecture.md` describing that acyclicity helpers consume normalized constraints and normalization state is raw-phase owned.
   - Add a short `implementation_notes.md` entry for the phase-helper classification. Add a `CHANGELOG.md` Changed bullet only if the final diff is more than compile-only type annotations.

7. Validate before publishing:
   - Run targeted checks while iterating, at minimum `cabal build all` and focused Hspec matches for `Acyclicity`, `Normalize`, and `Repository guardrails` if the local test runner accepts `--match`.
   - Run the required full gate before completion: `cabal build all && cabal test`.
   - Re-run `rg "castConstraint" src src-public app test` and inspect `rg "Constraint p|Constraint 'Raw"` in the touched modules to confirm only intentional polymorphic or raw compatibility uses remain.

8. Publish through the existing PR only:
   - Run `gh auth status` and `gh auth setup-git` before pushing.
   - Inspect `git status --short` and relevant diffs; stage only issue-related files.
   - Commit as `codex-watcher <codex-watcher@users.noreply.github.com>` with an imperative message, push `codex/issue-127`, and do not create another PR because #132 already exists.


---
Implementation plan synced by codex-watcher before implementation starts. Implementation commits will be pushed to this PR.