### PR TITLE
Extract generalization preparation artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
   partial applications now run through shared backend parity.
 
 ### Changed
+- Moved elaboration-side generalization preparation into
+  `MLF.Elab.Run.Generalize.Prepare`, which now produces a shared
+  `PreparedGeneralizationArtifact` for elaboration, root generalization, and
+  result-type reconstruction while leaving `MLF.Elab.Run.Pipeline` as the
+  phase orchestrator.
 - Tightened the Phase 4 presolution boundary so the public entry/output remains
   `Constraint 'Acyclic` to `Constraint 'Presolved`, with the internal raw
   in-progress bridge named privately and final presolved construction delayed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# mlf2 Thesis Pipeline
+
+Domain language for the paper-faithful MLF to xMLF implementation and its checked `.mlfp` pipeline.
+
+## Language
+
+**Acyclic Base Constraint**:
+The post-acyclicity constraint graph that preserves original binding-tree ownership for thesis ga-prime recovery.
+_Avoid_: raw graph, old constraint
+
+**Presolution View**:
+The canonical read model built from a presolution or solved snapshot for elaboration and reification.
+_Avoid_: solved wrapper, query bag
+
+**Generalization Preparation**:
+The elaboration-side alignment step that turns presolution outputs, the **Acyclic Base Constraint**, and annotated terms into the shared generalization input.
+_Avoid_: pipeline glue, setup tuple
+
+**Prepared Generalization Artifact**:
+The single artifact produced by **Generalization Preparation** and consumed by elaboration, result-type reconstruction, and root-scheme generalization.
+_Avoid_: constraint tuple, prep bag
+
+## Relationships
+
+- **Generalization Preparation** consumes one **Acyclic Base Constraint** and one **Presolution View**.
+- **Generalization Preparation** produces one **Prepared Generalization Artifact**.
+- A **Prepared Generalization Artifact** is shared by elaboration, result-type reconstruction, and root-scheme generalization.
+
+## Example Dialogue
+
+> **Dev:** "Should `Pipeline` build copy maps and scope overrides before elaboration?"
+> **Domain expert:** "No. `Pipeline` should ask **Generalization Preparation** for a **Prepared Generalization Artifact** and pass that artifact to the consumers."
+
+## Flagged Ambiguities
+
+- "generalization input" can mean either individual maps or the **Prepared Generalization Artifact**; prefer the artifact name when talking about the shared Interface.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,11 @@ runtime invariants as compile-time types:
 - Legacy expansion-to-instantiation translation lives in `MLF.Elab.Legacy` and is re-exported by `MLF.Elab.Elaborate` and `MLF.Elab.Pipeline`.
 - Presolution state access should go through `MonadPresolution` plus `MLF.Constraint.Presolution.Ops` and `StateAccess`; edge processing is split across planner/interpreter passes with typed `EdgePlan`.
 - Elaboration entrypoints bundle inputs as `ElabConfig`/`ElabEnv`, and tracing is explicit via `TraceConfig`.
+- `MLF.Elab.Run.Generalize.Prepare` owns the elaboration-side Generalization
+  Preparation step. It produces the `PreparedGeneralizationArtifact` consumed
+  by elaboration, root-scheme generalization, and result-type reconstruction,
+  while keeping redirect/canonicalization, copy-node recovery, scope overrides,
+  and the transitional acyclic-base phase bridge out of `MLF.Elab.Run.Pipeline`.
 
 ## Typed backend IR and lowering boundary
 

--- a/mlf2.cabal
+++ b/mlf2.cabal
@@ -246,6 +246,7 @@ library mlf2-internal
                       MLF.Elab.Run.Generalize.Phase2,
                       MLF.Elab.Run.Generalize.Phase3,
                       MLF.Elab.Run.Generalize.Phase4,
+                      MLF.Elab.Run.Generalize.Prepare,
                       MLF.Elab.Run.Generalize.Types,
                       MLF.Elab.Run.Instantiation,
                       MLF.Elab.Run.Pipeline,

--- a/mlf2.cabal
+++ b/mlf2.cabal
@@ -149,6 +149,7 @@ library mlf2-internal
                       MLF.Constraint.Presolution.Base,
                       MLF.Elab.Run.Annotation,
                       MLF.Elab.Run.Generalize,
+                      MLF.Elab.Run.Generalize.Prepare,
                       MLF.Elab.Types
     other-modules:    MLF.Constraint.Normalize.Internal,
                        MLF.Constraint.Normalize.Graft,
@@ -246,7 +247,6 @@ library mlf2-internal
                       MLF.Elab.Run.Generalize.Phase2,
                       MLF.Elab.Run.Generalize.Phase3,
                       MLF.Elab.Run.Generalize.Phase4,
-                      MLF.Elab.Run.Generalize.Prepare,
                       MLF.Elab.Run.Generalize.Types,
                       MLF.Elab.Run.Instantiation,
                       MLF.Elab.Run.Pipeline,

--- a/src/MLF/Elab/Run/Generalize/Prepare.hs
+++ b/src/MLF/Elab/Run/Generalize/Prepare.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE DataKinds #-}
+
+module MLF.Elab.Run.Generalize.Prepare (
+    PreparedGeneralizationArtifact(..),
+    prepareGeneralizationArtifact,
+) where
+
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet as IntSet
+
+import MLF.Constraint.Canonicalizer (Canonicalizer, canonicalizeNode)
+import qualified MLF.Constraint.Finalize as Finalize
+import MLF.Constraint.Presolution
+    ( EdgeTrace(..)
+    , PresolutionPlanBuilder
+    , PresolutionResult(..)
+    )
+import MLF.Constraint.Presolution.Base (EdgeArtifacts(..))
+import MLF.Constraint.Presolution.View (PresolutionView, pvCanonical)
+import MLF.Constraint.Solve (SolveError)
+import qualified MLF.Constraint.Solved as Solved
+import MLF.Constraint.Types.Graph
+    ( Constraint
+    , NodeId
+    , NodeRef
+    , castConstraint
+    , cNodes
+    , lookupNodeIn
+    )
+import MLF.Constraint.Types.Phase (Phase(Acyclic, Presolved))
+import MLF.Constraint.Types.Presolution (PresolutionSnapshot(..))
+import MLF.Elab.Generalize (GaBindParents)
+import MLF.Elab.Run.Annotation (redirectAndCanonicalizeAnn)
+import MLF.Elab.Run.Generalize
+    ( GeneralizeAtView
+    , constraintForGeneralization
+    , generalizeAtWithBuilder
+    , instantiationCopyNodes
+    )
+import MLF.Elab.Run.Provenance (buildTraceCopyMap, collectBaseNamedKeys)
+import MLF.Elab.Run.Scope (letScopeOverrides)
+import MLF.Elab.Run.Util
+    ( canonicalizeExpansion
+    , canonicalizeTrace
+    , canonicalizeWitness
+    , makeCanonicalizer
+    )
+import MLF.Frontend.ConstraintGen (AnnExpr)
+import MLF.Util.Trace (TraceConfig)
+
+{- Note [Prepared generalization artifact]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generalization preparation is elaboration-owned because it aligns the solved
+presolution output with source annotations, result-type reconstruction, and the
+root generalization call.  Keeping the alignment here avoids letting
+MLF.Elab.Run.Pipeline rebuild copy maps, redirects, scope overrides, and
+canonical edge artifacts as unrelated local values.
+
+The artifact intentionally exposes the few shared values the current consumers
+need, while hiding the mechanics that produce them:
+
+* the legacy phase bridge from the acyclic base graph to the prepared presolved
+  phase;
+* instantiation copy-node and base-copy-map recovery from edge traces;
+* the redirect plus union-find canonicalizer used for annotations and edge
+  artifacts;
+* the constraint-for-generalization rewrite plus finalized presolution view;
+* let-scope override comparison between the acyclic base graph and the
+  generalization graph.
+
+`pgaAcyclicBaseConstraint` is transitional.  Result-type reconstruction still
+expects the thesis base graph in the same phantom phase as the prepared view,
+so the artifact names that graph explicitly instead of leaking `castConstraint`
+back to the pipeline.
+-}
+data PreparedGeneralizationArtifact = PreparedGeneralizationArtifact
+    { pgaPresolutionView :: PresolutionView 'Presolved
+    , pgaBindParentsGa :: GaBindParents 'Presolved
+    , pgaGeneralizeAt :: GeneralizeAtView 'Presolved
+    , pgaEdgeArtifacts :: EdgeArtifacts
+    , pgaScopeOverrides :: IntMap.IntMap NodeRef
+    , pgaAnnotated :: AnnExpr
+    , pgaAnnNodeCanonical :: NodeId -> NodeId
+    , pgaCanonical :: NodeId -> NodeId
+    , pgaAcyclicBaseConstraint :: Constraint 'Presolved
+    , pgaPlanBuilder :: PresolutionPlanBuilder
+    , pgaRedirects :: IntMap.IntMap NodeId
+    }
+
+prepareGeneralizationArtifact
+    :: TraceConfig
+    -> Constraint 'Acyclic
+    -> PresolutionResult
+    -> AnnExpr
+    -> Either SolveError PreparedGeneralizationArtifact
+prepareGeneralizationArtifact traceCfg acyclicBase pres ann = do
+    let preRewrite = snapshotConstraint pres
+    solvedClean <- Finalize.finalizeSolvedFromSnapshot preRewrite (snapshotUnionFind pres)
+    presolutionViewClean <- Finalize.finalizePresolutionViewFromSnapshot preRewrite (snapshotUnionFind pres)
+    let canonNode = makeCanonicalizer (Solved.canonicalMap solvedClean) (prRedirects pres)
+        acyclicBaseForGeneralization = castConstraint acyclicBase :: Constraint 'Presolved
+        planBuilder = prPlanBuilder pres
+        TraceCopyArtifacts
+            { tcaInstCopyNodes = instCopyNodes
+            , tcaInstCopyMapFull = instCopyMapFull
+            } =
+            prepareTraceCopyArtifacts
+                acyclicBase
+                presolutionViewClean
+                (prRedirects pres)
+                canonNode
+                (prEdgeTraces pres)
+        (constraintForGen, bindParentsGa) =
+            constraintForGeneralization
+                traceCfg
+                presolutionViewClean
+                (prRedirects pres)
+                instCopyNodes
+                instCopyMapFull
+                acyclicBaseForGeneralization
+                ann
+    presolutionViewForGen <-
+        Finalize.finalizePresolutionViewFromSnapshot
+            constraintForGen
+            (Solved.canonicalMap solvedClean)
+    let annNodeCanonical = canonicalizeNode canonNode
+        annCanon = redirectAndCanonicalizeAnn annNodeCanonical (prRedirects pres) ann
+        edgeArtifacts =
+            EdgeArtifacts
+                { eaEdgeExpansions = IntMap.map (canonicalizeExpansion canonNode) (prEdgeExpansions pres)
+                , eaEdgeWitnesses = IntMap.map (canonicalizeWitness canonNode) (prEdgeWitnesses pres)
+                , eaEdgeTraces = IntMap.map (canonicalizeTrace canonNode) (prEdgeTraces pres)
+                }
+        scopeOverrides =
+            letScopeOverrides
+                acyclicBaseForGeneralization
+                constraintForGen
+                presolutionViewClean
+                (prRedirects pres)
+                annCanon
+        generalizeAtWithView mbGa =
+            generalizeAtWithBuilder
+                planBuilder
+                mbGa
+                presolutionViewForGen
+    pure
+        PreparedGeneralizationArtifact
+            { pgaPresolutionView = presolutionViewForGen
+            , pgaBindParentsGa = bindParentsGa
+            , pgaGeneralizeAt = generalizeAtWithView
+            , pgaEdgeArtifacts = edgeArtifacts
+            , pgaScopeOverrides = scopeOverrides
+            , pgaAnnotated = annCanon
+            , pgaAnnNodeCanonical = annNodeCanonical
+            , pgaCanonical = pvCanonical presolutionViewForGen
+            , pgaAcyclicBaseConstraint = acyclicBaseForGeneralization
+            , pgaPlanBuilder = planBuilder
+            , pgaRedirects = prRedirects pres
+            }
+
+data TraceCopyArtifacts = TraceCopyArtifacts
+    { tcaInstCopyNodes :: IntSet.IntSet
+    , tcaInstCopyMapFull :: IntMap.IntMap NodeId
+    }
+
+prepareTraceCopyArtifacts
+    :: Constraint p
+    -> PresolutionView q
+    -> IntMap.IntMap NodeId
+    -> Canonicalizer
+    -> IntMap.IntMap EdgeTrace
+    -> TraceCopyArtifacts
+prepareTraceCopyArtifacts baseConstraint presolutionView redirects canonNode edgeTraces =
+    let adoptNode = canonicalizeNode canonNode
+        baseNodes = cNodes baseConstraint
+        edgeTracesForCopy =
+            IntMap.filter
+                ( \tr ->
+                    case lookupNodeIn baseNodes (etRoot tr) of
+                        Just _ -> True
+                        Nothing -> False
+                )
+                edgeTraces
+        instCopyNodes =
+            instantiationCopyNodes presolutionView redirects edgeTracesForCopy
+        instCopyMapFull =
+            let baseNamedKeysAll = collectBaseNamedKeys baseConstraint
+                traceMaps =
+                    map
+                        (buildTraceCopyMap baseConstraint baseNamedKeysAll adoptNode)
+                        (IntMap.elems edgeTracesForCopy)
+             in foldl' IntMap.union IntMap.empty traceMaps
+     in TraceCopyArtifacts
+            { tcaInstCopyNodes = instCopyNodes
+            , tcaInstCopyMapFull = instCopyMapFull
+            }

--- a/src/MLF/Elab/Run/Pipeline.hs
+++ b/src/MLF/Elab/Run/Pipeline.hs
@@ -18,24 +18,14 @@ module MLF.Elab.Run.Pipeline
 where
 
 import qualified Data.IntMap.Strict as IntMap
-import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import MLF.Constraint.Acyclicity (breakCyclesAndCheckAcyclicity)
-import MLF.Constraint.Canonicalizer (Canonicalizer, canonicalizeNode)
-import qualified MLF.Constraint.Finalize as Finalize
 import MLF.Constraint.Normalize (normalize)
-import MLF.Constraint.Presolution
-  ( EdgeTrace (..),
-    PresolutionResult (..),
-    computePresolution,
-  )
-import MLF.Constraint.Presolution.Base (EdgeArtifacts (..))
-import MLF.Constraint.Presolution.View (PresolutionView, pvCanonical)
-import qualified MLF.Constraint.Solved as Solved
-import MLF.Constraint.Types.Graph (BaseTy (..), Constraint, NodeId (..), PolySyms, castConstraint, cNodes, getEdgeId, getNodeId, lookupNodeIn)
-import MLF.Constraint.Types.Phase (Phase(Presolved, Raw))
-import MLF.Constraint.Types.Presolution (PresolutionSnapshot (..))
+import MLF.Constraint.Presolution (computePresolution)
+import MLF.Constraint.Presolution.Base (EdgeArtifacts (eaEdgeWitnesses))
+import MLF.Constraint.Types.Graph (BaseTy (..), NodeId (..), PolySyms, getEdgeId, getNodeId)
+import MLF.Constraint.Types.Phase (Phase(Raw))
 import MLF.Elab.Elaborate (ElabConfig (..), ElabEnv (..), elaborateWithEnv)
 import MLF.Elab.Inst (schemeToType)
 import MLF.Elab.PipelineConfig (PipelineConfig (..), defaultPipelineConfig)
@@ -48,24 +38,15 @@ import MLF.Elab.PipelineError
     fromSolveError,
     fromTypeCheckError,
   )
-import MLF.Elab.Run.Annotation (annNode, redirectAndCanonicalizeAnn)
-import MLF.Elab.Run.Generalize
-  ( constraintForGeneralization,
-    generalizeAtWithBuilder,
-    instantiationCopyNodes,
+import MLF.Elab.Run.Annotation (annNode)
+import MLF.Elab.Run.Generalize.Prepare
+  ( PreparedGeneralizationArtifact (..),
+    prepareGeneralizationArtifact,
   )
-import MLF.Elab.Run.Provenance (buildTraceCopyMap, collectBaseNamedKeys)
 import MLF.Elab.Run.ResultType (computeResultTypeFallback, computeResultTypeFromAnn, mkResultTypeInputs)
 import MLF.Elab.Run.Scope
-  ( letScopeOverrides,
-    resolveCanonicalScope,
+  ( resolveCanonicalScope,
     schemeBodyTarget,
-  )
-import MLF.Elab.Run.Util
-  ( canonicalizeExpansion,
-    canonicalizeTrace,
-    canonicalizeWitness,
-    makeCanonicalizer,
   )
 import MLF.Elab.TermClosure
   ( closeTermWithSchemeSubstIfNeeded,
@@ -90,18 +71,6 @@ import MLF.Frontend.Syntax (NormSrcType, NormSurfaceExpr, StructBound)
 import qualified MLF.Frontend.Syntax as Surface
 import MLF.Reify.TypeOps (freeTypeVarsType, freshNameLike, substTypeCapture)
 import MLF.Util.Trace (TraceConfig, traceGeneralize)
-
-data SnapshotViews = SnapshotViews
-  { svSolvedClean :: Solved.Solved,
-    svPresolutionViewClean :: PresolutionView 'Presolved,
-    svCanonNode :: Canonicalizer
-  }
-
-data TraceCopyArtifacts = TraceCopyArtifacts
-  { tcaEdgeTracesForCopy :: IntMap.IntMap EdgeTrace,
-    tcaInstCopyNodes :: IntSet.IntSet,
-    tcaInstCopyMapFull :: IntMap.IntMap NodeId
-  }
 
 data PipelineElabDetailedResult = PipelineElabDetailedResult
   { pedTerm :: ElabTerm,
@@ -234,31 +203,16 @@ runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints ex
   let c1 = normalize c0
   (cAcyclic, acyc) <- fromCycleError (breakCyclesAndCheckAcyclicity c1)
   pres <- fromPresolutionError (computePresolution traceCfg acyc cAcyclic)
-  SnapshotViews
-    { svSolvedClean = solvedClean,
-      svPresolutionViewClean = presolutionViewClean,
-      svCanonNode = canonNode
-    } <-
-    prepareSnapshotViews pres
-  -- | Named phase bridge: the acyclic base constraint must share a phase
-  -- index with the presolved view for constraintForGeneralization.
-  -- The constraint graph data is structurally identical across phases;
-  -- only the phantom type tag differs.
-  let cAcyclicAsPresolved = castConstraint cAcyclic :: Constraint 'Presolved
-  let planBuilder = prPlanBuilder pres
-  TraceCopyArtifacts
-    { tcaInstCopyNodes = instCopyNodes,
-      tcaInstCopyMapFull = instCopyMapFull
-    } <-
-    pure (prepareTraceCopyArtifacts cAcyclic presolutionViewClean (prRedirects pres) canonNode (prEdgeTraces pres))
-  let (constraintForGen, bindParentsGa) =
-        constraintForGeneralization traceCfg presolutionViewClean (prRedirects pres) instCopyNodes instCopyMapFull cAcyclicAsPresolved ann
-  presolutionViewForGen <- fromSolveError (Finalize.finalizePresolutionViewFromSnapshot constraintForGen (Solved.canonicalMap solvedClean))
-  let generalizeAtWithView mbGa =
-        generalizeAtWithBuilder
-          planBuilder
-          mbGa
-          presolutionViewForGen
+  prepared <-
+    fromSolveError $
+      prepareGeneralizationArtifact traceCfg cAcyclic pres ann
+  let presolutionViewForGen = pgaPresolutionView prepared
+      bindParentsGa = pgaBindParentsGa prepared
+      generalizeAtWithView = pgaGeneralizeAt prepared
+      edgeArtifacts = pgaEdgeArtifacts prepared
+      scopeOverrides = pgaScopeOverrides prepared
+      annCanon = pgaAnnotated prepared
+      acyclicBaseForGeneralization = pgaAcyclicBaseConstraint prepared
   -- Build authoritative SchemeInfo map and TypeCheck.Env from external
   -- source types.  We derive schemes directly from the caller-supplied
   -- NormSrcType values (which preserve lowerType naming) instead of
@@ -269,20 +223,6 @@ runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints ex
           { TypeCheck.termEnv = Map.map (schemeToType . siScheme) initialSchemeInfos,
             TypeCheck.typeEnv = Map.empty
           }
-  let annCanon = redirectAndCanonicalizeAnn (canonicalizeNode canonNode) (prRedirects pres) ann
-  let edgeArtifacts =
-        EdgeArtifacts
-          { eaEdgeExpansions = IntMap.map (canonicalizeExpansion canonNode) (prEdgeExpansions pres),
-            eaEdgeWitnesses = IntMap.map (canonicalizeWitness canonNode) (prEdgeWitnesses pres),
-            eaEdgeTraces = IntMap.map (canonicalizeTrace canonNode) (prEdgeTraces pres)
-          }
-  let scopeOverrides =
-        letScopeOverrides
-          cAcyclicAsPresolved
-          constraintForGen
-          presolutionViewClean
-          (prRedirects pres)
-          annCanon
   let elabConfig =
         ElabConfig
           { ecTraceConfig = traceCfg,
@@ -296,7 +236,7 @@ runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints ex
             eeScopeOverrides = scopeOverrides,
             eeAnnSourceTypes =
               IntMap.fromList
-                [ (getNodeId (canonicalizeNode canonNode nid), ty)
+                [ (getNodeId (pgaAnnNodeCanonical prepared nid), ty)
                   | (k, ty) <- IntMap.toList annSourceTypes,
                     let nid = NodeId k
                 ],
@@ -312,7 +252,11 @@ runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints ex
   rootScope <-
     fromElabError $
       bindingToElab $
-        resolveCanonicalScope cAcyclicAsPresolved presolutionViewForGen (prRedirects pres) (annNode authoritativeAnnPreFinal)
+        resolveCanonicalScope
+          acyclicBaseForGeneralization
+          presolutionViewForGen
+          (pgaRedirects prepared)
+          (annNode authoritativeAnnPreFinal)
   let rootTarget = schemeBodyTarget presolutionViewForGen (annNode authoritativeAnnCanonFinal)
   (rootScheme, rootSubst) <-
     fromElabError $
@@ -320,16 +264,15 @@ runPipelineElabWith requireFinalTypeCheck traceCfg extBindings genConstraints ex
   let termSubst = substInTerm rootSubst term
 
   -- Build context for result type computation
-  let canonical = pvCanonical presolutionViewForGen
-      resultTypeInputs =
+  let resultTypeInputs =
         mkResultTypeInputs
-          canonical
+          (pgaCanonical prepared)
           edgeArtifacts
           presolutionViewForGen
           bindParentsGa
-          planBuilder
-          cAcyclicAsPresolved
-          (prRedirects pres)
+          (pgaPlanBuilder prepared)
+          acyclicBaseForGeneralization
+          (pgaRedirects prepared)
           traceCfg
       retainedChildAuthoritativeCandidate =
         case preserveRetainedChildAuthoritativeResult termSubst of
@@ -516,52 +459,6 @@ renameTypeVarInTerm old new term =
         ETyInst t inst -> ETyInst (renameTypeVarInTerm old new t) (renameInst inst)
         ERoll ty body -> ERoll (renameTy ty) (renameTypeVarInTerm old new body)
         EUnroll body -> EUnroll (renameTypeVarInTerm old new body)
-
-prepareSnapshotViews :: PresolutionResult -> Either PipelineError SnapshotViews
-prepareSnapshotViews pres = do
-  let preRewrite = snapshotConstraint pres
-  solvedClean <- fromSolveError (Finalize.finalizeSolvedFromSnapshot preRewrite (snapshotUnionFind pres))
-  presolutionViewClean <- fromSolveError (Finalize.finalizePresolutionViewFromSnapshot preRewrite (snapshotUnionFind pres))
-  let canonNode = makeCanonicalizer (Solved.canonicalMap solvedClean) (prRedirects pres)
-  pure
-    SnapshotViews
-      { svSolvedClean = solvedClean,
-        svPresolutionViewClean = presolutionViewClean,
-        svCanonNode = canonNode
-      }
-
-prepareTraceCopyArtifacts ::
-  Constraint p ->
-  PresolutionView q ->
-  IntMap.IntMap NodeId ->
-  Canonicalizer ->
-  IntMap.IntMap EdgeTrace ->
-  TraceCopyArtifacts
-prepareTraceCopyArtifacts baseConstraint presolutionView redirects canonNode edgeTraces =
-  let adoptNode = canonicalizeNode canonNode
-      baseNodes = cNodes baseConstraint
-      edgeTracesForCopy =
-        IntMap.filter
-          ( \tr ->
-              case lookupNodeIn baseNodes (etRoot tr) of
-                Just _ -> True
-                Nothing -> False
-          )
-          edgeTraces
-      instCopyNodes =
-        instantiationCopyNodes presolutionView redirects edgeTracesForCopy
-      instCopyMapFull =
-        let baseNamedKeysAll = collectBaseNamedKeys baseConstraint
-            traceMaps =
-              map
-                (buildTraceCopyMap baseConstraint baseNamedKeysAll adoptNode)
-                (IntMap.elems edgeTracesForCopy)
-         in foldl' IntMap.union IntMap.empty traceMaps
-   in TraceCopyArtifacts
-        { tcaEdgeTracesForCopy = edgeTracesForCopy,
-          tcaInstCopyNodes = instCopyNodes,
-          tcaInstCopyMapFull = instCopyMapFull
-        }
 
 authoritativeRootAnn :: ElabTerm -> AnnExpr -> AnnExpr
 authoritativeRootAnn term annExpr =

--- a/test/PipelineSpec.hs
+++ b/test/PipelineSpec.hs
@@ -15,9 +15,11 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, isJust, listToMaybe)
 import Data.Set qualified as Set
 import MLF.Binding.Tree qualified as Binding
+import MLF.Constraint.Acyclicity qualified as Acyc
 import MLF.Constraint.Canonicalizer (canonicalizeNode, canonicalizerFrom)
 import MLF.Constraint.Finalize qualified as Finalize
 import MLF.Constraint.NodeAccess qualified as NodeAccess
+import MLF.Constraint.Normalize qualified as CNormalize
 import MLF.Constraint.Presolution
 import MLF.Constraint.Presolution.Plan.Context (GaBindParents (..))
 import MLF.Constraint.Presolution.TestSupport
@@ -49,6 +51,10 @@ import MLF.Elab.Pipeline
     pattern Forall,
   )
 import MLF.Elab.Pipeline qualified as Elab
+import MLF.Elab.Run.Generalize.Prepare
+  ( PreparedGeneralizationArtifact (..),
+    prepareGeneralizationArtifact,
+  )
 import MLF.Elab.Run.Provenance (buildTraceCopyMap, collectBaseNamedKeys)
 import MLF.Elab.Run.ResultType
   ( ResultTypeInputs (..),
@@ -64,6 +70,7 @@ import MLF.Elab.Run.ResultType.Util
     selectUniqueCandidate,
     selectUniqueCandidateBy,
   )
+import MLF.Elab.Run.Scope (resolveCanonicalScope, schemeBodyTarget)
 import MLF.Elab.Run.Util
   ( canonicalizeExpansion,
     canonicalizeTrace,
@@ -82,6 +89,7 @@ import SpecUtil
     collectVarNodes,
     defaultTraceConfig,
     emptyConstraint,
+    firstShowE,
     mkForalls,
     requireRight,
     runConstraintDefault,
@@ -6131,6 +6139,88 @@ spec = describe "Pipeline (Phases 1-5)" $ do
           let nodes = cNodes (Solved.originalConstraint res)
           baseNames nodes `shouldContain` [BaseTy "Int"]
           noExpNodes nodes
+
+    it "prepared generalization artifact drives redirecting instantiation behavior" $ do
+      let expr =
+            ELet
+              "id"
+              (ELam "x" (EVar "x"))
+              ( ELet
+                  "a"
+                  (EApp (EVar "id") (ELit (LInt 1)))
+                  (EApp (EVar "id") (ELit (LBool True)))
+              )
+      ConstraintResult {crConstraint = c0, crAnnotated = ann} <-
+        requireRight (runConstraintDefault defaultPolySyms expr)
+      let cNorm = CNormalize.normalize c0
+      (cAcyclic, acyc) <-
+        requireRight (firstShowE (Acyc.breakCyclesAndCheckAcyclicity cNorm))
+      pres <-
+        requireRight (firstShowE (computePresolution defaultTraceConfig acyc cAcyclic))
+      artifact <-
+        requireRight
+          (firstShowE (prepareGeneralizationArtifact defaultTraceConfig cAcyclic pres ann))
+      let redirects = prRedirects pres
+          redirectedAnn = applyRedirectsToAnn redirects ann
+          canonicalizedAnn = canonicalizeAnn (pgaAnnNodeCanonical artifact) redirectedAnn
+          GaBindParents
+            { gaBaseConstraint = baseConstraint,
+              gaSolvedToBase = solvedToBase
+            } = pgaBindParentsGa artifact
+          baseNamedKeysAll = collectBaseNamedKeys (pgaAcyclicBaseConstraint artifact)
+          baseCopyPairs =
+            [ (baseKey, copyN)
+              | tr <- IntMap.elems (prEdgeTraces pres),
+                (baseKey, copyN) <- IntMap.toList (getCopyMapping (etCopyMap tr)),
+                IntSet.member baseKey baseNamedKeysAll
+            ]
+      redirects `shouldSatisfy` (not . IntMap.null)
+      pgaAnnotated artifact `shouldBe` canonicalizedAnn
+      annNodeOccurrences (pgaAnnotated artifact)
+        `shouldBe` map (pgaAnnNodeCanonical artifact) (annNodeOccurrences redirectedAnn)
+      baseConstraint `shouldBe` pgaAcyclicBaseConstraint artifact
+      baseNamedKeysAll `shouldSatisfy` (not . IntSet.null)
+      baseCopyPairs `shouldSatisfy` (not . null)
+      forM_ baseCopyPairs $ \(_baseKey, copyN) -> do
+        let copyKey = getNodeId (pgaAnnNodeCanonical artifact copyN)
+        case IntMap.lookup copyKey solvedToBase of
+          Nothing ->
+            expectationFailure ("Prepared artifact missed copy provenance for " ++ show copyN)
+          Just actualBase ->
+            lookupNodeIn (cNodes baseConstraint) actualBase `shouldSatisfy` isJust
+      rootScope <-
+        requireRight
+          ( firstShowE
+              ( resolveCanonicalScope
+                  (pgaAcyclicBaseConstraint artifact)
+                  (pgaPresolutionView artifact)
+                  (pgaRedirects artifact)
+                  (annRootNode ann)
+              )
+          )
+      let rootTarget =
+            schemeBodyTarget
+              (pgaPresolutionView artifact)
+              (annRootNode (pgaAnnotated artifact))
+          resultTypeInputs =
+            mkResultTypeInputs
+              (pgaCanonical artifact)
+              (pgaEdgeArtifacts artifact)
+              (pgaPresolutionView artifact)
+              (pgaBindParentsGa artifact)
+              (pgaPlanBuilder artifact)
+              (pgaAcyclicBaseConstraint artifact)
+              (pgaRedirects artifact)
+              defaultTraceConfig
+      case pgaGeneralizeAt artifact (Just (pgaBindParentsGa artifact)) rootScope rootTarget of
+        Right (Forall _ ty, _subst) ->
+          pretty ty `shouldSatisfy` ("Bool" `isInfixOf`)
+        Left err ->
+          expectationFailure ("Prepared artifact generalize-at failed: " ++ show err)
+      resultTy <-
+        requireRight
+          (firstShowE (computeResultTypeFallback resultTypeInputs (pgaAnnotated artifact) ann))
+      pretty resultTy `shouldSatisfy` ("Bool" `isInfixOf`)
 
     it "tracks instantiation copy maps for named binders" $ do
       -- Non-trivial instantiation: polymorphic id used at two types

--- a/test/PipelineSpec.hs
+++ b/test/PipelineSpec.hs
@@ -871,11 +871,24 @@ spec = describe "Pipeline (Phases 1-5)" $ do
       elabSrc `shouldSatisfy` isInfixOf "eeEdgeArtifacts :: EdgeArtifacts"
       resultTypeTypesSrc `shouldSatisfy` isInfixOf "rtcEdgeArtifacts :: EdgeArtifacts"
 
-    it "assembly helper guard: pipeline and driver expose the remaining prep helpers explicitly" $ do
+    it "assembly helper guard: generalization preparation owns shared artifact assembly" $ do
       pipelineSrc <- readFile "src/MLF/Elab/Run/Pipeline.hs"
+      prepareSrc <- readFile "src/MLF/Elab/Run/Generalize/Prepare.hs"
       driverSrc <- readFile "src/MLF/Constraint/Presolution/Driver.hs"
-      pipelineSrc `shouldSatisfy` isInfixOf "data TraceCopyArtifacts = TraceCopyArtifacts"
-      pipelineSrc `shouldSatisfy` isInfixOf "prepareTraceCopyArtifacts"
+      pipelineSrc `shouldSatisfy` isInfixOf "prepareGeneralizationArtifact"
+      forM_
+        [ "data TraceCopyArtifacts = TraceCopyArtifacts",
+          "prepareTraceCopyArtifacts",
+          "castConstraint",
+          "constraintForGeneralization",
+          "instantiationCopyNodes",
+          "letScopeOverrides"
+        ]
+        $ \marker ->
+          pipelineSrc `shouldSatisfy` (not . isInfixOf marker)
+      prepareSrc `shouldSatisfy` isInfixOf "data PreparedGeneralizationArtifact"
+      prepareSrc `shouldSatisfy` isInfixOf "prepareTraceCopyArtifacts"
+      prepareSrc `shouldSatisfy` isInfixOf "pgaAcyclicBaseConstraint :: Constraint 'Presolved"
       driverSrc `shouldSatisfy` isInfixOf "mkInitialPresolutionState ::"
       driverSrc `shouldSatisfy` isInfixOf "tyExpNodeIds ::"
 


### PR DESCRIPTION
## Summary

- Add `MLF.Elab.Run.Generalize.Prepare` with a shared `PreparedGeneralizationArtifact`.
- Route `MLF.Elab.Run.Pipeline` through the prepared artifact instead of rebuilding generalization inputs inline.
- Document the generalization-preparation boundary and guard that the pipeline no longer owns the low-level prep helpers.
- Add behavioral coverage that exercises the prepared artifact on a redirecting instantiation path.

Closes #135

## Validation

- `cabal test mlf2-test --test-options='--match "prepared generalization artifact drives redirecting instantiation behavior"'`
- `cabal test mlf2-test --test-options='--match "assembly helper guard: generalization preparation owns shared artifact assembly"'`
- `cabal build all && cabal test`